### PR TITLE
Update Info.plist to avoid conflict with Sonarr

### DIFF
--- a/osx/Radarr.app/Contents/Info.plist
+++ b/osx/Radarr.app/Contents/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleIconFile</key>
 	<string>radarr.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.osx.radarr.tv</string>
+	<string>com.osx.radarr.video</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/osx/Radarr.app/Contents/Info.plist
+++ b/osx/Radarr.app/Contents/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleIconFile</key>
 	<string>radarr.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.osx.sonarr.tv</string>
+	<string>com.osx.radarr.tv</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
#### Database Migration
NO

#### Description

This fixes the issue with Radarr not being able to start for some users from the Finder.

According to Apple:

> CFBundleIdentifier (String - iOS, macOS) uniquely identifies the bundle. **Each distinct app or bundle on the system must have a unique bundle ID**. The system uses this string to identify your app in many ways. For example, the preferences system uses this string to identify the app for which a given preference applies; Launch Services uses the bundle identifier to locate an app capable of opening a particular file, using the first app it finds with the given identifier; in iOS, the bundle identifier is used in validating the app’s signature.

Because the same Identifier was used on Sonarr, the OS was getting confused on which settings to use when starting the App from the finder.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #1773 
