### PR TITLE
availability specification to prevent downloading before released

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using NLog;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
+{
+    public class AvailabilitySpecification : IDecisionEngineSpecification
+    {
+        private readonly Logger _logger;
+
+        public AvailabilitySpecification(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public RejectionType Type => RejectionType.Permanent;
+
+        public Decision IsSatisfiedBy(RemoteMovie subject, SearchCriteriaBase searchCriteria)
+        {
+            if (searchCriteria != null)
+            {
+                if (searchCriteria.UserInvokedSearch)
+                {
+                    _logger.Debug("Skipping availability check during search");
+                    return Decision.Accept();
+                }
+            }
+
+            if (subject.Movie.Status != MovieStatusType.Released)
+            {
+                return Decision.Reject("Movie is not available");
+            }
+
+            return Decision.Accept();
+        }
+
+        public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        {
+            if (searchCriteria != null)
+            {
+                if (!searchCriteria.MonitoredEpisodesOnly)
+                {
+                    _logger.Debug("Skipping availability check during search");
+                    return Decision.Accept();
+                }
+            }
+
+            /*if (subject.Series.Status != MovieStatusType.Released)
+            {
+                _logger.Debug("{0} is present in the DB but not yet available. skipping.", subject.Series);
+                return Decision.Reject("Series is not yet available");
+            }
+
+            /*var monitoredCount = subject.Episodes.Count(episode => episode.Monitored);
+            if (monitoredCount == subject.Episodes.Count)
+            {
+                return Decision.Accept();
+            }
+
+            _logger.Debug("Only {0}/{1} episodes are monitored. skipping.", monitoredCount, subject.Episodes.Count);*/
+            return Decision.Reject("Episode is not yet available");
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -394,6 +394,7 @@
     <Compile Include="DecisionEngine\Specifications\RssSync\DelaySpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RssSync\HistorySpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RssSync\MonitoredEpisodeSpecification.cs" />
+    <Compile Include="DecisionEngine\Specifications\RssSync\AvailabilitySpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RssSync\ProperSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\Search\DailyEpisodeMatchSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\Search\EpisodeRequestedSpecification.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I doubt that this fully handles the situation but I was poking around in the code and thought to add something here similar to the MonitorSpecification... not sure if its valuable or not but I am just opening this PR so that @galli-leo may see it and we could have some kind of discussion.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR
https://github.com/Radarr/Radarr/issues/740
* #
