### PR TITLE
Delay profiles are no longer hidden under advanced settings

### DIFF
--- a/src/UI/Settings/Profile/Delay/DelayProfileLayoutTemplate.hbs
+++ b/src/UI/Settings/Profile/Delay/DelayProfileLayoutTemplate.hbs
@@ -1,4 +1,4 @@
-<fieldset class="advanced-setting">
+<fieldset>
     <legend>Delay Profiles</legend>
 
     <div class="col-md-12">


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Move delay profiles from advanced settings. I agree it should be more visible on the UI and not hidden behind advanced settings.