### PR TITLE
Fix: A small bug fix for items loading as undefined in organize modal

### DIFF
--- a/src/UI/Movies/Editor/MovieEditorFooterView.js
+++ b/src/UI/Movies/Editor/MovieEditorFooterView.js
@@ -52,9 +52,7 @@ module.exports = Marionette.ItemView.extend({
 
         this.listenTo(FullMovieCollection, 'save', function() {
 			window.alert(' Done Saving');
-			
-			var selected = FullMovieCollection.where({ selected : true });
-		});
+        });
 
 
         this.listenTo(RootFolders, 'all', this.render);
@@ -181,7 +179,7 @@ module.exports = Marionette.ItemView.extend({
     },
 
     _organizeFiles : function() {
-        var selected = this.editorGrid.getSelectedModels();
+        var selected = FullMovieCollection.where({ selected : true });
         var updateFilesMoviesView = new UpdateFilesMoviesView({ movies : selected });
         this.listenToOnce(updateFilesMoviesView, 'updatingFiles', this._afterSave);
 

--- a/src/UI/Wanted/Missing/MissingLayout.js
+++ b/src/UI/Wanted/Missing/MissingLayout.js
@@ -120,7 +120,7 @@ module.exports = Marionette.Layout.extend({
                 {
                     title      : 'Rescan Drone Factory Folder',
                     icon       : 'icon-sonarr-refresh',
-                    command    : 'downloadedMovieScan',
+                    command    : 'downloadedMoviesScan',
                     properties : { sendUpdates : true }
                 },
                 {


### PR DESCRIPTION


#### Database Migration
NO

#### Description
I updated both backbone.backgrid.js and backbone.backgrid.selectall.js.
I also sorted the returned collection from  getSelectedModels()

before:
![radarrbug](https://cloud.githubusercontent.com/assets/25711186/25299655/b87749f4-26be-11e7-87a1-b984431fd96c.PNG)

after:
![radarrfix](https://cloud.githubusercontent.com/assets/25711186/25299699/0f7607a4-26bf-11e7-8ff1-60850bb2464b.PNG)


#### Todos
let me know if you thinking any tests are necesarry to this change. The only thing I see that is testable is the sort I perform, which I would be happy to test if you think its necessary.
- [ ] Tests

#### Issues Fixed or Closed by this PR

* # The organize modal under movie editor was pulling undefined items for items that weren't on the current page.

* # The organize modal was not showing items by their sortTitle
