### PR TITLE
Fixed: Radarr not importing torrents in Vuze if the torrent already finished seeding and was stopped

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
@@ -145,8 +145,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
         [TestCase(TransmissionTorrentStatus.Check, DownloadItemStatus.Downloading)]
         [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Queued)]
         [TestCase(TransmissionTorrentStatus.Downloading, DownloadItemStatus.Downloading)]
-        [TestCase(TransmissionTorrentStatus.SeedingWait, DownloadItemStatus.Completed)]
-        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Completed)]
+        [TestCase(TransmissionTorrentStatus.SeedingWait, DownloadItemStatus.Downloading)]
+        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Downloading)]
         public void GetItems_should_return_queued_item_as_downloadItemStatus(TransmissionTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus)
         {
             _queued.Status = apiStatus;
@@ -160,7 +160,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
 
         [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Queued)]
         [TestCase(TransmissionTorrentStatus.Downloading, DownloadItemStatus.Downloading)]
-        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Completed)]
+        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Downloading)]
         public void GetItems_should_return_downloading_item_as_downloadItemStatus(TransmissionTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus)
         {
             _downloading.Status = apiStatus;

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
@@ -13,6 +13,13 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
     [TestFixture]
     public class VuzeFixture : TransmissionFixtureBase<Vuze>
     {
+        [SetUp]
+        public void Setup_Vuze()
+        {
+            // Vuze never sets isFinished.
+            _completed.IsFinished = false;
+        }
+
         [Test]
         public void queued_item_should_have_required_properties()
         {
@@ -147,8 +154,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
         [TestCase(TransmissionTorrentStatus.Check, DownloadItemStatus.Downloading)]
         [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Queued)]
         [TestCase(TransmissionTorrentStatus.Downloading, DownloadItemStatus.Downloading)]
-        [TestCase(TransmissionTorrentStatus.SeedingWait, DownloadItemStatus.Completed)]
-        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Completed)]
+        [TestCase(TransmissionTorrentStatus.SeedingWait, DownloadItemStatus.Downloading)]
+        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Downloading)]
         public void GetItems_should_return_queued_item_as_downloadItemStatus(TransmissionTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus)
         {
             _queued.Status = apiStatus;
@@ -162,7 +169,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
 
         [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Queued)]
         [TestCase(TransmissionTorrentStatus.Downloading, DownloadItemStatus.Downloading)]
-        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Completed)]
+        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Downloading)]
         public void GetItems_should_return_downloading_item_as_downloadItemStatus(TransmissionTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus)
         {
             _downloading.Status = apiStatus;
@@ -177,7 +184,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
         [TestCase(TransmissionTorrentStatus.Stopped, DownloadItemStatus.Completed, false)]
         [TestCase(TransmissionTorrentStatus.CheckWait, DownloadItemStatus.Downloading, true)]
         [TestCase(TransmissionTorrentStatus.Check, DownloadItemStatus.Downloading, true)]
-        [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Completed, true)]
+        [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Queued, true)]
         [TestCase(TransmissionTorrentStatus.SeedingWait, DownloadItemStatus.Completed, true)]
         [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Completed, true)]
         public void GetItems_should_return_completed_item_as_downloadItemStatus(TransmissionTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus, bool expectedReadOnly)

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -86,8 +86,9 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                     item.Status = DownloadItemStatus.Warning;
                     item.Message = torrent.ErrorString;
                 }
-                else if (torrent.Status == TransmissionTorrentStatus.Seeding ||
-                         torrent.Status == TransmissionTorrentStatus.SeedingWait)
+                else if (torrent.LeftUntilDone == 0 && (torrent.Status == TransmissionTorrentStatus.Stopped ||
+                                                        torrent.Status == TransmissionTorrentStatus.Seeding ||
+                                                        torrent.Status == TransmissionTorrentStatus.SeedingWait))
                 {
                     item.Status = DownloadItemStatus.Completed;
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Sonarr not importing torrents in Vuze if the torrent already finished seeding and was stopped.

#### References
https://github.com/Sonarr/Sonarr/commit/a003a89b14165c5ed7513b3117e27a603a457a2b