### PR TITLE
Change smtp.google.com to smtp.gmail.com

### DIFF
--- a/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Notifications.Email
 
         public EmailSettings()
         {
-            Server = "smtp.google.com";
+            Server = "smtp.gmail.com";
             Port = 587;
             Ssl = true;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Rename smtp.google.com to smtp.gmail.com

#### Todos

#### Issues Fixed or Closed by this PR

* Issue #1392 