### PR TITLE
Fix poster placeholder height on small screens

### DIFF
--- a/src/UI/Movies/movies.less
+++ b/src/UI/Movies/movies.less
@@ -170,7 +170,7 @@
     }
 
     @media (max-width: @screen-xs-max) {
-      height  : 283px;
+      height  : 302px;
       margin  : 5px;
       padding : 6px 5px;
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Follow up on the previous PR, poster placeholder was still too small on mobile screen sizes.