### PR TITLE
Fixed: Zero length file causes MediaInfo hanging in 100% cpu load.

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoLib.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoLib.cs
@@ -189,6 +189,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
         public int Open(Stream stream)
         {
+            if (stream.Length < 1024)
+            {
+                return 0;
+            }
+
             var isValid = (int)MediaInfo_Open_Buffer_Init(_handle, stream.Length, 0);
             if (isValid == 1)
             {
@@ -203,7 +208,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                     totalRead += bufferRead;
 
                     var status = (BufferStatus)MediaInfo_Open_Buffer_Continue(_handle, buffer, (IntPtr)bufferRead);
-                    
+
                     if (status.HasFlag(BufferStatus.Finalized) || status <= 0 || bufferRead == 0)
                     {
                         Logger.Trace("Read file offset {0}-{1} ({2} bytes)", seekStart, stream.Position, stream.Position - seekStart);


### PR DESCRIPTION
#### Database Migration
NO

#### Description


Reference:
https://github.com/Sonarr/Sonarr/commit/2e08f195e45966387f5b5d5e76ef8a8d7cf7a8e3