### PR TITLE
Simplify completed download service

### DIFF
--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -135,7 +135,7 @@ namespace NzbDrone.Core.Download
             {
                 var statusMessages = importResults
                     .Where(v => v.Result != ImportResultType.Imported)
-                    .Select(v => new TrackedDownloadStatusMessage(Path.GetFileName(v.ImportDecision.LocalEpisode.Path), v.Errors))
+                    .Select(v => new TrackedDownloadStatusMessage(Path.GetFileName(v.ImportDecision.LocalMovie.Path), v.Errors))
                     .ToArray();
 
                 trackedDownload.Warn(statusMessages);

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -94,86 +94,18 @@ namespace NzbDrone.Core.Download
                     return;
                 }
 
-                var series = _parsingService.GetSeries(trackedDownload.DownloadItem.Title);
-
-                if (series == null)
+                var movie = _parsingService.GetMovie(trackedDownload.DownloadItem.Title);
+                if (movie == null)
                 {
                     if (historyItem != null)
                     {
-                        //series = _seriesService.GetSeries(historyItem.SeriesId);
+                        movie = _movieService.GetMovie(historyItem.MovieId);
                     }
 
-                    if (series == null)
+                    if (movie == null)
                     {
-                        var movie = _parsingService.GetMovie(trackedDownload.DownloadItem.Title);
-
-                        if (movie == null)
-                        {
-                            if (historyItem != null)
-                            {
-                                movie = _movieService.GetMovie(historyItem.MovieId);
-                                if (movie.MovieFile != null)
-                                {
-                                    movie.MovieFile.LazyLoad();
-                                    if (movie.MovieFile.Value != null)
-                                    {
-                                        _logger.Debug("File Title: {0}, download item title: {1}", Parser.Parser.CleanSeriesTitle(movie.MovieFile.Value.RelativePath), Parser.Parser.CleanSeriesTitle(trackedDownload.DownloadItem.Title));
-                                        if (Parser.Parser.CleanSeriesTitle(movie.MovieFile.Value.RelativePath).Contains(Parser.Parser.CleanSeriesTitle(trackedDownload.DownloadItem.Title)))
-                                        {
-                                            trackedDownload.Warn("Seems like the movie already has a file associated with this download item. Maybe the History failed?");
-                                            return;
-                                        }
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                var parserResult = Parser.Parser.ParseMovieTitle(trackedDownload.DownloadItem.Title);
-                                if (parserResult != null)
-                                {
-                                    movie = _movieService.FindByTitle(parserResult.MovieTitle);
-                                    if (movie.MovieFile != null)
-                                    {
-                                        movie.MovieFile.LazyLoad();
-                                        if (movie.MovieFile.Value != null)
-                                        {
-                                            _logger.Debug("File Title: {0}, download item title: {1}", Parser.Parser.CleanSeriesTitle(movie.MovieFile.Value.RelativePath), Parser.Parser.CleanSeriesTitle(trackedDownload.DownloadItem.Title));
-                                            if (Parser.Parser.CleanSeriesTitle(movie.MovieFile.Value.RelativePath).Contains(Parser.Parser.CleanSeriesTitle(trackedDownload.DownloadItem.Title)))
-                                            {
-                                                trackedDownload.Warn("Seems like the movie already has a file associated with this download item. Maybe the History failed?");
-                                                return;
-                                            }
-                                        }
-                                    }
-                                }
-                                
-                            }
-
-
-                            if (movie == null)
-                            {
-                                trackedDownload.Warn("Movie title mismatch, automatic import is not possible.");
-                                return;
-                            }
-                        }
-                        else
-                        {
-                            if (movie.MovieFile != null)
-                            {
-                                movie.MovieFile.LazyLoad();
-                                if (movie.MovieFile.Value != null)
-                                {
-                                    _logger.Debug("File Title: {0}, download item title: {1}", Parser.Parser.CleanSeriesTitle(movie.MovieFile.Value.RelativePath), Parser.Parser.CleanSeriesTitle(trackedDownload.DownloadItem.Title));
-                                    if (Parser.Parser.CleanSeriesTitle(movie.MovieFile.Value.RelativePath).Contains(Parser.Parser.CleanSeriesTitle(trackedDownload.DownloadItem.Title)))
-                                    {
-                                        trackedDownload.Warn("Seems like the movie already has a file associated with this download item. Maybe the History failed?");
-                                        return;
-                                    }
-                                }
-                            }
-                        }
-                        //trackedDownload.Warn("Series title mismatch, automatic import is not possible.");
-                        //return;
+                        trackedDownload.Warn("Movie title mismatch, automatic import is not possible.");
+                        return;
                     }
                 }
             }
@@ -184,61 +116,30 @@ namespace NzbDrone.Core.Download
         private void Import(TrackedDownload trackedDownload)
         {
             var outputPath = trackedDownload.DownloadItem.OutputPath.FullPath;
-            if (trackedDownload.RemoteMovie != null && trackedDownload.RemoteMovie.Movie != null)
+            var importResults = _downloadedMovieImportService.ProcessPath(outputPath, ImportMode.Auto, trackedDownload.RemoteMovie.Movie, trackedDownload.DownloadItem);
+
+            if (importResults.Empty())
             {
-                var importResults = _downloadedMovieImportService.ProcessPath(outputPath, ImportMode.Auto, trackedDownload.RemoteMovie.Movie, trackedDownload.DownloadItem);
-
-                if (importResults.Empty())
-                {
-                    trackedDownload.Warn("No files found are eligible for import in {0}", outputPath);
-                    return;
-                }
-
-                if (importResults.Count(c => c.Result == ImportResultType.Imported) >= 1)
-                {
-                    trackedDownload.State = TrackedDownloadStage.Imported;
-                    _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload));
-                    return;
-                }
-
-                if (importResults.Any(c => c.Result != ImportResultType.Imported))
-                {
-                    var statusMessages = importResults
-                        .Where(v => v.Result != ImportResultType.Imported)
-                        .Select(v => new TrackedDownloadStatusMessage(Path.GetFileName(v.ImportDecision.LocalEpisode.Path), v.Errors))
-                        .ToArray();
-
-                    trackedDownload.Warn(statusMessages);
-                }
-            }
-            else if (trackedDownload.RemoteEpisode != null && trackedDownload.RemoteEpisode.Series != null)
-            {
-                var importResults = _downloadedEpisodesImportService.ProcessPath(outputPath, ImportMode.Auto, trackedDownload.RemoteEpisode.Series, trackedDownload.DownloadItem);
-
-                if (importResults.Empty())
-                {
-                    trackedDownload.Warn("No files found are eligible for import in {0}", outputPath);
-                    return;
-                }
-
-                if (importResults.Count(c => c.Result == ImportResultType.Imported) >= Math.Max(1, trackedDownload.RemoteEpisode.Episodes.Count))
-                {
-                    trackedDownload.State = TrackedDownloadStage.Imported;
-                    _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload));
-                    return;
-                }
-
-                if (importResults.Any(c => c.Result != ImportResultType.Imported))
-                {
-                    var statusMessages = importResults
-                        .Where(v => v.Result != ImportResultType.Imported)
-                        .Select(v => new TrackedDownloadStatusMessage(Path.GetFileName(v.ImportDecision.LocalEpisode.Path), v.Errors))
-                        .ToArray();
-
-                    trackedDownload.Warn(statusMessages);
-                }
+                trackedDownload.Warn("No files found are eligible for import in {0}", outputPath);
+                return;
             }
 
