### PR TITLE
Indexer flags implementation.

### DIFF
--- a/src/NzbDrone.Api/Indexers/ReleaseResource.cs
+++ b/src/NzbDrone.Api/Indexers/ReleaseResource.cs
@@ -133,7 +133,7 @@ namespace NzbDrone.Api.Indexers
                     Seeders = torrentInfo.Seeders,
                     Leechers = (torrentInfo.Peers.HasValue && torrentInfo.Seeders.HasValue) ? (torrentInfo.Peers.Value - torrentInfo.Seeders.Value) : (int?)null,
                     Protocol = releaseInfo.DownloadProtocol,
-		IndexerFlags = torrentInfo.IndexerFlags.ToString().Split(','),
+		IndexerFlags = torrentInfo.IndexerFlags.ToString().Split(new string[] { ", " }, StringSplitOptions.None),
                     Edition = parsedMovieInfo.Edition,
 
                     IsDaily = false,

--- a/src/NzbDrone.Api/Indexers/ReleaseResource.cs
+++ b/src/NzbDrone.Api/Indexers/ReleaseResource.cs
@@ -46,6 +46,7 @@ namespace NzbDrone.Api.Indexers
         public bool DownloadAllowed { get; set; }
         public int ReleaseWeight { get; set; }
 
+	public IEnumerable<string> IndexerFlags { get; set; }
 
         public string MagnetUrl { get; set; }
         public string InfoHash { get; set; }
@@ -132,7 +133,7 @@ namespace NzbDrone.Api.Indexers
                     Seeders = torrentInfo.Seeders,
                     Leechers = (torrentInfo.Peers.HasValue && torrentInfo.Seeders.HasValue) ? (torrentInfo.Peers.Value - torrentInfo.Seeders.Value) : (int?)null,
                     Protocol = releaseInfo.DownloadProtocol,
-
+		IndexerFlags = torrentInfo.IndexerFlags.ToString().Split(','),
                     Edition = parsedMovieInfo.Edition,
 
                     IsDaily = false,

--- a/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornParser.cs
+++ b/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornParser.cs
@@ -55,15 +55,16 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
                 {
                     var id = torrent.Id;
                     var title = torrent.ReleaseName;
+			IndexerFlags flags = 0;
 
                     if (torrent.GoldenPopcorn)
                     {
-                        title = $"{title} 🍿";
+			flags |= IndexerFlags.PTP_Golden;//title = $"{title} 🍿";
                     }
 
                     if (torrent.Checked)
                     {
-                        title = $"{title} ✔";
+                        flags |= IndexerFlags.PTP_Approved;//title = $"{title} ✔";
                     }
 
                     // Only add approved torrents
@@ -82,7 +83,8 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
                             Golden = torrent.GoldenPopcorn,
                             Scene = torrent.Scene,
                             Approved = torrent.Checked,
-                            ImdbId = (result.ImdbId.IsNotNullOrWhiteSpace() ? int.Parse(result.ImdbId) : 0)
+                            ImdbId = (result.ImdbId.IsNotNullOrWhiteSpace() ? int.Parse(result.ImdbId) : 0),
+				IndexerFlags = flags
                         });
                     }
                     // Add all torrents
@@ -101,7 +103,8 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
                             Golden = torrent.GoldenPopcorn,
                             Scene = torrent.Scene,
                             Approved = torrent.Checked,
-                            ImdbId = (result.ImdbId.IsNotNullOrWhiteSpace() ? int.Parse(result.ImdbId) : 0)
+                            ImdbId = (result.ImdbId.IsNotNullOrWhiteSpace() ? int.Parse(result.ImdbId) : 0),
+				IndexerFlags = flags
                         });
                     }
                     // Don't add any torrents

--- a/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornParser.cs
+++ b/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornParser.cs
@@ -87,6 +87,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
 				IndexerFlags = flags
                         });
                     }
+
                     // Add all torrents
                     else if (!_settings.RequireApproved)
                     {

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgParser.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgParser.cs
@@ -69,8 +69,6 @@ namespace NzbDrone.Core.Indexers.Rarbg
                     }
                 }
 
