### PR TITLE
Min availability

### DIFF
--- a/src/NzbDrone.Api/Config/IndexerConfigResource.cs
+++ b/src/NzbDrone.Api/Config/IndexerConfigResource.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Api.Config
         public int MinimumAge { get; set; }
         public int Retention { get; set; }
         public int RssSyncInterval { get; set; }
+	public int AvailabilityDelay { get; set; }
     }
 
     public static class IndexerConfigResourceMapper
@@ -19,6 +20,7 @@ namespace NzbDrone.Api.Config
                 MinimumAge = model.MinimumAge,
                 Retention = model.Retention,
                 RssSyncInterval = model.RssSyncInterval,
+		AvailabilityDelay = model.AvailabilityDelay,
             };
         }
     }

--- a/src/NzbDrone.Api/NetImport/NetImportModule.cs
+++ b/src/NzbDrone.Api/NetImport/NetImportModule.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Api.NetImport
             resource.ProfileId = definition.ProfileId;
             resource.RootFolderPath = definition.RootFolderPath;
             resource.ShouldMonitor = definition.ShouldMonitor;
-            resource.Minimumavailability = definition.Minimumavailability;
+            resource.MinimumAvailability = definition.MinimumAvailability;
         }
 
         protected override void MapToModel(NetImportDefinition definition, NetImportResource resource)
@@ -34,7 +34,7 @@ namespace NzbDrone.Api.NetImport
             definition.ProfileId = resource.ProfileId;
             definition.RootFolderPath = resource.RootFolderPath;
             definition.ShouldMonitor = resource.ShouldMonitor;
-            definition.Minimumavailability = resource.Minimumavailability;
+            definition.MinimumAvailability = resource.MinimumAvailability;
         }
 
         protected override void Validate(NetImportDefinition definition, bool includeWarnings)

--- a/src/NzbDrone.Api/NetImport/NetImportModule.cs
+++ b/src/NzbDrone.Api/NetImport/NetImportModule.cs
@@ -22,6 +22,7 @@ namespace NzbDrone.Api.NetImport
             resource.ProfileId = definition.ProfileId;
             resource.RootFolderPath = definition.RootFolderPath;
             resource.ShouldMonitor = definition.ShouldMonitor;
+            resource.Minimumavailability = definition.Minimumavailability;
         }
 
         protected override void MapToModel(NetImportDefinition definition, NetImportResource resource)
@@ -33,6 +34,7 @@ namespace NzbDrone.Api.NetImport
             definition.ProfileId = resource.ProfileId;
             definition.RootFolderPath = resource.RootFolderPath;
             definition.ShouldMonitor = resource.ShouldMonitor;
+            definition.Minimumavailability = resource.Minimumavailability;
         }
 
         protected override void Validate(NetImportDefinition definition, bool includeWarnings)

--- a/src/NzbDrone.Api/NetImport/NetImportResource.cs
+++ b/src/NzbDrone.Api/NetImport/NetImportResource.cs
@@ -1,4 +1,5 @@
 ﻿using NzbDrone.Core.NetImport;
+using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Api.NetImport
 {
@@ -9,6 +10,6 @@ namespace NzbDrone.Api.NetImport
         public bool ShouldMonitor { get; set; }
         public string RootFolderPath { get; set; }
         public int ProfileId { get; set; }
-        public string Minimumavailability { get; set; }
+        public MovieStatusType Minimumavailability { get; set; }
     }
 }

--- a/src/NzbDrone.Api/NetImport/NetImportResource.cs
+++ b/src/NzbDrone.Api/NetImport/NetImportResource.cs
@@ -9,5 +9,6 @@ namespace NzbDrone.Api.NetImport
         public bool ShouldMonitor { get; set; }
         public string RootFolderPath { get; set; }
         public int ProfileId { get; set; }
+        public string Minimumavailability { get; set; }
     }
 }

--- a/src/NzbDrone.Api/NetImport/NetImportResource.cs
+++ b/src/NzbDrone.Api/NetImport/NetImportResource.cs
@@ -10,6 +10,6 @@ namespace NzbDrone.Api.NetImport
         public bool ShouldMonitor { get; set; }
         public string RootFolderPath { get; set; }
         public int ProfileId { get; set; }
-        public MovieStatusType Minimumavailability { get; set; }
+        public MovieStatusType MinimumAvailability { get; set; }
     }
 }

--- a/src/NzbDrone.Api/Series/MovieResource.cs
+++ b/src/NzbDrone.Api/Series/MovieResource.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Api.Movie
 
         //Editing Only
         public bool Monitored { get; set; }
-	    public MovieStatusType Minimumavailability { get; set; }
+	public MovieStatusType MinimumAvailability { get; set; }
         public int Runtime { get; set; }
         public DateTime? LastInfoSync { get; set; }
         public string CleanTitle { get; set; }
@@ -130,7 +130,7 @@ namespace NzbDrone.Api.Movie
                 ProfileId = model.ProfileId,
                 
                 Monitored = model.Monitored,
-                Minimumavailability = model.Minimumavailability,
+                MinimumAvailability = model.MinimumAvailability,
 
                 SizeOnDisk = size,
 
@@ -183,7 +183,7 @@ namespace NzbDrone.Api.Movie
                 ProfileId = resource.ProfileId,
 
                 Monitored = resource.Monitored,
-                Minimumavailability = resource.Minimumavailability,
+                MinimumAvailability = resource.MinimumAvailability,
 
                 Runtime = resource.Runtime,
                 LastInfoSync = resource.LastInfoSync,
@@ -213,7 +213,7 @@ namespace NzbDrone.Api.Movie
             movie.ProfileId = resource.ProfileId;
 
             movie.Monitored = resource.Monitored;
-	    movie.Minimumavailability = resource.Minimumavailability;
+	    movie.MinimumAvailability = resource.MinimumAvailability;
 
             movie.RootFolderPath = resource.RootFolderPath;
             movie.Tags = resource.Tags;

--- a/src/NzbDrone.Api/Series/MovieResource.cs
+++ b/src/NzbDrone.Api/Series/MovieResource.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Api.Movie
 
         //Editing Only
         public bool Monitored { get; set; }
-	    public string Minimumavailability { get; set; }
+	    public MovieStatusType Minimumavailability { get; set; }
         public int Runtime { get; set; }
         public DateTime? LastInfoSync { get; set; }
         public string CleanTitle { get; set; }

--- a/src/NzbDrone.Api/Series/MovieResource.cs
+++ b/src/NzbDrone.Api/Series/MovieResource.cs
@@ -43,6 +43,7 @@ namespace NzbDrone.Api.Movie
 
         //Editing Only
         public bool Monitored { get; set; }
+	    public string Minimumavailability { get; set; }
         public int Runtime { get; set; }
         public DateTime? LastInfoSync { get; set; }
         public string CleanTitle { get; set; }
@@ -129,6 +130,7 @@ namespace NzbDrone.Api.Movie
                 ProfileId = model.ProfileId,
                 
                 Monitored = model.Monitored,
+                Minimumavailability = model.Minimumavailability,
 
                 SizeOnDisk = size,
 
@@ -181,6 +183,7 @@ namespace NzbDrone.Api.Movie
                 ProfileId = resource.ProfileId,
 
                 Monitored = resource.Monitored,
+                Minimumavailability = resource.Minimumavailability,
 
                 Runtime = resource.Runtime,
                 LastInfoSync = resource.LastInfoSync,
@@ -210,6 +213,7 @@ namespace NzbDrone.Api.Movie
             movie.ProfileId = resource.ProfileId;
 
             movie.Monitored = resource.Monitored;
+	    movie.Minimumavailability = resource.Minimumavailability;
 
             movie.RootFolderPath = resource.RootFolderPath;
             movie.Tags = resource.Tags;

--- a/src/NzbDrone.Api/Series/MovieResource.cs
+++ b/src/NzbDrone.Api/Series/MovieResource.cs
@@ -43,7 +43,9 @@ namespace NzbDrone.Api.Movie
 
         //Editing Only
         public bool Monitored { get; set; }
-	public MovieStatusType MinimumAvailability { get; set; }
+	    public MovieStatusType MinimumAvailability { get; set; }
+        public bool IsAvailable { get; set; }
+
         public int Runtime { get; set; }
         public DateTime? LastInfoSync { get; set; }
         public string CleanTitle { get; set; }
@@ -131,6 +133,8 @@ namespace NzbDrone.Api.Movie
                 
                 Monitored = model.Monitored,
                 MinimumAvailability = model.MinimumAvailability,
+		
+                IsAvailable = model.IsAvailable(),
 
                 SizeOnDisk = size,
 
@@ -184,7 +188,7 @@ namespace NzbDrone.Api.Movie
 
                 Monitored = resource.Monitored,
                 MinimumAvailability = resource.MinimumAvailability,
-
+		
                 Runtime = resource.Runtime,
                 LastInfoSync = resource.LastInfoSync,
                 CleanTitle = resource.CleanTitle,
@@ -213,8 +217,8 @@ namespace NzbDrone.Api.Movie
             movie.ProfileId = resource.ProfileId;
 
             movie.Monitored = resource.Monitored;
-	    movie.MinimumAvailability = resource.MinimumAvailability;
-
+	        movie.MinimumAvailability = resource.MinimumAvailability;
+	   
             movie.RootFolderPath = resource.RootFolderPath;
             movie.Tags = resource.Tags;
             movie.AddOptions = resource.AddOptions;

--- a/src/NzbDrone.Api/Wanted/MovieMissingModule.cs
+++ b/src/NzbDrone.Api/Wanted/MovieMissingModule.cs
@@ -34,9 +34,30 @@ namespace NzbDrone.Api.Wanted
             {
                 pagingSpec.FilterExpression = v => v.Monitored == false;
             }
-            else
+            else if (pagingResource.FilterKey == "monitored" && pagingResource.FilterValue == "true")
             {
                 pagingSpec.FilterExpression = v => v.Monitored == true;
+            }
+            else if (pagingResource.FilterKey == "moviestatus"  && pagingResource.FilterValue == "available")
+            {
+                //TODO: might need to handle PreDB here
+                pagingSpec.FilterExpression = v =>
+                             (v.MinimumAvailability == MovieStatusType.Released && v.Status >= MovieStatusType.Released) ||
+                             (v.MinimumAvailability == MovieStatusType.InCinemas && v.Status >= MovieStatusType.InCinemas) ||
+                             (v.MinimumAvailability == MovieStatusType.Announced && v.Status >= MovieStatusType.Announced) ||
+                             (v.MinimumAvailability == MovieStatusType.PreDB && v.Status >= MovieStatusType.Released);
+            }
+            else if (pagingResource.FilterKey == "moviestatus" && pagingResource.FilterValue == "announced")
+            {
+                pagingSpec.FilterExpression = v => v.Status == MovieStatusType.Announced;
+            }
+            else if (pagingResource.FilterKey == "moviestatus" && pagingResource.FilterValue == "incinemas")
+            {
+                pagingSpec.FilterExpression = v => v.Status == MovieStatusType.InCinemas;
+            }
+            else if (pagingResource.FilterKey == "moviestatus" && pagingResource.FilterValue == "released")
+            {
+                pagingSpec.FilterExpression = v => v.Status == MovieStatusType.Released;
             }
 
             var resource = ApplyToPage(_movieService.MoviesWithoutFiles, pagingSpec, v => MapToResource(v, true));

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -105,6 +105,12 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("RssSyncInterval", value); }
         }
 
