### PR TITLE
Add helptext for Jackett API key

### DIFF
--- a/src/NzbDrone.Core/Indexers/TorrentPotato/TorrentPotatoSettings.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentPotato/TorrentPotatoSettings.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
         [FieldDefinition(1, Label = "Username", HelpText = "The username you use at your indexer.")]
         public string User { get; set; }
 
-        [FieldDefinition(2, Label = "Passkey", HelpText = "The password you use at your Indexer,")]
+        [FieldDefinition(2, Label = "Passkey", HelpText = "The password you use at your Indexer (or your API key if you're using Jackett).")]
         public string Passkey { get; set; }
         public NzbDroneValidationResult Validate()
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When using Jackett, the TorrentPotato settings Passkey field should set to Jackett's API key (not the user's tracker password). The helptext was updated to be clearer.

#### Todos
- N/A (small UI change)

#### Issues Fixed or Closed by this PR

N/A
