### PR TITLE
Fixed: Radarr UI Authentication cookie should be placed on path (UrlBase) instead of domain alone.

### DIFF
--- a/src/NzbDrone.Api/Authentication/EnableAuthInNancy.cs
+++ b/src/NzbDrone.Api/Authentication/EnableAuthInNancy.cs
@@ -70,6 +70,7 @@ namespace NzbDrone.Api.Authentication
             {
                 RedirectUrl = _configFileProvider.UrlBase + "/login",
                 UserMapper = _authenticationService,
+                Path = _configFileProvider.UrlBase,
                 CryptographyConfiguration = cryptographyConfiguration
             });
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Cookies are all set to / which makes them collide with other apps that use the same cookie names on the same server. Plus it makes cookies bleed into other apps.

One of the maintainers can confirm, if this pull request still makes sense on top of https://github.com/Radarr/Radarr/commit/12e74aa38b4fd98b7048df42cffae5203fa56e1e

#### Reference
https://github.com/Sonarr/Sonarr/commit/d726a7acb21e8cbbcb331e928c419d00969ac3ed