### PR TITLE
Make Movie Title and Status sortable on Wanted tab

### DIFF
--- a/src/UI/Wanted/Missing/MissingLayout.js
+++ b/src/UI/Wanted/Missing/MissingLayout.js
@@ -41,7 +41,6 @@ module.exports = Marionette.Layout.extend({
             name     : 'this',
             label    : 'Movie Title',
             cell     : MovieTitleCell,
-            sortable : false
         },
         {
             name  : 'inCinemas',
@@ -57,7 +56,6 @@ module.exports = Marionette.Layout.extend({
             name     : 'status',
             label    : 'Status',
             cell     : MovieStatusWithTextCell,
-            sortable : false
         },
 
     ],


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Unless there is a reason not to make Movie Title and Status sortable on Wanted tab this commit should enable it.

#### Issues Fixed or Closed by this PR
* https://github.com/Radarr/Radarr/issues/481
