### PR TITLE
#292 - Allow longer threshold for RSS Sync

### DIFF
--- a/src/NzbDrone.Core.Test/Configuration/ConfigServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Configuration/ConfigServiceFixture.cs
@@ -32,7 +32,7 @@ namespace NzbDrone.Core.Test.Configuration
         [Test]
         public void Get_value_should_return_default_when_no_value()
         {
-            Subject.RssSyncInterval.Should().Be(15);
+            Subject.RssSyncInterval.Should().Be(60);
         }
 
         [Test]
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Test.Configuration
         public void get_value_with_out_persist_should_not_store_default_value()
         {
             var interval = Subject.RssSyncInterval;
-            interval.Should().Be(15);
+            interval.Should().Be(60);
             Mocker.GetMock<IConfigRepository>().Verify(c => c.Insert(It.IsAny<Config>()), Times.Never());
         }
 

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.Configuration
 
         public int RssSyncInterval
         {
-            get { return GetValueInt("RssSyncInterval", 15); }
+            get { return GetValueInt("RssSyncInterval", 60); }
 
             set { SetValue("RssSyncInterval", value); }
         }

--- a/src/NzbDrone.Core/Jobs/TaskManager.cs
+++ b/src/NzbDrone.Core/Jobs/TaskManager.cs
@@ -125,9 +125,9 @@ namespace NzbDrone.Core.Jobs
         {
             var interval = _configService.RssSyncInterval;
 
-            if (interval > 0 && interval < 10)
+            if (interval > 0 && interval < 60)
             {
-                return 10;
+                return 60;
             }
 
             if (interval < 0)

--- a/src/NzbDrone.Core/Jobs/TaskManager.cs
+++ b/src/NzbDrone.Core/Jobs/TaskManager.cs
@@ -125,9 +125,9 @@ namespace NzbDrone.Core.Jobs
         {
             var interval = _configService.RssSyncInterval;
 
-            if (interval > 0 && interval < 60)
+            if (interval > 0 && interval < 10)
             {
-                return 60;
+                return 10;
             }
 
             if (interval < 0)

--- a/src/UI/Settings/Indexers/Options/IndexerOptionsViewTemplate.hbs
+++ b/src/UI/Settings/Indexers/Options/IndexerOptionsViewTemplate.hbs
@@ -34,7 +34,7 @@
         </div>
 
         <div class="col-sm-2 col-sm-pull-1">
-            <input type="number" name="rssSyncInterval" class="form-control" min="0" max="120"/>
+            <input type="number" name="rssSyncInterval" class="form-control" min="0" max="720"/>
         </div>
     </div>
 </fieldset>


### PR DESCRIPTION
Update RSS Sync interval default to 60 minutes, and don't allow values below 10 or higher than 720 minutes (12 hours)

#### Database Migration
NO

#### Issues Fixed or Closed by this PR
#292
