### PR TITLE
List sync with removal

### DIFF
--- a/src/NzbDrone.Api/Config/NetImportConfigResource.cs
+++ b/src/NzbDrone.Api/Config/NetImportConfigResource.cs
@@ -6,6 +6,8 @@ namespace NzbDrone.Api.Config
     public class NetImportConfigResource : RestResource
     {
         public int NetImportSyncInterval { get; set; }
+	public string ListSyncLevel { get; set; }
+	public string ImportExclusions { get; set; }
     }
 
     public static class NetImportConfigResourceMapper
@@ -14,7 +16,9 @@ namespace NzbDrone.Api.Config
         {
             return new NetImportConfigResource
             {
-                NetImportSyncInterval = model.NetImportSyncInterval
+                NetImportSyncInterval = model.NetImportSyncInterval,
+		ListSyncLevel = model.ListSyncLevel,
+		ImportExclusions = model.ImportExclusions,
             };
         }
     }

--- a/src/NzbDrone.Api/Series/MovieLookupModule.cs
+++ b/src/NzbDrone.Api/Series/MovieLookupModule.cs
@@ -21,6 +21,7 @@ namespace NzbDrone.Api.Movie
             _searchProxy = searchProxy;
             Get["/"] = x => Search();
             Get["/tmdb"] = x => SearchByTmdbId();
+            Get["/imdb"] = x => SearchByImdbId();
         }
 
         private Response SearchByTmdbId()
@@ -35,6 +36,12 @@ namespace NzbDrone.Api.Movie
             throw new BadRequestException("Tmdb Id was not valid");
         }
 
+        private Response SearchByImdbId()
+        {
+            string imdbId = Request.Query.imdbId;
+            var result = _movieInfo.GetMovieInfo(imdbId);
+            return result.ToResource().AsResponse();
+        }
 
         private Response Search()
         {

--- a/src/NzbDrone.Api/Series/MovieModule.cs
+++ b/src/NzbDrone.Api/Series/MovieModule.cs
@@ -186,14 +186,20 @@ namespace NzbDrone.Api.Movie
         private void DeleteMovie(int id)
         {
             var deleteFiles = false;
+            var addExclusion = false;
             var deleteFilesQuery = Request.Query.deleteFiles;
+            var addExclusionQuery = Request.Query.addExclusion;
 
             if (deleteFilesQuery.HasValue)
             {
                 deleteFiles = Convert.ToBoolean(deleteFilesQuery.Value);
             }
+            if (addExclusionQuery.HasValue)
+            {
+                addExclusion = Convert.ToBoolean(addExclusionQuery.Value);
+            }
 
-            _moviesService.DeleteMovie(id, deleteFiles);
+            _moviesService.DeleteMovie(id, deleteFiles, addExclusion);
         }
 
         private void MapCoversToLocal(params MovieResource[] movies)

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -118,6 +118,18 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("NetImportSyncInterval", value); }
         }
 
+	public string ListSyncLevel
+	{
+	    get { return GetValue("ListSyncLevel", "disabled"); }
+	    set { SetValue("ListSyncLevel", value); }
+	}
+
+	public string ImportExclusions
+	{
+	    get { return GetValue("ImportExclusions", string.Empty); }
+	    set { SetValue("ImportExclusions", value); }
+	}
+
         public int MinimumAge
         {
             get { return GetValueInt("MinimumAge", 0); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -49,6 +49,8 @@ namespace NzbDrone.Core.Configuration
 	int AvailabilityDelay { get; set; }
 
         int NetImportSyncInterval { get; set; }
+	string ListSyncLevel { get; set; }
+	string ImportExclusions { get; set; }
 
         //UI
         int FirstDayOfWeek { get; set; }

--- a/src/NzbDrone.Core/MediaFiles/DeleteMediaFileReason.cs
+++ b/src/NzbDrone.Core/MediaFiles/DeleteMediaFileReason.cs
@@ -5,7 +5,6 @@
         MissingFromDisk,
         Manual,
         Upgrade,
-        NoLinkedEpisodes,
-	    NotInList
+        NoLinkedEpisodes
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/DeleteMediaFileReason.cs
+++ b/src/NzbDrone.Core/MediaFiles/DeleteMediaFileReason.cs
@@ -5,6 +5,7 @@
         MissingFromDisk,
         Manual,
         Upgrade,
-        NoLinkedEpisodes
+        NoLinkedEpisodes,
+	    NotInList
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
@@ -169,6 +169,7 @@ namespace NzbDrone.Core.MediaFiles
 			{
 				var files = GetFilesByMovie(message.Movie.Id);
 				_movieFileRepository.DeleteMany(files);
+                //this doesnt actually delete the files, i think it just deletes the file ids etc. in the db..
 			}
 		}
 	}