+	public int AvailabilityDelay
+	{
+	    get { return GetValueInt("AvailabilityDelay",0); }
+	    set { SetValue("AvailabilityDelay", value); }
+	}
+
         public int NetImportSyncInterval
         {
             get { return GetValueInt("NetImportSyncInterval", 60); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -46,6 +46,8 @@ namespace NzbDrone.Core.Configuration
         int RssSyncInterval { get; set; }
         int MinimumAge { get; set; }
 
+	int AvailabilityDelay { get; set; }
+
         int NetImportSyncInterval { get; set; }
 
         //UI

--- a/src/NzbDrone.Core/Datastore/Migration/133_add_minimumavailability.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/133_add_minimumavailability.cs
@@ -12,12 +12,12 @@ namespace NzbDrone.Core.Datastore.Migration
         {
             if (!this.Schema.Schema("dbo").Table("NetImport").Column("Minimumavailability").Exists())
             {
-                Alter.Table("NetImport").AddColumn("Minimumavailability").AsString().Nullable();
+                Alter.Table("NetImport").AddColumn("Minimumavailability").AsInt32().WithDefaultValue(MovieStatusType.Released);
             }
-	    if (!this.Schema.Schema("dbo").Table("Movies").Column("Minimumavailability").Exists())
-	    {
-		Alter.Table("Movies").AddColumn("Minimumavailability").AsInt32().WithDefaultValue(MovieStatusType.Released);
-	    }
+	        if (!this.Schema.Schema("dbo").Table("Movies").Column("Minimumavailability").Exists())
+	        {
+		        Alter.Table("Movies").AddColumn("Minimumavailability").AsInt32().WithDefaultValue(MovieStatusType.Released);
+	        }
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/133_add_minimumavailability.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/133_add_minimumavailability.cs
@@ -1,6 +1,7 @@
 ﻿using FluentMigrator;
-using FluentMigrator.Expressions;
+//using FluentMigrator.Expressions;
 using NzbDrone.Core.Datastore.Migration.Framework;
+using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Datastore.Migration
 {
@@ -15,7 +16,7 @@ namespace NzbDrone.Core.Datastore.Migration
             }
 	    if (!this.Schema.Schema("dbo").Table("Movies").Column("Minimumavailability").Exists())
 	    {
-		Alter.Table("Movies").AddColumn("Minimumavailability").AsString().Nullable();
+		Alter.Table("Movies").AddColumn("Minimumavailability").AsInt32().WithDefaultValue(MovieStatusType.Released);
 	    }
         }
     }

--- a/src/NzbDrone.Core/Datastore/Migration/133_add_minimumavailability.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/133_add_minimumavailability.cs
@@ -10,13 +10,13 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            if (!this.Schema.Schema("dbo").Table("NetImport").Column("Minimumavailability").Exists())
+            if (!this.Schema.Schema("dbo").Table("NetImport").Column("MinimumAvailability").Exists())
             {
-                Alter.Table("NetImport").AddColumn("Minimumavailability").AsInt32().WithDefaultValue(MovieStatusType.Released);
+                Alter.Table("NetImport").AddColumn("MinimumAvailability").AsInt32().WithDefaultValue(MovieStatusType.Released);
             }
-	        if (!this.Schema.Schema("dbo").Table("Movies").Column("Minimumavailability").Exists())
+	        if (!this.Schema.Schema("dbo").Table("Movies").Column("MinimumAvailability").Exists())
 	        {
-		        Alter.Table("Movies").AddColumn("Minimumavailability").AsInt32().WithDefaultValue(MovieStatusType.Released);
+		        Alter.Table("Movies").AddColumn("MinimumAvailability").AsInt32().WithDefaultValue(MovieStatusType.Released);
 	        }
         }
     }

--- a/src/NzbDrone.Core/Datastore/Migration/133_add_minimumavailability.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/133_add_minimumavailability.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using FluentMigrator;
+﻿using FluentMigrator;
+using FluentMigrator.Expressions;
 using NzbDrone.Core.Datastore.Migration.Framework;
-using System.Data;
 
 namespace NzbDrone.Core.Datastore.Migration
 {
@@ -13,9 +9,14 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            Alter.Table("Movies").AddColumn("Minimumavailability").AsString().Nullable();
-
+            if (!this.Schema.Schema("dbo").Table("NetImport").Column("Minimumavailability").Exists())
+            {
+                Alter.Table("NetImport").AddColumn("Minimumavailability").AsString().Nullable();
+            }
+	    if (!this.Schema.Schema("dbo").Table("Movies").Column("Minimumavailability").Exists())
+	    {
+		Alter.Table("Movies").AddColumn("Minimumavailability").AsString().Nullable();
+	    }
         }
-
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/133_add_minimumavailability.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/133_add_minimumavailability.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+using System.Data;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(133)]
+    public class add_minimumavailability : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Movies").AddColumn("Minimumavailability").AsString().Nullable();
+
+        }
+
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/133_add_minimumavailability.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/133_add_minimumavailability.cs
@@ -12,11 +12,11 @@ namespace NzbDrone.Core.Datastore.Migration
         {
             if (!this.Schema.Schema("dbo").Table("NetImport").Column("MinimumAvailability").Exists())
             {
-                Alter.Table("NetImport").AddColumn("MinimumAvailability").AsInt32().WithDefaultValue(MovieStatusType.Released);
+                Alter.Table("NetImport").AddColumn("MinimumAvailability").AsInt32().WithDefaultValue(MovieStatusType.PreDB);
             }
 	        if (!this.Schema.Schema("dbo").Table("Movies").Column("MinimumAvailability").Exists())
 	        {
-		        Alter.Table("Movies").AddColumn("MinimumAvailability").AsInt32().WithDefaultValue(MovieStatusType.Released);
+		        Alter.Table("Movies").AddColumn("MinimumAvailability").AsInt32().WithDefaultValue(MovieStatusType.PreDB);
 	        }
         }
     }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
@@ -4,15 +4,18 @@ using NLog;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Tv;
+using NzbDrone.Core.Configuration;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
 {
     public class AvailabilitySpecification : IDecisionEngineSpecification
     {
+        private readonly IConfigService _settingsService;
         private readonly Logger _logger;
 
-        public AvailabilitySpecification(Logger logger)
+        public AvailabilitySpecification(IConfigService settingsService, Logger logger)
         {
+            _settingsService = settingsService;
             _logger = logger;
         }
 
@@ -28,9 +31,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
                     return Decision.Accept();
                 }
             }
-            if (!subject.Movie.IsAvailable())
+            if (!subject.Movie.IsAvailable(_settingsService.AvailabilityDelay))
             {
-                return Decision.Reject("Movie is not available");
+                return Decision.Reject("Movie {0} will only be considered available {1} days after {2}", subject.Movie, _settingsService.AvailabilityDelay, subject.Movie.MinimumAvailability.ToString());
             }
 
             return Decision.Accept();

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using NLog;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
+{
+    public class AvailabilitySpecification : IDecisionEngineSpecification
+    {
+        private readonly Logger _logger;
+
+        public AvailabilitySpecification(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public RejectionType Type => RejectionType.Permanent;
+
+        public Decision IsSatisfiedBy(RemoteMovie subject, SearchCriteriaBase searchCriteria)
+        {
+            if (searchCriteria != null)
+            {
+                if (searchCriteria.UserInvokedSearch)
+                {
+                    _logger.Debug("Skipping availability check during search");
+                    return Decision.Accept();
+                }
+            }
+
+            if (subject.Movie.Status != MovieStatusType.Released)
+            {
+                return Decision.Reject("Movie is not available");
+            }
+
+            return Decision.Accept();
+        }
+
+        public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        {
+            if (searchCriteria != null)
+            {
+                if (!searchCriteria.MonitoredEpisodesOnly)
+                {
+                    _logger.Debug("Skipping availability check during search");
+                    return Decision.Accept();
+                }
+            }
+
+            /*if (subject.Series.Status != MovieStatusType.Released)
+            {
+                _logger.Debug("{0} is present in the DB but not yet available. skipping.", subject.Series);
+                return Decision.Reject("Series is not yet available");
+            }
+
+            /*var monitoredCount = subject.Episodes.Count(episode => episode.Monitored);
+            if (monitoredCount == subject.Episodes.Count)
+            {
+                return Decision.Accept();
+            }
+
+            _logger.Debug("Only {0}/{1} episodes are monitored. skipping.", monitoredCount, subject.Episodes.Count);*/
+            return Decision.Reject("Episode is not yet available");
+        }
+    }
+}

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
@@ -29,26 +29,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
                 }
             }
 
-            /*MovieStatusType minAvail;
-            int x = 0;
-            bool result = Int32.TryParse(subject.Movie.Minimumavailability, out x);
-            //should match cases from: src\NzbDrone.Core\Tv\MovieStatusType.cs
-            switch (subject.Movie)
-            {
-                case 1:
-                    minAvail = MovieStatusType.Announced;
-                    break;
-                case 2:
-                    minAvail = MovieStatusType.InCinemas;
-                    break;
-                case 3:
-                    minAvail = MovieStatusType.Released;
-                    break;
-                default:
-                    minAvail = MovieStatusType.Released;
-                    break;
-            }*/
-            if (subject.Movie.Status < subject.Movie.Minimumavailability)
+            if (subject.Movie.Status < subject.Movie.MinimumAvailability)
             {
                 return Decision.Reject("Movie is not available");
             }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
@@ -28,8 +28,27 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
                     return Decision.Accept();
                 }
             }
-            //this should then become a check if subject.Movie.Status >= subject.Movie.MinimumAvailability
-            if (subject.Movie.Status != MovieStatusType.Released)
+
+            MovieStatusType minAvail;
+            int x = 0;
+            bool result = Int32.TryParse(subject.Movie.Minimumavailability, out x);
+            //should match cases from: src\NzbDrone.Core\Tv\MovieStatusType.cs
+            switch (x)
+            {
+                case 1:
+                    minAvail = MovieStatusType.Announced;
+                    break;
+                case 2:
+                    minAvail = MovieStatusType.InCinemas;
+                    break;
+                case 3:
+                    minAvail = MovieStatusType.Released;
+                    break;
+                default:
+                    minAvail = MovieStatusType.Released;
+                    break;
+            }
+            if (subject.Movie.Status < minAvail)
             {
                 return Decision.Reject("Movie is not available");
             }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
@@ -28,8 +28,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
                     return Decision.Accept();
                 }
             }
-            //TODO: will need to handle the case for PreDB but for now, treat PreDB the same as Released
-            if (subject.Movie.Status < subject.Movie.MinimumAvailability || (subject.Movie.MinimumAvailability == MovieStatusType.PreDB && subject.Movie.Status < MovieStatusType.Released))
+            if (!subject.Movie.IsAvailable())
             {
                 return Decision.Reject("Movie is not available");
             }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
                     return Decision.Accept();
                 }
             }
-
+            //this should then become a check if subject.Movie.Status >= subject.Movie.MinimumAvailability
             if (subject.Movie.Status != MovieStatusType.Released)
             {
                 return Decision.Reject("Movie is not available");

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
@@ -28,8 +28,8 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
                     return Decision.Accept();
                 }
             }
-
-            if (subject.Movie.Status < subject.Movie.MinimumAvailability)
+            //TODO: will need to handle the case for PreDB but for now, treat PreDB the same as Released
+            if (subject.Movie.Status < subject.Movie.MinimumAvailability || (subject.Movie.MinimumAvailability == MovieStatusType.PreDB && subject.Movie.Status < MovieStatusType.Released))
             {
                 return Decision.Reject("Movie is not available");
             }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/AvailabilitySpecification.cs
@@ -29,11 +29,11 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
                 }
             }
 
-            MovieStatusType minAvail;
+            /*MovieStatusType minAvail;
             int x = 0;
             bool result = Int32.TryParse(subject.Movie.Minimumavailability, out x);
             //should match cases from: src\NzbDrone.Core\Tv\MovieStatusType.cs
-            switch (x)
+            switch (subject.Movie)
             {
                 case 1:
                     minAvail = MovieStatusType.Announced;
@@ -47,8 +47,8 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
                 default:
                     minAvail = MovieStatusType.Released;
                     break;
-            }
-            if (subject.Movie.Status < minAvail)
+            }*/
+            if (subject.Movie.Status < subject.Movie.Minimumavailability)
             {
                 return Decision.Reject("Movie is not available");
             }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -707,7 +707,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             newMovie.ProfileId = movie.ProfileId;
             newMovie.Monitored = movie.Monitored;
             newMovie.MovieFile = movie.MovieFile;
-            newMovie.Minimumavailability = movie.Minimumavailability;
+            newMovie.MinimumAvailability = movie.MinimumAvailability;
 
             return newMovie;
         }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -707,6 +707,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             newMovie.ProfileId = movie.ProfileId;
             newMovie.Monitored = movie.Monitored;
             newMovie.MovieFile = movie.MovieFile;
+            newMovie.Minimumavailability = movie.Minimumavailability;
 
             return newMovie;
         }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -185,14 +185,22 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 movie.Genres.Add(genre.name);
             }
 
