### PR TITLE
Parserfix for issue 1407 (second try)

### DIFF
--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -38,6 +38,10 @@ namespace NzbDrone.Core.Parser
 			//As a last resort for movies that have ( or [ in their title.
 			new Regex(@"^(?<title>.+?)?(?:(?:[-_\W](?<![)\[!]))*(?<year>(19|20)\d{2}(?!p|i|\d+|\]|\W\d+)))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
+            //Movies without Year, try both
+            new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))|(?i:(German|French))|(?<year>(19|20)\d{2}(?!p|i|\d+|\]|\W\d+)))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))|(?i:(German))|(?i:(French))|(?<year>(19|20)\d{2}(?!p|i|\d+|\]|\W\d+)))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
         };
 
         private static readonly Regex[] ReportMovieTitleFolderRegex = new[]

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -352,6 +352,7 @@ namespace NzbDrone.Core.Parser
             // TODO: Answer me this: Wouldn't it be smarter to start out looking for a movie if we have an ImDb Id?
             if (!String.IsNullOrWhiteSpace(imdbId) && imdbId != "0")
             {
+                _logger.Debug("Try matching by imdbID");
                 Movie movieByImDb;
                 if (TryGetMovieByImDbId(parsedMovieInfo, imdbId, out movieByImDb))
                 {
@@ -361,6 +362,7 @@ namespace NzbDrone.Core.Parser
 
             if (searchCriteria != null)
             {
+                _logger.Debug("Try matching by SearchCriteria");
                 Movie movieBySearchCriteria;
                 if (TryGetMovieBySearchCriteria(parsedMovieInfo, searchCriteria, out movieBySearchCriteria))
                 {
@@ -369,6 +371,7 @@ namespace NzbDrone.Core.Parser
             }
             else
             {
+                _logger.Debug("Try matching by TitleAndOrYear");
                 Movie movieByTitleAndOrYear;
                 if (TryGetMovieByTitleAndOrYear(parsedMovieInfo, out movieByTitleAndOrYear))
                 {
@@ -431,6 +434,7 @@ namespace NzbDrone.Core.Parser
 
             foreach (string title in possibleTitles)
             {
+                _logger.Debug("compare '{0}' with '{1}'", title, parsedMovieInfo.MovieTitle.CleanSeriesTitle());
                 if (title == parsedMovieInfo.MovieTitle.CleanSeriesTitle())
                 {
                     possibleMovie = searchCriteria.Movie;
@@ -441,7 +445,7 @@ namespace NzbDrone.Core.Parser
                     string arabicNumeral = numeralMapping.ArabicNumeralAsString;
                     string romanNumeral = numeralMapping.RomanNumeralLowerCase;
 
-                    _logger.Debug(cleanTitle);
+                    _logger.Debug("cleanTitle: {0}", cleanTitle);
 
                     if (title.Replace(arabicNumeral, romanNumeral) == parsedMovieInfo.MovieTitle.CleanSeriesTitle())
                     {


### PR DESCRIPTION
#### Description
- cleans up release title before parsing
- removes diacritics, commas, colons
- replaces german umlauts
- place the language if found behind year
- implement more logging
- bugfix, regex for german and french without a year

#### Todos
- Add more languages in regex
- Solution for Releases without year and Tags between title and language
- (cosmetic with disabled renaming by radarr:)
in case of reorganized language tag order in the release title, this name will be published to downloader. downloader (sabnzbd) will rename after extraction to the given name. in this case the releasetitle will not match the source name from PreDB
- seems that "MD" were not rejected

#### Issues Fixed or Closed by this PR
* #1407
