### PR TITLE
use clone so that we only detect empty collection

### DIFF
--- a/src/UI/Movies/Index/MoviesIndexLayout.js
+++ b/src/UI/Movies/Index/MoviesIndexLayout.js
@@ -137,8 +137,13 @@ module.exports = Marionette.Layout.extend({
 
     initialize : function() {
     	//this variable prevents us from showing the list before seriesCollection has been fetched the first time
-        this.seriesCollection = MoviesCollection;//.clone();
+        this.seriesCollection = MoviesCollection.clone();
         this.seriesCollection.bindSignalR();
+
+
+        //this.listenTo(MoviesCollection, 'sync', function() {
+		//	this.seriesCollection.fetch();
+		//});
 
 	    this.listenTo(FullMovieCollection, 'sync', function() {
 			this._showFooter();


### PR DESCRIPTION
when collection is empty.. not when current filter is empty but collectionis not

#### Database Migration
NO

#### Description


#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #
