### PR TITLE
Movie status improvement

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using NLog;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
+{
+    public class AvailabilitySpecification : IDecisionEngineSpecification
+    {
+        private readonly Logger _logger;
+
+        public AvailabilitySpecification(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public RejectionType Type => RejectionType.Permanent;
+
+        public Decision IsSatisfiedBy(RemoteMovie subject, SearchCriteriaBase searchCriteria)
+        {
+            if (searchCriteria != null)
+            {
+                if (searchCriteria.UserInvokedSearch)
+                {
+                    _logger.Debug("Skipping availability check during search");
+                    return Decision.Accept();
+                }
+            }
+
+            if (subject.Movie.Status != MovieStatusType.Released)
+            {
+                return Decision.Reject("Movie is not available");
+            }
+
+            return Decision.Accept();
+        }
+
+        public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        {
+            if (searchCriteria != null)
+            {
+                if (!searchCriteria.MonitoredEpisodesOnly)
+                {
+                    _logger.Debug("Skipping availability check during search");
+                    return Decision.Accept();
+                }
+            }
+
+            /*if (subject.Series.Status != MovieStatusType.Released)
+            {
+                _logger.Debug("{0} is present in the DB but not yet available. skipping.", subject.Series);
+                return Decision.Reject("Series is not yet available");
+            }
+
+            /*var monitoredCount = subject.Episodes.Count(episode => episode.Monitored);
+            if (monitoredCount == subject.Episodes.Count)
+            {
+                return Decision.Accept();
+            }
+
+            _logger.Debug("Only {0}/{1} episodes are monitored. skipping.", monitoredCount, subject.Episodes.Count);*/
+            return Decision.Reject("Episode is not yet available");
+        }
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -185,14 +185,22 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 movie.Genres.Add(genre.name);
             }
 
-            if (resource.status == "Released")
+            var now = DateTime.Now;
+            if (now < movie.InCinemas)
+                movie.Status = MovieStatusType.Announced;
+            if (now >= movie.InCinemas) 
+                movie.Status = MovieStatusType.InCinemas;
+            if (now >= movie.PhysicalRelease)
+                movie.Status = MovieStatusType.Released;
+
+            /*if (resource.status == "Released")
             {
                 movie.Status = MovieStatusType.Released;
             }
             else
             {
                 movie.Status = MovieStatusType.Announced;
-            }
+            }*/
 
             if (resource.videos != null)
             {

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -185,17 +185,66 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 movie.Genres.Add(genre.name);
             }
 
-            var now = DateTime.Now;
+            //this is the way it should be handled
+            //but unfortunately it seems
+            //tmdb lacks alot of release date info
+            //omdbapi is actually quite good for this info
+            //except omdbapi has been having problems recently
+            //so i will just leave this in as a comment
+            //and use the 3 month logic that we were using before           
+            /*var now = DateTime.Now;
             if (now < movie.InCinemas)
                 movie.Status = MovieStatusType.Announced;
             if (now >= movie.InCinemas) 
                 movie.Status = MovieStatusType.InCinemas;
             if (now >= movie.PhysicalRelease)
                 movie.Status = MovieStatusType.Released;
+            */
 
-            /*if (resource.status == "Released")
+            
+            var now = DateTime.Now;
+            //handle the case when we have both theatrical and physical release dates
+            if (movie.InCinemas.HasValue && movie.PhysicalRelease.HasValue)
+            {
+                if (now < movie.InCinemas)
+                    movie.Status = MovieStatusType.Announced;
+                else if (now >= movie.InCinemas)
+                    movie.Status = MovieStatusType.InCinemas;
+                if (now >= movie.PhysicalRelease)
+                    movie.Status = MovieStatusType.Released;
+            }
+            //handle the case when we have theatrical release dates but we dont know the physical release date
+            else if (movie.InCinemas.HasValue && (now >= movie.InCinemas))
+            {
+                movie.Status = MovieStatusType.InCinemas;
+            }
+            //handle the case where we only have a physical release date
+            else if (movie.PhysicalRelease.HasValue && (now >= movie.PhysicalRelease))
             {
                 movie.Status = MovieStatusType.Released;
+            }
+            //otherwise the title has only been announced
+            else
+            {
+                movie.Status = MovieStatusType.Announced;
+            }
+            //since TMDB lacks alot of information lets assume that stuff is released if its been in cinemas for longer than 3 months.
+            if (movie.Status == MovieStatusType.InCinemas && (((DateTime.Now).Subtract(movie.InCinemas.Value)).TotalSeconds > 60*60*24*30*3))
+            {
+                movie.Status = MovieStatusType.Released;
+            }
+
+            //this matches with the old behavior before the creation of the MovieStatusType.InCinemas
+            /*if (resource.status == "Released")
+            {
+                if (movie.InCinemas.HasValue && (((DateTime.Now).Subtract(movie.InCinemas.Value)).TotalSeconds <= 60 * 60 * 24 * 30 * 3))
+                {
+                    movie.Status = MovieStatusType.InCinemas;
+                }
+                else
+                {
+                    movie.Status = MovieStatusType.Released;
+                }
             }
             else
             {

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -394,6 +394,7 @@
     <Compile Include="DecisionEngine\Specifications\RssSync\DelaySpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RssSync\HistorySpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RssSync\MonitoredEpisodeSpecification.cs" />
+    <Compile Include="DecisionEngine\Specifications\RssSync\AvailabilitySpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RssSync\ProperSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\Search\DailyEpisodeMatchSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\Search\EpisodeRequestedSpecification.cs" />

--- a/src/NzbDrone.Core/Tv/MovieStatusType.cs
+++ b/src/NzbDrone.Core/Tv/MovieStatusType.cs
@@ -4,6 +4,7 @@
     {
         TBA = 0, //Nothing yet announced, only rumors, but still IMDb page
         Announced = 1, //AirDate is announced
-        Released = 2 //Has at least one PreDB release
+        InCinemas = 2,
+        Released = 3 //Has at least one PreDB release
     }
 }

--- a/src/UI/Cells/MovieStatusCell.js
+++ b/src/UI/Cells/MovieStatusCell.js
@@ -17,12 +17,12 @@ module.exports = NzbDroneCell.extend({
             this._setStatusWeight(3);
         }
 
-        if (numOfMonths > 3) {
-          this.$el.html('<i class="icon-sonarr-movie-released grid-icon" title="Released"></i>');//TODO: Update for PreDB.me
-          this._setStatusWeight(2);
-        }
+        //if (numOfMonths > 3) {
+        //  this.$el.html('<i class="icon-sonarr-movie-released grid-icon" title="Released"></i>');//TODO: Update for PreDB.me
+        //  this._setStatusWeight(2);
+        //}
 
-        if (numOfMonths < 3) {
+        if (status === 'inCinemas') {
           this.$el.html('<i class="icon-sonarr-movie-cinemas grid-icon" title="In Cinemas"></i>');
           this._setStatusWeight(2);
         }

--- a/src/UI/Cells/MovieStatusWithTextCell.js
+++ b/src/UI/Cells/MovieStatusWithTextCell.js
@@ -18,12 +18,12 @@ module.exports = NzbDroneCell.extend({
             this._setStatusWeight(3);
         }
 
-        if (numOfMonths > 3) {
-            this.$el.html('<div class="released-banner"><i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released</div>');//TODO: Update for PreDB.me
-            this._setStatusWeight(2);
-        }
+        //if (numOfMonths > 3) {
+        //    this.$el.html('<div class="released-banner"><i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released</div>');//TODO: Update for PreDB.me
+        //    this._setStatusWeight(2);
+        //}
 
-        if (numOfMonths < 3) {
+        if (status ==='inCinemas') {
             this.$el.html('<div class="cinemas-banner"><i class="icon-sonarr-movie-cinemas grid-icon" title=""></i>&nbsp;In Cinemas</div>');
             this._setStatusWeight(2);
         }

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -82,16 +82,17 @@ Handlebars.registerHelper('GetStatus', function() {
   if (status === "announced") {
     return new Handlebars.SafeString('<i class="icon-sonarr-movie-announced grid-icon" title=""></i>&nbsp;Announced');
   }
+  
 
-  if (numOfMonths < 3) {
-
+  if (status ==="inCinemas") {
     return new Handlebars.SafeString('<i class="icon-sonarr-movie-cinemas grid-icon" title=""></i>&nbsp;In Cinemas');
   }
-
-  if (numOfMonths > 3) {
-    return new Handlebars.SafeString('<i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released');//TODO: Update for PreDB.me
-  }
-
+  //if (numOfMonths < 3) {
+  //  return new Handlebars.SafeString('<i class="icon-sonarr-movie-cinemas grid-icon" title=""></i>&nbsp;In Cinemas');
+  //}
+  //if (numOfMonths > 3) {
+  //  return new Handlebars.SafeString('<i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released');//TODO: Update for PreDB.me
+  //}
   if (status === 'released') {
       return new Handlebars.SafeString('<i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released');
   }
@@ -113,7 +114,7 @@ Handlebars.registerHelper('GetBannerStatus', function() {
     return new Handlebars.SafeString('<div class="announced-banner"><i class="icon-sonarr-movie-announced grid-icon" title=""></i>&nbsp;Announced</div>');
   }
 
-  if (numOfMonths < 3) {
+  if (status === "inCinemas") {
     return new Handlebars.SafeString('<div class="cinemas-banner"><i class="icon-sonarr-movie-cinemas grid-icon" title=""></i>&nbsp;In Cinemas</div>');
   }
 
@@ -121,9 +122,9 @@ Handlebars.registerHelper('GetBannerStatus', function() {
       return new Handlebars.SafeString('<div class="released-banner"><i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released</div>');
   }
 
-  if (numOfMonths > 3) {
-    return new Handlebars.SafeString('<div class="released-banner"><i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released</div>');//TODO: Update for PreDB.me
-  }
+  //if (numOfMonths > 3) {
+  //  return new Handlebars.SafeString('<div class="released-banner"><i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released</div>');//TODO: Update for PreDB.me
+  //}
 
 
 

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -197,12 +197,7 @@ Handlebars.registerHelper('inCinemas', function() {
     var cinemasDate = new Date(this.inCinemas);
     var year = cinemasDate.getFullYear();
     var month = monthNames[cinemasDate.getMonth()];
-    if (this.status === 'announced') {
-	    return "Announced(In Cinemas: " + month + " " + year+")";
-    }
-    else {
     return "In Cinemas: " + month + " " + year;
-    }
   }
   return "To be announced";
 });

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -54,6 +54,9 @@ Handlebars.registerHelper('tmdbUrl', function() {
 Handlebars.registerHelper('youTubeTrailerUrl', function() {
     return 'https://www.youtube.com/watch?v=' + this.youTubeTrailerId;
 });
+Handlebars.registerHelper('allFlicksUrl', function() {
+    return this.allFlicksUrl;
+});
 
 Handlebars.registerHelper('homepage', function() {
     return this.website;
@@ -155,14 +158,18 @@ Handlebars.registerHelper('DownloadedStatusColor', function() {
 
 Handlebars.registerHelper('DownloadedStatus', function() {
 
+  //if (this.allFlicksUrl) {
+  //  return "On Netflix";
+  //}
   if (this.downloaded) {
     return "Downloaded";
   }
   if (!this.monitored) {
     return "Not Monitored";
   }
-
-
+  //if (this.allFlicksUrl) {
+  //  return "On Netflix";
+  //}
   return "Missing";
 });
 
@@ -190,7 +197,12 @@ Handlebars.registerHelper('inCinemas', function() {
     var cinemasDate = new Date(this.inCinemas);
     var year = cinemasDate.getFullYear();
     var month = monthNames[cinemasDate.getMonth()];
+    if (this.status === 'announced') {
+	    return "Announced(In Cinemas: " + month + " " + year+")";
+    }
+    else {
     return "In Cinemas: " + month + " " + year;
+    }
   }
   return "To be announced";
 });

--- a/src/UI/Movies/Details/InfoViewTemplate.hbs
+++ b/src/UI/Movies/Details/InfoViewTemplate.hbs
@@ -17,11 +17,11 @@
         {{/if}}
 
         <span class="label label-info">{{Bytes sizeOnDisk}}</span>
-        {{#if_eq status compare="announced"}}
-            <span class="label label-default">Announced</span>
+	{{#if_eq status  compare="announced"}}
+	    <span class="label label-default">{{inCinemas}}</span>
 	{{else}}
             <span class="label label-info">{{inCinemas}}</span>
-        {{/if_eq}}
+	{{/if_eq}}
         <span class="label label-{{DownloadedStatusColor}}" title="{{DownloadedQuality}}">{{DownloadedStatus}}</span>
     </div>
     <div class="col-md-4">
@@ -39,6 +39,10 @@
             {{#if youTubeTrailerId}}
                 <a href="{{youTubeTrailerUrl}}" class="label label-info">Trailer</a>
             {{/if}}
+	    
+	    {{#if allFlicksUrl}}
+	        <a href="{{allFlicksUrl}}" class="label label-info">AllFlicks</a>
+	    {{/if}}
         </span>
     </div>
 </div>

--- a/src/UI/Movies/Details/InfoViewTemplate.hbs
+++ b/src/UI/Movies/Details/InfoViewTemplate.hbs
@@ -21,7 +21,11 @@
         {{#if_eq status compare="released"}}
             <span class="label label-info">{{inCinemas}}</span>
         {{else}}
-            <span class="label label-default">Announced</span>
+	    {{#if_eq status compare="inCinemas"}}
+	        <span class="label label-info">{{inCinemas}}</span>
+	    {{else}}
+                <span class="label label-default">Announced</span>
+	    {{/if_eq}}
         {{/if_eq}}
         <span class="label label-{{DownloadedStatusColor}}" title="{{DownloadedQuality}}">{{DownloadedStatus}}</span>
     </div>

--- a/src/UI/Movies/Details/InfoViewTemplate.hbs
+++ b/src/UI/Movies/Details/InfoViewTemplate.hbs
@@ -17,15 +17,10 @@
         {{/if}}
 
         <span class="label label-info">{{Bytes sizeOnDisk}}</span>
-
-        {{#if_eq status compare="released"}}
+        {{#if_eq status compare="announced"}}
+            <span class="label label-default">Announced</span>
+	{{else}}
             <span class="label label-info">{{inCinemas}}</span>
-        {{else}}
-	    {{#if_eq status compare="inCinemas"}}
-	        <span class="label label-info">{{inCinemas}}</span>
-	    {{else}}
-                <span class="label label-default">Announced</span>
-	    {{/if_eq}}
         {{/if_eq}}
         <span class="label label-{{DownloadedStatusColor}}" title="{{DownloadedQuality}}">{{DownloadedStatus}}</span>
     </div>

--- a/src/UI/Movies/Index/FooterViewTemplate.hbs
+++ b/src/UI/Movies/Index/FooterViewTemplate.hbs
@@ -18,7 +18,7 @@
                     <dd>{{released}}</dd>
 
 		    <dt>In Cinemas</dt>
-		    <<dd>{{incinemas}}</dd>
+		    <dd>{{incinemas}}</dd>
 
                     <dt>Announced</dt>
                     <dd>{{announced}}</dd>

--- a/src/UI/Movies/Index/FooterViewTemplate.hbs
+++ b/src/UI/Movies/Index/FooterViewTemplate.hbs
@@ -17,6 +17,9 @@
                     <dt>Released</dt>
                     <dd>{{released}}</dd>
 
+		    <dt>In Cinemas</dt>
+		    <<dd{{incinemas}}</dd>
+
                     <dt>Announced</dt>
                     <dd>{{announced}}</dd>
                 </dl>

--- a/src/UI/Movies/Index/FooterViewTemplate.hbs
+++ b/src/UI/Movies/Index/FooterViewTemplate.hbs
@@ -18,7 +18,7 @@
                     <dd>{{released}}</dd>
 
 		    <dt>In Cinemas</dt>
-		    <<dd{{incinemas}}</dd>
+		    <<dd>{{incinemas}}</dd>
 
                     <dt>Announced</dt>
                     <dd>{{announced}}</dd>

--- a/src/UI/Movies/Index/MoviesIndexLayout.js
+++ b/src/UI/Movies/Index/MoviesIndexLayout.js
@@ -328,6 +328,7 @@ module.exports = Marionette.Layout.extend({
         var episodeFiles = 0;
         var announced = 0;
         var released = 0;
+	var incinemas = 0;
         var monitored = 0;
 
         _.each(MoviesCollection.models, function(model) {
@@ -336,6 +337,8 @@ module.exports = Marionette.Layout.extend({
 
             if (model.get('status').toLowerCase() === 'released') {
                 released++;
+	    } else if (model.get('status').toLowerCase() === 'incinemas') {
+                incinemas++;
             } else {
                 announced++;
             }
@@ -348,6 +351,7 @@ module.exports = Marionette.Layout.extend({
         footerModel.set({
             series       : series,
             released   : released,
+	    incinemas    : incinemas,
             announced    : announced,
             monitored : monitored,
             unmonitored  : series - monitored,

--- a/src/UI/Movies/MovieModel.js
+++ b/src/UI/Movies/MovieModel.js
@@ -23,7 +23,7 @@ module.exports = Backbone.Model.extend({
         return "announced"
       }
 
-      if (numOfMonths < 3 && numOfMonths > 0) {
+      if (status === "inCinemas") {
 
         return "inCinemas";
       }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
pull out the logic that determines the status of a movie from the javascript
so as to have one place that controls this and then everything else abides by it.

now instead of having a <3 month specification for Cinemas, it will be based on the release dates, but even if we still wanted to use the <3 months estimation at last the code would not need to be duplicated in multiple places, there would be a single place it would be set. This makes future additions to the states and eventual ability to control a minimum release being available before downloading much easier to implement.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR
this makes InCinemas status of movies be based on the release dates instead of rough 3 month estimation.
* #