--- a/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
@@ -169,7 +169,6 @@ namespace NzbDrone.Core.MediaFiles
 			{
 				var files = GetFilesByMovie(message.Movie.Id);
 				_movieFileRepository.DeleteMany(files);
-                //this doesnt actually delete the files, i think it just deletes the file ids etc. in the db..
 			}
 		}
 	}

--- a/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
@@ -70,6 +70,31 @@ namespace NzbDrone.Core.NetImport
 
         public void Execute(NetImportSyncCommand message)
         {
+            bool fullSync = false; // this should come from the option 
+            if (fullSync)
+            {
+                var listedMovies = Fetch(0,true);
+                var moviesInLibrary = _movieService.GetAllMovies();
+                foreach (var movie in moviesInLibrary)
+                    {
+                    bool foundMatch = false;
+                    foreach (var listedMovie in listedMovies)
+                    {
+                        if (movie.ImdbId == listedMovie.ImdbId)
+                        {
+                            foundMatch = true;
+                            break;
+                        }
+
+                    }
+                    if (!foundMatch)
+                    {
+                        _logger.Debug("Movie: {0} was in your library, but not found in your lists --> it should be deleted", movie.ImdbId);
+                        //_movieService.DeleteMovie(movie.Id, false); //second parameter true if files to be deleted too 
+                    }
+                }
+            }
+
             var movies = FetchAndFilter(0, true);
 
             _logger.Debug("Found {0} movies on your auto enabled lists not in your library", movies.Count);

--- a/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
@@ -92,25 +92,26 @@ namespace NzbDrone.Core.NetImport
                     }
                     if (!foundMatch)
                     {
-                        if (_configService.ListSyncLevel == "logOnly")
+                        switch(_configService.ListSyncLevel)
                         {
-                            _logger.Info("Movie: {0} was in your library, but not found in your lists --> you might want to unmonitor or remove it", movie.ImdbId);
-                        }
-                        else if (_configService.ListSyncLevel == "keepAndUnmonitor")
-                        {
-                            _logger.Info("Movie: {0} was in your library, but was not found in your lists --> Keeping in library but Unmonitoring it", movie.ImdbId);
-                            movie.Monitored = false;
-                        }
-                        else if (_configService.ListSyncLevel == "removeAndKeep")
-                        {
-                            _logger.Info("Movie: {0} was in your library, but not found in your lists --> removing from library (keeping files)", movie.ImdbId);
-                            _movieService.DeleteMovie(movie.Id, false); 
-                        }
-                        else if (_configService.ListSyncLevel == "removeAndDelete")
-                        {
-                            _logger.Info("Movie: {0} was in your library, but not found in your lists --> removing from library and deleting files", movie.ImdbId);
-                            _movieService.DeleteMovie(movie.Id, true); 
-                            //TODO: for some reason the files are not deleted in this case... any idea why? 
+                            case "logOnly":
+                                _logger.Info("Movie: {0} was in your library, but not found in your lists --> you might want to unmonitor or remove it", movie.ImdbId);
+                                break;
+                            case "keepAndUnmonitor":
+                                _logger.Info("Movie: {0} was in your library, but was not found in your lists --> Keeping in library but Unmonitoring it", movie.ImdbId);
+                                movie.Monitored = false;
+                                break;
+                            case "removeAndKeep":
+                                _logger.Info("Movie: {0} was in your library, but not found in your lists --> removing from library (keeping files)", movie.ImdbId);
+                                _movieService.DeleteMovie(movie.Id, false);
+                                break;
+                            case "removeAndDelete":
+                                _logger.Info("Movie: {0} was in your library, but not found in your lists --> removing from library and deleting files", movie.ImdbId);
+                                _movieService.DeleteMovie(movie.Id, true);
+                                //TODO: for some reason the files are not deleted in this case... any idea why?
+                                break;
+                            default:
+                                break; 
                         }
                     }
                 }

