### PR TITLE
Set Drone Factory Interval default to 0

### DIFF
--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -176,7 +176,7 @@ namespace NzbDrone.Core.Configuration
 
         public int DownloadedEpisodesScanInterval
         {
-            get { return GetValueInt("DownloadedEpisodesScanInterval", 1); }
+            get { return GetValueInt("DownloadedEpisodesScanInterval", 0); }
 
             set { SetValue("DownloadedEpisodesScanInterval", value); }
         }


### PR DESCRIPTION
Fixes #447

#### Database Migration
NO

#### Description
Set the default interval to 0 for the Drone Factory folder so that it doesn't run and fail by default

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* 447
