### PR TITLE
Fixed: Ensure an API Key is set when starting Radarr

### DIFF
--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -141,7 +141,21 @@ namespace NzbDrone.Core.Configuration
 
         public bool LaunchBrowser => GetValueBoolean("LaunchBrowser", true);
 
-        public string ApiKey => GetValue("ApiKey", GenerateApiKey());
+        public string ApiKey
+        {
+            get
+            {
+                var apiKey = GetValue("ApiKey", GenerateApiKey());
+
+                if (apiKey.IsNullOrWhiteSpace())
+                {
+                    apiKey = GenerateApiKey();
+                    SetValue("ApiKey", apiKey);
+                }
+
+                return apiKey;
+            }
+        }
 
         public AuthenticationType AuthenticationMethod
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Ensure an API Key is set when starting Sonarr

#### Reference
https://github.com/Sonarr/Sonarr/commit/6bbe4ce066bbcda46ded450ac450aa641d483bc1
