### PR TITLE
reverting a change made yesterday regarding sorting

### DIFF
--- a/src/UI/Movies/MoviesCollection.js
+++ b/src/UI/Movies/MoviesCollection.js
@@ -111,9 +111,9 @@ var Collection = PageableCollection.extend({
     },
 
     sort : function(options){
-    	if (this.mode == 'server' && this.state.order == '-1'){
-            this.origSort(options);
-        }
+    	//if (this.mode == 'server' && this.state.order == '-1' && this.state.sortKey === 'sortTitle'){
+        //    this.origSort(options);
+        //}
     },
 
     save : function() {


### PR DESCRIPTION
the change fixed sorting titles of newly added movies without a refresh
however, people have noticed it broke sorting of "In Cinemas" column in general.
i commented out the change; but also added a special case in the comment, that would fix the case in question, without
breaking the others; however, more investigating is needed because there is an issue with sorting newly added movies in general and the
fix this reverts was never good enough anyway.

#### Database Migration
NO

#### Description


#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #
