### PR TITLE
Trakt private list support

### DIFF
--- a/src/NzbDrone.Api/Config/NetImportConfigResource.cs
+++ b/src/NzbDrone.Api/Config/NetImportConfigResource.cs
@@ -8,6 +8,8 @@ namespace NzbDrone.Api.Config
         public int NetImportSyncInterval { get; set; }
 	public string TraktAuthToken { get; set; }
 	public string TraktRefreshToken { get; set; }
+	public string TraktTokenCreatedAt { get; set; }
+	public string TraktTokenExpiresIn { get; set; }
     }
 
     public static class NetImportConfigResourceMapper
@@ -19,6 +21,8 @@ namespace NzbDrone.Api.Config
                 NetImportSyncInterval = model.NetImportSyncInterval,
 		TraktAuthToken = model.TraktAuthToken,
 		TraktRefreshToken = model.TraktRefreshToken,
+		TraktTokenCreatedAt = model.TraktTokenCreatedAt,
+		TraktTokenExpiresIn = model.TraktTokenExpiresIn,
             };
         }
     }

--- a/src/NzbDrone.Api/Config/NetImportConfigResource.cs
+++ b/src/NzbDrone.Api/Config/NetImportConfigResource.cs
@@ -8,8 +8,7 @@ namespace NzbDrone.Api.Config
         public int NetImportSyncInterval { get; set; }
 	public string TraktAuthToken { get; set; }
 	public string TraktRefreshToken { get; set; }
-	public string TraktTokenCreatedAt { get; set; }
-	public string TraktTokenExpiresIn { get; set; }
+	public int TraktTokenExpiry { get; set; }
     }
 
     public static class NetImportConfigResourceMapper
@@ -21,8 +20,7 @@ namespace NzbDrone.Api.Config
                 NetImportSyncInterval = model.NetImportSyncInterval,
 		TraktAuthToken = model.TraktAuthToken,
 		TraktRefreshToken = model.TraktRefreshToken,
-		TraktTokenCreatedAt = model.TraktTokenCreatedAt,
-		TraktTokenExpiresIn = model.TraktTokenExpiresIn,
+		TraktTokenExpiry = model.TraktTokenExpiry,
             };
         }
     }

--- a/src/NzbDrone.Api/Config/NetImportConfigResource.cs
+++ b/src/NzbDrone.Api/Config/NetImportConfigResource.cs
@@ -6,6 +6,8 @@ namespace NzbDrone.Api.Config
     public class NetImportConfigResource : RestResource
     {
         public int NetImportSyncInterval { get; set; }
+	public string TraktAuthToken { get; set; }
+	public string TraktRefreshToken { get; set; }
     }
 
     public static class NetImportConfigResourceMapper
@@ -14,7 +16,9 @@ namespace NzbDrone.Api.Config
         {
             return new NetImportConfigResource
             {
-                NetImportSyncInterval = model.NetImportSyncInterval
+                NetImportSyncInterval = model.NetImportSyncInterval,
+		TraktAuthToken = model.TraktAuthToken,
+		TraktRefreshToken = model.TraktRefreshToken,
             };
         }
     }

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -126,19 +126,11 @@ namespace NzbDrone.Core.Configuration
 	    set {SetValue("TraktRefreshToken", value); }
 	}
 
-	public string TraktTokenExpiresIn
+	public int TraktTokenExpiry
 	{
-		get { return GetValue("TraktTokenExpiresIn", string.Empty); }
+		get { return GetValueInt("TraktTokenExpiry", 0); }
 
-		set { SetValue("TraktTokenExpiresIn", value); }
-	}
-
-	public string TraktTokenCreatedAt
-	{
-		get { return GetValue("TraktTokenCreatedAt", string.Empty); }
-
-		set { SetValue("TraktTokenCreatedAt", value); }
-
+		set { SetValue("TraktTokenExpiry", value); }
 	}
 
         public int MinimumAge

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -126,6 +126,21 @@ namespace NzbDrone.Core.Configuration
 	    set {SetValue("TraktRefreshToken", value); }
 	}
 
+	public string TraktTokenExpiresIn
+	{
+		get { return GetValue("TraktTokenExpiresIn", string.Empty); }
+
+		set { SetValue("TraktTokenExpiresIn", value); }
+	}
+
+	public string TraktTokenCreatedAt
+	{
+		get { return GetValue("TraktTokenCreatedAt", string.Empty); }
+
+		set { SetValue("TraktTokenCreatedAt", value); }
+
+	}
+
         public int MinimumAge
         {
             get { return GetValueInt("MinimumAge", 0); }

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -112,6 +112,20 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("NetImportSyncInterval", value); }
         }
 
+	public string TraktAuthToken
+	{
+            get { return GetValue("TraktAuthToken", string.Empty); }
+
+            set { SetValue("TraktAuthToken", value); }
+	}
+
+	public string TraktRefreshToken
+	{
+	    get { return GetValue("TraktRefreshToken", string.Empty); }
+
+	    set {SetValue("TraktRefreshToken", value); }
+	}
+
         public int MinimumAge
         {
             get { return GetValueInt("MinimumAge", 0); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -49,8 +49,7 @@ namespace NzbDrone.Core.Configuration
         int NetImportSyncInterval { get; set; }
 	string TraktAuthToken { get; set; }
 	string TraktRefreshToken { get; set; }
-	string TraktTokenExpiresIn { get; set; }
-	string TraktTokenCreatedAt { get; set; }
+	int TraktTokenExpiry { get; set; }
 
         //UI
         int FirstDayOfWeek { get; set; }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -47,6 +47,8 @@ namespace NzbDrone.Core.Configuration
         int MinimumAge { get; set; }
 
         int NetImportSyncInterval { get; set; }
+	string TraktAuthToken { get; set; }
+	string TraktRefreshToken { get; set; }
 
         //UI
         int FirstDayOfWeek { get; set; }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -49,6 +49,8 @@ namespace NzbDrone.Core.Configuration
         int NetImportSyncInterval { get; set; }
 	string TraktAuthToken { get; set; }
 	string TraktRefreshToken { get; set; }
+	string TraktTokenExpiresIn { get; set; }
+	string TraktTokenCreatedAt { get; set; }
 
         //UI
         int FirstDayOfWeek { get; set; }

--- a/src/NzbDrone.Core/NetImport/Trakt/TraktImport.cs
+++ b/src/NzbDrone.Core/NetImport/Trakt/TraktImport.cs
@@ -18,14 +18,15 @@ namespace NzbDrone.Core.NetImport.Trakt
         public override string Name => "Trakt List";
         public override bool Enabled => true;
         public override bool EnableAuto => false;
+        public IConfigService _configService;
 
         public TraktImport(IHttpClient httpClient, IConfigService configService, IParsingService parsingService, Logger logger)
             : base(httpClient, configService, parsingService, logger)
-        { }
+        { _configService = configService; }
 
         public override INetImportRequestGenerator GetRequestGenerator()
         {
-            return new TraktRequestGenerator() { Settings = Settings };
+            return new TraktRequestGenerator() { Settings = Settings, _configService = _configService };
         }
 
         public override IParseNetImportResponse GetParser()

--- a/src/NzbDrone.Core/NetImport/Trakt/TraktRequestGenerator.cs
+++ b/src/NzbDrone.Core/NetImport/Trakt/TraktRequestGenerator.cs
@@ -74,10 +74,10 @@ namespace NzbDrone.Core.NetImport.Trakt
                 {
                     var url = Settings.Link.Trim();
                     url = url + "/oauth/token";
-
+                    //this code is not going to work right now -- need to implement with apiServer
                     string postData = "{\"refresh_token\":\""+ _configService.TraktRefreshToken+"\"";
-                    postData += ",\"client_id\":\"657bb899dcb81ec8ee838ff09f6e013ff7c740bf0ccfa54dd41e791b9a70b2f0\"";
-                    postData += ",\"client_secret\":\"b16be19076b515553bb830141e08729c1d987fe686b3c3bc0316ba4382c2b810\"";
+                    //postData += ",\"client_id\":\"657bb899dcb81ec8ee838ff09f6e013ff7c740bf0ccfa54dd41e791b9a70b2f0\""; //radarr
+                    postData += ",\"client_id\":\"8a54ed7b5e1b56d874642770ad2e8b73e2d09d6e993c3a92b1e89690bb1c9014\""; //couchpotato
                     postData += ",\"redirect_uri\":\"urn:ietf:wg:oauth:2.0:oob\"";
                     postData += ",\"grant_type\":\"refresh_token\"}";
 
@@ -96,14 +96,16 @@ namespace NzbDrone.Core.NetImport.Trakt
                     _configService.TraktAuthToken = j1.access_token;
                     _configService.TraktRefreshToken = j1.refresh_token;
                     string createdAt = j1.created_at;
-                    string expiresIn = j1.expires_in;
-                    _configService.TraktTokenExpiry = int.Parse(createdAt) + int.Parse(expiresIn);
+                    //string expiresIn = j1.expires_in;
+		    //lets have it expire in 8 weeks (4838400 seconds)
+                    _configService.TraktTokenExpiry = int.Parse(createdAt) + 4838400;//int.Parse(expiresIn);
                 }
             }
 
             var request = new NetImportRequest($"{link}", HttpAccept.Json);
             request.HttpRequest.Headers.Add("trakt-api-version", "2");
-            request.HttpRequest.Headers.Add("trakt-api-key", "657bb899dcb81ec8ee838ff09f6e013ff7c740bf0ccfa54dd41e791b9a70b2f0");
+            //request.HttpRequest.Headers.Add("trakt-api-key", "657bb899dcb81ec8ee838ff09f6e013ff7c740bf0ccfa54dd41e791b9a70b2f0"); //radarr
+	    request.HttpRequest.Headers.Add("trakt-api-key", "8a54ed7b5e1b56d874642770ad2e8b73e2d09d6e993c3a92b1e89690bb1c9014"); //couchpotato
             if (_configService.TraktAuthToken != null)
             {
                 request.HttpRequest.Headers.Add("Authorization", "Bearer " + _configService.TraktAuthToken);

--- a/src/NzbDrone.Core/NetImport/Trakt/TraktRequestGenerator.cs
+++ b/src/NzbDrone.Core/NetImport/Trakt/TraktRequestGenerator.cs
@@ -69,14 +69,8 @@ namespace NzbDrone.Core.NetImport.Trakt
             {
                 TimeSpan span = (DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, 0,DateTimeKind.Utc));
                 double unixTime = span.TotalSeconds;
-                int expiryTime = 0;
-                int createdAt, expiresIn;
-                if (int.TryParse(_configService.TraktTokenExpiresIn, out expiresIn) && int.TryParse(_configService.TraktTokenCreatedAt, out createdAt))
-                {
-                    expiryTime = createdAt + expiresIn;
-                }
                              
-                if ( unixTime > expiryTime)
+                if ( unixTime > _configService.TraktTokenExpiry)
                 {
                     var url = Settings.Link.Trim();
                     url = url + "/oauth/token";
@@ -101,13 +95,11 @@ namespace NzbDrone.Core.NetImport.Trakt
 
                     _configService.TraktAuthToken = j1.access_token;
                     _configService.TraktRefreshToken = j1.refresh_token;
-                    _configService.TraktTokenCreatedAt = j1.created_at; 
-                    _configService.TraktTokenExpiresIn = j1.expires_in; 
+                    string createdAt = j1.created_at;
+                    string expiresIn = j1.expires_in;
+                    _configService.TraktTokenExpiry = int.Parse(createdAt) + int.Parse(expiresIn);
                 }
             }
-
-            //Console.WriteLine(_configService.TraktTokenCreatedAt);
-            //_configService.TraktTokenCreatedAt += "t";
 
             var request = new NetImportRequest($"{link}", HttpAccept.Json);
             request.HttpRequest.Headers.Add("trakt-api-version", "2");

--- a/src/NzbDrone.Core/NetImport/Trakt/TraktRequestGenerator.cs
+++ b/src/NzbDrone.Core/NetImport/Trakt/TraktRequestGenerator.cs
@@ -6,11 +6,13 @@ using System.Text;
 using System.Net;
 using System.IO;
 using Newtonsoft.Json.Linq;
+using NzbDrone.Core.Configuration;
 
 namespace NzbDrone.Core.NetImport.Trakt
 {
     public class TraktRequestGenerator : INetImportRequestGenerator
     {
+        public IConfigService _configService;
         public TraktSettings Settings { get; set; }
 
         public virtual NetImportPageableRequestChain GetMovies()
@@ -63,28 +65,27 @@ namespace NzbDrone.Core.NetImport.Trakt
                     break;
             }
 
-            /*
-            if (Settings.Refreshtoken ! = null) //if a refreshToken exists
+            if (_configService.TraktRefreshToken != null) //if a refreshToken exists
             {
-                TimeSpan span = (DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, 0,DateTimeKind.Utc));
-                double unixTime = span.TotalSeconds;
-                bool tokenExpired = false; //TokenCreatedAt + TokenExpiresIn < unixTime()
+                //TimeSpan span = (DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, 0,DateTimeKind.Utc));
+                //double unixTime = span.TotalSeconds;
+                bool tokenExpired = true; //TokenCreatedAt + TokenExpiresIn < unixTime()
                 if (tokenExpired)
                 {
                     var url = Settings.Link.Trim();
                     url = url + "/oauth/token";
 
-                    string postData = "refresh_token=" + Settings.Refreshtoken.Trim();
-                    postData += "&client_id=" + Settings.Authtoken.Trim();
-                    postData += "&client_secret=b16be19076b515553bb830141e08729c1d987fe686b3c3bc0316ba4382c2b810";
-                    postData += "&redirect_uri=urn:ietf:wg:oauth:2.0:oob";
-                    postData += "&grant_type=refresh_token";
+                    string postData = "{\"refresh_token\":\""+ _configService.TraktRefreshToken+"\"";
+                    postData += ",\"client_id\":\"657bb899dcb81ec8ee838ff09f6e013ff7c740bf0ccfa54dd41e791b9a70b2f0\"";
+                    postData += ",\"client_secret\":\"b16be19076b515553bb830141e08729c1d987fe686b3c3bc0316ba4382c2b810\"";
+                    postData += ",\"redirect_uri\":\"urn:ietf:wg:oauth:2.0:oob\"";
+                    postData += ",\"grant_type\":\"refresh_token\"}";
 
                     byte[] byteArray = Encoding.UTF8.GetBytes(postData);
 
                     HttpWebRequest rquest = (HttpWebRequest)WebRequest.Create(url);
                     rquest.Method = "POST";
-                    rquest.Headers.ContentType = "application/json";
+                    rquest.ContentType = "application/json";
                     using (var st = rquest.GetRequestStream())
                         st.Write(byteArray, 0, byteArray.Length);
                     var rsponse = (HttpWebResponse)rquest.GetResponse();
@@ -92,22 +93,19 @@ namespace NzbDrone.Core.NetImport.Trakt
                     rsponse.Close();
                     dynamic j1 = JObject.Parse(rsponseString);
 
-                    //these need to be updated and need to but so far dont know how
-                    //this shoud only be done if the post request was successful.
-                    Settings.Authtoken = j1.access_token;
-                    Settings.Refreshtoken = j1.refresh_token;
-                    TokenCreatedAt = j1.created_at; //convert to double
-                    TokenExpiresIn = j1.expires_in; //convert to double
+                    _configService.TraktAuthToken = j1.access_token;
+                    _configService.TraktRefreshToken = j1.refresh_token;
+                    //TokenCreatedAt = j1.created_at; //convert to double
+                    //TokenExpiresIn = j1.expires_in; //convert to double
                 }
             }
-            */
 
             var request = new NetImportRequest($"{link}", HttpAccept.Json);
             request.HttpRequest.Headers.Add("trakt-api-version", "2");
             request.HttpRequest.Headers.Add("trakt-api-key", "657bb899dcb81ec8ee838ff09f6e013ff7c740bf0ccfa54dd41e791b9a70b2f0");
-            if (Settings.Authtoken != null)
+            if (_configService.TraktAuthToken != null)
             {
-                request.HttpRequest.Headers.Add("Authorization", "Bearer " + Settings.Authtoken.Trim());
+                request.HttpRequest.Headers.Add("Authorization", "Bearer " + _configService.TraktAuthToken);
             }
 
                 yield return request;

--- a/src/NzbDrone.Core/NetImport/Trakt/TraktRequestGenerator.cs
+++ b/src/NzbDrone.Core/NetImport/Trakt/TraktRequestGenerator.cs
@@ -67,38 +67,49 @@ namespace NzbDrone.Core.NetImport.Trakt
 
             if (_configService.TraktRefreshToken != null) 
             {
-                TimeSpan span = (DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, 0,DateTimeKind.Utc));
-                double unixTime = span.TotalSeconds;
-                             
+                // TimeSpan span = (DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, 0,DateTimeKind.Utc));
+                //double unixTime = span.TotalSeconds;
+                Int32 unixTime= (Int32)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
+
                 if ( unixTime > _configService.TraktTokenExpiry)
                 {
-                    var url = Settings.Link.Trim();
-                    url = url + "/oauth/token";
+                    //var url = Settings.Link.Trim();
+                    //url = url + "/oauth/token";
+                    var url = "https://api.couchpota.to/authorize/trakt_refresh?token="+_configService.TraktRefreshToken;
+                    ////var options= "?token="+_configService.TraktRefreshToken;
                     //this code is not going to work right now -- need to implement with apiServer
-                    string postData = "{\"refresh_token\":\""+ _configService.TraktRefreshToken+"\"";
+                    //string postData = "{\"refresh_token\":\""+ _configService.TraktRefreshToken+"\"";
                     //postData += ",\"client_id\":\"657bb899dcb81ec8ee838ff09f6e013ff7c740bf0ccfa54dd41e791b9a70b2f0\""; //radarr
-                    postData += ",\"client_id\":\"8a54ed7b5e1b56d874642770ad2e8b73e2d09d6e993c3a92b1e89690bb1c9014\""; //couchpotato
-                    postData += ",\"redirect_uri\":\"urn:ietf:wg:oauth:2.0:oob\"";
-                    postData += ",\"grant_type\":\"refresh_token\"}";
+                    //postData += ",\"client_id\":\"8a54ed7b5e1b56d874642770ad2e8b73e2d09d6e993c3a92b1e89690bb1c9014\""; //couchpotato
+                    //postData += ",\"redirect_uri\":\"urn:ietf:wg:oauth:2.0:oob\"";
+                    //postData += ",\"grant_type\":\"refresh_token\"}";
 
-                    byte[] byteArray = Encoding.UTF8.GetBytes(postData);
+                    //byte[] byteArray = Encoding.UTF8.GetBytes(postData);
 
                     HttpWebRequest rquest = (HttpWebRequest)WebRequest.Create(url);
-                    rquest.Method = "POST";
-                    rquest.ContentType = "application/json";
-                    using (var st = rquest.GetRequestStream())
-                        st.Write(byteArray, 0, byteArray.Length);
-                    var rsponse = (HttpWebResponse)rquest.GetResponse();
-                    var rsponseString = new StreamReader(rsponse.GetResponseStream()).ReadToEnd();
-                    rsponse.Close();
+                    //rquest.Method = "GET";
+                    //rquest.ContentType = "application/json";
+                    //using (var st = rquest.GetRequestStream())
+                    //    st.Write(byteArray, 0, byteArray.Length);
+                    //var rsponse = (HttpWebResponse)rquest.GetResponse();
+                    //var rsponseString = new StreamReader(rsponse.GetResponseStream()).ReadToEnd();
+                    //rsponse.Close();
+                    //dynamic j1 = JObject.Parse(rsponseString);
+                    string rsponseString = string.Empty;
+                    using (HttpWebResponse rsponse = (HttpWebResponse)rquest.GetResponse())
+                    using (Stream stream = rsponse.GetResponseStream())
+                    using (StreamReader reader = new StreamReader(stream))
+                    {
+                        rsponseString = reader.ReadToEnd();
+                    }
                     dynamic j1 = JObject.Parse(rsponseString);
-
-                    _configService.TraktAuthToken = j1.access_token;
-                    _configService.TraktRefreshToken = j1.refresh_token;
-                    string createdAt = j1.created_at;
+                    _configService.TraktAuthToken = j1.oauth;
+                    _configService.TraktRefreshToken = j1.refresh;
+                    //int createdAt = unixTime;
+                    //string createdAt = j1.created_at;
                     //string expiresIn = j1.expires_in;
-		    //lets have it expire in 8 weeks (4838400 seconds)
-                    _configService.TraktTokenExpiry = int.Parse(createdAt) + 4838400;//int.Parse(expiresIn);
+                    //lets have it expire in 8 weeks (4838400 seconds)
+                    _configService.TraktTokenExpiry = unixTime + 4838400;//int.Parse(expiresIn);
                 }
             }
 

--- a/src/NzbDrone.Core/NetImport/Trakt/TraktRequestGenerator.cs
+++ b/src/NzbDrone.Core/NetImport/Trakt/TraktRequestGenerator.cs
@@ -3,6 +3,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Net;
+using System.IO;
+using Newtonsoft.Json.Linq;
 
 namespace NzbDrone.Core.NetImport.Trakt
 {
@@ -60,11 +63,54 @@ namespace NzbDrone.Core.NetImport.Trakt
                     break;
             }
 
+            /*
+            if (Settings.Refreshtoken ! = null) //if a refreshToken exists
+            {
+                TimeSpan span = (DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, 0,DateTimeKind.Utc));
+                double unixTime = span.TotalSeconds;
+                bool tokenExpired = false; //TokenCreatedAt + TokenExpiresIn < unixTime()
+                if (tokenExpired)
+                {
+                    var url = Settings.Link.Trim();
+                    url = url + "/oauth/token";
+
+                    string postData = "refresh_token=" + Settings.Refreshtoken.Trim();
+                    postData += "&client_id=" + Settings.Authtoken.Trim();
+                    postData += "&client_secret=b16be19076b515553bb830141e08729c1d987fe686b3c3bc0316ba4382c2b810";
+                    postData += "&redirect_uri=urn:ietf:wg:oauth:2.0:oob";
+                    postData += "&grant_type=refresh_token";
+
+                    byte[] byteArray = Encoding.UTF8.GetBytes(postData);
+
+                    HttpWebRequest rquest = (HttpWebRequest)WebRequest.Create(url);
+                    rquest.Method = "POST";
+                    rquest.Headers.ContentType = "application/json";
+                    using (var st = rquest.GetRequestStream())
+                        st.Write(byteArray, 0, byteArray.Length);
+                    var rsponse = (HttpWebResponse)rquest.GetResponse();
+                    var rsponseString = new StreamReader(rsponse.GetResponseStream()).ReadToEnd();
+                    rsponse.Close();
+                    dynamic j1 = JObject.Parse(rsponseString);
+
+                    //these need to be updated and need to but so far dont know how
+                    //this shoud only be done if the post request was successful.
+                    Settings.Authtoken = j1.access_token;
+                    Settings.Refreshtoken = j1.refresh_token;
+                    TokenCreatedAt = j1.created_at; //convert to double
+                    TokenExpiresIn = j1.expires_in; //convert to double
+                }
+            }
+            */
+
             var request = new NetImportRequest($"{link}", HttpAccept.Json);
             request.HttpRequest.Headers.Add("trakt-api-version", "2");
             request.HttpRequest.Headers.Add("trakt-api-key", "657bb899dcb81ec8ee838ff09f6e013ff7c740bf0ccfa54dd41e791b9a70b2f0");
+            if (Settings.Authtoken != null)
+            {
+                request.HttpRequest.Headers.Add("Authorization", "Bearer " + Settings.Authtoken.Trim());
+            }
 
-            yield return request;
+                yield return request;
         }
     }
 }