-            if (resource.status == "Released")
+            var now = DateTime.Now;
+            if (now < movie.InCinemas)
+                movie.Status = MovieStatusType.Announced;
+            if (now >= movie.InCinemas) 
+                movie.Status = MovieStatusType.InCinemas;
+            if (now >= movie.PhysicalRelease)
+                movie.Status = MovieStatusType.Released;
+
+            /*if (resource.status == "Released")
             {
                 movie.Status = MovieStatusType.Released;
             }
             else
             {
                 movie.Status = MovieStatusType.Announced;
-            }
+            }*/
 
             if (resource.videos != null)
             {

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -229,7 +229,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 movie.Status = MovieStatusType.Announced;
             }
             //since TMDB lacks alot of information lets assume that stuff is released if its been in cinemas for longer than 3 months.
-            if (movie.Status == MovieStatusType.InCinemas && (((DateTime.Now).Subtract(movie.InCinemas.Value)).TotalSeconds > 60*60*24*30*3))
+            if (!movie.PhysicalRelease.HasValue && (movie.Status == MovieStatusType.InCinemas) && (((DateTime.Now).Subtract(movie.InCinemas.Value)).TotalSeconds > 60*60*24*30*3))
             {
                 movie.Status = MovieStatusType.Released;
             }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -185,17 +185,66 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 movie.Genres.Add(genre.name);
             }
 
-            var now = DateTime.Now;
+            //this is the way it should be handled
+            //but unfortunately it seems
+            //tmdb lacks alot of release date info
+            //omdbapi is actually quite good for this info
+            //except omdbapi has been having problems recently
+            //so i will just leave this in as a comment
+            //and use the 3 month logic that we were using before           
+            /*var now = DateTime.Now;
             if (now < movie.InCinemas)
                 movie.Status = MovieStatusType.Announced;
             if (now >= movie.InCinemas) 
                 movie.Status = MovieStatusType.InCinemas;
             if (now >= movie.PhysicalRelease)
                 movie.Status = MovieStatusType.Released;
+            */
 
