### PR TITLE
refactor so that filteringExpressions are constructed in one place

### DIFF
--- a/src/NzbDrone.Api/Series/MovieModule.cs
+++ b/src/NzbDrone.Api/Series/MovieModule.cs
@@ -116,56 +116,9 @@ namespace NzbDrone.Api.Movie
 		{
 			var pagingSpec = pagingResource.MapToPagingSpec<MovieResource, Core.Tv.Movie>();
 
-			if (pagingResource.FilterKey == "monitored" && pagingResource.FilterValue == "false")
-			{
-				pagingSpec.FilterExpression = v => v.Monitored == false;
-			}
-			else if (pagingResource.FilterKey == "monitored")
-			{
-				pagingSpec.FilterExpression = v => v.Monitored == true;
-			}
+            pagingSpec.FilterExpression = _moviesService.ConstructFilterExpression(pagingResource.FilterKey, pagingResource.FilterValue, pagingResource.FilterType);
 
-			if (pagingResource.FilterKey == "status")
-			{
-				switch (pagingResource.FilterValue)
-				{
-					case "released":
-						pagingSpec.FilterExpression = v => v.Status == MovieStatusType.Released;
-						break;
-					case "inCinemas":
-						pagingSpec.FilterExpression = v => v.Status == MovieStatusType.InCinemas;
-						break;
-					case "announced":
-						pagingSpec.FilterExpression = v => v.Status == MovieStatusType.Announced;
-						break;
-				}
-			}
-
-			if (pagingResource.FilterKey == "downloaded")
-			{
-				pagingSpec.FilterExpression = v => v.MovieFileId == 0;
-			}
-
-           if (pagingResource.FilterKey == "title")
-            {
-                if (pagingResource.FilterValue == string.Empty || pagingResource.FilterValue == null)
-                {
-                    pagingSpec.FilterExpression = v => true;
-                }
-                else
-                {
-                    if (pagingResource.FilterType == "contains")
-                    {
-                        pagingSpec.FilterExpression = v => v.CleanTitle.Contains(pagingResource.FilterValue);
-                    }
-                    else
-                    {
-                        pagingSpec.FilterExpression = v => v.CleanTitle == pagingResource.FilterValue;
-                    }
-                }
-            }
-
-			return ApplyToPage(_moviesService.Paged, pagingSpec, MovieResourceMapper.ToResource);
+            return ApplyToPage(_moviesService.Paged, pagingSpec, MovieResourceMapper.ToResource);
 		}
 
         protected MovieResource MapToResource(Core.Tv.Movie movies)

--- a/src/UI/Movies/MoviesCollection.js
+++ b/src/UI/Movies/MoviesCollection.js
@@ -19,33 +19,33 @@ var filterModes = {
         null
     ],
     'continuing' : [
-        'status',
+        'moviestatus',
         'continuing'
     ],
     'ended'      : [
-        'status',
+        'moviestatus',
         'ended'
     ],
     'monitored'  : [
-        'monitored',
+        'moviemonitored',
         true
     ],
     'missing'  : [
-        'downloaded',
+        'moviedownloaded',
         false
     ],
     'released'  : [
-        "status",
+        "moviestatus",
         "released",
         //function(model) { return model.getStatus() == "released"; }
     ],
     'announced'  : [
-        "status",
+        "moviestatus",
         "announced",
         //function(model) { return model.getStatus() == "announced"; }
     ],
     'cinemas'  : [
-        "status",
+        "moviestatus",
         "inCinemas",
         //function(model) { return model.getStatus() == "inCinemas"; }
     ]

--- a/src/UI/Wanted/Cutoff/CutoffUnmetCollection.js
+++ b/src/UI/Wanted/Cutoff/CutoffUnmetCollection.js
@@ -31,11 +31,11 @@ var Collection = PagableCollection.extend({
 
     filterModes : {
         'monitored'   : [
-            'monitored',
+            'moviemonitored',
             'true'
         ],
         'unmonitored' : [
-            'monitored',
+            'moviemonitored',
             'false'
         ],
         'announced' : [
@@ -44,7 +44,7 @@ var Collection = PagableCollection.extend({
         ],
         'incinemas' : [
             'moviestatus',
-            'incinemas'
+            'inCinemas'
         ],
         'released' : [
             'moviestatus',

--- a/src/UI/Wanted/Missing/MissingCollection.js
+++ b/src/UI/Wanted/Missing/MissingCollection.js
@@ -30,11 +30,11 @@ var Collection = PagableCollection.extend({
 
     filterModes : {
         'monitored'   : [
-            'monitored',
+            'moviemonitored',
             'true'
         ],
         'unmonitored' : [
-            'monitored',
+            'moviemonitored',
             'false'
         ],
     	'announced' : [
@@ -43,7 +43,7 @@ var Collection = PagableCollection.extend({
     	],
     	'incinemas' : [
     		'moviestatus',
-    		'incinemas'
+    		'inCinemas'
     	],
     	'released' : [
     		'moviestatus',


### PR DESCRIPTION
less code duplication, easier to manage moving forward

#### Database Migration
NO

#### Description

this should not change anythnig functionally. Now there is only one place to maintain filtering Expressions.

Previous code was duplicated.. now its in one place - easier to maintain and keep up to date.
#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #
