### PR TITLE
Fixed error when processing manual import decisions 

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
@@ -368,6 +368,11 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                 decision = new ImportDecision(localEpisode, new Rejection("Unexpected error processing file"));
             }
 
+            if (decision == null)
+            {
+                _logger.Error("Unable to make a decision on {0}", file);
+            }
+
             return decision;
         }
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -160,7 +160,17 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
             var importDecisions = _importDecisionMaker.GetImportDecisions(new List<string> { file },
                 movie, null, SceneSource(movie, folder), true);
 
-            return importDecisions.Any() ? MapItem(importDecisions.First(), folder, downloadId) : null;
+            return importDecisions.Any() ? MapItem(importDecisions.First(), folder, downloadId) : new ManualImportItem
+                                                                                                  {
+                                                                                                      DownloadId = downloadId,
+                                                                                                      Path = file,
+                                                                                                      RelativePath = folder.GetRelativePath(file),
+                                                                                                      Name = Path.GetFileNameWithoutExtension(file),
+                                                                                                      Rejections = new List<Rejection>
+                                                                                                                   {
+                                                                                                                       new Rejection("Unable to process file")
+                                                                                                                   }
+                                                                                                  };
         }
 
         //private ManualImportItem ProcessFile(string file, string downloadId, string folder = null)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes the following error:

https://github.com/Radarr/Radarr/blob/9fbe06ad683a4556afa55128b8b8a888a6223198/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs#L89
https://github.com/Radarr/Radarr/blob/9fbe06ad683a4556afa55128b8b8a888a6223198/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs#L155

May return a null item, which in turn causes the API resource mapper to crash.

Looks like it happens when the user points manualimport at a file that can't be identified at all.
If that's the case then the workaround would be to point it at a folder instead.

#### References
https://github.com/Sonarr/Sonarr/commit/285288db1a49fde28f9b997b06f16c36293ebb48
https://github.com/Sonarr/Sonarr/commit/baf83b4c710100dd04a1f0ed951fbc0141693952