+            if (importResults.Count(c => c.Result == ImportResultType.Imported) >= 1)
+            {
+                trackedDownload.State = TrackedDownloadStage.Imported;
+                _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload));
+                return;
+            }
+
+            if (importResults.Any(c => c.Result != ImportResultType.Imported))
+            {
+                var statusMessages = importResults
+                    .Where(v => v.Result != ImportResultType.Imported)
+                    .Select(v => new TrackedDownloadStatusMessage(Path.GetFileName(v.ImportDecision.LocalEpisode.Path), v.Errors))
+                    .ToArray();
+
+                trackedDownload.Warn(statusMessages);
+            }
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

Fix for

```
System.NullReferenceException: Object reference not set to an instance of an object
  at NzbDrone.Core.Download.CompletedDownloadService.Process (NzbDrone.Core.Download.TrackedDownloads.TrackedDownload trackedDownload, System.Boolean ignoreWarnings) [0x0020f] in <1d557e64627d470ea0b64c34030b31a3>:0 
  at NzbDrone.Core.Download.TrackedDownloads.DownloadMonitoringService.ProcessClientItems (NzbDrone.Core.Download.IDownloadClient downloadClient, NzbDrone.Core.Download.DownloadClientItem downloadItem) [0x00042] in <1d557e64627d470ea0b64c34030b31a3>:0```