### PR TITLE
Fix ical ics feed file

### DIFF
--- a/src/UI/Calendar/CalendarFeedView.js
+++ b/src/UI/Calendar/CalendarFeedView.js
@@ -29,7 +29,7 @@ module.exports = Marionette.Layout.extend({
     },
 
     _updateUrl : function() {
-        var icalUrl = window.location.host + StatusModel.get('urlBase') + '/feed/calendar/NzbDrone.ics?';
+        var icalUrl = window.location.host + StatusModel.get('urlBase') + '/feed/calendar/Radarr.ics?';
 
         if (this.ui.includeUnmonitored.prop('checked')) {
             icalUrl += 'unmonitored=true&';

--- a/src/UI/index.html
+++ b/src/UI/index.html
@@ -47,7 +47,7 @@
     <meta name="msapplication-config" content="/Content/Images/favicon/browserconfig.xml">
     <meta name="theme-color" content="#272727">
 
-    <link rel="alternate" type="text/calendar" title="iCalendar feed for Radarr" href="/feed/calendar/NzbDrone.ics"/>
+    <link rel="alternate" type="text/calendar" title="iCalendar feed for Radarr" href="/feed/calendar/Radarr.ics"/>
 </head>
 <body>
 <div class="container">


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Version (nightly)  0.2.0.285 still points to Nzbdrone.ics when you click Get iCal Link in Calender view.