--- a/src/NzbDrone.Core/NetImport/Trakt/TraktSettings.cs
+++ b/src/NzbDrone.Core/NetImport/Trakt/TraktSettings.cs
@@ -21,8 +21,6 @@ namespace NzbDrone.Core.NetImport.Trakt
             Link = "https://api.trakt.tv";
             Username = "";
             Listname = "";
-	        Authtoken = "";
-	        Refreshtoken = "";
         }
 
         [FieldDefinition(0, Label = "Trakt API URL", HelpText = "Link to to Trakt API URL, do not change unless you know what you are doing.")]
@@ -36,12 +34,6 @@ namespace NzbDrone.Core.NetImport.Trakt
 
         [FieldDefinition(3, Label = "Trakt List Name", HelpText = "Required for Custom List")]
         public string Listname { get; set; }
-
-        [FieldDefinition(4, Label = "Trakt auth_token", HelpText = "Required for Private Lists (expires every 3 months)")]
-        public string Authtoken { get; set; }
-
-        [FieldDefinition(5, Label = "Trakt refresh_token", HelpText = "Required for to refresh auth_token every 3 months")]
-        public string Refreshtoken { get; set; }
         
     }
 

--- a/src/NzbDrone.Core/NetImport/Trakt/TraktSettings.cs
+++ b/src/NzbDrone.Core/NetImport/Trakt/TraktSettings.cs
@@ -21,6 +21,8 @@ namespace NzbDrone.Core.NetImport.Trakt
             Link = "https://api.trakt.tv";
             Username = "";
             Listname = "";
