### PR TITLE
Follow 301 redirects when fetching torrents

### DIFF
--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Download
             _httpClient = httpClient;
             _torrentFileInfoReader = torrentFileInfoReader;
         }
-        
+
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
 
         public virtual bool PreferTorrentFile => false;
@@ -149,7 +149,7 @@ namespace NzbDrone.Core.Download
             {
                 magnetUrl = torrentInfo.MagnetUrl;
             }
-            
+
             if (PreferTorrentFile)
             {
                 if (torrentUrl.IsNotNullOrWhiteSpace())
@@ -221,7 +221,9 @@ namespace NzbDrone.Core.Download
 
                 var response = _httpClient.Get(request);
 
-                if (response.StatusCode == HttpStatusCode.SeeOther || response.StatusCode == HttpStatusCode.Found)
+                if (response.StatusCode == HttpStatusCode.MovedPermanently ||
+                    response.StatusCode == HttpStatusCode.Found ||
+                    response.StatusCode == HttpStatusCode.SeeOther)
                 {
                     var locationHeader = response.Headers.GetSingleValue("Location");
 
@@ -321,7 +323,9 @@ namespace NzbDrone.Core.Download
 
                 var response = _httpClient.Get(request);
 
-                if (response.StatusCode == HttpStatusCode.SeeOther || response.StatusCode == HttpStatusCode.Found)
+                if (response.StatusCode == HttpStatusCode.MovedPermanently ||
+                    response.StatusCode == HttpStatusCode.Found ||
+                    response.StatusCode == HttpStatusCode.SeeOther)
                 {
                     var locationHeader = response.Headers.GetSingleValue("Location");
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently only 302 and 303 redirects are followed, but certain RSS feeds uses 301 redirects and they aren't followed.

Closes #1564.

#### Reference
https://github.com/Sonarr/Sonarr/commit/755575d107ecd0bf0bd70cde074f18113c573d99
