### PR TITLE
Fix being unable bulk import manually fixed duplicate movies

### DIFF
--- a/src/UI/AddMovies/BulkImport/BulkImportSelectAllCell.js
+++ b/src/UI/AddMovies/BulkImport/BulkImportSelectAllCell.js
@@ -13,9 +13,7 @@ module.exports = SelectAllCell.extend({
     initialize : function() {
         this._originalInit.apply(this, arguments);
 
-        var tmdbId = this.model.get('tmdbId');
-        var existingMovie = FullMovieCollection.where({ tmdbId: tmdbId });
-        this.isDuplicate = existingMovie.length > 0 ? true : false;
+        this._refreshIsDuplicate();
 
         this.listenTo(this.model, 'change', this._refresh);
     },
@@ -39,6 +37,13 @@ module.exports = SelectAllCell.extend({
     },
 
     _refresh: function() {
+        this._refreshIsDuplicate();
         this.render();
+    },
+
+    _refreshIsDuplicate: function() {
+        var tmdbId = this.model.get('tmdbId');
+        var existingMovie = FullMovieCollection.where({ tmdbId: tmdbId });
+        this.isDuplicate = existingMovie.length > 0 ? true : false;
     }
 });


### PR DESCRIPTION
#### Database Migration
NO

#### Description

The IsDuplicate state of the import checkboxes was not refreshed when the tmdbId was changed by the user, making it impossible to import the fixed movies. I fixed this by rechecking IsDuplicate when the checkbox got the 'change' event.

#### Todos
- Tests - not needed

#### Issues Fixed or Closed by this PR

* #850 
