### PR TITLE
revert some changes -- use FullCollection (maybe just for now)

### DIFF
--- a/src/UI/AddMovies/BulkImport/BulkImportSelectAllCell.js
+++ b/src/UI/AddMovies/BulkImport/BulkImportSelectAllCell.js
@@ -2,8 +2,7 @@ var $ = require('jquery');
 var _ = require('underscore');
 var SelectAllCell = require('../../Cells/SelectAllCell');
 var Backgrid = require('backgrid');
-//var FullMovieCollection = require('../../Movies/FullMovieCollection');
-var MoviesCollectionClient = require('../../Movies/MoviesCollectionClient');
+var FullMovieCollection = require('../../Movies/FullMovieCollection');
 
 
 module.exports = SelectAllCell.extend({
@@ -15,7 +14,7 @@ module.exports = SelectAllCell.extend({
         this._originalInit.apply(this, arguments);
 
         var tmdbId = this.model.get('tmdbId');
-        var existingMovie = MoviesCollectionClient.fullCollection.where({ tmdbId: tmdbId });
+        var existingMovie = FullMovieCollection.where({ tmdbId: tmdbId });
         this.isDuplicate = existingMovie.length > 0 ? true : false;
 
         this.listenTo(this.model, 'change', this._refresh);

--- a/src/UI/AddMovies/SearchResultCollectionView.js
+++ b/src/UI/AddMovies/SearchResultCollectionView.js
@@ -1,7 +1,6 @@
 var Marionette = require('marionette');
 var SearchResultView = require('./SearchResultView');
-//var FullMovieCollection = require('../Movies/FullMovieCollection');
-var MoviesCollectionClient = require('../Movies/MoviesCollectionClient');
+var FullMovieCollection = require('../Movies/FullMovieCollection');
 var vent = require('vent');
 
 module.exports = Marionette.CollectionView.extend({
@@ -49,7 +48,7 @@ module.exports = Marionette.CollectionView.extend({
 
 		appendHtml : function(collectionView, itemView, index) {
 				var tmdbId = itemView.model.get('tmdbId');
-				var existingMovies = MoviesCollectionClient.fullCollection.where({ tmdbId: tmdbId });
+				var existingMovies = FullMovieCollection.where({ tmdbId: tmdbId });
 				if(existingMovies.length > 0) {
 						if(this.showExisting) {
 								if (index < this.showing || index === 0) {

--- a/src/UI/AddMovies/SearchResultView.js
+++ b/src/UI/AddMovies/SearchResultView.js
@@ -6,8 +6,7 @@ var Marionette = require('marionette');
 var Profiles = require('../Profile/ProfileCollection');
 var RootFolders = require('./RootFolders/RootFolderCollection');
 var RootFolderLayout = require('./RootFolders/RootFolderLayout');
-//var FullMovieCollection = require('../Movies/FullMovieCollection');
-var MoviesCollectionClient = require('../Movies/MoviesCollectionClient');
+var FullMovieCollection = require('../Movies/FullMovieCollection');
 var Config = require('../Config');
 var Messenger = require('../Shared/Messenger');
 var AsValidatedView = require('../Mixins/AsValidatedView');
@@ -107,7 +106,7 @@ var view = Marionette.ItemView.extend({
     },
 
     _configureTemplateHelpers : function() {
-        var existingMovies = MoviesCollectionClient.fullCollection.where({ tmdbId : this.model.get('tmdbId') });
+        var existingMovies = FullMovieCollection.where({ tmdbId : this.model.get('tmdbId') });
         if (existingMovies.length > 0) {
             this.templateHelpers.existing = existingMovies[0].toJSON();
         }
@@ -218,7 +217,7 @@ var view = Marionette.ItemView.extend({
         });
 
         promise.done(function() {
-            MoviesCollectionClient.fullCollection.add(self.model);
+            FullMovieCollection.add(self.model);
 
             self.close();
 

--- a/src/UI/Movies/FullMovieCollection.js
+++ b/src/UI/Movies/FullMovieCollection.js
@@ -1,12 +1,12 @@
-/*var movieCollection = require('./MoviesCollection');
+var movieCollection = require('./MoviesCollection');
 
 var fullCollection = movieCollection.clone();
 fullCollection.bindSignalR();
 fullCollection.state.pageSize = 100000;
 fullCollection.fetch({reset : true});
-module.exports = fullCollection;*/
+module.exports = fullCollection;
 
-var movieCollection = require('./MoviesCollectionClient');
+/*var movieCollection = require('./MoviesCollectionClient');
 
 movieCollection.bindSignalR();
-module.exports = movieCollection.fullCollection;
+module.exports = movieCollection.fullCollection;*/

--- a/src/UI/Movies/MoviesCollectionClient.js
+++ b/src/UI/Movies/MoviesCollectionClient.js
@@ -1,7 +1,6 @@
 var movieCollection = require('./MoviesCollection');
 
-var GCCollection = movieCollection.clone();
-GCCollection.bindSignalR();
-GCCollection.switchMode('client'); //state.pageSize = 100000;
-//CCollection.fetch();
-module.exports = GCCollection;
+var ClientCollection = movieCollection.clone();
+ClientCollection.bindSignalR();
+ClientCollection.switchMode('client'); //state.pageSize = 100000;
+module.exports = ClientCollection;

--- a/src/UI/Movies/MoviesController.js
+++ b/src/UI/Movies/MoviesController.js
@@ -1,8 +1,7 @@
 var NzbDroneController = require('../Shared/NzbDroneController');
 var AppLayout = require('../AppLayout');
 var MoviesCollection = require('./MoviesCollection');
-//var FullMovieCollection = require("./FullMovieCollection");
-var MoviesCollectionClient = require('./MoviesCollectionClient');
+var FullMovieCollection = require("./FullMovieCollection");
 var MoviesIndexLayout = require('./Index/MoviesIndexLayout');
 var MoviesDetailsLayout = require('./Details/MoviesDetailsLayout');
 var SeriesDetailsLayout = require('../Series/Details/SeriesDetailsLayout');
@@ -24,7 +23,7 @@ module.exports = NzbDroneController.extend({
 		},
 
 		seriesDetails : function(query) {
-				var series = MoviesCollectionClient.fullCollection.where({ titleSlug : query });
+				var series = FullMovieCollection.where({ titleSlug : query });
 				if (series.length !== 0) {
 						var targetMovie = series[0];
 						console.log(AppLayout.mainRegion);

--- a/src/UI/Navbar/Search.js
+++ b/src/UI/Navbar/Search.js
@@ -2,8 +2,7 @@ var _ = require('underscore');
 var $ = require('jquery');
 var vent = require('vent');
 var Backbone = require('backbone');
-//var FullMovieCollection = require('../Movies/FullMovieCollection');
-var MoviesCollectionClient = require('../Movies/MoviesCollectionClient');
+var FullMovieCollection = require('../Movies/FullMovieCollection');
 require('typeahead');
 
 vent.on(vent.Hotkeys.NavbarSearch, function() {
@@ -12,7 +11,7 @@ vent.on(vent.Hotkeys.NavbarSearch, function() {
 
 var substringMatcher = function() {
     return function findMatches (q, cb) {
-        var matches = _.select(MoviesCollectionClient.fullCollection.toJSON(), function(series) {
+        var matches = _.select(FullMovieCollection.toJSON(), function(series) {
             return series.title.toLowerCase().indexOf(q.toLowerCase()) > -1;
         });
         cb(matches);


### PR DESCRIPTION
#### Database Migration
 NO

#### Description
this reverts some changes from previous merge.... fixes the filters in the movieEditor Index... 

"So two issues with this now!

in the movieEditor... saving across pages: no problem.... save across filters... well, the save will work... everything selected will be saved... but, only entries corresponding to movies in the currently visible filter will be reflected in the table.... of course on a refresh.. they will be visible....

There are two solutions to this problem. The obvious one --> when we save, fetch the collection.. but since this is in client mode it has to fetch the entire collection.. so, this could mean that old values will be visible in the table for quite some time until they are fetched...... (this is only for items that were selected, but at the time of saving, were not on the visible filter)... paging is fine.. even if items are selected on other pages.. the changes will be reflected in the table immediaetly......

i suppose the other solution, would be to switch to filtermode ALL... just prior to saving.... then switch back to the desired filter.... if the filtering is done client side, this would be really fast... i think...

anyway/// i think i worked out alot of buugs.. and i reverted some previous changes that werent necessary.. at least at this time...

Please let me know what you think and if you encounter any problems..."

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR
https://cloud.githubusercontent.com/assets/23205277/23457045/0de26fac-fe44-11e6-84b6-c32ba84ae9b0.png
* #
