### PR TITLE
cleans up release title before parsing 

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -10,6 +10,12 @@ using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 
+//silv3r23
+using System.Text;
+using System.Globalization;
+using System.Text.RegularExpressions;
+//END silv3r23
+
 namespace NzbDrone.Core.DecisionEngine
 {
     public interface IMakeDownloadDecision
@@ -22,14 +28,14 @@ namespace NzbDrone.Core.DecisionEngine
     {
         private readonly IEnumerable<IDecisionEngineSpecification> _specifications;
         private readonly IParsingService _parsingService;
-	private readonly IConfigService _configService;
+        private readonly IConfigService _configService;
         private readonly Logger _logger;
 
         public DownloadDecisionMaker(IEnumerable<IDecisionEngineSpecification> specifications, IParsingService parsingService, IConfigService configService, Logger logger)
         {
             _specifications = specifications;
             _parsingService = parsingService;
-		_configService = configService;
+            _configService = configService;
             _logger = logger;
         }
 
@@ -64,57 +70,123 @@ namespace NzbDrone.Core.DecisionEngine
 
             foreach (var report in reports)
             {
+                //silv3r23
+                //get wanted Language for this movie
+                var wantedLanguage = searchCriteria.Movie.Profile.Value.Language.ToString();
+                _logger.ProgressTrace("DEV: Wanted Language: {0}", wantedLanguage);
+                _logger.ProgressTrace("DEV: Title before cleanup: {0}", report.Title);
+                //seperate Group from MovieTitle
+                string[] stringSeparators = new string[] { "-" };
+                string[] titleAndGroup = report.Title.Split(stringSeparators, StringSplitOptions.RemoveEmptyEntries);
+                //prepare MovieTitle for parsing
+                _logger.ProgressTrace("DEV: Title w/o Group: {0}", titleAndGroup[0]);
+                _logger.ProgressTrace("DEV: Group: {0}", String.IsNullOrEmpty(titleAndGroup[1]) ? "EmptyGroup" : titleAndGroup[1]);
+                titleAndGroup[0] = titleAndGroup[0].Replace(" ", ".").Replace(":", ".").Replace("(", ".").Replace(")", ".").Replace("[", ".").Replace("]", ".").Replace("..", ".").Replace("ß", "ss");
+                //Remove RemoveDiacritics
+                titleAndGroup[0] = RemoveDiacritics(titleAndGroup[0]);
+
+                //check if there is a year in the movie title
+                string year = @"\d{4}";
+                System.Text.RegularExpressions.Regex r = new System.Text.RegularExpressions.Regex(year);
+                string yearInTitle = r.Match(titleAndGroup[0]).ToString();
+                //if true, get year and put language after year
+                if (yearInTitle != "" || yearInTitle != null)
+                {
+                    _logger.ProgressTrace("DEV: Year found in title: {0}", yearInTitle);
+                    //check if wanted language is found in Title String
+                    if (titleAndGroup[0].IndexOf(wantedLanguage) != -1)
+                    {
+                        //remove wanted language from movie title and place language after the year
+                        //titleAndGroup[0] = titleAndGroup[0].ToLower().Replace(wantedLanguage.ToLower(), "").Replace("..", ".");
+
+                        titleAndGroup[0] = Regex.Replace(titleAndGroup[0], wantedLanguage, "", RegexOptions.IgnoreCase);
+                        titleAndGroup[0] = titleAndGroup[0].Replace("..", ".");
+
+                        _logger.ProgressTrace("DEV: Language '{0}' has been removed: {1}", wantedLanguage, titleAndGroup[0]);
+
+                        string[] stringSeparatorsTemp = new string[] { yearInTitle };
+                        string[] titleTemp = titleAndGroup[0].Split(stringSeparatorsTemp, StringSplitOptions.RemoveEmptyEntries);
+                        titleAndGroup[0] = "";
+                        int i = 0;
+                        foreach (string ttemp in titleTemp)
+                        {
+                            _logger.ProgressTrace("DEV-Temp0: Array-Position : {0}", ttemp);
+                            if (i == 1) //because the year is the first seperator
+                            {
+                                titleAndGroup[0] = titleAndGroup[0] + yearInTitle + "." + wantedLanguage + ttemp;
+                                _logger.ProgressTrace("DEV-Temp1: New Title : {0}", titleAndGroup[0]);
+                            }
+                            else titleAndGroup[0] += ttemp;
+                            _logger.ProgressTrace("DEV-Temp2: New Title : {0}", titleAndGroup[0]);
+                            i++;
+                        }
+                        _logger.ProgressTrace("DEV: Language has been placed to the right order: {0}", titleAndGroup[0]);
+                    }
+                    else _logger.ProgressTrace("DEV: No Language found, seems to be an English RLS: {0}", titleAndGroup[0]);
+                }
+                else _logger.ProgressTrace("DEV: NO Year found in title: {0}", titleAndGroup[0]);
+
+
+                report.Title = titleAndGroup[0] + "-" + titleAndGroup[1];
+                _logger.ProgressTrace("DEV: Title after cleanup: {0}", report.Title);
+
+                //END silv3r23
                 DownloadDecision decision = null;
                 _logger.ProgressTrace("Processing release {0}/{1}", reportNumber, reports.Count);
 
                 try
                 {
-                    var parsedMovieInfo = Parser.Parser.ParseMovieTitle(report.Title);
+                    // silv3r23
+                    //var parsedMovieInfo = Parser.Parser.ParseMovieTitle(report.Title);
 
-					if (parsedMovieInfo != null && !parsedMovieInfo.MovieTitle.IsNullOrWhiteSpace())
-					{
-						RemoteMovie remoteMovie = _parsingService.Map(parsedMovieInfo, report.ImdbId.ToString(), searchCriteria);
-						remoteMovie.Release = report;
+                    //result from indexer
+                    var parsedMovieInfo = Parser.Parser.ParseMovieTitle(RemoveDiacritics(Parser.Parser.ReplaceGermanUmlauts(report.Title.Replace(":", " ").Replace(",", ""))));
+                    _logger.ProgressTrace("DEV: Looking for: '{0}'", parsedMovieInfo.MovieTitle);
+                    //END silv3r23
+                    if (parsedMovieInfo != null && !parsedMovieInfo.MovieTitle.IsNullOrWhiteSpace())
+                    {
+                        RemoteMovie remoteMovie = _parsingService.Map(parsedMovieInfo, report.ImdbId.ToString(), searchCriteria);
+                        remoteMovie.Release = report;
 
-						if (remoteMovie.Movie == null)
-						{
-							decision = new DownloadDecision(remoteMovie, new Rejection("Unknown movie. Movie found does not match wanted movie."));
-						}
-						else
-						{
-							if (parsedMovieInfo.Quality.HardcodedSubs.IsNotNullOrWhiteSpace())
-							{
-								remoteMovie.DownloadAllowed = true;
-								if (_configService.AllowHardcodedSubs)
-								{
-									decision = GetDecisionForReport(remoteMovie, searchCriteria);
-								}
-								else
-								{
-									var whitelisted = _configService.WhitelistedHardcodedSubs.Split(',');
-									_logger.Debug("Testing: {0}", whitelisted);
-									if (whitelisted != null && whitelisted.Any(t => (parsedMovieInfo.Quality.HardcodedSubs.ToLower().Contains(t.ToLower()) && t.IsNotNullOrWhiteSpace())))
-									{
-										decision = GetDecisionForReport(remoteMovie, searchCriteria);
-									}
-									else
-									{
-										decision = new DownloadDecision(remoteMovie, new Rejection("Hardcoded subs found: " + parsedMovieInfo.Quality.HardcodedSubs));
-									}
-								}
-							}
-							else
-							{
-								remoteMovie.DownloadAllowed = true;
-								decision = GetDecisionForReport(remoteMovie, searchCriteria);
-							}
+                        if (remoteMovie.Movie == null)
+                        {
+                            decision = new DownloadDecision(remoteMovie, new Rejection("Unknown movie. Movie found does not match wanted movie."));
+                        }
+                        else
+                        {
+                            if (parsedMovieInfo.Quality.HardcodedSubs.IsNotNullOrWhiteSpace())
+                            {
+                                remoteMovie.DownloadAllowed = true;
+                                if (_configService.AllowHardcodedSubs)
+                                {
+                                    decision = GetDecisionForReport(remoteMovie, searchCriteria);
+                                }
+                                else
+                                {
+                                    var whitelisted = _configService.WhitelistedHardcodedSubs.Split(',');
+                                    _logger.Debug("Testing: {0}", whitelisted);
+                                    if (whitelisted != null && whitelisted.Any(t => (parsedMovieInfo.Quality.HardcodedSubs.ToLower().Contains(t.ToLower()) && t.IsNotNullOrWhiteSpace())))
+                                    {
+                                        decision = GetDecisionForReport(remoteMovie, searchCriteria);
+                                    }
+                                    else
+                                    {
+                                        decision = new DownloadDecision(remoteMovie, new Rejection("Hardcoded subs found: " + parsedMovieInfo.Quality.HardcodedSubs));
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                remoteMovie.DownloadAllowed = true;
+                                decision = GetDecisionForReport(remoteMovie, searchCriteria);
+                            }
 
-						}
-					}
-					else
-					{
-						_logger.Trace("{0} could not be parsed :(.", report.Title);
-					}
+                        }
+                    }
+                    else
+                    {
+                        _logger.Trace("{0} could not be parsed :(.", report.Title);
+                    }
                 }
                 catch (Exception e)
                 {
@@ -142,6 +214,23 @@ namespace NzbDrone.Core.DecisionEngine
                 }
             }
         }
+
+        //silv3r23
+        public static String RemoveDiacritics(String s)
+        {
+            String normalizedString = s.Normalize(NormalizationForm.FormD);
+            StringBuilder stringBuilder = new StringBuilder();
+
+            for (int i = 0; i < normalizedString.Length; i++)
+            {
+                Char c = normalizedString[i];
+                if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)
+                    stringBuilder.Append(c);
+            }
+
+            return stringBuilder.ToString();
+        }
+        //END silv3r23
 
         private IEnumerable<DownloadDecision> GetDecisions(List<ReleaseInfo> reports, SearchCriteriaBase searchCriteria = null)
         {
@@ -189,7 +278,7 @@ namespace NzbDrone.Core.DecisionEngine
                         }
                         else if (remoteEpisode.Episodes.Empty())
                         {
-                            decision = new DownloadDecision(remoteEpisode, new Rejection("Unable to parse episodes from release name"));                            
+                            decision = new DownloadDecision(remoteEpisode, new Rejection("Unable to parse episodes from release name"));
                         }
                         else
                         {

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.Parser
         private readonly IMovieService _movieService;
         private readonly Logger _logger;
         private static HashSet<ArabicRomanNumeral> _arabicRomanNumeralMappings;
- 
+
 
         public ParsingService(IEpisodeService episodeService,
                               ISeriesService seriesService,
@@ -197,9 +197,9 @@ namespace NzbDrone.Core.Parser
         public RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, int tvdbId, int tvRageId, SearchCriteriaBase searchCriteria = null)
         {
             var remoteEpisode = new RemoteEpisode
-                {
-                    ParsedEpisodeInfo = parsedEpisodeInfo,
-                };
+            {
+                ParsedEpisodeInfo = parsedEpisodeInfo,
+            };
 
             var series = GetSeries(parsedEpisodeInfo, tvdbId, tvRageId, searchCriteria);
 
@@ -236,11 +236,11 @@ namespace NzbDrone.Core.Parser
         public RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, int seriesId, IEnumerable<int> episodeIds)
         {
             return new RemoteEpisode
-                   {
-                       ParsedEpisodeInfo = parsedEpisodeInfo,
-                       Series = _seriesService.GetSeries(seriesId),
-                       Episodes = _episodeService.GetEpisodes(episodeIds)
-                   };
+            {
+                ParsedEpisodeInfo = parsedEpisodeInfo,
+                Series = _seriesService.GetSeries(seriesId),
+                Episodes = _episodeService.GetEpisodes(episodeIds)
+            };
         }
 
         public List<Episode> GetEpisodes(ParsedEpisodeInfo parsedEpisodeInfo, Series series, bool sceneSource, SearchCriteriaBase searchCriteria = null)
@@ -352,6 +352,7 @@ namespace NzbDrone.Core.Parser
             // TODO: Answer me this: Wouldn't it be smarter to start out looking for a movie if we have an ImDb Id?
             if (!String.IsNullOrWhiteSpace(imdbId) && imdbId != "0")
             {
+                _logger.Debug("Try matching by imdbID");
                 Movie movieByImDb;
                 if (TryGetMovieByImDbId(parsedMovieInfo, imdbId, out movieByImDb))
                 {
@@ -361,6 +362,7 @@ namespace NzbDrone.Core.Parser
 
             if (searchCriteria != null)
             {
+                _logger.Debug("Try matching by SearchCriteria");
                 Movie movieBySearchCriteria;
                 if (TryGetMovieBySearchCriteria(parsedMovieInfo, searchCriteria, out movieBySearchCriteria))
                 {
@@ -369,6 +371,7 @@ namespace NzbDrone.Core.Parser
             }
             else
             {
+                _logger.Debug("Try matching by TitleAndOrYear");
                 Movie movieByTitleAndOrYear;
                 if (TryGetMovieByTitleAndOrYear(parsedMovieInfo, out movieByTitleAndOrYear))
                 {
@@ -377,13 +380,14 @@ namespace NzbDrone.Core.Parser
             }
 
             // nothing found up to here => logging that and returning null
-            _logger.Debug($"No matching movie {parsedMovieInfo.MovieTitle}");
+            _logger.Debug($"No matching movie: {parsedMovieInfo.MovieTitle}");
             return null;
         }
 
         private bool TryGetMovieByImDbId(ParsedMovieInfo parsedMovieInfo, string imdbId, out Movie movie)
         {
             movie = _movieService.FindByImdbId(imdbId);
+            //_logger.Debug("parsedMovieInfo.Year: '{0}'", parsedMovieInfo.Year);
             //Should fix practically all problems, where indexer is shite at adding correct imdbids to movies.
             if (movie != null && parsedMovieInfo.Year > 1800 && parsedMovieInfo.Year != movie.Year)
             {
@@ -431,6 +435,7 @@ namespace NzbDrone.Core.Parser
 
             foreach (string title in possibleTitles)
             {
+                _logger.Debug("compare '{0}' with '{1}'", title, parsedMovieInfo.MovieTitle.CleanSeriesTitle());
                 if (title == parsedMovieInfo.MovieTitle.CleanSeriesTitle())
                 {
                     possibleMovie = searchCriteria.Movie;
@@ -441,7 +446,7 @@ namespace NzbDrone.Core.Parser
                     string arabicNumeral = numeralMapping.ArabicNumeralAsString;
                     string romanNumeral = numeralMapping.RomanNumeralLowerCase;
 
-                    _logger.Debug(cleanTitle);
+                    _logger.Debug("cleanTitle: {0}", cleanTitle);
 
                     if (title.Replace(arabicNumeral, romanNumeral) == parsedMovieInfo.MovieTitle.CleanSeriesTitle())
                     {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- removes diacritics, commas, colons
- replaces german umlauts
- place the language if found behind year
- implement more logging
- Radarr issue #1407

#### Todos
- Workaround for Releases without year-tag
- movie-title with new tag order is pushed to sabnzbd as download name -> sabnzbd will extract and rename like that. want do leave the original name from search result (just cosmetic for non-renamers)

#### Issues Fixed or Closed by this PR
#1407 (not complete, but on a good way)
* #