-		torrentInfo.IndexerFlags |= IndexerFlags.PTP_Approved;
-
                 results.Add(torrentInfo);
             }
 

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgParser.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgParser.cs
@@ -69,6 +69,8 @@ namespace NzbDrone.Core.Indexers.Rarbg
                     }
                 }
 
+		torrentInfo.IndexerFlags |= IndexerFlags.PTP_Approved;
+
                 results.Add(torrentInfo);
             }
 

--- a/src/NzbDrone.Core/Parser/Model/ReleaseInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ReleaseInfo.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 using NzbDrone.Core.Indexers;
 
@@ -25,6 +25,8 @@ namespace NzbDrone.Core.Parser.Model
         public string Container { get; set; }
         public string Codec { get; set; }
         public string Resolution { get; set; }
+
+	public IndexerFlags IndexerFlags { get; set; }
 
         public int Age
         {
@@ -91,4 +93,11 @@ namespace NzbDrone.Core.Parser.Model
             }
         }
     }
+
+	[Flags]
+	public enum IndexerFlags
+	{
+		PTP_Golden = 1, //PTP
+		PTP_Approved = 2, //PTP
+	}
 }

--- a/src/UI/Release/ReleaseLayout.js
+++ b/src/UI/Release/ReleaseLayout.js
@@ -8,6 +8,7 @@ var QualityCell = require('../Cells/QualityCell');
 var ApprovalStatusCell = require('../Cells/ApprovalStatusCell');
 var LoadingView = require('../Shared/LoadingView');
 var EditionCell = require('../Cells/EditionCell');
+var ReleaseTitleCell = require("./ReleaseTitleCell");
 
 module.exports = Marionette.Layout.extend({
     template : 'Release/ReleaseLayoutTemplate',
@@ -34,7 +35,7 @@ module.exports = Marionette.Layout.extend({
             name     : 'title',
             label    : 'Title',
             sortable : true,
-            cell     : Backgrid.StringCell
+            cell     : ReleaseTitleCell
         },
         /*{
             name     : 'episodeNumbers',

--- a/src/UI/Release/ReleaseTitleCell.js
+++ b/src/UI/Release/ReleaseTitleCell.js
@@ -1,19 +1,19 @@
-var NzbDroneCell = require('./NzbDroneCell');
+var _ = require('underscore');
+var Backgrid = require('backgrid');
 
-module.exports = NzbDroneCell.extend({
-    className : 'release-title-cell',
+var FormatHelpers = require('../Shared/FormatHelpers');
+
+module.exports = Backgrid.Cell.extend({
+    className : 'title-cell',
 
     render : function() {
-        this.$el.empty();
-
+      debugger;
         var title = this.model.get('title');
-        var infoUrl = this.model.get('infoUrl');
-
         var flags = this.model.get("indexerFlags");
         if (flags) {
           _.each(flags, function(flag){
             var addon = "";
-
+            debugger;
             switch (flag) {
               case "PTP_Golden":
               addon = "🍿";
@@ -26,12 +26,7 @@ module.exports = NzbDroneCell.extend({
             title += addon;
           });
         }
-
-        if (infoUrl) {
-            this.$el.html('<a href="{0}">{1}</a>'.format(infoUrl, title));
-        } else {
-            this.$el.html(title);
-        }
+        this.$el.html(title);
 
         return this;
     }


### PR DESCRIPTION
@onedr0p So this is how I would (and did) implement different additional infos for the releases of different indexers. With this, we could for example to something like this in a IndexerFlagsSpecification:

```
if (!release.IndexerFlags.HasFlag(PTP_Golden) && release.indexer.RequireGolden)
{
    return Decision.Reject("Requires Golden");
}

//Or in prioritization service
if (release1.indexer.PreferGolden)
{
    return release1.HasFlag(PTP_Golden) - release2.HasFlag(PTP_Golden); //If both have flag, 0 -> neutral, if release1, 1 -> prefer release 1, etc.
}
```