### PR TITLE
Use shorter format Profile string for DTS profiles.

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -747,19 +747,19 @@ namespace NzbDrone.Core.Organizer
                     break;
 
                 case "DTS":
-                    if (movieFile.MediaInfo.AudioProfile == "ES Discrete / Core" || movieFile.MediaInfo.AudioProfile == "ES Matrix / Core")
+                    if (movieFile.MediaInfo.AudioProfile == "ES Discrete" || movieFile.MediaInfo.AudioProfile == "ES Matrix")
                     {
                         audioCodec = "DTS-ES";
                     }
-                    else if (movieFile.MediaInfo.AudioProfile == "MA / Core" || movieFile.MediaInfo.AudioProfile == "MA / ES Matrix / Core")
+                    else if (movieFile.MediaInfo.AudioProfile == "MA")
                     {
                         audioCodec = "DTS-HD MA";
                     }
-                    else if (movieFile.MediaInfo.AudioProfile == "HRA / Core")
+                    else if (movieFile.MediaInfo.AudioProfile == "HRA")
                     {
                         audioCodec = "DTS-HD HRA";
                     }
-                    else if (movieFile.MediaInfo.AudioProfile == "X / MA / Core")
+                    else if (movieFile.MediaInfo.AudioProfile == "X")
                     {
                         audioCodec = "DTS-X";
                     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
In my local setup where I was detecting the strings, I forgot they need to only contain the left portion of the string.