### PR TITLE
clean up the fetching on loading of MovieEditor and MovieIndex once a…

### DIFF
--- a/src/UI/Movies/Editor/MovieEditorLayout.js
+++ b/src/UI/Movies/Editor/MovieEditorLayout.js
@@ -3,7 +3,7 @@ var Marionette = require('marionette');
 var Backgrid = require('backgrid');
 var EmptyView = require('../Index/EmptyView');
 var FullMovieCollection = require ('../FullMovieCollection');
-var MoviesCollection = require('../MoviesCollectionClient');
+var MoviesCollection = require('../MoviesCollection');
 var MovieTitleCell = require('../../Cells/MovieTitleCell');
 var DownloadedQualityCell = require('../../Cells/DownloadedQualityCell');
 var ProfileCell = require('../../Cells/ProfileCell');
@@ -81,7 +81,8 @@ module.exports = Marionette.Layout.extend({
     },
 
     initialize : function() {
-		this.movieCollection = MoviesCollection; 
+		this.movieCollection = MoviesCollection.clone(); 
+		this.movieCollection.switchMode('client');
         this.movieCollection.bindSignalR();
 		this.movieCollection.fullCollection.bindSignalR();
 
@@ -94,6 +95,7 @@ module.exports = Marionette.Layout.extend({
 			this._showToolbar();
 			this._showTable();
 			this._showPager();
+			window.shownOnce = true;
 		});
 
 		this.listenTo(this.movieCollection.fullCollection, 'sync', function() {
@@ -156,13 +158,13 @@ module.exports = Marionette.Layout.extend({
     },
 
     onRender : function() {
-      	this._showToolbar();
-       	this._showTable();
-       	this._showPager(); 
-		if (window.shownOnce){
-			this.movieCollection.fetch();
-		}
-		window.shownOnce = true;
+      	//this._showToolbar();
+       	//this._showTable();
+       	//this._showPager(); 
+		//if (window.shownOnce){
+		//	this.movieCollection.fetch();
+		//}
+		//window.shownOnce = true;
     },
 
     onClose : function() {

--- a/src/UI/Movies/Index/MoviesIndexLayout.js
+++ b/src/UI/Movies/Index/MoviesIndexLayout.js
@@ -292,8 +292,9 @@ module.exports = Marionette.Layout.extend({
 
     onShow : function() {
         this._showToolbar();
-		this._fetchCollection();
+		//this._fetchCollection();
 		if (window.shownOnce) {
+			this._fetchCollection();
 			this._showFooter();
 		}
 		window.shownOnce = true;

--- a/src/UI/Movies/MoviesCollectionClient.js
+++ b/src/UI/Movies/MoviesCollectionClient.js
@@ -1,6 +1,0 @@
-var movieCollection = require('./MoviesCollection');
-
-var ClientCollection = movieCollection.clone();
-ClientCollection.bindSignalR();
-ClientCollection.switchMode('client'); //state.pageSize = 100000;
-module.exports = ClientCollection;


### PR DESCRIPTION
…nd for all

#### Database Migration
NO

#### Description
this was especially problematic when loading the MovieEditor.. since the user could start selecting items and then a few seconds later, the sync would complete and his selections might be messed up. Now we dont show it until its loaded...

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #
