### PR TITLE
[http://feathub.com/Radarr/Radarr/+42]Remove movie once the movie folder is removed

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -181,11 +181,20 @@ namespace NzbDrone.Core.MediaFiles
             var videoFilesStopwatch = Stopwatch.StartNew();
             var mediaFileList = FilterFiles(movie, GetVideoFiles(movie.Path)).ToList();
 
+
             videoFilesStopwatch.Stop();
             _logger.Trace("Finished getting episode files for: {0} [{1}]", movie, videoFilesStopwatch.Elapsed);
 
             _logger.Debug("{0} Cleaning up media files in DB", movie);
             _mediaFileTableCleanupService.Clean(movie, mediaFileList);
+
+            var anyMovieFilesExist = mediaFileList.Any(file => _diskProvider.FileExists(Path.Combine(movie.Path, file)));
+            if (!anyMovieFilesExist && _diskProvider.FolderExists(movie.Path))
+            {
+                _logger.Debug($"{movie} file missing, but folder still present. Setting movie to be monitored.");
+                _movieService.SetMovieMonitored(movie.Id, true);
+            }
+
 
             var decisionsStopwatch = Stopwatch.StartNew();
             var decisions = _importDecisionMaker.GetImportDecisions(mediaFileList, movie, true);

--- a/src/NzbDrone.Core/MediaFiles/MediaFileTableCleanupService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileTableCleanupService.cs
@@ -93,10 +93,9 @@ namespace NzbDrone.Core.MediaFiles
         public void Clean(Movie movie, List<string> filesOnDisk)
         {
             var movieFiles = _mediaFileService.GetFilesByMovie(movie.Id);
-
             var filesOnDiskKeys = new HashSet<string>(filesOnDisk, PathEqualityComparer.Instance);
 
-            foreach(var movieFile in movieFiles)
+            foreach (var movieFile in movieFiles)
             {
                 var movieFilePath = Path.Combine(movie.Path, movieFile.RelativePath);
 
@@ -108,15 +107,6 @@ namespace NzbDrone.Core.MediaFiles
                         _mediaFileService.Delete(movieFile, DeleteMediaFileReason.MissingFromDisk);
                         continue;
                     }
-
-                    //var localMovie = _parsingService.GetLocalMovie(movieFile.Path, movie);
-
-                    //if (localMovie == null)
-                    //{
-                    //    _logger.Debug("File [{0}] parsed episodes has changed, removing from db", localMovie.Path);
-                    //    _mediaFileService.Delete(localMovie);
-                    //    continue;
-                    //}
                 }
 
                 catch (Exception ex)

--- a/src/NzbDrone.Core/Tv/MovieRepository.cs
+++ b/src/NzbDrone.Core/Tv/MovieRepository.cs
@@ -24,6 +24,7 @@ namespace NzbDrone.Core.Tv
         List<Movie> MoviesWithFiles(int movieId);
         PagingSpec<Movie> MoviesWithoutFiles(PagingSpec<Movie> pagingSpec);
         List<Movie> GetMoviesByFileId(int fileId);
+        void SetMonitored(Movie movie, bool monitored);
         void SetFileId(int fileId, int movieId);
         PagingSpec<Movie> MoviesWhereCutoffUnmet(PagingSpec<Movie> pagingSpec, List<QualitiesBelowCutoff> qualitiesBelowCutoff);
     }
@@ -63,6 +64,13 @@ namespace NzbDrone.Core.Tv
         {
             return Query.Where(m => m.MovieFileId == fileId).ToList();
         }
+
+        public void SetMonitored(Movie movie, bool monitored)
+        {
+            movie.Monitored = monitored;
+            SetFields(movie, p => p.Monitored);
+        }
+
 
         public void SetFileId(int fileId, int episodeId)
         {

--- a/src/NzbDrone.Core/Tv/MovieService.cs
+++ b/src/NzbDrone.Core/Tv/MovieService.cs
@@ -37,6 +37,7 @@ namespace NzbDrone.Core.Tv
         void DeleteMovie(int movieId, bool deleteFiles, bool addExclusion = false);
         List<Movie> GetAllMovies();
         Movie UpdateMovie(Movie movie);
+        void SetMovieMonitored(int movieId, bool monitored);
         List<Movie> UpdateMovie(List<Movie> movie);
         bool MoviePathExists(string folder);
         void RemoveAddOptions(Movie movie);
@@ -317,6 +318,14 @@ namespace NzbDrone.Core.Tv
             _logger.Debug("{0} movie updated", movie.Count);
 
             return movie;
+        }
+
+        public void SetMovieMonitored(int movieId, bool monitored)
+        {
+            Movie movie = _movieRepository.Get(movieId);
+            _movieRepository.SetMonitored(movie, monitored);
+
+            _logger.Debug($"Monitored flag for Movie:{movieId} was set to {monitored}");
         }
 
         public bool MoviePathExists(string folder)


### PR DESCRIPTION
As the OP suggested in F+42:
>My suggested behavior is that if you remove the file itself, you are actually indicating that you want to keep the movie in the list (most likely to redownload it) and when you delete the whole folder you want to remove the movie from the list because you are one with it.


#### Database Migration
NO

#### Description
For now I have added that movies, that have been manually deleted from disk without their parent folders gone, will be marked as monitored again as opposed how it is handled now. Now manually deleted movies from disk whose parent folder still exists, will be left in the library but won't be set to unmonitored.

#### Todos
- [ ] Tests (can't run all tests locally so I decided to PR half-way into the feature)
- [ ] Setting correct monitoring state for movies that have been **manually deleted from disk** with their parent folder remaining depending on the setting `Ignore Deleted Movies`
- [ ] Handling **manually from disk deleted** movies as well as their parent folders correctly, so that the user has control over what happens by way of a UI control (movie is deleted from library, movie folder is recreated and movie set to monitored, movie folder is created and movie set to unmonitored)
- [ ] In all cases check if some form of housekeeping is necessary such as deleting folders with empty or irrelevant content
#### Issues Fixed or Closed by this PR
* [+42](http://feathub.com/Radarr/Radarr/+42) Intended to add feature F+42 as described [here](http://feathub.com/Radarr/Radarr/+42) by OP and specified [here](https://goo.gl/DzO37N) in more detail

