### PR TITLE
Added HDBits Category, Codec, and Medium Filtering Capability

### DIFF
--- a/src/NzbDrone.Api/ClientSchema/SchemaBuilder.cs
+++ b/src/NzbDrone.Api/ClientSchema/SchemaBuilder.cs
@@ -165,7 +165,7 @@ namespace NzbDrone.Api.ClientSchema
             var options = from Enum e in Enum.GetValues(selectOptions)
                           select new SelectOption { Value = Convert.ToInt32(e), Name = e.ToString() };
 
-            return options.OrderBy(o => o.Value).ToList();
+            return options.OrderBy(o => o.Name).ToList();
         }
     }
 }

--- a/src/NzbDrone.Api/ClientSchema/SchemaBuilder.cs
+++ b/src/NzbDrone.Api/ClientSchema/SchemaBuilder.cs
@@ -46,7 +46,7 @@ namespace NzbDrone.Api.ClientSchema
                         field.Value = value;
                     }
 
-                    if (fieldAttribute.Type == FieldType.Select)
+                    if (fieldAttribute.Type == FieldType.Select || fieldAttribute.Type == FieldType.Tag)
                     {
                         field.SelectOptions = GetSelectOptions(fieldAttribute.SelectOptions);
                     }
@@ -150,7 +150,7 @@ namespace NzbDrone.Api.ClientSchema
 
         private static List<SelectOption> GetSelectOptions(Type selectOptions)
         {
-            if (selectOptions == typeof(Profile))
+            if (selectOptions == null || selectOptions == typeof(Profile))
             {
                 return new List<SelectOption>();
             }

--- a/src/NzbDrone.Core/Indexers/HDBits/HDBitsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/HDBits/HDBitsRequestGenerator.cs
@@ -59,9 +59,9 @@ namespace NzbDrone.Core.Indexers.HDBits
             query.Username = Settings.Username;
             query.Passkey = Settings.ApiKey;
 
-            query.Category = Settings.GetIntList(Settings.Categories);
-            query.Codec = Settings.GetIntList(Settings.Codec);
-            query.Medium = Settings.GetIntList(Settings.Medium);
+            query.Category = Settings.Categories.ToArray();
+            query.Codec = Settings.Codecs.ToArray();
+            query.Medium = Settings.Mediums.ToArray();
 
             // Require Internal only if came from RSS sync
             if (Settings.RequireInternal && query.ImdbInfo == null)

--- a/src/NzbDrone.Core/Indexers/HDBits/HDBitsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/HDBits/HDBitsRequestGenerator.cs
@@ -59,6 +59,10 @@ namespace NzbDrone.Core.Indexers.HDBits
             query.Username = Settings.Username;
             query.Passkey = Settings.ApiKey;
 
+            query.Category = Settings.GetIntList(Settings.Categories);
+            query.Codec = Settings.GetIntList(Settings.Codec);
+            query.Medium = Settings.GetIntList(Settings.Medium);
+
             // Require Internal only if came from RSS sync
             if (Settings.RequireInternal && query.ImdbInfo == null)
             {

--- a/src/NzbDrone.Core/Indexers/HDBits/HDBitsSettings.cs
+++ b/src/NzbDrone.Core/Indexers/HDBits/HDBitsSettings.cs
@@ -1,7 +1,11 @@
-﻿using FluentValidation;
+﻿using System;
+using System.Linq;
+using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
+using System.Linq.Expressions;
+using FluentValidation.Results;
 
 namespace NzbDrone.Core.Indexers.HDBits
 {
@@ -38,9 +42,68 @@ namespace NzbDrone.Core.Indexers.HDBits
         [FieldDefinition(4, Label = "Require Internal", Type = FieldType.Checkbox, HelpText = "Require Internal releases for release to be accepted.")]
         public bool RequireInternal { get; set; }
 
+        [FieldDefinition(5, Label = "Categories", Advanced = true, HelpText = "A comma delimited list of integers. Options: 1=Movie, 2=TV, 3=Documentary, 4=Music, 5=Sport, 6=Audio, 7=XXX, 8=Misc/Demo. Example: 1,3")]
+        public string Categories { get; set; }
+
+        [FieldDefinition(6, Label = "Codec", Advanced = true, HelpText = "A comma delimited list of integers. Options: 1=h264, 2=Mpeg2, 3=VC1, 4=Xvid. Example: 1,2")]
+        public string Codec { get; set; }
+
+        [FieldDefinition(7, Label = "Medium", Advanced = true, HelpText = "A comma delimited list of integers. Options: 1=BluRay, 3=Encode, 4=Capture, 5=Remux, 6=WebDL. Example: 3,4,6")]
+        public string Medium { get; set; }
+
+        public int[] GetIntList(string input)
+        {
+            if (!String.IsNullOrWhiteSpace(input))
+                return input.Split(',').Select(t => int.Parse(t.Trim())).ToArray();
+
+            return new int[0];
+        }
+
         public NzbDroneValidationResult Validate()
         {
-            return new NzbDroneValidationResult(Validator.Validate(this));
+            var results = Validator.Validate(this);
+
+            Validate<string, HdBitsCategory>(results, () => this.Categories);
+            Validate<string, HdBitsCodec>(results, () => this.Codec);
+            Validate<string, HdBitsMedium>(results, () => this.Medium);
+
+            return new NzbDroneValidationResult(results);
+        }
+
+        private void Validate<T, K>(ValidationResult results, Expression<Func<T>> expr) where K: struct
+        {
+            var propertyName = ((MemberExpression)expr.Body).Member.Name;
+            var propertyValue = expr.Compile()() as string;
+
+            // Nothing selected means no filtering, which is valid
+            if (String.IsNullOrWhiteSpace(propertyValue))
+                return;
+
+            try
+            {
+                // I am not using ToIntList because that assumes the data is valid. This way doesn't
+                // assume that and we try to identify specifically if a value is not an integer.
+
+                var choices = Enum.GetValues(typeof(K)).Cast<K>().ToLookup(k => Convert.ToInt32(k));
+                var candidates = propertyValue.Split(',').Select(t => t.Trim());
+
+                foreach (var candidate in candidates)
+                {
+                    if (int.TryParse(candidate, out int v))
+                    {
+                        if (!choices.Contains(v))
+                            results.Errors.Add(new ValidationFailure(propertyName, $"\"{candidate}\" is not a valid choice", candidate));
+                    }
+                    else
+                    {
+                        results.Errors.Add(new ValidationFailure(propertyName, $"\"{candidate}\" is not a valid number", candidate));
+                    }
+                }
+            }
+            catch
+            {
+                results.Errors.Add(new ValidationFailure(propertyName, "Uknown error validating property"));
+            }
         }
     }
 

--- a/src/UI/Form/TagTemplate.hbs
+++ b/src/UI/Form/TagTemplate.hbs
@@ -1,8 +1,8 @@
-<div class="form-group {{#if advanced}}advanced-setting{{/if}}">
+﻿<div class="form-group {{#if advanced}}advanced-setting{{/if}}">
     <label class="col-sm-3 control-label">{{label}}</label>
 
     <div class="col-sm-5">
-        <input type="text" name="fields.{{order}}.value" validation-name="{{name}}" class="form-control x-form-tag"/>
+        <input type="text" name="fields.{{order}}.value" validation-name="{{name}}" tag-source="{{json selectOptions}}" class="form-control x-form-tag"/>
     </div>
 
     {{> FormHelpPartial}}

--- a/src/UI/Handlebars/Helpers/String.js
+++ b/src/UI/Handlebars/Helpers/String.js
@@ -1,7 +1,11 @@
-var Handlebars = require('handlebars');
+﻿var Handlebars = require('handlebars');
 
 Handlebars.registerHelper('TitleCase', function(input) {
     return new Handlebars.SafeString(input.replace(/\w\S*/g, function(txt) {
         return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
     }));
+});
+
+Handlebars.registerHelper('json', function (obj) {
+    return JSON.stringify(obj);
 });

--- a/src/UI/Mixins/TagInput.js
+++ b/src/UI/Mixins/TagInput.js
@@ -3,7 +3,6 @@ var _ = require('underscore');
 var TagCollection = require('../Tags/TagCollection');
 var TagModel = require('../Tags/TagModel');
 require('bootstrap.tagsinput');
-//require('./AutoComplete');
 
 var substringMatcher = function(tags, selector) {
     return function findMatches (q, cb) {

--- a/src/UI/Mixins/TagInput.js
+++ b/src/UI/Mixins/TagInput.js
@@ -1,14 +1,15 @@
-var $ = require('jquery');
+﻿var $ = require('jquery');
 var _ = require('underscore');
 var TagCollection = require('../Tags/TagCollection');
 var TagModel = require('../Tags/TagModel');
 require('bootstrap.tagsinput');
+//require('./AutoComplete');
 
-var substringMatcher = function(tagCollection) {
+var substringMatcher = function(tags, selector) {
     return function findMatches (q, cb) {
         q = q.replace(/[^-_a-z0-9]/gi, '').toLowerCase();
-        var matches = _.select(tagCollection.toJSON(), function(tag) {
-            return tag.label.toLowerCase().indexOf(q) > -1;
+        var matches = _.select(tags, function(tag) {
+            return selector(tag).toLowerCase().indexOf(q) > -1;
         });
         cb(matches);
     };
@@ -108,49 +109,91 @@ $.fn.tagsinput.Constructor.prototype.build = function(options) {
 };
 
 $.fn.tagInput = function(options) {
-    options = $.extend({}, { allowNew : true }, options);
 
-    var input = this;
-    var model = options.model;
-    var property = options.property;
+    this.each(function () {
 
-    var tagInput = $(this).tagsinput({
-        tagCollection : TagCollection,
-        freeInput     : true,
-        allowNew      : options.allowNew,
-        itemValue     : 'id',
-        itemText      : 'label',
-        trimValue     : true,
-        typeaheadjs   : {
-            name       : 'tags',
-            displayKey : 'label',
-            source     : substringMatcher(TagCollection)
+        var input = $(this);
+        var tagInput = null;
+        
+        if (input[0].hasAttribute('tag-source')) {
+
+            var listItems = JSON.parse(input.attr('tag-source'));
+
+            tagInput = input.tagsinput({
+                freeInput: false,
+                allowNew: false,
+                allowDuplicates: false,
+                itemValue: 'value',
+                itemText: 'name',
+                typeaheadjs: {
+                    displayKey: 'name',
+                    source: substringMatcher(listItems, function (t) { return t.name; })
+                }
+            });
+
+            var origValue = input.val();
+
+            input.tagsinput('removeAll');
+
+            if (origValue) {
+                _.each(origValue.split(','), function (v) {
+                    var parsed = parseInt(v);
+                    var found = _.find(listItems, function (t) { return t.value === parsed; });
+
+                    if (found) {
+                        input.tagsinput('add', found);
+                    }
+                });
+            }
         }
+        else {
+
+            options = $.extend({}, { allowNew: true }, options);
+
+            var model = options.model;
+            var property = options.property;
+
+            tagInput = input.tagsinput({
+                tagCollection: TagCollection,
+                freeInput: true,
+                allowNew: options.allowNew,
+                itemValue: 'id',
+                itemText: 'label',
+                trimValue: true,
+                typeaheadjs: {
+                    name: 'tags',
+                    displayKey: 'label',
+                    source: substringMatcher(TagCollection.toJSON(), function (t) { return t.label; })
+                }
+            });
+
+            //Override the free input being set to false because we're using objects
+            $(tagInput)[0].options.freeInput = true;
+
+            if (model) {
+                var tags = getExistingTags(model.get(property));
+
+                //Remove any existing tags and re-add them
+                input.tagsinput('removeAll');
+                _.each(tags, function (tag) {
+                    input.tagsinput('add', tag);
+                });
+                input.tagsinput('refresh');
+                input.on('itemAdded', function (event) {
+                    var tags = model.get(property);
+                    tags.push(event.item.id);
+                    model.set(property, tags);
+                });
+                input.on('itemRemoved', function (event) {
+                    if (!event.item) {
+                        return;
+                    }
+                    var tags = _.without(model.get(property), event.item.id);
+                    model.set(property, tags);
+                });
+            }
+        }
+
     });
 
-    //Override the free input being set to false because we're using objects
-    $(tagInput)[0].options.freeInput = true;
-
-    if (model) {
-        var tags = getExistingTags(model.get(property));
-
-        //Remove any existing tags and re-add them
-        $(this).tagsinput('removeAll');
-        _.each(tags, function(tag) {
-            $(input).tagsinput('add', tag);
-        });
-        $(this).tagsinput('refresh');
-        $(this).on('itemAdded', function(event) {
-            var tags = model.get(property);
-            tags.push(event.item.id);
-            model.set(property, tags);
-        });
-        $(this).on('itemRemoved', function(event) {
-            if (!event.item) {
-                return;
-            }
-            var tags = _.without(model.get(property), event.item.id);
-            model.set(property, tags);
-        });
-    }
 };

--- a/src/UI/Settings/Indexers/Edit/IndexerEditView.js
+++ b/src/UI/Settings/Indexers/Edit/IndexerEditView.js
@@ -7,9 +7,9 @@ var AsModelBoundView = require('../../../Mixins/AsModelBoundView');
 var AsValidatedView = require('../../../Mixins/AsValidatedView');
 var AsEditModalView = require('../../../Mixins/AsEditModalView');
 require('../../../Form/FormBuilder');
+require('../../../Mixins/AutoComplete');
 require('../../../Mixins/TagInput');
 require('bootstrap');
-require('typeahead');
 
 var view = Marionette.ItemView.extend({
     template : 'Settings/Indexers/Edit/IndexerEditViewTemplate',

--- a/src/UI/Settings/Indexers/Edit/IndexerEditView.js
+++ b/src/UI/Settings/Indexers/Edit/IndexerEditView.js
@@ -7,7 +7,7 @@ var AsModelBoundView = require('../../../Mixins/AsModelBoundView');
 var AsValidatedView = require('../../../Mixins/AsValidatedView');
 var AsEditModalView = require('../../../Mixins/AsEditModalView');
 require('../../../Form/FormBuilder');
-require('../../../Mixins/AutoComplete');
+require('../../../Mixins/TagInput');
 require('bootstrap');
 require('typeahead');
 
@@ -29,63 +29,8 @@ var view = Marionette.ItemView.extend({
         this.targetCollection = options.targetCollection;
     },
 
-    tagMatcher: function (tagCollection) {
-        return function findMatches(q, cb) {
-            q = q.replace(/[^-_a-z0-9]/gi, '').toLowerCase();
-            var matches = _.select(tagCollection, function (tag) {
-                return tag.name.toLowerCase().indexOf(q) > -1;
-            });
-            cb(matches);
-        };
-    },
-
     onRender: function () {
-
-        var that = this;
-
-        this.ui.tags.each(function (index, tagEl) {
-
-            var tagCollection = JSON.parse(tagEl.getAttribute('tag-source'));
-            var opts = {
-                trimValue: true,                
-                tagClass: 'label label-success'                
-            };
-
-            if (tagCollection && tagCollection.length) {
-                opts.freeInput = false;
-                opts.allowNew = false;
-                opts.allowDuplicates = false;
-                opts.itemValue = 'value';
-                opts.itemText = 'name';
-                opts.typeaheadjs = {
-                    displayKey: 'name',
-                    source: that.tagMatcher(tagCollection)
-                };                
-            } 
-
-            var tag = $(tagEl);
-            tag.tagsinput(opts);
-
-            if (tagCollection && tagCollection.length && tagEl.value) {
-
-                var origValue = tagEl.value;
-                tag.tagsinput('removeAll');
-
-                _.each(origValue.split(','), function (v) {
-
-                    var parsed = parseInt(v);
-                    var found = _.find(tagCollection, function (t) {
-                        return t.value === parsed;
-                    });
-                    
-                    if (found) {
-                        tag.tagsinput('add', found);
-                    }
-                });
-            }
-
-        });
-
+        this.ui.tags.tagInput({});
     },
 
     _onAfterSave : function() {


### PR DESCRIPTION
Added advanced configuration options to support filtering Categories, Codecs, and Medium to the HDBits indexer.

#### Database Migration
NO

#### Description
Adds support for hdbits category, codec, and medium api filter. The UI for these options is a little ugly and could be made prettier in the future once some sort of multiselect UI control is created. Instead of saving 17 different booleans and presenting the user with 17 different toggles, 3 comma delimited lists was used. Not the most end user friendly way, so it was hidden as an advanced configuration option.

The default behavior, if nothing is entered, is to work as it did before the change. Defaulting the categories might be a good thing to do in the future.

![19ddffd0-2b5b-11e7-8c40-9602462dbfd6](https://cloud.githubusercontent.com/assets/7727467/25531865/c60c9d94-2bf0-11e7-9671-acf8b90343e7.jpg)


#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR
https://github.com/Radarr/Radarr/issues/1419

* #
