### PR TITLE
i believe these are old code that is not needed since pagination..

### DIFF
--- a/src/UI/Movies/MoviesCollection.js
+++ b/src/UI/Movies/MoviesCollection.js
@@ -146,17 +146,17 @@ var Collection = PageableCollection.extend({
         'released'  : [
             "status",
             "released",
-            function(model) { return model.getStatus() == "released"; }
+            //function(model) { return model.getStatus() == "released"; }
         ],
         'announced'  : [
             "status",
             "announced",
-            function(model) { return model.getStatus() == "announced"; }
+            //function(model) { return model.getStatus() == "announced"; }
         ],
         'cinemas'  : [
             "status",
             "inCinemas",
-            function(model) { return model.getStatus() == "inCinemas"; }
+            //function(model) { return model.getStatus() == "inCinemas"; }
         ]
     },
 


### PR DESCRIPTION
the recent change to include filterType hits this when model is undefined..
commenting out these lines fixes the problem

#### Database Migration
NO

#### Description
released, announced and incinemas filtering was not working on the main MovieIndex

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #
