### PR TITLE
Increase timeout when waiting for rTorrent to finish adding torrent

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -75,8 +75,8 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
         {
             _proxy.AddTorrentFromFile(filename, fileContent, Settings);
 
-            var tries = 2;
-            var retryDelay = 100;
+            var tries = 5;
+            var retryDelay = 200;
             if (WaitForTorrent(hash, tries, retryDelay))
             {
                 _proxy.SetTorrentLabel(hash, Settings.MovieCategory, Settings);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
As per https://github.com/Sonarr/Sonarr/issues/1665, it looks like 2x100ms isn't enough in some cases, up it to 5x200ms instead.

Reference:
https://github.com/Sonarr/Sonarr/commit/0255eb3aca0a2ab97086c8be1e3cc3bbe7774256

