### PR TITLE
Move Travis builds to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 solution: src/NzbDrone.sln
-script:    # the following commands are just examples, use whatever your build process requires
+script:
   - ./build.sh
   - chmod +x test.sh
 #  - ./test.sh Linux Unit Takes far too long, maybe even crashes travis :/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: csharp
 solution: src/NzbDrone.sln
+addons:
+  apt:
+    packages:
+      - nodejs
+      - npm
 script:
   - ./build.sh
   - chmod +x test.sh
 #  - ./test.sh Linux Unit Takes far too long, maybe even crashes travis :/
-install:
-  - sudo apt-get install nodejs
-  - sudo apt-get install npm
 after_success:
   - chmod +x package.sh
   - ./package.sh


### PR DESCRIPTION
#### Database Migration
NO

#### Description
By modifying the way apt packages work in `.travis.yml` (remove the need to directly require sudo), the builds can now run on container-based infrastructure. 

Information on migrating from legacy to container-based infrastructure can be found [here](https://docs.travis-ci.com/user/migrating-from-legacy/).