### PR TITLE
Fixed: Parsing headers that have a trailing semi-colon

### DIFF
--- a/src/NzbDrone.Common.Test/Http/HttpHeaderFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpHeaderFixture.cs
@@ -5,6 +5,7 @@ using System;
 using System.Text;
 using NzbDrone.Common.Http;
 using System.Collections.Specialized;
+using System.Linq;
 
 namespace NzbDrone.Common.Test.Http
 {
@@ -35,6 +36,18 @@ namespace NzbDrone.Common.Test.Http
 
             Action action = () => httpheader.GetEncodingFromContentType();
             action.ShouldThrow<ArgumentException>();
+        }
+
+        [Test]
+        public void should_parse_cookie_with_trailing_semi_colon()
+        {
+            var cookies = HttpHeader.ParseCookies("uid=123456; pass=123456b2f3abcde42ac3a123f3f1fc9f;");
+
+            cookies.Count.Should().Be(2);
+            cookies.First().Key.Should().Be("uid");
+            cookies.First().Value.Should().Be("123456");
+            cookies.Last().Key.Should().Be("pass");
+            cookies.Last().Value.Should().Be("123456b2f3abcde42ac3a123f3f1fc9f");
         }
     }
 }

--- a/src/NzbDrone.Common/Http/HttpHeader.cs
+++ b/src/NzbDrone.Common/Http/HttpHeader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -169,7 +169,7 @@ namespace NzbDrone.Common.Http
 
         public static List<KeyValuePair<string, string>> ParseCookies(string cookies)
         {
-            return cookies.Split(';')
+            return cookies.Split(new[] { ";" }, StringSplitOptions.RemoveEmptyEntries)
                           .Select(v => v.Trim().Split('='))
                           .Select(v => new KeyValuePair<string, string>(v[0], v[1]))
                           .ToList();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes parsing headers that have a trailing semi-colon.

Reference:
https://github.com/Sonarr/Sonarr/commit/ebcce05588f7be7b0ed56a45b9758f9d960eb617
