### PR TITLE
Fix/implement Webhook notifications

### DIFF
--- a/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
@@ -19,21 +19,21 @@ namespace NzbDrone.Core.Notifications.Webhook
 
         public override void OnGrab(GrabMessage message)
         {
-            _service.OnGrab(message.Series, message.Episode, message.Quality, Settings);
+            _service.OnGrab(message.Movie, message.RemoteMovie, message.Quality, Settings);
         }
 
         public override void OnDownload(DownloadMessage message)
         {
-            _service.OnDownload(message.Series, message.EpisodeFile, Settings);
+            _service.OnDownload(message.Movie, message.MovieFile, Settings);
         }
 
         public override void OnMovieRename(Movie movie)
         {
+            _service.OnRename(movie, Settings);
         }
-		
+
         public override void OnRename(Series series)
         {
-            _service.OnRename(series, Settings);
         }
 
         public override string Name => "Webhook";

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookMovie.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookMovie.cs
@@ -1,0 +1,28 @@
+using System.IO;
+﻿using NzbDrone.Core.Tv;
+using NzbDrone.Core.MediaFiles;
+
+namespace NzbDrone.Core.Notifications.Webhook
+{
+    public class WebhookMovie
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string FilePath { get; set; }
+
+        public WebhookMovie() { }
+
+        public WebhookMovie(Movie movie)
+        {
+            Id = movie.Id;
+            Title = movie.Title;
+        }
+
+        public WebhookMovie(Movie movie, MovieFile movieFile)
+        {
+            Id = movie.Id;
+            Title = movie.Title;
+            FilePath = Path.Combine(movie.Path, movieFile.RelativePath);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookPayload.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookPayload.cs
@@ -5,7 +5,7 @@ namespace NzbDrone.Core.Notifications.Webhook
     public class WebhookPayload
     {
         public string EventType { get; set; }
-        public WebhookSeries Series { get; set; }
-        public List<WebhookEpisode> Episodes { get; set; }
+        public WebhookMovie Movie { get; set; }
+        public WebhookRemoteMovie RemoteMovie { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookRemoteMovie.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookRemoteMovie.cs
@@ -1,0 +1,25 @@
+﻿using NzbDrone.Core.Tv;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.Notifications.Webhook
+{
+    public class WebhookRemoteMovie
+    {
+        public string ImdbId { get; set; }
+        public string Title { get; set; }
+
+        public WebhookRemoteMovie() { }
+
+        public WebhookRemoteMovie(RemoteMovie remoteMovie)
+        {
+            ImdbId = remoteMovie.Movie.ImdbId;
+            Title = remoteMovie.Release.Title;
+        }
+
+        public WebhookRemoteMovie(Movie movie)
+        {
+            ImdbId = movie.ImdbId;
+            Title = movie.Title;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookService.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookService.cs
@@ -12,54 +12,44 @@ namespace NzbDrone.Core.Notifications.Webhook
 {
     public interface IWebhookService
     {
-        void OnDownload(Series series, EpisodeFile episodeFile, WebhookSettings settings);
-        void OnRename(Series series, WebhookSettings settings);
-        void OnGrab(Series series, RemoteEpisode episode, QualityModel quality, WebhookSettings settings);
+        void OnDownload(Movie movie, MovieFile movieFile, WebhookSettings settings);
+        void OnRename(Movie movie, WebhookSettings settings);
+        void OnGrab(Movie movie, RemoteMovie remoteMovie, QualityModel quality, WebhookSettings settings);
         ValidationFailure Test(WebhookSettings settings);
     }
 
     public class WebhookService : IWebhookService
     {
-        public void OnDownload(Series series, EpisodeFile episodeFile, WebhookSettings settings)
+        public void OnDownload(Movie movie, MovieFile movieFile, WebhookSettings settings)
         {
             var payload = new WebhookPayload
             {
                 EventType = "Download",
-                Series = new WebhookSeries(series),
-                Episodes = episodeFile.Episodes.Value.ConvertAll(x => new WebhookEpisode(x) {
-                    Quality = episodeFile.Quality.Quality.Name,
-                    QualityVersion = episodeFile.Quality.Revision.Version,
-                    ReleaseGroup = episodeFile.ReleaseGroup,
-                    SceneName = episodeFile.SceneName
-                })
+                Movie = new WebhookMovie(movie, movieFile),
+                RemoteMovie = new WebhookRemoteMovie(movie)
             };
 
             NotifyWebhook(payload, settings);
         }
 
-        public void OnRename(Series series, WebhookSettings settings)
+        public void OnRename(Movie movie, WebhookSettings settings)
         {
             var payload = new WebhookPayload
             {
                 EventType = "Rename",
-                Series = new WebhookSeries(series)
+                Movie = new WebhookMovie(movie)
             };
 
             NotifyWebhook(payload, settings);
         }
 
-        public void OnGrab(Series series, RemoteEpisode episode, QualityModel quality, WebhookSettings settings)
+        public void OnGrab(Movie movie, RemoteMovie remoteMovie, QualityModel quality, WebhookSettings settings)
         {
             var payload = new WebhookPayload
             {
                 EventType = "Grab",
-                Series = new WebhookSeries(series),
-                Episodes = episode.Episodes.ConvertAll(x => new WebhookEpisode(x)
-                {
-                    Quality = quality.Quality.Name,
-                    QualityVersion = quality.Revision.Version,
-                    ReleaseGroup = episode.ParsedEpisodeInfo.ReleaseGroup
-                })
+                Movie = new WebhookMovie(movie),
+                RemoteMovie = new WebhookRemoteMovie(remoteMovie)
             };
             NotifyWebhook(payload, settings);
         }
@@ -87,23 +77,18 @@ namespace NzbDrone.Core.Notifications.Webhook
                     new WebhookPayload
                     {
                         EventType = "Test",
-                        Series = new WebhookSeries()
+                        Movie = new WebhookMovie()
                         {
                             Id = 1,
                             Title = "Test Title",
-                            Path = "C:\\testpath",
-                            TvdbId = 1234
+                            FilePath = "C:\\testpath",
                         },
-                        Episodes = new List<WebhookEpisode>() {
-                            new WebhookEpisode()
-                            {
-                                Id = 123,
-                                EpisodeNumber = 1,
-                                SeasonNumber = 1,
-                                Title = "Test title"
-                            }
+                        RemoteMovie = new WebhookRemoteMovie(){
+                            ImdbId = "tt012345",
+                        	Title = "My Awesome Movie!"
                         }
                     },
+
                     settings
                 );
             }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -973,6 +973,8 @@
     <Compile Include="Notifications\Webhook\WebhookMethod.cs" />
     <Compile Include="Notifications\Webhook\WebhookPayload.cs" />
     <Compile Include="Notifications\Webhook\WebhookSeries.cs" />
+    <Compile Include="Notifications\Webhook\WebhookMovie.cs" />
+    <Compile Include="Notifications\Webhook\WebhookRemoteMovie.cs" />
     <Compile Include="Notifications\Webhook\WebhookService.cs" />
     <Compile Include="Notifications\Webhook\WebhookSettings.cs" />
     <Compile Include="Notifications\Webhook\Webhook.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Implement/fix webhook notifications that were previously using Sonarr format payloads causing a `NullReferenceException`.

#### Todos
- Review/add any other fields to the payload

#### Issues Fixed or Closed by this PR

```
17-2-25 16:36:08.8|Error|NotificationService|Unable to send OnGrab notification to: Test Webhook

[v0.2.0.375] System.NullReferenceException: Object reference not set to an instance of an object
  at NzbDrone.Core.Notifications.Webhook.WebhookSeries..ctor (NzbDrone.Core.Tv.Series series) [0x00000] in C:\projects\radarr-usby1\src\NzbDrone.Core\Notifications\Webhook\WebhookSeries.cs:14 
  at NzbDrone.Core.Notifications.Webhook.WebhookService.OnGrab (NzbDrone.Core.Tv.Series series, NzbDrone.Core.Parser.Model.RemoteEpisode episode, NzbDrone.Core.Qualities.QualityModel quality, NzbDrone.Core.Notifications.Webhook.WebhookSettings settings) [0x00014] in C:\projects\radarr-usby1\src\NzbDrone.Core\Notifications\Webhook\WebhookService.cs:53 
  at NzbDrone.Core.Notifications.Webhook.Webhook.OnGrab (NzbDrone.Core.Notifications.GrabMessage message) [0x00000] in C:\projects\radarr-usby1\src\NzbDrone.Core\Notifications\Webhook\Webhook.cs:22 
  at NzbDrone.Core.Notifications.NotificationService.Handle (NzbDrone.Core.Download.MovieGrabbedEvent message) [0x000a4] in C:\projects\radarr-usby1\src\NzbDrone.Core\Notifications\NotificationService.cs:172
```