--- a/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
@@ -74,6 +74,12 @@ namespace NzbDrone.Core.NetImport
 
         public void Execute(NetImportSyncCommand message)
         {
+            //if there are no lists that are enabled for automatic import then dont do anything
+            if((_netImportFactory.GetAvailableProviders()).Where(a => ((NetImportDefinition)a.Definition).EnableAuto).Empty())
+            {
+                return;
+            }
+
             var listedMovies = Fetch(0, true);
             if (_configService.ListSyncLevel != "disabled")
             {

--- a/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
@@ -94,7 +94,12 @@ namespace NzbDrone.Core.NetImport
                     {
                         if (_configService.ListSyncLevel == "logOnly")
                         {
-                            _logger.Info("Movie: {0} was in your library, but not found in your lists --> you might want to remove it", movie.ImdbId);
+                            _logger.Info("Movie: {0} was in your library, but not found in your lists --> you might want to unmonitor or remove it", movie.ImdbId);
+                        }
+                        else if (_configService.ListSyncLevel == "keepAndUnmonitor")
+                        {
+                            _logger.Info("Movie: {0} was in your library, but was not found in your lists --> Keeping in library but Unmonitoring it", movie.ImdbId);
+                            movie.Monitored = false;
                         }
                         else if (_configService.ListSyncLevel == "removeAndKeep")
                         {
@@ -128,9 +133,9 @@ namespace NzbDrone.Core.NetImport
                 {
                     foreach (var exclusion in importExclusions)
                     {
-                        if (exclusion == movie.ImdbId)
+                        if (exclusion == movie.ImdbId || exclusion == movie.TmdbId.ToString())
                         {
-                            _logger.Info("Movie: {0} was found but will not be added because it imdbId was found on your exclusion list", movie.ImdbId);
+                            _logger.Info("Movie: {0} was found but will not be added because it {exclusion} was found on your exclusion list", exclusion);
                             shouldAdd = false;
                             break;
                         }

--- a/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
@@ -79,6 +79,7 @@ namespace NzbDrone.Core.NetImport
             //if there are no lists that are enabled for automatic import then dont do anything
             if((_netImportFactory.GetAvailableProviders()).Where(a => ((NetImportDefinition)a.Definition).EnableAuto).Empty())
             {
+		        _logger.Info("No lists are enabled for auto-import.");
                 return;
             }
 

--- a/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
@@ -101,18 +101,18 @@ namespace NzbDrone.Core.NetImport
                         switch(_configService.ListSyncLevel)
                         {
                             case "logOnly":
-                                _logger.Info("Movie: {0} was in your library, but not found in your lists --> you might want to unmonitor or remove it", movie.ImdbId);
+                                _logger.Info("{0} was in your library, but not found in your lists --> You might want to unmonitor or remove it", movie.TitleSlug);
                                 break;
                             case "keepAndUnmonitor":
-                                _logger.Info("Movie: {0} was in your library, but was not found in your lists --> Keeping in library but Unmonitoring it", movie.ImdbId);
+                                _logger.Info("{0} was in your library, but not found in your lists --> Keeping in library but Unmonitoring it", movie.TitleSlug);
                                 movie.Monitored = false;
                                 break;
                             case "removeAndKeep":
-                                _logger.Info("Movie: {0} was in your library, but not found in your lists --> removing from library (keeping files)", movie.ImdbId);
+                                _logger.Info("{0} was in your library, but not found in your lists --> Removing from library (keeping files)", movie.TitleSlug);
                                 _movieService.DeleteMovie(movie.Id, false);
                                 break;
                             case "removeAndDelete":
-                                _logger.Info("Movie: {0} was in your library, but not found in your lists --> removing from library and deleting files", movie.ImdbId);
+                                _logger.Info("{0} was in your library, but not found in your lists --> Removing from library and deleting files", movie.TitleSlug);
                                 _movieService.DeleteMovie(movie.Id, true);
                                 //TODO: for some reason the files are not deleted in this case... any idea why?
                                 break;

--- a/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
@@ -101,18 +101,18 @@ namespace NzbDrone.Core.NetImport
                         switch(_configService.ListSyncLevel)
                         {
                             case "logOnly":
-                                _logger.Info("{0} was in your library, but not found in your lists --> You might want to unmonitor or remove it", movie.TitleSlug);
+                                _logger.Info("{0} was in your library, but not found in your lists --> You might want to unmonitor or remove it", movie);
                                 break;
                             case "keepAndUnmonitor":
-                                _logger.Info("{0} was in your library, but not found in your lists --> Keeping in library but Unmonitoring it", movie.TitleSlug);
+                                _logger.Info("{0} was in your library, but not found in your lists --> Keeping in library but Unmonitoring it", movie);
                                 movie.Monitored = false;
                                 break;
                             case "removeAndKeep":
-                                _logger.Info("{0} was in your library, but not found in your lists --> Removing from library (keeping files)", movie.TitleSlug);
+                                _logger.Info("{0} was in your library, but not found in your lists --> Removing from library (keeping files)", movie);
                                 _movieService.DeleteMovie(movie.Id, false);
                                 break;
                             case "removeAndDelete":
-                                _logger.Info("{0} was in your library, but not found in your lists --> Removing from library and deleting files", movie.TitleSlug);
+                                _logger.Info("{0} was in your library, but not found in your lists --> Removing from library and deleting files", movie);
                                 _movieService.DeleteMovie(movie.Id, true);
                                 //TODO: for some reason the files are not deleted in this case... any idea why?
                                 break;

--- a/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System;
 using System.Linq;
 using NLog;
 using NzbDrone.Core.Messaging.Commands;
@@ -6,6 +7,7 @@ using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.RootFolders;
 using NzbDrone.Core.Tv;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Core.NetImport
 {

--- a/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
@@ -74,10 +74,9 @@ namespace NzbDrone.Core.NetImport
 
         public void Execute(NetImportSyncCommand message)
         {
-
+            var listedMovies = Fetch(0, true);
             if (_configService.ListSyncLevel != "disabled")
             {
-                var listedMovies = Fetch(0,true);
                 var moviesInLibrary = _movieService.GetAllMovies();
                 foreach (var movie in moviesInLibrary)
                     {
@@ -117,8 +116,8 @@ namespace NzbDrone.Core.NetImport
             {
                 importExclusions = _configService.ImportExclusions.Split(',').ToList();
             }
-          
-            var movies = FetchAndFilter(0, true);
+
+            var movies = listedMovies.Where(x => !_movieService.MovieExists(x)).ToList();
 
             _logger.Debug("Found {0} movies on your auto enabled lists not in your library", movies.Count);
 

--- a/src/NzbDrone.Core/Tv/MovieService.cs
+++ b/src/NzbDrone.Core/Tv/MovieService.cs
@@ -51,13 +51,9 @@ namespace NzbDrone.Core.Tv
         private readonly IConfigService _configService;
         private readonly IEventAggregator _eventAggregator;
         private readonly IBuildFileNames _fileNameBuilder;
-        private readonly IMediaFileService _mediaFileService;
-        private readonly IRecycleBinProvider _recycleBinProvider;
         private readonly Logger _logger;
 
         public MovieService(IMovieRepository movieRepository,
-                             IMediaFileService mediaFileService,
-                             IRecycleBinProvider recycleBinProvider,
                              IEventAggregator eventAggregator,
                              ISceneMappingService sceneMappingService,
                              IEpisodeService episodeService,
@@ -243,7 +239,7 @@ namespace NzbDrone.Core.Tv
 
         public void DeleteMovie(int movieId, bool deleteFiles)
         {
-            //this next block was added in order to implement listsynccleaning
+            /*//this next block was added in order to implement listsynccleaning
             //start of block
             if (deleteFiles)
             {
@@ -268,6 +264,7 @@ namespace NzbDrone.Core.Tv
                 //}
             }
             //end of block
+            */
             var movie = _movieRepository.Get(movieId);
             _movieRepository.Delete(movieId);
             _eventAggregator.PublishEvent(new MovieDeletedEvent(movie, deleteFiles));

--- a/src/UI/Movies/Delete/DeleteMovieTemplate.hbs
+++ b/src/UI/Movies/Delete/DeleteMovieTemplate.hbs
@@ -38,6 +38,30 @@
                     <div class="col-md-offset-1 col-md-5 delete-files-info x-delete-files-info">
                         {{#if hasFile}}1{{else}}0{{/if}} movie file(s) will be deleted
                     </div>
+
+                    <div class="form-group">
+                        <label class="col-sm-4 control-label">Exclude movie from Auto List Import?</label>
+
+                        <div class="col-sm-8">
+                            <div class="input-group">
+                                <label class="checkbox toggle well">
+                                    <input type="checkbox" class="x-add-exclusion"/>
+                                    <p>
+                                        <span>Yes</span>
+                                        <span>No</span>
+                                    </p>
+
+                                    <div class="btn slide-button btn-danger"/>
+                                </label>
+
+                                    <span class="help-inline-checkbox">
+                                        <i class="icon-sonarr-form-info" title="Do you want to prevent this movie from being readded during Automatic List syncing?"/>
+                                        <i class="icon-sonarr-form-info" title="Movies can be removed from the exclusions list via Lists tab in Settings"/>
+                                    </span>
+                                </div>
+                        </div>
+                    </div>
+
                 </div>
             </div>
         </div>

--- a/src/UI/Movies/Delete/DeleteMovieView.js
+++ b/src/UI/Movies/Delete/DeleteMovieView.js
@@ -12,16 +12,19 @@ module.exports = Marionette.ItemView.extend({
     ui : {
         deleteFiles     : '.x-delete-files',
         deleteFilesInfo : '.x-delete-files-info',
-        indicator       : '.x-indicator'
+        indicator       : '.x-indicator',
+        addExclusion    : '.x-add-exclusion'
     },
 
     removeSeries : function() {
         var self = this;
         var deleteFiles = this.ui.deleteFiles.prop('checked');
+        var addExclusion = this.ui.addExclusion.prop('checked');
         this.ui.indicator.show();
-
+        
         this.model.destroy({
-            data : { 'deleteFiles' : deleteFiles },
+            data : { 'deleteFiles' : deleteFiles,
+                     'addExclusion' : addExclusion },
             wait : true
         }).done(function() {
             vent.trigger(vent.Events.SeriesDeleted, { series : self.model });

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsView.js
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsView.js
@@ -1,9 +1,70 @@
 var Marionette = require('marionette');
 var AsModelBoundView = require('../../../Mixins/AsModelBoundView');
 var AsValidatedView = require('../../../Mixins/AsValidatedView');
+var $ = require('jquery');
+require('../../../Mixins/TagInput');
+require('bootstrap');
+require('bootstrap.tagsinput');
 
 var view = Marionette.ItemView.extend({
-		template : 'Settings/NetImport/Options/NetImportOptionsViewTemplate'
+		template : 'Settings/NetImport/Options/NetImportOptionsViewTemplate',
+
+	ui : { 
+		importExclusions : '.x-import-exclusions'
+	},
+
+	onRender : function() {
+		this.ui.importExclusions.tagsinput({
+			trimValue : true,
+			tagClass  : 'label label-danger',
+			itemText : function(item) {
+				var uri;
+                var text;
+            	if (item.startsWith('tt')) {
+                	uri = window.NzbDrone.ApiRoot + '/movies/lookup/imdb?imdbId='+item;
+            	}
+            	else {
+                	uri = window.NzbDrone.ApiRoot + '/movies/lookup/tmdb?tmdbId='+item;
+            	}
+            	var promise = $.ajax({
+                	url     : uri,
+                	type    : 'GET',
+                	async   : false,
+            	});
+            	promise.success(function(response) {
+                     text=response['title']+' ('+response['year']+')';
+            	});
+
+            	promise.error(function(request, status, error) {
+                     text=item;
+            	});
+                return text;
+			}
+		});
+		this.ui.importExclusions.on('beforeItemAdd', function(event) {
+            var uri;
+			if (event.item.startsWith('tt')) {
+                uri = window.NzbDrone.ApiRoot + '/movies/lookup/imdb?imdbId='+event.item;
+            }
+            else {
+                uri = window.NzbDrone.ApiRoot + '/movies/lookup/tmdb?tmdbId='+event.item; 
+            }
+            var promise = $.ajax({
+				url		: uri,
+				type	: 'GET',
+                async   : false,
+			});
+            promise.success(function(response) {
+                event.cancel=false;
+			});
+
+			promise.error(function(request, status, error) {
+                event.cancel = true;
+               	window.alert(event.item+' is not a valid! Must be valid tt#### IMDB ID or #### TMDB ID');
+			});
+		});
+	},
+
 });
 
 AsModelBoundView.call(view);

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
@@ -16,7 +16,7 @@
 		<div class="form-group">
 	              <label class="col-sm-3 control-label">Clean Library Level</label>
                       <div class="col-sm-1 col-sm-push-2 help-inline">
-		      <i class="icon-sonarr-form-warning" title="Disable unless you are sure. Reccomend enabling Recycle bin before this"/>
+		      <i class="icon-sonarr-form-warning" title="Disable unless you are sure. Enabling Recycle bin before this is recommended"/>
 		      <i class="icon-sonarr-form-info" title="Movies in library will be removed or unmonitored if not found in your lists"/>
 		      </div>
 

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
@@ -13,4 +13,21 @@
 						<input type="number" name="netImportSyncInterval" class="form-control" min="0" max="1440"/>
 				</div>
 		</div>
+		<div class="form-group">
+	              <label class="col-sm-3 control-label">Clean Library Level</label>
+	              <div class="col-sm-4">
+	                  <select name="listSyncLevel" class="form-control">
+	                      <option value="disabled">Disabled</option>
+		                    <option value="logOnly">Log Only</option>
+				    <option value="removeAndKeep">Remove but Keep Files</option>
+				    <option value="removeAndDelete">Remove and Delete Files</option>
+                    </select>
+	              </div>
+	          </div>
+		  <div class="form-group">
+		                <label class="col-sm-3 control-label">Import Exclusions</label>
+				<div class="col-sm-4">
+				                <input type="text" name="importExclusions" class="form-control"/>
+				</div>
+	        </div>
 </fieldset>

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
@@ -15,18 +15,27 @@
 		</div>
 		<div class="form-group">
 	              <label class="col-sm-3 control-label">Clean Library Level</label>
-	              <div class="col-sm-4">
+                      <div class="col-sm-1 col-sm-push-2 help-inline">
+		      <i class="icon-sonarr-form-warning" title="Disable unless you are sure."/>
+		      <i class="icon-sonarr-form-info" title="Movies in library will be removed if not found in your lists"/>
+		      </div>
+
+	              <div class="col-sm-2 col-sm-pull-1">
 	                  <select name="listSyncLevel" class="form-control">
 	                      <option value="disabled">Disabled</option>
-		                    <option value="logOnly">Log Only</option>
-				    <option value="removeAndKeep">Remove but Keep Files</option>
-				    <option value="removeAndDelete">Remove and Delete Files</option>
+		                    <option value="logOnly">LogOnly</option>
+				    <option value="removeAndKeep">Remove & Keep Files</option>
+				    <option value="removeAndDelete">Remove & Delete Files</option>
                     </select>
 	              </div>
 	          </div>
 		  <div class="form-group">
 		                <label class="col-sm-3 control-label">Import Exclusions</label>
-				<div class="col-sm-4">
+				<div class="col-sm-1 col-sm-push-2 help-inline">
+				<i class="icon-sonarr-form-warning" title="Movies in this field will not be imported even if they exist on your lists."/>
+				<i class="icon-sonarr-form-info" title="Comma separated imdb ids: tt0120915,tt0121765"/>
+				</div>
+				<div class="col-sm-2 col-sm-pull-1">
 				                <input type="text" name="importExclusions" class="form-control"/>
 				</div>
 	        </div>

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
@@ -16,14 +16,15 @@
 		<div class="form-group">
 	              <label class="col-sm-3 control-label">Clean Library Level</label>
                       <div class="col-sm-1 col-sm-push-2 help-inline">
-		      <i class="icon-sonarr-form-warning" title="Disable unless you are sure."/>
-		      <i class="icon-sonarr-form-info" title="Movies in library will be removed if not found in your lists"/>
+		      <i class="icon-sonarr-form-warning" title="Disable unless you are sure. Reccomend enabling Recycle bin before this"/>
+		      <i class="icon-sonarr-form-info" title="Movies in library will be removed or unmonitored if not found in your lists"/>
 		      </div>
 
 	              <div class="col-sm-2 col-sm-pull-1">
 	                  <select name="listSyncLevel" class="form-control">
 	                      <option value="disabled">Disabled</option>
 		                    <option value="logOnly">LogOnly</option>
+				    <option value="keepAndUnmonitor">Keep but Unmonitor</option>
 				    <option value="removeAndKeep">Remove & Keep Files</option>
 				    <option value="removeAndDelete">Remove & Delete Files</option>
                     </select>
@@ -33,7 +34,7 @@
 		                <label class="col-sm-3 control-label">Import Exclusions</label>
 				<div class="col-sm-1 col-sm-push-2 help-inline">
 				<i class="icon-sonarr-form-warning" title="Movies in this field will not be imported even if they exist on your lists."/>
-				<i class="icon-sonarr-form-info" title="Comma separated imdb ids: tt0120915,tt0121765"/>
+				<i class="icon-sonarr-form-info" title="Comma separated imdbd or tmdbid: tt0120915,216138,tt0121765"/>
 				</div>
 				<div class="col-sm-2 col-sm-pull-1">
 				                <input type="text" name="importExclusions" class="form-control"/>

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
@@ -37,7 +37,8 @@
 				<i class="icon-sonarr-form-info" title="Comma separated imdbid or tmdbid: tt0120915,216138,tt0121765"/>
 				</div>
 				<div class="col-sm-2 col-sm-pull-1">
-				                <input type="text" name="importExclusions" class="form-control"/>
+				                
+				                <input type="text" name="importExclusions" class="form-control x-import-exclusions"/>
 				</div>
 	        </div>
-</fieldset>
+</fieldset> 

--- a/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
@@ -34,7 +34,7 @@
 		                <label class="col-sm-3 control-label">Import Exclusions</label>
 				<div class="col-sm-1 col-sm-push-2 help-inline">
 				<i class="icon-sonarr-form-warning" title="Movies in this field will not be imported even if they exist on your lists."/>
-				<i class="icon-sonarr-form-info" title="Comma separated imdbd or tmdbid: tt0120915,216138,tt0121765"/>
+				<i class="icon-sonarr-form-info" title="Comma separated imdbid or tmdbid: tt0120915,216138,tt0121765"/>
 				</div>
 				<div class="col-sm-2 col-sm-pull-1">
 				                <input type="text" name="importExclusions" class="form-control"/>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
One of the features on featHub was one I opened.. regarding having items in your library, that dont exists on your trakt watchlist be removed from your library (on options, and with varying degree)...

I ended up trying to implement that. and while I was at it, I implemented a feature requested by somebody else regarding the ability to specify movies to exclude from importing even if they are found on your net import lists...

Everything should be fully functional.... except, the option to delete the files along with the movie does not delete the files.

RemoveAndDelete does the same thing as removeAndKeep.. 

i need to look more into why DeleteMovie(movieId,true) is not deleting the files. It appears to do the same thing as DeleteMovie(movieId,false)

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR
http://feathub.com/Radarr/Radarr/+59
http://feathub.com/Radarr/Radarr/+74  (created by me)
* 