-            /*if (resource.status == "Released")
+            
+            var now = DateTime.Now;
+            //handle the case when we have both theatrical and physical release dates
+            if (movie.InCinemas.HasValue && movie.PhysicalRelease.HasValue)
+            {
+                if (now < movie.InCinemas)
+                    movie.Status = MovieStatusType.Announced;
+                else if (now >= movie.InCinemas)
+                    movie.Status = MovieStatusType.InCinemas;
+                if (now >= movie.PhysicalRelease)
+                    movie.Status = MovieStatusType.Released;
+            }
+            //handle the case when we have theatrical release dates but we dont know the physical release date
+            else if (movie.InCinemas.HasValue && (now >= movie.InCinemas))
+            {
+                movie.Status = MovieStatusType.InCinemas;
+            }
+            //handle the case where we only have a physical release date
+            else if (movie.PhysicalRelease.HasValue && (now >= movie.PhysicalRelease))
             {
                 movie.Status = MovieStatusType.Released;
+            }
+            //otherwise the title has only been announced
+            else
+            {
+                movie.Status = MovieStatusType.Announced;
+            }
+            //since TMDB lacks alot of information lets assume that stuff is released if its been in cinemas for longer than 3 months.
+            if (movie.Status == MovieStatusType.InCinemas && (((DateTime.Now).Subtract(movie.InCinemas.Value)).TotalSeconds > 60*60*24*30*3))
+            {
+                movie.Status = MovieStatusType.Released;
+            }
+
+            //this matches with the old behavior before the creation of the MovieStatusType.InCinemas
+            /*if (resource.status == "Released")
+            {
+                if (movie.InCinemas.HasValue && (((DateTime.Now).Subtract(movie.InCinemas.Value)).TotalSeconds <= 60 * 60 * 24 * 30 * 3))
+                {
+                    movie.Status = MovieStatusType.InCinemas;
+                }
+                else
+                {
+                    movie.Status = MovieStatusType.Released;
+                }
             }
             else
             {

--- a/src/NzbDrone.Core/NetImport/HttpNetImportBase.cs
+++ b/src/NzbDrone.Core/NetImport/HttpNetImportBase.cs
@@ -112,6 +112,7 @@ namespace NzbDrone.Core.NetImport
                 m.RootFolderPath = ((NetImportDefinition) Definition).RootFolderPath;
                 m.ProfileId = ((NetImportDefinition) Definition).ProfileId;
                 m.Monitored = ((NetImportDefinition) Definition).ShouldMonitor;
+		        m.Minimumavailability = ((NetImportDefinition) Definition).Minimumavailability;
                 return m;
             }).ToList();
         }

--- a/src/NzbDrone.Core/NetImport/HttpNetImportBase.cs
+++ b/src/NzbDrone.Core/NetImport/HttpNetImportBase.cs
@@ -112,7 +112,7 @@ namespace NzbDrone.Core.NetImport
                 m.RootFolderPath = ((NetImportDefinition) Definition).RootFolderPath;
                 m.ProfileId = ((NetImportDefinition) Definition).ProfileId;
                 m.Monitored = ((NetImportDefinition) Definition).ShouldMonitor;
-		        m.Minimumavailability = ((NetImportDefinition) Definition).Minimumavailability;
+		        m.MinimumAvailability = ((NetImportDefinition) Definition).MinimumAvailability;
                 return m;
             }).ToList();
         }

--- a/src/NzbDrone.Core/NetImport/NetImportBase.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportBase.cs
@@ -44,6 +44,7 @@ namespace NzbDrone.Core.NetImport
                     Enabled = config.Validate().IsValid && Enabled,
                     EnableAuto = true,
                     ProfileId = 1,
+		    Minimumavailability = "3",
                     Implementation = GetType().Name,
                     Settings = config
                 };

--- a/src/NzbDrone.Core/NetImport/NetImportBase.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportBase.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.NetImport
                     Enabled = config.Validate().IsValid && Enabled,
                     EnableAuto = true,
                     ProfileId = 1,
-		    MinimumAvailability = MovieStatusType.Released,
+		    MinimumAvailability = MovieStatusType.PreDB,
                     Implementation = GetType().Name,
                     Settings = config
                 };

--- a/src/NzbDrone.Core/NetImport/NetImportBase.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportBase.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.NetImport
                     Enabled = config.Validate().IsValid && Enabled,
                     EnableAuto = true,
                     ProfileId = 1,
-		    Minimumavailability = "3",
+		            Minimumavailability = MovieStatusType.Released,
                     Implementation = GetType().Name,
                     Settings = config
                 };

--- a/src/NzbDrone.Core/NetImport/NetImportBase.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportBase.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.NetImport
                     Enabled = config.Validate().IsValid && Enabled,
                     EnableAuto = true,
                     ProfileId = 1,
-		            Minimumavailability = MovieStatusType.Released,
+		    MinimumAvailability = MovieStatusType.Released,
                     Implementation = GetType().Name,
                     Settings = config
                 };

--- a/src/NzbDrone.Core/NetImport/NetImportDefinition.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportDefinition.cs
@@ -9,6 +9,7 @@ namespace NzbDrone.Core.NetImport
         public bool Enabled { get; set; }
         public bool EnableAuto { get; set; }
         public bool ShouldMonitor { get; set; }
+	    public string Minimumavailability { get; set; }
         public int ProfileId { get; set; }
         public LazyLoaded<Profile> Profile { get; set; }
         public string RootFolderPath { get; set; }

--- a/src/NzbDrone.Core/NetImport/NetImportDefinition.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using Marr.Data;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.NetImport
 {
@@ -9,7 +10,7 @@ namespace NzbDrone.Core.NetImport
         public bool Enabled { get; set; }
         public bool EnableAuto { get; set; }
         public bool ShouldMonitor { get; set; }
-	    public string Minimumavailability { get; set; }
+	    public MovieStatusType Minimumavailability { get; set; }
         public int ProfileId { get; set; }
         public LazyLoaded<Profile> Profile { get; set; }
         public string RootFolderPath { get; set; }

--- a/src/NzbDrone.Core/NetImport/NetImportDefinition.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportDefinition.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.NetImport
         public bool Enabled { get; set; }
         public bool EnableAuto { get; set; }
         public bool ShouldMonitor { get; set; }
-	    public MovieStatusType Minimumavailability { get; set; }
+        public MovieStatusType MinimumAvailability { get; set; }
         public int ProfileId { get; set; }
         public LazyLoaded<Profile> Profile { get; set; }
         public string RootFolderPath { get; set; }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -394,6 +394,7 @@
     <Compile Include="DecisionEngine\Specifications\RssSync\DelaySpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RssSync\HistorySpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RssSync\MonitoredEpisodeSpecification.cs" />
+    <Compile Include="DecisionEngine\Specifications\RssSync\AvailabilitySpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RssSync\ProperSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\Search\DailyEpisodeMatchSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\Search\EpisodeRequestedSpecification.cs" />

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Datastore\Migration\128_remove_kickass.cs" />
     <Compile Include="Datastore\Migration\130_remove_wombles_kickass.cs" />
     <Compile Include="Datastore\Migration\132_rename_torrent_downloadstation.cs" />
+    <Compile Include="Datastore\Migration\133_add_minimumavailability.cs" />
     <Compile Include="NetImport\TMDb\TMDbLanguageCodes.cs" />
     <Compile Include="NetImport\TMDb\TMDbSettings.cs" />
     <Compile Include="NetImport\TMDb\TMDbListType.cs" />

--- a/src/NzbDrone.Core/Tv/Movie.cs
+++ b/src/NzbDrone.Core/Tv/Movie.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Tv
         public MovieStatusType Status { get; set; }
         public string Overview { get; set; }
         public bool Monitored { get; set; }
-	public MovieStatusType MinimumAvailability { get; set; }
+	    public MovieStatusType MinimumAvailability { get; set; }
         public int ProfileId { get; set; }
         public DateTime? LastInfoSync { get; set; }
         public int Runtime { get; set; }
@@ -53,6 +53,12 @@ namespace NzbDrone.Core.Tv
         public string Studio { get; set; }
 
         public bool HasFile => MovieFileId > 0;
+
+        public bool IsAvailable()
+        {
+            //TODO might need to update this for preDB.
+            return (Status >= MinimumAvailability || (MinimumAvailability==MovieStatusType.PreDB && Status >= MovieStatusType.Released));
+        }
 
         public override string ToString()
         {

--- a/src/NzbDrone.Core/Tv/Movie.cs
+++ b/src/NzbDrone.Core/Tv/Movie.cs
@@ -26,6 +26,7 @@ namespace NzbDrone.Core.Tv
         public MovieStatusType Status { get; set; }
         public string Overview { get; set; }
         public bool Monitored { get; set; }
+	public string Minimumavailability { get; set; }
         public int ProfileId { get; set; }
         public DateTime? LastInfoSync { get; set; }
         public int Runtime { get; set; }

--- a/src/NzbDrone.Core/Tv/Movie.cs
+++ b/src/NzbDrone.Core/Tv/Movie.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Tv
         public MovieStatusType Status { get; set; }
         public string Overview { get; set; }
         public bool Monitored { get; set; }
-	    public MovieStatusType Minimumavailability { get; set; }
+	public MovieStatusType MinimumAvailability { get; set; }
         public int ProfileId { get; set; }
         public DateTime? LastInfoSync { get; set; }
         public int Runtime { get; set; }

--- a/src/NzbDrone.Core/Tv/Movie.cs
+++ b/src/NzbDrone.Core/Tv/Movie.cs
@@ -56,6 +56,10 @@ namespace NzbDrone.Core.Tv
 
         public bool IsAvailable(int delay = 0)
         {
+            //the below line is what was used before delay was implemented, could still be used for cases when delay==0
+            //return (Status >= MinimumAvailability || (MinimumAvailability == MovieStatusType.PreDB && Status >= MovieStatusType.Released));
+
+            //This more complex sequence handles the delay 
             DateTime MinimumAvailabilityDate;
             switch (MinimumAvailability)
             {

--- a/src/NzbDrone.Core/Tv/Movie.cs
+++ b/src/NzbDrone.Core/Tv/Movie.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Tv
         public MovieStatusType Status { get; set; }
         public string Overview { get; set; }
         public bool Monitored { get; set; }
-	public string Minimumavailability { get; set; }
+	    public MovieStatusType Minimumavailability { get; set; }
         public int ProfileId { get; set; }
         public DateTime? LastInfoSync { get; set; }
         public int Runtime { get; set; }

--- a/src/NzbDrone.Core/Tv/MovieRepository.cs
+++ b/src/NzbDrone.Core/Tv/MovieRepository.cs
@@ -196,15 +196,6 @@ namespace NzbDrone.Core.Tv
         {
             return Query.Where(pagingSpec.FilterExpression)
                              .AndWhere(m => m.MovieFileId == 0)
-                             //note: this doesnt respect the availability delay that is used for RssSync
-                             //should be .AndWhere (m=> m.IsAvailable(delay)) where delay corresponds to AvailabilityDelay on Indexers Settings page
-                             //but that doesnt seem to work
-			                 //TODO: will need to update for preDB for now treat PreDB like Released
-                             .AndWhere(m=> 
-                             (m.MinimumAvailability==MovieStatusType.Released && m.Status >=MovieStatusType.Released) ||
-                             (m.MinimumAvailability==MovieStatusType.InCinemas && m.Status >= MovieStatusType.InCinemas) ||
-                             (m.MinimumAvailability==MovieStatusType.Announced && m.Status >=MovieStatusType.Announced) ||
-                             (m.MinimumAvailability==MovieStatusType.PreDB && m.Status >= MovieStatusType.Released))
                              .OrderBy(pagingSpec.OrderByClause(), pagingSpec.ToSortDirection())
                              .Skip(pagingSpec.PagingOffset())
                              .Take(pagingSpec.PageSize);

--- a/src/NzbDrone.Core/Tv/MovieRepository.cs
+++ b/src/NzbDrone.Core/Tv/MovieRepository.cs
@@ -194,10 +194,14 @@ namespace NzbDrone.Core.Tv
 
         public SortBuilder<Movie> GetMoviesWithoutFilesQuery(PagingSpec<Movie> pagingSpec)
         {
+            
             return Query.Where(pagingSpec.FilterExpression)
                              .AndWhere(m => m.MovieFileId == 0)
-			     //this next line shouldchange to something like >= m.minmumAvailability
-                             .AndWhere(m => m.Status == MovieStatusType.Released)
+                             //this needs to handle the cases from src\nzbdrone.core\tv\moviestatustype.cs
+                             .AndWhere(m => 
+                             (m.MinimumAvailability==MovieStatusType.Released && m.Status >=MovieStatusType.Released) ||
+                             (m.MinimumAvailability==MovieStatusType.InCinemas && m.Status >= MovieStatusType.InCinemas) ||
+                             (m.MinimumAvailability==MovieStatusType.Announced && m.Status >=MovieStatusType.Announced))
                              .OrderBy(pagingSpec.OrderByClause(), pagingSpec.ToSortDirection())
                              .Skip(pagingSpec.PagingOffset())
                              .Take(pagingSpec.PageSize);

--- a/src/NzbDrone.Core/Tv/MovieRepository.cs
+++ b/src/NzbDrone.Core/Tv/MovieRepository.cs
@@ -198,10 +198,12 @@ namespace NzbDrone.Core.Tv
             return Query.Where(pagingSpec.FilterExpression)
                              .AndWhere(m => m.MovieFileId == 0)
                              //this needs to handle the cases from src\nzbdrone.core\tv\moviestatustype.cs
+			                 //TODO: will need to update for preDB for now treat PreDB like Released
                              .AndWhere(m => 
                              (m.MinimumAvailability==MovieStatusType.Released && m.Status >=MovieStatusType.Released) ||
                              (m.MinimumAvailability==MovieStatusType.InCinemas && m.Status >= MovieStatusType.InCinemas) ||
-                             (m.MinimumAvailability==MovieStatusType.Announced && m.Status >=MovieStatusType.Announced))
+                             (m.MinimumAvailability==MovieStatusType.Announced && m.Status >=MovieStatusType.Announced) ||
+                             (m.MinimumAvailability==MovieStatusType.PreDB && m.Status >= MovieStatusType.Released))
                              .OrderBy(pagingSpec.OrderByClause(), pagingSpec.ToSortDirection())
                              .Skip(pagingSpec.PagingOffset())
                              .Take(pagingSpec.PageSize);

--- a/src/NzbDrone.Core/Tv/MovieRepository.cs
+++ b/src/NzbDrone.Core/Tv/MovieRepository.cs
@@ -194,12 +194,13 @@ namespace NzbDrone.Core.Tv
 
         public SortBuilder<Movie> GetMoviesWithoutFilesQuery(PagingSpec<Movie> pagingSpec)
         {
-            
             return Query.Where(pagingSpec.FilterExpression)
                              .AndWhere(m => m.MovieFileId == 0)
-                             //this needs to handle the cases from src\nzbdrone.core\tv\moviestatustype.cs
+                             //note: this doesnt respect the availability delay that is used for RssSync
+                             //should be .AndWhere (m=> m.IsAvailable(delay)) where delay corresponds to AvailabilityDelay on Indexers Settings page
+                             //but that doesnt seem to work
 			                 //TODO: will need to update for preDB for now treat PreDB like Released
-                             .AndWhere(m => 
+                             .AndWhere(m=> 
                              (m.MinimumAvailability==MovieStatusType.Released && m.Status >=MovieStatusType.Released) ||
                              (m.MinimumAvailability==MovieStatusType.InCinemas && m.Status >= MovieStatusType.InCinemas) ||
                              (m.MinimumAvailability==MovieStatusType.Announced && m.Status >=MovieStatusType.Announced) ||

--- a/src/NzbDrone.Core/Tv/MovieRepository.cs
+++ b/src/NzbDrone.Core/Tv/MovieRepository.cs
@@ -196,6 +196,7 @@ namespace NzbDrone.Core.Tv
         {
             return Query.Where(pagingSpec.FilterExpression)
                              .AndWhere(m => m.MovieFileId == 0)
+			     //this next line shouldchange to something like >= m.minmumAvailability
                              .AndWhere(m => m.Status == MovieStatusType.Released)
                              .OrderBy(pagingSpec.OrderByClause(), pagingSpec.ToSortDirection())
                              .Skip(pagingSpec.PagingOffset())

--- a/src/NzbDrone.Core/Tv/MovieStatusType.cs
+++ b/src/NzbDrone.Core/Tv/MovieStatusType.cs
@@ -2,9 +2,10 @@
 {
     public enum MovieStatusType
     {
-        TBA = 0, //Nothing yet announced, only rumors, but still IMDb page
-        Announced = 1, //AirDate is announced
-        InCinemas = 2,
-        Released = 3 //Has at least one PreDB release
+        TBA = 0,       //Nothing yet announced, only rumors, but still IMDb page (this might not be used)
+        Announced = 1, //Movie is announced but Cinema date is in the future or unknown
+        InCinemas = 2, //Been in Cinemas for less than 3 months (since TMDB lacks complete information)
+        Released = 3,  //Physical or Web Release or been in cinemas for > 3 months (since TMDB lacks complete information)
+        PreDB    = 4   //this is only used for MinimumAvailability. Movie items should never be in this state.
     }
 }

--- a/src/NzbDrone.Core/Tv/MovieStatusType.cs
+++ b/src/NzbDrone.Core/Tv/MovieStatusType.cs
@@ -4,6 +4,7 @@
     {
         TBA = 0, //Nothing yet announced, only rumors, but still IMDb page
         Announced = 1, //AirDate is announced
-        Released = 2 //Has at least one PreDB release
+        InCinemas = 2,
+        Released = 3 //Has at least one PreDB release
     }
 }

--- a/src/UI/AddMovies/MinimumavailabilityTooltipTemplate.hbs
+++ b/src/UI/AddMovies/MinimumavailabilityTooltipTemplate.hbs
@@ -1,0 +1,8 @@
+<dl class="minimumavailability-tooltip-contents">
+    <dt>Announced</dt>
+    <dd>Consider the movie available after it has been announced</dd>
+    <dt>In Cinemas</dt>
+    <dd>Consider the movie available once it is In Cinemas</dd>
+    <dt>Physical/Web</dt>
+    <dd>Consider the movie available after Physical/Web release</dd>
+</dl>

--- a/src/UI/AddMovies/MinimumavailabilityTooltipTemplate.hbs
+++ b/src/UI/AddMovies/MinimumavailabilityTooltipTemplate.hbs
@@ -5,4 +5,6 @@
     <dd>Consider the movie available once it is In Cinemas</dd>
     <dt>Physical/Web</dt>
     <dd>Consider the movie available after Physical/Web release</dd>
+    <dt>PreDB</dt>
+    <dd>Consider the movie available if preDB contains at least one entry</dd>
 </dl>

--- a/src/UI/AddMovies/SearchResultView.js
+++ b/src/UI/AddMovies/SearchResultView.js
@@ -73,7 +73,7 @@ var view = Marionette.ItemView.extend({
 
         this.ui.seasonFolder.prop('checked', useSeasonFolder);
         this.ui.monitor.val(defaultMonitorEpisodes);
-	this.ui.minimumavailability.val("3");
+	this.ui.minimumavailability.val("released");
 
         //TODO: make this work via onRender, FM?
         //works with onShow, but stops working after the first render

--- a/src/UI/AddMovies/SearchResultView.js
+++ b/src/UI/AddMovies/SearchResultView.js
@@ -72,7 +72,7 @@ var view = Marionette.ItemView.extend({
 
         this.ui.seasonFolder.prop('checked', useSeasonFolder);
         this.ui.monitor.val(defaultMonitorEpisodes);
-	this.ui.minimumAvailability.val("released");
+	this.ui.minimumAvailability.val("preDB");
 
         //TODO: make this work via onRender, FM?
         //works with onShow, but stops working after the first render

--- a/src/UI/AddMovies/SearchResultView.js
+++ b/src/UI/AddMovies/SearchResultView.js
@@ -22,6 +22,8 @@ var view = Marionette.ItemView.extend({
         rootFolder      : '.x-root-folder',
         seasonFolder    : '.x-season-folder',
         monitor         : '.x-monitor',
+	minimumavailability : '.x-minimumavailability',
+	minimumavailabilityTooltip : '.x-minimumavailability-tooltip',
         monitorTooltip  : '.x-monitor-tooltip',
         addButton       : '.x-add',
         addSearchButton : '.x-add-search',
@@ -34,6 +36,7 @@ var view = Marionette.ItemView.extend({
         'change .x-profile'       : '_profileChanged',
         'change .x-root-folder'   : '_rootFolderChanged',
         'change .x-season-folder' : '_seasonFolderChanged',
+	'change .x-minimumavailability' : '_minimumavailabilityChanged',
         'change .x-monitor'       : '_monitorChanged'
     },
 
@@ -70,6 +73,7 @@ var view = Marionette.ItemView.extend({
 
         this.ui.seasonFolder.prop('checked', useSeasonFolder);
         this.ui.monitor.val(defaultMonitorEpisodes);
+	this.ui.minimumavailability.val("3");
 
         //TODO: make this work via onRender, FM?
         //works with onShow, but stops working after the first render
@@ -88,6 +92,18 @@ var view = Marionette.ItemView.extend({
             placement : 'right',
             container : this.$el
         });
+
+	this.templateFunction = Marionette.TemplateCache.get('AddMovies/MinimumavailabilityTooltipTemplate');
+	var content1 = this.templateFunction();
+	
+	this.ui.minimumavailabilityTooltip.popover({
+		content : content1,
+		html :true,
+		trigger : 'hover',
+		title : 'When to Consider a Movie Available',
+		placement : 'right',
+		container : this.$el
+	});
     },
 
     _configureTemplateHelpers : function() {
@@ -168,6 +184,7 @@ var view = Marionette.ItemView.extend({
         var profile = this.ui.profile.val();
         var rootFolderPath = this.ui.rootFolder.children(':selected').text();
         var monitor = this.ui.monitor.val();
+        var minAvail = this.ui.minimumavailability.val();
 
         var options = this._getAddMoviesOptions();
         options.searchForMovie = searchForMovie;
@@ -177,6 +194,7 @@ var view = Marionette.ItemView.extend({
             profileId      : profile,
             rootFolderPath : rootFolderPath,
             addOptions     : options,
+	    minimumavailability : minAvail,
             monitored      : (monitor === 'all' ? true : false)
         }, { silent : true });
 

--- a/src/UI/AddMovies/SearchResultView.js
+++ b/src/UI/AddMovies/SearchResultView.js
@@ -22,8 +22,8 @@ var view = Marionette.ItemView.extend({
         rootFolder      : '.x-root-folder',
         seasonFolder    : '.x-season-folder',
         monitor         : '.x-monitor',
-	minimumavailability : '.x-minimumavailability',
-	minimumavailabilityTooltip : '.x-minimumavailability-tooltip',
+	minimumAvailability : '.x-minimumavailability',
+	minimumAvailabilityTooltip : '.x-minimumavailability-tooltip',
         monitorTooltip  : '.x-monitor-tooltip',
         addButton       : '.x-add',
         addSearchButton : '.x-add-search',
@@ -36,7 +36,6 @@ var view = Marionette.ItemView.extend({
         'change .x-profile'       : '_profileChanged',
         'change .x-root-folder'   : '_rootFolderChanged',
         'change .x-season-folder' : '_seasonFolderChanged',
-	'change .x-minimumavailability' : '_minimumavailabilityChanged',
         'change .x-monitor'       : '_monitorChanged'
     },
 
@@ -73,7 +72,7 @@ var view = Marionette.ItemView.extend({
 
         this.ui.seasonFolder.prop('checked', useSeasonFolder);
         this.ui.monitor.val(defaultMonitorEpisodes);
-	this.ui.minimumavailability.val("released");
+	this.ui.minimumAvailability.val("released");
 
         //TODO: make this work via onRender, FM?
         //works with onShow, but stops working after the first render
@@ -93,10 +92,10 @@ var view = Marionette.ItemView.extend({
             container : this.$el
         });
 
-	this.templateFunction = Marionette.TemplateCache.get('AddMovies/MinimumavailabilityTooltipTemplate');
+	this.templateFunction = Marionette.TemplateCache.get('AddMovies/MinimumAvailabilityTooltipTemplate');
 	var content1 = this.templateFunction();
 	
-	this.ui.minimumavailabilityTooltip.popover({
+	this.ui.minimumAvailabilityTooltip.popover({
 		content : content1,
 		html :true,
 		trigger : 'hover',
@@ -184,7 +183,7 @@ var view = Marionette.ItemView.extend({
         var profile = this.ui.profile.val();
         var rootFolderPath = this.ui.rootFolder.children(':selected').text();
         var monitor = this.ui.monitor.val();
-        var minAvail = this.ui.minimumavailability.val();
+        var minAvail = this.ui.minimumAvailability.val();
 
         var options = this._getAddMoviesOptions();
         options.searchForMovie = searchForMovie;
@@ -194,7 +193,7 @@ var view = Marionette.ItemView.extend({
             profileId      : profile,
             rootFolderPath : rootFolderPath,
             addOptions     : options,
-	    minimumavailability : minAvail,
+	    minimumAvailability : minAvail,
             monitored      : (monitor === 'all' ? true : false)
         }, { silent : true });
 

--- a/src/UI/AddMovies/SearchResultViewTemplate.hbs
+++ b/src/UI/AddMovies/SearchResultViewTemplate.hbs
@@ -47,7 +47,7 @@
                         </select>
                     </div>
 
-		    <div class="form-group col-md-3">
+		    <div class="form-group col-md-2">
 		        <label>Min Availability <i class="icon-sonarr-form-info minimumavailability-tooltop x-minimumavailability-tooltip"></i></label>
 			<select class="form-control col-md-2 x-minimumavailability">
 			    <option value="1">Announced</option>

--- a/src/UI/AddMovies/SearchResultViewTemplate.hbs
+++ b/src/UI/AddMovies/SearchResultViewTemplate.hbs
@@ -53,6 +53,7 @@
 			    <option value="announced">Announced</option>
 			    <option value="inCinemas">In Cinemas</option>
 			    <option value="released">Physical/Web</option>
+			    <option value="preDB">PreDB</option>
 			</select>
 	            </div>
 

--- a/src/UI/AddMovies/SearchResultViewTemplate.hbs
+++ b/src/UI/AddMovies/SearchResultViewTemplate.hbs
@@ -47,6 +47,15 @@
                         </select>
                     </div>
 
+		    <div class="form-group col-md-3">
+		        <label>Min Availability <i class="icon-sonarr-form-info minimumavailability-tooltop x-minimumavailability-tooltip"></i></label>
+			<select class="form-control col-md-2 x-minimumavailability">
+			    <option value="1">Announced</option>
+			    <option value="2">In Cinemas</option>
+			    <option value="3">Physical/Web</option>
+			</select>
+	            </div>
+
                     <div class="form-group col-md-2">
                         <label>Profile</label>
                         {{> ProfileSelectionPartial profiles}}

--- a/src/UI/AddMovies/SearchResultViewTemplate.hbs
+++ b/src/UI/AddMovies/SearchResultViewTemplate.hbs
@@ -50,9 +50,9 @@
 		    <div class="form-group col-md-2">
 		        <label>Min Availability <i class="icon-sonarr-form-info minimumavailability-tooltop x-minimumavailability-tooltip"></i></label>
 			<select class="form-control col-md-2 x-minimumavailability">
-			    <option value="1">Announced</option>
-			    <option value="2">In Cinemas</option>
-			    <option value="3">Physical/Web</option>
+			    <option value="announced">Announced</option>
+			    <option value="inCinemas">In Cinemas</option>
+			    <option value="released">Physical/Web</option>
 			</select>
 	            </div>
 

--- a/src/UI/AddMovies/SearchResultViewTemplate.hbs
+++ b/src/UI/AddMovies/SearchResultViewTemplate.hbs
@@ -48,7 +48,7 @@
                     </div>
 
 		    <div class="form-group col-md-2">
-		        <label>Min Availability <i class="icon-sonarr-form-info minimumavailability-tooltop x-minimumavailability-tooltip"></i></label>
+		        <label>Min Availability <i class="icon-sonarr-form-info minimumavailability-tooltip x-minimumavailability-tooltip"></i></label>
 			<select class="form-control col-md-2 x-minimumavailability">
 			    <option value="announced">Announced</option>
 			    <option value="inCinemas">In Cinemas</option>

--- a/src/UI/AddMovies/addMovies.less
+++ b/src/UI/AddMovies/addMovies.less
@@ -117,6 +117,9 @@
     .monitor-tooltip {
       margin-left : 5px;
     }
+    .minimumavailability-tooltip {
+      margin-left : 5px;
+    }
   }
 
   .loading-folders {
@@ -134,6 +137,13 @@
 
     dd {
       padding-bottom : 8px;
+    }
+  }
+  .minimumavailability-tooltip-contents {
+    padding-bottom : 0px;
+
+    dd {
+      padding-bottom :8px;
     }
   }
 }

--- a/src/UI/Cells/MovieStatusCell.js
+++ b/src/UI/Cells/MovieStatusCell.js
@@ -17,11 +17,6 @@ module.exports = NzbDroneCell.extend({
             this._setStatusWeight(3);
         }
 
-        //if (numOfMonths > 3) {
-        //  this.$el.html('<i class="icon-sonarr-movie-released grid-icon" title="Released"></i>');//TODO: Update for PreDB.me
-        //  this._setStatusWeight(2);
-        //}
-
         if (status === 'inCinemas') {
           this.$el.html('<i class="icon-sonarr-movie-cinemas grid-icon" title="In Cinemas"></i>');
           this._setStatusWeight(2);
@@ -32,11 +27,6 @@ module.exports = NzbDroneCell.extend({
           this._setStatusWeight(1);
         }
 
-        // else if (!monitored) {
-        //     this.$el.html('<i class="icon-sonarr-series-unmonitored grid-icon" title="Not Monitored"></i>');
-        //     this._setStatusWeight(0);
-        // }
-        
         return this;
     },
 

--- a/src/UI/Cells/MovieStatusCell.js
+++ b/src/UI/Cells/MovieStatusCell.js
@@ -17,12 +17,12 @@ module.exports = NzbDroneCell.extend({
             this._setStatusWeight(3);
         }
 
-        if (numOfMonths > 3) {
-          this.$el.html('<i class="icon-sonarr-movie-released grid-icon" title="Released"></i>');//TODO: Update for PreDB.me
-          this._setStatusWeight(2);
-        }
+        //if (numOfMonths > 3) {
+        //  this.$el.html('<i class="icon-sonarr-movie-released grid-icon" title="Released"></i>');//TODO: Update for PreDB.me
+        //  this._setStatusWeight(2);
+        //}
 
-        if (numOfMonths < 3) {
+        if (status === 'inCinemas') {
           this.$el.html('<i class="icon-sonarr-movie-cinemas grid-icon" title="In Cinemas"></i>');
           this._setStatusWeight(2);
         }

--- a/src/UI/Cells/MovieStatusWithTextCell.js
+++ b/src/UI/Cells/MovieStatusWithTextCell.js
@@ -18,12 +18,12 @@ module.exports = NzbDroneCell.extend({
             this._setStatusWeight(3);
         }
 
-        if (numOfMonths > 3) {
-            this.$el.html('<div class="released-banner"><i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released</div>');//TODO: Update for PreDB.me
-            this._setStatusWeight(2);
-        }
+        //if (numOfMonths > 3) {
+        //    this.$el.html('<div class="released-banner"><i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released</div>');//TODO: Update for PreDB.me
+        //    this._setStatusWeight(2);
+        //}
 
-        if (numOfMonths < 3) {
+        if (status ==='inCinemas') {
             this.$el.html('<div class="cinemas-banner"><i class="icon-sonarr-movie-cinemas grid-icon" title=""></i>&nbsp;In Cinemas</div>');
             this._setStatusWeight(2);
         }

--- a/src/UI/Cells/MovieStatusWithTextCell.js
+++ b/src/UI/Cells/MovieStatusWithTextCell.js
@@ -18,11 +18,6 @@ module.exports = NzbDroneCell.extend({
             this._setStatusWeight(3);
         }
 
-        //if (numOfMonths > 3) {
-        //    this.$el.html('<div class="released-banner"><i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released</div>');//TODO: Update for PreDB.me
-        //    this._setStatusWeight(2);
-        //}
-
         if (status ==='inCinemas') {
             this.$el.html('<div class="cinemas-banner"><i class="icon-sonarr-movie-cinemas grid-icon" title=""></i>&nbsp;In Cinemas</div>');
             this._setStatusWeight(2);

--- a/src/UI/Content/icons.less
+++ b/src/UI/Content/icons.less
@@ -60,6 +60,10 @@
   .fa-icon-color(@brand-warning);
 }
 
+.icon-sonarr-available {
+  .fa-icon-content(@fa-var-clock-o);
+}
+
 .icon-sonarr-edit {
   .fa-icon-content(@fa-var-wrench);
 }

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -164,7 +164,7 @@ Handlebars.registerHelper('DownloadedStatusColor', function() {
     }
 
   //if (this.status != "released") {
-  var minAvail = parseInt(this.minimumavailability);
+  var minAvail = parseInt(this.minimumavailability,10);
   if (x < (isNaN(minAvail) ? 3 : minAvail)) {
     return "primary";
   }

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -164,7 +164,8 @@ Handlebars.registerHelper('DownloadedStatusColor', function() {
     }
 
   //if (this.status != "released") {
-  if (x < parseInt(this.minimumavailability)) {
+  var minAvail = parseInt(this.minimumavailability);
+  if (x < (isNaN(minAvail) ? 3 : minAvail)) {
     return "primary";
   }
 

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -82,16 +82,17 @@ Handlebars.registerHelper('GetStatus', function() {
   if (status === "announced") {
     return new Handlebars.SafeString('<i class="icon-sonarr-movie-announced grid-icon" title=""></i>&nbsp;Announced');
   }
+  
 
-  if (numOfMonths < 3) {
-
+  if (status ==="inCinemas") {
     return new Handlebars.SafeString('<i class="icon-sonarr-movie-cinemas grid-icon" title=""></i>&nbsp;In Cinemas');
   }
-
-  if (numOfMonths > 3) {
-    return new Handlebars.SafeString('<i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released');//TODO: Update for PreDB.me
-  }
-
+  //if (numOfMonths < 3) {
+  //  return new Handlebars.SafeString('<i class="icon-sonarr-movie-cinemas grid-icon" title=""></i>&nbsp;In Cinemas');
+  //}
+  //if (numOfMonths > 3) {
+  //  return new Handlebars.SafeString('<i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released');//TODO: Update for PreDB.me
+  //}
   if (status === 'released') {
       return new Handlebars.SafeString('<i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released');
   }
@@ -113,7 +114,7 @@ Handlebars.registerHelper('GetBannerStatus', function() {
     return new Handlebars.SafeString('<div class="announced-banner"><i class="icon-sonarr-movie-announced grid-icon" title=""></i>&nbsp;Announced</div>');
   }
 
-  if (numOfMonths < 3) {
+  if (status === "inCinemas") {
     return new Handlebars.SafeString('<div class="cinemas-banner"><i class="icon-sonarr-movie-cinemas grid-icon" title=""></i>&nbsp;In Cinemas</div>');
   }
 
@@ -121,9 +122,9 @@ Handlebars.registerHelper('GetBannerStatus', function() {
       return new Handlebars.SafeString('<div class="released-banner"><i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released</div>');
   }
 
-  if (numOfMonths > 3) {
-    return new Handlebars.SafeString('<div class="released-banner"><i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released</div>');//TODO: Update for PreDB.me
-  }
+  //if (numOfMonths > 3) {
+  //  return new Handlebars.SafeString('<div class="released-banner"><i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released</div>');//TODO: Update for PreDB.me
+  //}
 
 
 

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -197,12 +197,7 @@ Handlebars.registerHelper('inCinemas', function() {
     var cinemasDate = new Date(this.inCinemas);
     var year = cinemasDate.getFullYear();
     var month = monthNames[cinemasDate.getMonth()];
-    if (this.status === 'announced') {
-	    return "Announced(In Cinemas: " + month + " " + year+")";
-    }
-    else {
     return "In Cinemas: " + month + " " + year;
-    }
   }
   return "To be announced";
 });

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -90,12 +90,7 @@ Handlebars.registerHelper('GetStatus', function() {
   if (status ==="inCinemas") {
     return new Handlebars.SafeString('<i class="icon-sonarr-movie-cinemas grid-icon" title=""></i>&nbsp;In Cinemas');
   }
-  //if (numOfMonths < 3) {
-  //  return new Handlebars.SafeString('<i class="icon-sonarr-movie-cinemas grid-icon" title=""></i>&nbsp;In Cinemas');
-  //}
-  //if (numOfMonths > 3) {
-  //  return new Handlebars.SafeString('<i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released');//TODO: Update for PreDB.me
-  //}
+  
   if (status === 'released') {
       return new Handlebars.SafeString('<i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released');
   }
@@ -124,14 +119,6 @@ Handlebars.registerHelper('GetBannerStatus', function() {
   if (status === 'released') {
       return new Handlebars.SafeString('<div class="released-banner"><i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released</div>');
   }
-
-  //if (numOfMonths > 3) {
-  //  return new Handlebars.SafeString('<div class="released-banner"><i class="icon-sonarr-movie-released grid-icon" title=""></i>&nbsp;Released</div>');//TODO: Update for PreDB.me
-  //}
-
-
-
-
   else if (!monitored) {
       return new Handlebars.SafeString('<div class="announced-banner"><i class="icon-sonarr-series-unmonitored grid-icon" title=""></i>&nbsp;Not Monitored</div>');
   }
@@ -153,7 +140,9 @@ Handlebars.registerHelper('DownloadedStatusColor', function() {
       tBA : 0, 
       announced : 1,
       inCinemas : 2,
-      released : 3
+      released : 3,
+      //TODO: preDB needs to be implemented but until then, treat preDB like released
+      preDB    : 3 //4
     };
   if (MovieStatusType[this.status] < MovieStatusType[this.minimumAvailability]) {
     return "primary";
@@ -164,18 +153,12 @@ Handlebars.registerHelper('DownloadedStatusColor', function() {
 
 Handlebars.registerHelper('DownloadedStatus', function() {
 
-  //if (this.allFlicksUrl) {
-  //  return "On Netflix";
-  //}
   if (this.downloaded) {
     return "Downloaded";
   }
   if (!this.monitored) {
     return "Not Monitored";
   }
-  //if (this.allFlicksUrl) {
-  //  return "On Netflix";
-  //}
   return "Missing";
 });
 

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -155,7 +155,7 @@ Handlebars.registerHelper('DownloadedStatusColor', function() {
       inCinemas : 2,
       released : 3
     };
-  if (MovieStatusType[this.status] < MovieStatusType[this.minimumavailability]) {
+  if (MovieStatusType[this.status] < MovieStatusType[this.minimumAvailability]) {
     return "primary";
   }
 

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -76,10 +76,10 @@ Handlebars.registerHelper('alternativeTitlesString', function() {
 Handlebars.registerHelper('GetStatus', function() {
   var monitored = this.monitored;
   var status = this.status;
-  var inCinemas = this.inCinemas;
-  var date = new Date(inCinemas);
-  var timeSince = new Date().getTime() - date.getTime();
-  var numOfMonths = timeSince / 1000 / 60 / 60 / 24 / 30;
+  //var inCinemas = this.inCinemas;
+  //var date = new Date(inCinemas);
+  //var timeSince = new Date().getTime() - date.getTime();
+  //var numOfMonths = timeSince / 1000 / 60 / 60 / 24 / 30;
 
 
   if (status === "announced") {
@@ -103,10 +103,10 @@ Handlebars.registerHelper('GetStatus', function() {
 Handlebars.registerHelper('GetBannerStatus', function() {
   var monitored = this.monitored;
   var status = this.status;
-  var inCinemas = this.inCinemas;
-  var date = new Date(inCinemas);
-  var timeSince = new Date().getTime() - date.getTime();
-  var numOfMonths = timeSince / 1000 / 60 / 60 / 24 / 30;
+  //var inCinemas = this.inCinemas;
+  //var date = new Date(inCinemas);
+  //var timeSince = new Date().getTime() - date.getTime();
+  //var numOfMonths = timeSince / 1000 / 60 / 60 / 24 / 30;
 
   if (status === "announced") {
     return new Handlebars.SafeString('<div class="announced-banner"><i class="icon-sonarr-movie-announced grid-icon" title=""></i>&nbsp;Announced</div>');

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -148,24 +148,14 @@ Handlebars.registerHelper('DownloadedStatusColor', function() {
     if (this.downloaded) {
       return "success";
     }
-  //need a check in here to determine if the status exceeds the minavailability specification for the movie
   //should match cases from: src\NzbDrone.Core\Tv\MovieStatusType.cs
-  var x;
-    switch(this.status) {
-	case "announced":
-		    x= 1;
-		    break;
-	case "inCinemas":
-		    x=2;
-		    break;
-	case "released":
-		    x=3;
-		    break;
-    }
-
-  //if (this.status != "released") {
-  var minAvail = parseInt(this.minimumavailability,10);
-  if (x < (isNaN(minAvail) ? 3 : minAvail)) {
+  var MovieStatusType = {
+      tBA : 0, 
+      announced : 1,
+      inCinemas : 2,
+      released : 3
+    };
+  if (MovieStatusType[this.status] < MovieStatusType[this.minimumavailability]) {
     return "primary";
   }
 

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -148,7 +148,7 @@ Handlebars.registerHelper('DownloadedStatusColor', function() {
     if (this.downloaded) {
       return "success";
     }
-
+  //need a check in here to determine if the status exceeds the minavailability specification for the movie
   if (this.status != "released") {
     return "primary";
   }

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -135,16 +135,8 @@ Handlebars.registerHelper('DownloadedStatusColor', function() {
     if (this.downloaded) {
       return "success";
     }
-  //should match cases from: src\NzbDrone.Core\Tv\MovieStatusType.cs
-  var MovieStatusType = {
-      tBA : 0, 
-      announced : 1,
-      inCinemas : 2,
-      released : 3,
-      //TODO: preDB needs to be implemented but until then, treat preDB like released
-      preDB    : 3 //4
-    };
-  if (MovieStatusType[this.status] < MovieStatusType[this.minimumAvailability]) {
+
+  if (!this.isAvailable){
     return "primary";
   }
 

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -149,7 +149,22 @@ Handlebars.registerHelper('DownloadedStatusColor', function() {
       return "success";
     }
   //need a check in here to determine if the status exceeds the minavailability specification for the movie
-  if (this.status != "released") {
+  //should match cases from: src\NzbDrone.Core\Tv\MovieStatusType.cs
+  var x;
+    switch(this.status) {
+	case "announced":
+		    x= 1;
+		    break;
+	case "inCinemas":
+		    x=2;
+		    break;
+	case "released":
+		    x=3;
+		    break;
+    }
+
+  //if (this.status != "released") {
+  if (x < parseInt(this.minimumavailability)) {
     return "primary";
   }
 

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -54,6 +54,9 @@ Handlebars.registerHelper('tmdbUrl', function() {
 Handlebars.registerHelper('youTubeTrailerUrl', function() {
     return 'https://www.youtube.com/watch?v=' + this.youTubeTrailerId;
 });
+Handlebars.registerHelper('allFlicksUrl', function() {
+    return this.allFlicksUrl;
+});
 
 Handlebars.registerHelper('homepage', function() {
     return this.website;
@@ -155,14 +158,18 @@ Handlebars.registerHelper('DownloadedStatusColor', function() {
 
 Handlebars.registerHelper('DownloadedStatus', function() {
 
+  //if (this.allFlicksUrl) {
+  //  return "On Netflix";
+  //}
   if (this.downloaded) {
     return "Downloaded";
   }
   if (!this.monitored) {
     return "Not Monitored";
   }
-
-
+  //if (this.allFlicksUrl) {
+  //  return "On Netflix";
+  //}
   return "Missing";
 });
 
@@ -190,7 +197,12 @@ Handlebars.registerHelper('inCinemas', function() {
     var cinemasDate = new Date(this.inCinemas);
     var year = cinemasDate.getFullYear();
     var month = monthNames[cinemasDate.getMonth()];
+    if (this.status === 'announced') {
+	    return "Announced(In Cinemas: " + month + " " + year+")";
+    }
+    else {
     return "In Cinemas: " + month + " " + year;
+    }
   }
   return "To be announced";
 });

--- a/src/UI/Movies/Details/InfoViewTemplate.hbs
+++ b/src/UI/Movies/Details/InfoViewTemplate.hbs
@@ -17,11 +17,11 @@
         {{/if}}
 
         <span class="label label-info">{{Bytes sizeOnDisk}}</span>
-        {{#if_eq status compare="announced"}}
-            <span class="label label-default">Announced</span>
+	{{#if_eq status  compare="announced"}}
+	    <span class="label label-default">{{inCinemas}}</span>
 	{{else}}
             <span class="label label-info">{{inCinemas}}</span>
-        {{/if_eq}}
+	{{/if_eq}}
         <span class="label label-{{DownloadedStatusColor}}" title="{{DownloadedQuality}}">{{DownloadedStatus}}</span>
     </div>
     <div class="col-md-4">
@@ -39,6 +39,10 @@
             {{#if youTubeTrailerId}}
                 <a href="{{youTubeTrailerUrl}}" class="label label-info">Trailer</a>
             {{/if}}
+	    
+	    {{#if allFlicksUrl}}
+	        <a href="{{allFlicksUrl}}" class="label label-info">AllFlicks</a>
+	    {{/if}}
         </span>
     </div>
 </div>

--- a/src/UI/Movies/Details/InfoViewTemplate.hbs
+++ b/src/UI/Movies/Details/InfoViewTemplate.hbs
@@ -21,7 +21,11 @@
         {{#if_eq status compare="released"}}
             <span class="label label-info">{{inCinemas}}</span>
         {{else}}
-            <span class="label label-default">Announced</span>
+	    {{#if_eq status compare="inCinemas"}}
+	        <span class="label label-info">{{inCinemas}}</span>
+	    {{else}}
+                <span class="label label-default">Announced</span>
+	    {{/if_eq}}
         {{/if_eq}}
         <span class="label label-{{DownloadedStatusColor}}" title="{{DownloadedQuality}}">{{DownloadedStatus}}</span>
     </div>

--- a/src/UI/Movies/Details/InfoViewTemplate.hbs
+++ b/src/UI/Movies/Details/InfoViewTemplate.hbs
@@ -17,15 +17,10 @@
         {{/if}}
 
         <span class="label label-info">{{Bytes sizeOnDisk}}</span>
-
-        {{#if_eq status compare="released"}}
+        {{#if_eq status compare="announced"}}
+            <span class="label label-default">Announced</span>
+	{{else}}
             <span class="label label-info">{{inCinemas}}</span>
-        {{else}}
-	    {{#if_eq status compare="inCinemas"}}
-	        <span class="label label-info">{{inCinemas}}</span>
-	    {{else}}
-                <span class="label label-default">Announced</span>
-	    {{/if_eq}}
         {{/if_eq}}
         <span class="label label-{{DownloadedStatusColor}}" title="{{DownloadedQuality}}">{{DownloadedStatus}}</span>
     </div>

--- a/src/UI/Movies/Edit/EditMovieTemplate.hbs
+++ b/src/UI/Movies/Edit/EditMovieTemplate.hbs
@@ -42,6 +42,7 @@
 				    <option value="announced">Announced</option>
 				    <option value="inCinemas">In Cinemas</option>
 				    <option value="released">Physical/Web</option>
+				    <option value="preDB">PreDB</option>
 				</select>
 			</div>
 		    </div>

--- a/src/UI/Movies/Edit/EditMovieTemplate.hbs
+++ b/src/UI/Movies/Edit/EditMovieTemplate.hbs
@@ -32,6 +32,21 @@
                             </div>
                         </div>
                     </div>
+		    <div class="form-group">
+		        <label class="col-sm-4 control-label"> Minimum Availability</label>
+			<div class="col-sm-1 col-sm-push-4 help-inline">
+			    <i class="icon-sonarr-form-info" title="When the movie is considered Available"/>
+			</div>
+			<div class="col-sm-4 col-sm-pull-1">
+			    <div class="input-group">
+			        <select name="minimumavailability" class="form-control">
+				    <option value="announced">Announced</option>
+				    <option value="inCinemas">In Cinemas</option>
+				    <option value="Released">Physical/Web</option>
+				</select>
+			    </div>
+			</div>
+		    </div>
 
                     <!--<div class="form-group">
                         <label class="col-sm-4 control-label">Use Season Folder</label>

--- a/src/UI/Movies/Edit/EditMovieTemplate.hbs
+++ b/src/UI/Movies/Edit/EditMovieTemplate.hbs
@@ -33,18 +33,16 @@
                         </div>
                     </div>
 		    <div class="form-group">
-		        <label class="col-sm-4 control-label"> Minimum Availability</label>
+		        <label class="col-sm-4 control-label">Minimum Availability</label>
 			<div class="col-sm-1 col-sm-push-4 help-inline">
 			    <i class="icon-sonarr-form-info" title="When the movie is considered Available"/>
 			</div>
 			<div class="col-sm-4 col-sm-pull-1">
-			    <div class="input-group">
-			        <select name="minimumavailability" class="form-control">
+			        <select class="form-control" name="minimumavailability">
 				    <option value="1">Announced</option>
 				    <option value="2">In Cinemas</option>
 				    <option value="3">Physical/Web</option>
 				</select>
-			    </div>
 			</div>
 		    </div>
 

--- a/src/UI/Movies/Edit/EditMovieTemplate.hbs
+++ b/src/UI/Movies/Edit/EditMovieTemplate.hbs
@@ -38,10 +38,10 @@
 			    <i class="icon-sonarr-form-info" title="When the movie is considered Available"/>
 			</div>
 			<div class="col-sm-4 col-sm-pull-1">
-			        <select class="form-control" name="minimumavailability">
-				    <option value="1">Announced</option>
-				    <option value="2">In Cinemas</option>
-				    <option value="3">Physical/Web</option>
+			        <select class="form-control x-minimumavailability" name="minimumavailability">
+				    <option value="announced">Announced</option>
+				    <option value="inCinemas">In Cinemas</option>
+				    <option value="released">Physical/Web</option>
 				</select>
 			</div>
 		    </div>

--- a/src/UI/Movies/Edit/EditMovieTemplate.hbs
+++ b/src/UI/Movies/Edit/EditMovieTemplate.hbs
@@ -40,9 +40,9 @@
 			<div class="col-sm-4 col-sm-pull-1">
 			    <div class="input-group">
 			        <select name="minimumavailability" class="form-control">
-				    <option value="announced">Announced</option>
-				    <option value="inCinemas">In Cinemas</option>
-				    <option value="Released">Physical/Web</option>
+				    <option value="1">Announced</option>
+				    <option value="2">In Cinemas</option>
+				    <option value="3">Physical/Web</option>
 				</select>
 			    </div>
 			</div>

--- a/src/UI/Movies/Edit/EditMovieTemplate.hbs
+++ b/src/UI/Movies/Edit/EditMovieTemplate.hbs
@@ -38,7 +38,7 @@
 			    <i class="icon-sonarr-form-info" title="When the movie is considered Available"/>
 			</div>
 			<div class="col-sm-4 col-sm-pull-1">
-			        <select class="form-control x-minimumavailability" name="minimumavailability">
+			        <select class="form-control x-minimumavailability" name="minimumAvailability">
 				    <option value="announced">Announced</option>
 				    <option value="inCinemas">In Cinemas</option>
 				    <option value="released">Physical/Web</option>

--- a/src/UI/Movies/Editor/MovieEditorFooterView.js
+++ b/src/UI/Movies/Editor/MovieEditorFooterView.js
@@ -13,7 +13,7 @@ module.exports = Marionette.ItemView.extend({
     ui : {
         monitored           : '.x-monitored',
         profile             : '.x-profiles',
-	minimumavailability : '.x-minimumavailability',
+	minimumAvailability : '.x-minimumavailability',
         seasonFolder        : '.x-season-folder',
         rootFolder          : '.x-root-folder',
         selectedCount       : '.x-selected-count',
@@ -54,7 +54,7 @@ module.exports = Marionette.ItemView.extend({
         var selected = this.editorGrid.getSelectedModels();
 
         var monitored = this.ui.monitored.val();
-	var minAvail = this.ui.minimumavailability.val();
+	var minAvail = this.ui.minimumAvailability.val();
         var profile = this.ui.profile.val();
         var seasonFolder = this.ui.seasonFolder.val();
         var rootFolder = this.ui.rootFolder.val();
@@ -67,7 +67,7 @@ module.exports = Marionette.ItemView.extend({
             }
 
             if (minAvail !=='noChange') {
-		model.set('Minimumavailability', parseInt(minAvail,10));
+		model.set('minimumAvailability', minAvail);
 	    }
 
             if (profile !== 'noChange') {

--- a/src/UI/Movies/Editor/MovieEditorFooterView.js
+++ b/src/UI/Movies/Editor/MovieEditorFooterView.js
@@ -13,6 +13,7 @@ module.exports = Marionette.ItemView.extend({
     ui : {
         monitored           : '.x-monitored',
         profile             : '.x-profiles',
+	minimumavailability : '.x-minimumavailability',
         seasonFolder        : '.x-season-folder',
         rootFolder          : '.x-root-folder',
         selectedCount       : '.x-selected-count',
@@ -53,6 +54,7 @@ module.exports = Marionette.ItemView.extend({
         var selected = this.editorGrid.getSelectedModels();
 
         var monitored = this.ui.monitored.val();
+	var minAvail = this.ui.minimumavailability.val();
         var profile = this.ui.profile.val();
         var seasonFolder = this.ui.seasonFolder.val();
         var rootFolder = this.ui.rootFolder.val();
@@ -63,6 +65,10 @@ module.exports = Marionette.ItemView.extend({
             } else if (monitored === 'false') {
                 model.set('monitored', false);
             }
+
+            if (minAvail !=='noChange') {
+		model.set('Minimumavailability', parseInt(minAvail,10));
+	    }
 
             if (profile !== 'noChange') {
                 model.set('profileId', parseInt(profile, 10));

--- a/src/UI/Movies/Editor/MovieEditorFooterViewTemplate.hbs
+++ b/src/UI/Movies/Editor/MovieEditorFooterViewTemplate.hbs
@@ -10,6 +10,17 @@
             </select>
         </div>
 
+	<div class="form-group col-md-2">
+	    <label>Min Availability</label>
+
+	    <select class="form-control x-action x-minimumavailability">
+	        <option value="noChange">No change</option>
+		<option value="1">Announced</option>
+		<option value="2">In Cinemas</option>
+		<option value="3">Physical/Web</option>
+	    </select>
+	</div>
+
         <div class="form-group col-md-2">
             <label>Profile</label>
 

--- a/src/UI/Movies/Editor/MovieEditorFooterViewTemplate.hbs
+++ b/src/UI/Movies/Editor/MovieEditorFooterViewTemplate.hbs
@@ -18,6 +18,7 @@
 		<option value="announced">Announced</option>
 		<option value="inCinemas">In Cinemas</option>
 		<option value="released">Physical/Web</option>
+		<option value="preDB">PreDB</option>
 	    </select>
 	</div>
 

--- a/src/UI/Movies/Editor/MovieEditorFooterViewTemplate.hbs
+++ b/src/UI/Movies/Editor/MovieEditorFooterViewTemplate.hbs
@@ -15,9 +15,9 @@
 
 	    <select class="form-control x-action x-minimumavailability">
 	        <option value="noChange">No change</option>
-		<option value="1">Announced</option>
-		<option value="2">In Cinemas</option>
-		<option value="3">Physical/Web</option>
+		<option value="announced">Announced</option>
+		<option value="inCinemas">In Cinemas</option>
+		<option value="released">Physical/Web</option>
 	    </select>
 	</div>
 

--- a/src/UI/Movies/Index/FooterViewTemplate.hbs
+++ b/src/UI/Movies/Index/FooterViewTemplate.hbs
@@ -18,7 +18,7 @@
                     <dd>{{released}}</dd>
 
 		    <dt>In Cinemas</dt>
-		    <<dd>{{incinemas}}</dd>
+		    <dd>{{incinemas}}</dd>
 
                     <dt>Announced</dt>
                     <dd>{{announced}}</dd>

--- a/src/UI/Movies/Index/FooterViewTemplate.hbs
+++ b/src/UI/Movies/Index/FooterViewTemplate.hbs
@@ -1,7 +1,7 @@
 <div class="row">
     <div class="series-legend legend col-xs-6 col-sm-4">
         <ul class='legend-labels'>
-            <li><span class="progress-bar"></span>Missing, but not yet available.</li>
+            <li><span class="progress-bar"></span>Missing, but not yet considered availabile</li>
             <li><span class="progress-bar-success"></span>Downloaded and imported.</li>
             <li><span class="progress-bar-danger"></span>Missing and monitored.</li>
             <li><span class="progress-bar-warning"></span>Missing, but not monitored.</li>

--- a/src/UI/Movies/Index/FooterViewTemplate.hbs
+++ b/src/UI/Movies/Index/FooterViewTemplate.hbs
@@ -17,6 +17,9 @@
                     <dt>Released</dt>
                     <dd>{{released}}</dd>
 
+		    <dt>In Cinemas</dt>
+		    <<dd{{incinemas}}</dd>
+
                     <dt>Announced</dt>
                     <dd>{{announced}}</dd>
                 </dl>

--- a/src/UI/Movies/Index/FooterViewTemplate.hbs
+++ b/src/UI/Movies/Index/FooterViewTemplate.hbs
@@ -18,7 +18,7 @@
                     <dd>{{released}}</dd>
 
 		    <dt>In Cinemas</dt>
-		    <<dd{{incinemas}}</dd>
+		    <<dd>{{incinemas}}</dd>
 
                     <dt>Announced</dt>
                     <dd>{{announced}}</dd>

--- a/src/UI/Movies/Index/MoviesIndexLayout.js
+++ b/src/UI/Movies/Index/MoviesIndexLayout.js
@@ -328,6 +328,7 @@ module.exports = Marionette.Layout.extend({
         var episodeFiles = 0;
         var announced = 0;
         var released = 0;
+	var incinemas = 0;
         var monitored = 0;
 
         _.each(MoviesCollection.models, function(model) {
@@ -336,6 +337,8 @@ module.exports = Marionette.Layout.extend({
 
             if (model.get('status').toLowerCase() === 'released') {
                 released++;
+	    } else if (model.get('status').toLowerCase() === 'incinemas') {
+                incinemas++;
             } else {
                 announced++;
             }
@@ -348,6 +351,7 @@ module.exports = Marionette.Layout.extend({
         footerModel.set({
             series       : series,
             released   : released,
+	    incinemas    : incinemas,
             announced    : announced,
             monitored : monitored,
             unmonitored  : series - monitored,

--- a/src/UI/Movies/MovieModel.js
+++ b/src/UI/Movies/MovieModel.js
@@ -23,7 +23,7 @@ module.exports = Backbone.Model.extend({
         return "announced"
       }
 
-      if (numOfMonths < 3 && numOfMonths > 0) {
+      if (status === "inCinemas") {
 
         return "inCinemas";
       }

--- a/src/UI/Movies/MovieModel.js
+++ b/src/UI/Movies/MovieModel.js
@@ -14,10 +14,10 @@ module.exports = Backbone.Model.extend({
     getStatus : function() {
       var monitored = this.get("monitored");
       var status = this.get("status");
-      var inCinemas = this.get("inCinemas");
-      var date = new Date(inCinemas);
-      var timeSince = new Date().getTime() - date.getTime();
-      var numOfMonths = timeSince / 1000 / 60 / 60 / 24 / 30;
+      //var inCinemas = this.get("inCinemas");
+      //var date = new Date(inCinemas);
+      //var timeSince = new Date().getTime() - date.getTime();
+      //var numOfMonths = timeSince / 1000 / 60 / 60 / 24 / 30;
 
       if (status === "announced") {
         return "announced"

--- a/src/UI/Movies/MovieModel.js
+++ b/src/UI/Movies/MovieModel.js
@@ -31,9 +31,5 @@ module.exports = Backbone.Model.extend({
       if (status === 'released') {
           return "released";
       }
-
-      if (numOfMonths > 3) {
-        return "released";//TODO: Update for PreDB.me
-      }
     }
 });

--- a/src/UI/Movies/MoviesCollection.js
+++ b/src/UI/Movies/MoviesCollection.js
@@ -113,11 +113,14 @@ var Collection = PageableCollection.extend({
         statusWeight : {
           sortValue : function(model, attr) {
             if (model.getStatus() == "released") {
-              return 1;
+              return 3;
             }
             if (model.getStatus() == "inCinemas") {
-              return 0;
+              return 2;
             }
+            if (mode.getStatus() == "announced") {
+	      return 1;
+	    }
             return -1;
           }
         },

--- a/src/UI/Settings/Indexers/Options/IndexerOptionsViewTemplate.hbs
+++ b/src/UI/Settings/Indexers/Options/IndexerOptionsViewTemplate.hbs
@@ -37,4 +37,15 @@
             <input type="number" name="rssSyncInterval" class="form-control" min="0" max="720"/>
         </div>
     </div>
+    <legend>Availability Options</legend>
+    <div class="form-group">
+        <label class="col-sm-3 control-label">Availability Delay</label>
+	<div class="col-sm-1 col-sm-push-2 help-inline">
+	    <i class="icon-sonarr-form-info" title="A movie will be considered to be available this many days after the Min Availability has been satisfied. (can be negative)"/>
+	    <i class="icon-sonarr-form-info" title="Will not take effect until Movie info is refreshed"/>
+	</div>
+	<div class="col-sm-2 col-sm-pull-1">
+	    <input type="number" name="availabilityDelay" class="form-control" min="-365" max="365"/>
+        </div>
+    </div>
 </fieldset>

--- a/src/UI/Settings/Indexers/Options/IndexerOptionsViewTemplate.hbs
+++ b/src/UI/Settings/Indexers/Options/IndexerOptionsViewTemplate.hbs
@@ -41,8 +41,8 @@
     <div class="form-group">
         <label class="col-sm-3 control-label">Availability Delay</label>
 	<div class="col-sm-1 col-sm-push-2 help-inline">
-	    <i class="icon-sonarr-form-info" title="A movie will be considered to be available this many days after the Min Availability has been satisfied. (can be negative)"/>
-	    <i class="icon-sonarr-form-info" title="Will not take effect until Movie info is refreshed"/>
+	    <i class="icon-sonarr-form-info" title="A movie will be considered available during RssSync this many days after(or before) the Min Availability has been satisfied. (can be negative)"/>
+	    <i class="icon-sonarr-form-info" title="This only effects RssSyncs, It does not effect how movies are displayed or what is shown in the Wanted/Missing View"/>
 	</div>
 	<div class="col-sm-2 col-sm-pull-1">
 	    <input type="number" name="availabilityDelay" class="form-control" min="-365" max="365"/>

--- a/src/UI/Settings/NetImport/Edit/NetImportEditView.js
+++ b/src/UI/Settings/NetImport/Edit/NetImportEditView.js
@@ -45,7 +45,6 @@ var view = Marionette.ItemView.extend({
 				if (RootFolders.get(defaultRoot)) {
 						this.ui.rootFolder.val(defaultRoot);
 				}
-			        this.ui.minimumAvailability.val("released");
 		},
 
 		_onBeforeSave : function() {

--- a/src/UI/Settings/NetImport/Edit/NetImportEditView.js
+++ b/src/UI/Settings/NetImport/Edit/NetImportEditView.js
@@ -19,7 +19,7 @@ var view = Marionette.ItemView.extend({
 
 		ui : {
 				profile         : '.x-profile',
-				minimumavailability : '.x-minimumavailability',
+				minimumAvailability : '.x-minimumavailability',
 				rootFolder      : '.x-root-folder',
 			},
 
@@ -45,17 +45,17 @@ var view = Marionette.ItemView.extend({
 				if (RootFolders.get(defaultRoot)) {
 						this.ui.rootFolder.val(defaultRoot);
 				}
-			        this.ui.minimumavailability.val("released");
+			        this.ui.minimumAvailability.val("released");
 		},
 
 		_onBeforeSave : function() {
 			var profile = this.ui.profile.val();
-			var minAvail = this.ui.minimumavailability.val();
+			var minAvail = this.ui.minimumAvailability.val();
 			var rootFolderPath = this.ui.rootFolder.children(':selected').text();
 			this.model.set({
 				profileId : profile,
 				rootFolderPath : rootFolderPath,
-				minimumavailability : minAvail,
+				minimumAvailability : minAvail,
 			})
 		},
 

--- a/src/UI/Settings/NetImport/Edit/NetImportEditView.js
+++ b/src/UI/Settings/NetImport/Edit/NetImportEditView.js
@@ -19,6 +19,7 @@ var view = Marionette.ItemView.extend({
 
 		ui : {
 				profile         : '.x-profile',
+				minimumavailability : '.x-minimumavailability',
 				rootFolder      : '.x-root-folder',
 			},
 
@@ -44,14 +45,17 @@ var view = Marionette.ItemView.extend({
 				if (RootFolders.get(defaultRoot)) {
 						this.ui.rootFolder.val(defaultRoot);
 				}
+			        this.ui.minimumavailability.val("3");
 		},
 
 		_onBeforeSave : function() {
 			var profile = this.ui.profile.val();
+			var minAvail = this.ui.minimumavailability.val();
 			var rootFolderPath = this.ui.rootFolder.children(':selected').text();
 			this.model.set({
 				profileId : profile,
 				rootFolderPath : rootFolderPath,
+				minimumavailability : minAvail,
 			})
 		},
 

--- a/src/UI/Settings/NetImport/Edit/NetImportEditView.js
+++ b/src/UI/Settings/NetImport/Edit/NetImportEditView.js
@@ -45,7 +45,7 @@ var view = Marionette.ItemView.extend({
 				if (RootFolders.get(defaultRoot)) {
 						this.ui.rootFolder.val(defaultRoot);
 				}
-			        this.ui.minimumavailability.val("3");
+			        this.ui.minimumavailability.val("released");
 		},
 
 		_onBeforeSave : function() {

--- a/src/UI/Settings/NetImport/Edit/NetImportEditViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Edit/NetImportEditViewTemplate.hbs
@@ -68,6 +68,7 @@
 									<option value="announced">Announced</option>
 									<option value="inCinemas">In Cinemas</option>
 									<option value="released">Physical/Web</option>
+									<option value="preDB">PreDB</option>
 								</select>
 							</div>
 						</div>

--- a/src/UI/Settings/NetImport/Edit/NetImportEditViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Edit/NetImportEditViewTemplate.hbs
@@ -64,7 +64,7 @@
 							<label class="col-sm-3 control-label">Minimum Availability</label>
 
 							<div class="col-sm-5">
-								<select class="form-control x-minimumavailability" name="minimumavailability">
+								<select class="form-control x-minimumavailability" name="minimumAvailability">
 									<option value="announced">Announced</option>
 									<option value="inCinemas">In Cinemas</option>
 									<option value="released">Physical/Web</option>

--- a/src/UI/Settings/NetImport/Edit/NetImportEditViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Edit/NetImportEditViewTemplate.hbs
@@ -65,9 +65,9 @@
 
 							<div class="col-sm-5">
 								<select class="form-control x-minimumavailability" name="minimumavailability">
-									<option value="1">Announced</option>
-									<option value="2">In Cinemas</option>
-									<option value="3">Physical/Web</option>
+									<option value="announced">Announced</option>
+									<option value="inCinemas">In Cinemas</option>
+									<option value="released">Physical/Web</option>
 								</select>
 							</div>
 						</div>

--- a/src/UI/Settings/NetImport/Edit/NetImportEditViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Edit/NetImportEditViewTemplate.hbs
@@ -60,7 +60,17 @@
 										</div>
 								</div>
 						</div>
+						<div class="form-group">
+							<label class="col-sm-3 control-label">Minimum Availability</label>
 
+							<div class="col-sm-5">
+								<select class="form-control x-minimumavailability" name="minimumavailability">
+									<option value="1">Announced</option>
+									<option value="2">In Cinemas</option>
+									<option value="3">Physical/Web</option>
+								</select>
+							</div>
+						</div>
 
 						<div class="form-group">
 							<label class="col-sm-3 control-label">Quality Profile</label>

--- a/src/UI/Wanted/Missing/MissingCollection.js
+++ b/src/UI/Wanted/Missing/MissingCollection.js
@@ -36,7 +36,23 @@ var Collection = PagableCollection.extend({
         'unmonitored' : [
             'monitored',
             'false'
-        ]
+        ],
+	'announced' : [
+		'moviestatus',
+		'announced'
+	],
+	'incinemas' : [
+		'moviestatus',
+		'incinemas'
+	],
+	'released' : [
+		'moviestatus',
+		'released'
+	],
+	'available' : [
+		'moviestatus',
+		'available',
+	]
     },
 
     parseState : function(resp) {

--- a/src/UI/Wanted/Missing/MissingLayout.js
+++ b/src/UI/Wanted/Missing/MissingLayout.js
@@ -132,7 +132,7 @@ module.exports = Marionette.Layout.extend({
         };
         var filterOptions = {
             type          : 'radio',
-            storeState    : false,
+            storeState    : true,
             menuKey       : 'wanted.filterMode',
             defaultAction : 'monitored',
             items         : [
@@ -149,9 +149,37 @@ module.exports = Marionette.Layout.extend({
                     tooltip  : 'Unmonitored Only',
                     icon     : 'icon-sonarr-unmonitored',
                     callback : this._setFilter
-                }
-            ]
-        };
+                },
+		    {
+			    key      : 'announced',
+			    title    : '',
+			    tooltip  : 'Announced Only',
+			    icon     : 'icon-sonarr-movie-announced',
+			    callback : this._setFilter
+		    },
+	            {     
+			    key      : 'incinemas',
+			    title    : '',
+			    tooltip  : 'In Cinemas Only',
+			    icon     : 'icon-sonarr-movie-cinemas',
+			    callback : this._setFilter
+		    },
+		    {
+			    key      : 'released',
+			    title    : '',
+			    tooltip  : 'Released Only',
+			    icon     : 'icon-sonarr-movie-released',
+			    callback : this._setFilter
+		    },
+		    {
+			    key      : 'available',
+			    title    : '',
+			    tooltip  : 'Available Only',
+			    icon     : 'icon-sonarr-available',
+			    callback : this._setFilter
+		    }
+		]
+	};
         this.toolbar.show(new ToolbarLayout({
             left    : [leftSideButtons],
             right   : [filterOptions],


### PR DESCRIPTION
#### Database Migration
YES

#### Description
This introduces a new field called "Minimum Availability" on the movie object that the user can specify. For now they can specify "Announced", "In Cinemas" or "Physical/Web"

depending on the movie.State and this user specification radarr will decide whether it should consider a title "available" and and thus grab a release during RSS Sync.

It could easily be extended to handle some other dates..... This doesn't effect the monitoring state of the movie but works along side it.

Please see the below screenshots for an example:

![image](https://cloud.githubusercontent.com/assets/23205277/23116174/2be94a5e-f717-11e6-92f9-e89fd2dbc92f.png)

![image](https://cloud.githubusercontent.com/assets/23205277/23116180/3418ec98-f717-11e6-81a6-59e63c7d21db.png)

the colour changes.. so basically anything that is missing and red will be grabbed during RSS sync.. anything tht is missing/blue will not be grabbed during RSSsync and the user can change the blue to red or red to blue from the movie properties.. or time will change the colour when the status of the movie changes itself.
i just need to make sure a default value is being set.. and then maybe update the add movie or movie editor to have that field..

![image](https://cloud.githubusercontent.com/assets/23205277/23116187/3b54c766-f717-11e6-9855-e2d7758a489a.png)


#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR
https://github.com/Radarr/Radarr/issues/740
* #
