### PR TITLE
Fixes - MovieMissingModule failed while processing [MovieDownloadedEvent]

### DIFF
--- a/src/NzbDrone.Api/Wanted/MovieMissingModule.cs
+++ b/src/NzbDrone.Api/Wanted/MovieMissingModule.cs
@@ -71,7 +71,8 @@ namespace NzbDrone.Api.Wanted
 
         public void Handle(MovieDownloadedEvent message)
         {
-            BroadcastResourceChange(ModelAction.Updated, message.Movie.Movie.Id);
+            var resource = message.Movie.Movie.ToResource();
+            BroadcastResourceChange(ModelAction.Updated, resource);
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

.. : Object reference not set to an instance of an object

#### Issues Fixed or Closed by this PR

* https://github.com/Radarr/Radarr/issues/676
