### PR TITLE
Fixed: Proper port validation for download clients and connections

### DIFF
--- a/src/NzbDrone.Api/ClientSchema/SchemaBuilder.cs
+++ b/src/NzbDrone.Api/ClientSchema/SchemaBuilder.cs
@@ -73,14 +73,14 @@ namespace NzbDrone.Api.ClientSchema
 
                     if (propertyInfo.PropertyType == typeof(int))
                     {
-                        var value = Convert.ToInt32(field.Value);
-                        propertyInfo.SetValue(target, value, null);
+                        var value = field.Value.ToString().ParseInt32();
+                        propertyInfo.SetValue(target, value ?? 0, null);
                     }
 
                     else if (propertyInfo.PropertyType == typeof(long))
                     {
-                        var value = Convert.ToInt64(field.Value);
-                        propertyInfo.SetValue(target, value, null);
+                        var value = field.Value.ToString().ParseInt64();
+                        propertyInfo.SetValue(target, value ?? 0, null);
                     }
 
                     else if (propertyInfo.PropertyType == typeof(int?))

--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
         public DelugeSettingsValidator()
         {
             RuleFor(c => c.Host).ValidHost();
-            RuleFor(c => c.Port).GreaterThan(0);
+            RuleFor(c => c.Port).InclusiveBetween(1, 65535);
 
             RuleFor(c => c.MovieCategory).Matches("^[-a-z]*$").WithMessage("Allowed characters a-z and -");
         }

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/HadoukenSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/HadoukenSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
         public HadoukenSettingsValidator()
         {
             RuleFor(c => c.Host).ValidHost();
-            RuleFor(c => c.Port).GreaterThan(0);
+            RuleFor(c => c.Port).InclusiveBetween(1, 65535);
 
             RuleFor(c => c.Username).NotEmpty()
                                     .WithMessage("Username must not be empty.");

--- a/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortexSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortexSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
         public NzbVortexSettingsValidator()
         {
             RuleFor(c => c.Host).ValidHost();
-            RuleFor(c => c.Port).GreaterThan(0);
+            RuleFor(c => c.Port).InclusiveBetween(1, 65535);
 
             RuleFor(c => c.ApiKey).NotEmpty()
                                   .WithMessage("API Key is required");

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
         public NzbgetSettingsValidator()
         {
             RuleFor(c => c.Host).ValidHost();
-            RuleFor(c => c.Port).GreaterThan(0);
+            RuleFor(c => c.Port).InclusiveBetween(1, 65535);
             RuleFor(c => c.Username).NotEmpty().When(c => !string.IsNullOrWhiteSpace(c.Password));
             RuleFor(c => c.Password).NotEmpty().When(c => !string.IsNullOrWhiteSpace(c.Username));
 

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         public QBittorrentSettingsValidator()
         {
             RuleFor(c => c.Host).ValidHost();
-            RuleFor(c => c.Port).InclusiveBetween(0, 65535);
+            RuleFor(c => c.Port).InclusiveBetween(1, 65535);
         }
     }
 

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
         public SabnzbdSettingsValidator()
         {
             RuleFor(c => c.Host).ValidHost();
-            RuleFor(c => c.Port).GreaterThan(0);
+            RuleFor(c => c.Port).InclusiveBetween(1, 65535);
 
             RuleFor(c => c.ApiKey).NotEmpty()
                                   .WithMessage("API Key is required when username/password are not configured")

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         public TransmissionSettingsValidator()
         {
             RuleFor(c => c.Host).ValidHost();
-            RuleFor(c => c.Port).GreaterThan(0);
+            RuleFor(c => c.Port).InclusiveBetween(1, 65535);
 
             RuleFor(c => c.UrlBase).ValidUrlBase();
 

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentSettings.cs
@@ -10,10 +10,10 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
         public RTorrentSettingsValidator()
         {
             RuleFor(c => c.Host).ValidHost();
-            RuleFor(c => c.Port).InclusiveBetween(0, 65535);
+            RuleFor(c => c.Port).InclusiveBetween(1, 65535);
             RuleFor(c => c.MovieCategory).NotEmpty()
                                       .WithMessage("A category is recommended")
-                                      .AsWarning(); 
+                                      .AsWarning();
         }
     }
 

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
         public UTorrentSettingsValidator()
         {
             RuleFor(c => c.Host).ValidHost();
-            RuleFor(c => c.Port).InclusiveBetween(0, 65535);
+            RuleFor(c => c.Port).InclusiveBetween(1, 65535);
             RuleFor(c => c.TvCategory).NotEmpty();
         }
     }

--- a/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Notifications.Email
         public EmailSettingsValidator()
         {
             RuleFor(c => c.Server).NotEmpty();
-            RuleFor(c => c.Port).GreaterThan(0);
+            RuleFor(c => c.Port).InclusiveBetween(1, 65535);
             RuleFor(c => c.From).NotEmpty();
             RuleFor(c => c.To).NotEmpty();
         }

--- a/src/NzbDrone.Core/Notifications/Growl/GrowlSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Growl/GrowlSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Notifications.Growl
         public GrowlSettingsValidator()
         {
             RuleFor(c => c.Host).ValidHost();
-            RuleFor(c => c.Port).GreaterThan(0);
+            RuleFor(c => c.Port).InclusiveBetween(1, 65535);
         }
     }
 

--- a/src/NzbDrone.Core/Notifications/Plex/PlexClientSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexClientSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Notifications.Plex
         public PlexClientSettingsValidator()
         {
             RuleFor(c => c.Host).ValidHost();
-            RuleFor(c => c.Port).GreaterThan(0);
+            RuleFor(c => c.Port).InclusiveBetween(1, 65535);
         }
     }
 

--- a/src/NzbDrone.Core/Notifications/Plex/PlexServerSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexServerSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Notifications.Plex
         public PlexServerSettingsValidator()
         {
             RuleFor(c => c.Host).ValidHost();
-            RuleFor(c => c.Port).GreaterThan(0);
+            RuleFor(c => c.Port).InclusiveBetween(1, 65535);
         }
     }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Proper port validation for download clients and connections.

Reference:
https://github.com/Sonarr/Sonarr/commit/ef03e9e9a7e8170d8166240d827e942362831c72

#### Issues Fixed or Closed by this PR

Fixes issue as described in the Sonarr repository (https://github.com/Sonarr/Sonarr/issues/1642):
When configuring the rTorrent downloader and specifying the port I'm guessing it's a required field. It just kept failing on me while trying to leave it empty, while assuming that empty would default to port 80. It should either provide some feedback that it is a required field, or upon pressing save/test, when empty, fall back to the default (8080 in this instance).
