### PR TITLE
Add expanded DTS audio codecs to FileNameBuilder and fix up Atmos TrueHD audioCodec string.

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -730,6 +730,10 @@ namespace NzbDrone.Core.Organizer
                 case "E-AC-3":
                     audioCodec = "EAC3";
                     break;
+                
+                case "Atmos / TrueHD":
+                    audioCodec = "Atmos TrueHD";
+                    break;
 
                 case "MPEG Audio":
                     if (movieFile.MediaInfo.AudioProfile == "Layer 3")

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -743,7 +743,26 @@ namespace NzbDrone.Core.Organizer
                     break;
 
                 case "DTS":
-                    audioCodec = movieFile.MediaInfo.AudioFormat;
+                    if (episodeFile.MediaInfo.AudioProfile == "ES Discrete / Core" || episodeFile.MediaInfo.AudioProfile == "ES Matrix / Core")
+                    {
+                        audioCodec = "DTS-ES";
+                    }
+                    else if (episodeFile.MediaInfo.AudioProfile == "MA / Core" || episodeFile.MediaInfo.AudioProfile == "MA / ES Matrix / Core")
+                    {
+                        audioCodec = "DTS-HD MA";
+                    }
+                    else if (episodeFile.MediaInfo.AudioProfile == "HRA / Core")
+                    {
+                        audioCodec = "DTS-HD HRA";
+                    }
+                    else if (episodeFile.MediaInfo.AudioProfile == "X / MA / Core")
+                    {
+                        audioCodec = "DTS-X";
+                    }
+                    else
+                    {
+                        audioCodec = episodeFile.MediaInfo.AudioFormat;
+                    }
                     break;
 
                 default:


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This expands the DTS audio codec based on the format profile provided by MediaInfo. I have also fixed up Atmos TrueHD to remove the ` /` so you don't end up with `Atmos.+.TrueHD` in the output filename.
