### PR TITLE
Fixed: Incorrect imports with Vuze when torrent contains a single file.

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
@@ -294,7 +294,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
         }
 
         [Test]
-        public void should_have_correct_output_directory()
+        public void should_have_correct_output_directory_for_multifile_torrents()
         {
             WindowsOnly();
 
@@ -309,6 +309,26 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
 
             items.Should().HaveCount(1);
             items.First().OutputPath.Should().Be(@"C:\Downloads\" + _title);
+        }
+
+        [Test]
+        public void should_have_correct_output_directory_for_singlefile_torrents()
+        {
+            WindowsOnly();
+
+            var fileName = _title + ".mkv";
+            _downloading.Name = fileName;
+            _downloading.DownloadDir = @"C:/Downloads";
+
+            GivenTorrents(new List<TransmissionTorrent>
+                {
+                    _downloading
+                });
+
+            var items = Subject.GetItems().ToList();
+
+            items.Should().HaveCount(1);
+            items.First().OutputPath.Should().Be(@"C:\Downloads\" + fileName);
         }
 
     }

--- a/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
+++ b/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
@@ -26,7 +26,19 @@ namespace NzbDrone.Core.Download.Clients.Vuze
 
         protected override OsPath GetOutputPath(OsPath outputPath, TransmissionTorrent torrent)
         {
-            _logger.Debug("Vuze output directory: {0}", outputPath);
+            // Vuze has similar behavior as uTorrent:
+            // - A multi-file torrent is downloaded in a job folder and 'outputPath' points to that directory directly.
+            // - A single-file torrent is downloaded in the root folder and 'outputPath' poinst to that root folder.
+            // We have to make sure the return value points to the job folder OR file.
+            if (outputPath == null || outputPath.FileName == torrent.Name)
+            {
+                _logger.Trace("Vuze output directory: {0}", outputPath);
+            }
+            else
+            {
+                outputPath = outputPath + torrent.Name;
+                _logger.Trace("Vuze output file: {0}", outputPath);
+            }
 
             return outputPath;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Vuze version 5.7.5.0

Single torrent download with file E:\Downloaded\Completed\Release Name.mp4
Vuze reported E:\Downloaded\Completed as output, although in previous versions it supposedly included the torrent Name.

This caused Radarr to import the entire completed folder and files.

#### Reference
https://github.com/Sonarr/Sonarr/commit/35fca89dad914265658a694426e57ec22714888c
