### PR TITLE
macOS chmod fix for Radarr executable file

### DIFF
--- a/build-appveyor.cake
+++ b/build-appveyor.cake
@@ -168,12 +168,6 @@ Task("PackageOsx").Does(() => {
 	// Adding MediaInfo dylib
 	CopyFiles(sourceFolder + "/Libraries/MediaInfo/*.dylib", outputFolderOsx);
 
-	// Chmod as executable
-	StartProcess(@"C:\cygwin64\bin\chmod.exe", new ProcessSettings()
-		.WithArguments(args => args
-			.Append("+x")
-			.Append(outputFolderOsx + "/Radarr")));
-	
 	// Adding Startup script
 	CopyFile("./osx/Radarr", outputFolderOsx + "/Radarr");
 });
@@ -189,6 +183,12 @@ Task("PackageOsxApp").Does(() => {
 	// Copy osx package files
 	CopyDirectory("./osx/Radarr.app", outputFolderOsxApp + "/Radarr.app");
 	CopyDirectory(outputFolderOsx, outputFolderOsxApp + "/Radarr.app/Contents/MacOS");
+
+	// Chmod as executable
+	StartProcess("C:\cygwin64\bin\chmod.exe", new ProcessSettings()
+		.WithArguments(args => args
+			.Append("+x")
+			.Append(outputFolderOsxApp + "/Radarr.app/Contents/MacOS")));
 });
 
 Task("PackageTests").Does(() => {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This is a possible fix for issue #745. It builds upon AeonLucid’s commit hash aace29e1e14dd142a4a6806682c55f4bcdba81ba (#1539), which was unfortunately not the solution to making Radarr.app/Contents/MacOS/Radarr be executable. Although I’m not familiar with appveyor, after looking at the code, my best guess is that moving the cygwin-powered chmod command from the PackageOsx Task to the PackageOsxApp Task may be the solution. Not sure, but thought I’d give it a shot. Also, this is my first ever pull request on a public github project, so, hope I did everything correctly.

#### Todos
 - Tests - not sure how to test other than submit this and then see the appveyor output

#### Issues Fixed or Closed by this PR
 - TBD
* #