+	        Authtoken = "";
+	        Refreshtoken = "";
         }
 
         [FieldDefinition(0, Label = "Trakt API URL", HelpText = "Link to to Trakt API URL, do not change unless you know what you are doing.")]
@@ -35,6 +37,12 @@ namespace NzbDrone.Core.NetImport.Trakt
         [FieldDefinition(3, Label = "Trakt List Name", HelpText = "Required for Custom List")]
         public string Listname { get; set; }
 
+        [FieldDefinition(4, Label = "Trakt auth_token", HelpText = "Required for Private Lists (expires every 3 months)")]
+        public string Authtoken { get; set; }
+
+        [FieldDefinition(5, Label = "Trakt refresh_token", HelpText = "Required for to refresh auth_token every 3 months")]
+        public string Refreshtoken { get; set; }
+        
     }
 
 

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsView.js
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsView.js
@@ -11,7 +11,8 @@ history.pushState('object', 'title', callback_url);
 var view = Marionette.ItemView.extend({
 	template : 'Settings/NetImport/Options/NetImportOptionsViewTemplate',
 	events : {
-		'click .x-reset-trakt-tokens' : '_resetTraktTokens'
+		'click .x-reset-trakt-tokens' : '_resetTraktTokens',
+		'click .x-revoke-trakt-tokens' : '_revokeTraktTokens'
 	},
 
         initialize : function() {
@@ -21,24 +22,47 @@ var view = Marionette.ItemView.extend({
 	onShow : function() {
 		if (oauth && refresh){
 	        this.ui.authToken.val(oauth).trigger('change');
-		this.ui.refreshToken.val(refresh).trigger('change');;
+		this.ui.refreshToken.val(refresh).trigger('change');
+		this.ui.tokenExpiry.val(Math.floor(Date.now() / 1000) + 4838400).trigger('change');  // this means the token will expire in 8 weeks (4838400 seconds)
 	        //this.model.isSaved = false;
 		}
+		if (this.ui.authToken.val() && this.ui.refreshToken.val()){
+                this.ui.resetTokensButton.hide();
+		this.ui.revokeTokensButton.show();
+		} else {
+		this.ui.resetTokensButton.show();
+		this.ui.revokeTokensButton.hide();
+		}
+	        
 	},
 
 	ui : {
 		resetTraktTokens : '.x-reset-trakt-tokens',
 		authToken : '.x-trakt-auth-token',
-		refreshToken : '.x-trakt-refresh-token'
+		refreshToken : '.x-trakt-refresh-token',
+		resetTokensButton : '.x-reset-trakt-tokens',
+		revokeTokensButton : '.x-revoke-trakt-tokens',
+                tokenExpiry : '.x-trakt-token-expiry'
 	},
 
 	_resetTraktTokens : function() {
 		if (window.confirm("You will now be taken to trakt.tv for authentication.\nYou will then be directed back here.\nDon't forget to click save when you get back!")){
-		//var q = window.location;
-		//var callback_url=l.protocol+'//'+l.hostname+(l.port ? ':' +l.port : '')+'/settings/netimport';
 		window.location='https://api.couchpota.to/authorize/trakt/?target='+callback_url;
+		//this.ui.resetTokensButton.hide();
+		}
+	},
+
+	_revokeTraktTokens : function() {
+		if (window.confirm("Your tokens will be revoked. Don't forget to click save!")){
+                //TODO: need to implement this: http://docs.trakt.apiary.io/#reference/authentication-oauth/revoke-token/revoke-an-access_token
+	        this.ui.authToken.val('').trigger('change');
+		this.ui.refreshToken.val('').trigger('change');
+		this.ui.tokenExpiry.val(0).trigger('change');
+	        this.ui.resetTokensButton.show();
+		this.ui.revokeTokensButton.hide();
 		}
 	}
+
 });
 
 

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsView.js
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsView.js
@@ -5,7 +5,9 @@ var AsValidatedView = require('../../../Mixins/AsValidatedView');
 var params = new URLSearchParams(window.location.search.slice(1));
 var oauth=params.get('oauth');
 var refresh=params.get('refresh');
-	
+var q = window.location;
+var url = q.protocol+'//'+q.hostname+(q.port ? ':' + q.port : '')+'/settings/netimport';
+history.pushState('object', 'title', url);
 var view = Marionette.ItemView.extend({
 	template : 'Settings/NetImport/Options/NetImportOptionsViewTemplate',
 	events : {
@@ -32,8 +34,8 @@ var view = Marionette.ItemView.extend({
 
 	_resetTraktTokens : function() {
 		if (window.confirm("You will now be taken to trakt.tv for authentication.\nYou will then be directed back here.\nDon't forget to click save when you get back!")){
-		l = window.location;
-		callback_url=l.protocol+'//'+l.hostname+(l.port ? ':' +l.port : '')+'/settings/netimport';
+		var l = window.location;
+		var callback_url=l.protocol+'//'+l.hostname+(l.port ? ':' +l.port : '')+'/settings/netimport';
 		window.location='https://api.couchpota.to/authorize/trakt/?target='+callback_url;
 		}
 	}

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsView.js
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsView.js
@@ -2,9 +2,40 @@ var Marionette = require('marionette');
 var AsModelBoundView = require('../../../Mixins/AsModelBoundView');
 var AsValidatedView = require('../../../Mixins/AsValidatedView');
 
+var params = new URLSearchParams(window.location.search.slice(1));
+var oauth=params.get('oauth');
+var refresh=params.get('refresh');
+	
 var view = Marionette.ItemView.extend({
-		template : 'Settings/NetImport/Options/NetImportOptionsViewTemplate'
+	template : 'Settings/NetImport/Options/NetImportOptionsViewTemplate',
+	events : {
+		'click .x-reset-trakt-tokens' : '_resetTraktTokens'
+	},
+
+        initialize : function() {
+
+	},
+	
+	onShow : function() {
+		if (oauth && refresh){
+		document.getElementById("t1").value = oauth;
+		document.getElementById("t2").value = refresh;
+		}
+	},
+
+	ui : {
+		resetTraktTokens : '.x-reset-trakt-tokens'
+	},
+
+	_resetTraktTokens : function() {
+		if (window.confirm("You will now be taken to trakt.tv for authentication.\nYou will then be directed back here.\nDon't forget to click save when you get back!")){
+		l = window.location;
+		callback_url=l.protocol+'//'+l.hostname+(l.port ? ':' +l.port : '')+'/settings/netimport';
+		window.location='https://api.couchpota.to/authorize/trakt/?target='+callback_url;
+		}
+	}
 });
+
 
 AsModelBoundView.call(view);
 AsValidatedView.call(view);

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsView.js
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsView.js
@@ -6,8 +6,8 @@ var params = new URLSearchParams(window.location.search.slice(1));
 var oauth=params.get('oauth');
 var refresh=params.get('refresh');
 var q = window.location;
-var url = q.protocol+'//'+q.hostname+(q.port ? ':' + q.port : '')+'/settings/netimport';
-history.pushState('object', 'title', url);
+var callback_url = q.protocol+'//'+q.hostname+(q.port ? ':' + q.port : '')+'/settings/netimport';
+history.pushState('object', 'title', callback_url);
 var view = Marionette.ItemView.extend({
 	template : 'Settings/NetImport/Options/NetImportOptionsViewTemplate',
 	events : {
@@ -34,8 +34,8 @@ var view = Marionette.ItemView.extend({
 
 	_resetTraktTokens : function() {
 		if (window.confirm("You will now be taken to trakt.tv for authentication.\nYou will then be directed back here.\nDon't forget to click save when you get back!")){
-		var l = window.location;
-		var callback_url=l.protocol+'//'+l.hostname+(l.port ? ':' +l.port : '')+'/settings/netimport';
+		//var q = window.location;
+		//var callback_url=l.protocol+'//'+l.hostname+(l.port ? ':' +l.port : '')+'/settings/netimport';
 		window.location='https://api.couchpota.to/authorize/trakt/?target='+callback_url;
 		}
 	}

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsView.js
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsView.js
@@ -18,13 +18,16 @@ var view = Marionette.ItemView.extend({
 	
 	onShow : function() {
 		if (oauth && refresh){
-		document.getElementById("t1").value = oauth;
-		document.getElementById("t2").value = refresh;
+	        this.ui.authToken.val(oauth).trigger('change');
+		this.ui.refreshToken.val(refresh).trigger('change');;
+	        //this.model.isSaved = false;
 		}
 	},
 
 	ui : {
-		resetTraktTokens : '.x-reset-trakt-tokens'
+		resetTraktTokens : '.x-reset-trakt-tokens',
+		authToken : '.x-trakt-auth-token',
+		refreshToken : '.x-trakt-refresh-token'
 	},
 
 	_resetTraktTokens : function() {

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
@@ -17,7 +17,7 @@
 		<div class="form-group">
 		                <label class="col-sm-1 control-label">Auth Token</label>
 				<div class="col-sm-4">
-				                <input type="text" id="t1" name="traktAuthToken" class="form-control"/>
+				                <input type="text" name="traktAuthToken" class="form-control x-trakt-auth-token"/>
 		</div></div>
                     <div class="input-group-btn">
 					         <button class="btn btn-danger btn-icon-only x-reset-trakt-tokens" title="Reset Trakt Token"><i class="icon-sonarr-refresh"></i></button>
@@ -25,7 +25,7 @@
 		<div class="form-group">
 		                <label class="col-sm-1 control-label">Refresh Token</label>
 				<div class="col-sm-4">
-				                <input type="text" id="t2" name="traktRefreshToken" class="form-control"/>
+				                <input type="text" name="traktRefreshToken" class="form-control x-trakt-refresh-token"/>
 				</div>
 	        </div>	
 </fieldset>

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
@@ -13,4 +13,16 @@
 						<input type="number" name="netImportSyncInterval" class="form-control" min="0" max="1440"/>
 				</div>
 		</div>
+		<legend>Trakt Authentication</legend>
+		<div class="form-group">
+		                <label class="col-sm-1 control-label">Auth Token</label>
+				<div class="col-sm-4">
+				                <input type="text" name="traktAuthToken" class="form-control"/>
+		</div></div>
+		<div class="form-group">
+		                <label class="col-sm-1 control-label">Refresh Token</label>
+				<div class="col-sm-4">
+				                <input type="text" name="traktRefreshToken" class="form-control"/>
+				</div>
+	        </div>	
 </fieldset>

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
@@ -17,15 +17,15 @@
 		<div class="form-group">
 		                <label class="col-sm-1 control-label">Auth Token</label>
 				<div class="col-sm-4">
-				                <input type="text" name="traktAuthToken" class="form-control x-trakt-auth-token"/>
+				                <input type="text" readonly="readonly" name="traktAuthToken" class="form-control x-trakt-auth-token"/>
 		</div></div>
-                    <div class="input-group-btn">
-					         <button class="btn btn-danger btn-icon-only x-reset-trakt-tokens" title="Reset Trakt Token"><i class="icon-sonarr-refresh"></i></button>
-								                        </div>
 		<div class="form-group">
 		                <label class="col-sm-1 control-label">Refresh Token</label>
 				<div class="col-sm-4">
-				                <input type="text" name="traktRefreshToken" class="form-control x-trakt-refresh-token"/>
-				</div>
-	        </div>	
+				                <input type="text" readonly="readonly" name="traktRefreshToken" class="form-control x-trakt-refresh-token"/>
+</div>
+<div class="input-group-btn">
+                                                 <button class="btn btn-danger btn-icon-only x-reset-trakt-tokens" title="Reset Trakt Token"><i class="icon-sonarr-refresh"></i></button>
+						                                                                                         </div >
+</div>	        
 </fieldset>

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
@@ -18,6 +18,7 @@
 		                <label class="col-sm-1 control-label">Auth Token</label>
 				<div class="col-sm-4">
 				                <input type="text" readonly="readonly" name="traktAuthToken" class="form-control x-trakt-auth-token"/>
+						<input type="text" readonly="readonly" name="traktTokenExpiry" class="form-control x-trakt-token-expiry"/>
 		</div></div>
 		<div class="form-group">
 		                <label class="col-sm-1 control-label">Refresh Token</label>
@@ -25,7 +26,9 @@
 				                <input type="text" readonly="readonly" name="traktRefreshToken" class="form-control x-trakt-refresh-token"/>
 </div>
 <div class="input-group-btn">
-                                                 <button class="btn btn-danger btn-icon-only x-reset-trakt-tokens" title="Reset Trakt Token"><i class="icon-sonarr-refresh"></i></button>
-						                                                                                         </div >
+                                                 <button class="btn btn-danger btn-icon-only x-reset-trakt-tokens" title="Reset Trakt Tokens"><i class="icon-sonarr-refresh"></i></button>
+	                                         <button class="btn btn-danger btn-icon-only x-revoke-trakt-tokens" title="Revoke Trakt Tokens"><i class="icon-sonarr-logout"></i></button>
+																							                                                                                                                                           </div >
+
 </div>	        
 </fieldset>

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
@@ -17,12 +17,15 @@
 		<div class="form-group">
 		                <label class="col-sm-1 control-label">Auth Token</label>
 				<div class="col-sm-4">
-				                <input type="text" name="traktAuthToken" class="form-control"/>
+				                <input type="text" id="t1" name="traktAuthToken" class="form-control"/>
 		</div></div>
+                    <div class="input-group-btn">
+					         <button class="btn btn-danger btn-icon-only x-reset-trakt-tokens" title="Reset Trakt Token"><i class="icon-sonarr-refresh"></i></button>
+								                        </div>
 		<div class="form-group">
 		                <label class="col-sm-1 control-label">Refresh Token</label>
 				<div class="col-sm-4">
-				                <input type="text" name="traktRefreshToken" class="form-control"/>
+				                <input type="text" id="t2" name="traktRefreshToken" class="form-control"/>
 				</div>
 	        </div>	
 </fieldset>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This allows users to specify Trakt API Auth Token and Refresh Tokens so that Radarr can access private lists

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR
http://feathub.com/Radarr/Radarr/+62
* 
This code assumes that the user has already obtained the auth_token and the refresh_token

we still should implement a button somewhere that performs the tasks described here: 

http://docs.trakt.apiary.io/#reference/authentication-oauth

so that radarr can help the user obtain these codes within radarr itself.