### PR TITLE
Fix old Plex ValidationFailure message

### DIFF
--- a/src/NzbDrone.Core/Notifications/Plex/PlexServerService.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexServerService.cs
@@ -170,7 +170,7 @@ namespace NzbDrone.Core.Notifications.Plex
 
                 if (sections.Empty())
                 {
-                    return new ValidationFailure("Host", "At least one film library is required");
+                    return new ValidationFailure("Host", "At least one movie library is required");
                 }
             }
             catch(PlexAuthenticationException ex)

--- a/src/NzbDrone.Core/Notifications/Plex/PlexServerService.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexServerService.cs
@@ -170,7 +170,7 @@ namespace NzbDrone.Core.Notifications.Plex
 
                 if (sections.Empty())
                 {
-                    return new ValidationFailure("Host", "At least one TV library is required");
+                    return new ValidationFailure("Host", "At least one film library is required");
                 }
             }
             catch(PlexAuthenticationException ex)


### PR DESCRIPTION
#### Database Migration
**NO**

#### Description
Fixes a really confusing error message I ran into when there isn't a film library in Plex. My guess is this is an old message from when you forked Sonarr.

#### Todos

#### Issues Fixed or Closed by this PR
* Rewords an out of date ValidationFailure exception message that is thrown when there isn't a film library in Plex 