### PR TITLE
Fix: Check for a Used Quality Profile before Deleting

### DIFF
--- a/src/NzbDrone.Core.Test/Profiles/ProfileServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Profiles/ProfileServiceFixture.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using FizzWare.NBuilder;
 using Moq;
 using NUnit.Framework;
@@ -39,15 +39,15 @@ namespace NzbDrone.Core.Test.Profiles
 
 
         [Test]
-        public void should_not_be_able_to_delete_profile_if_assigned_to_series()
+        public void should_not_be_able_to_delete_profile_if_assigned_to_movie()
         {
-            var seriesList = Builder<Series>.CreateListOfSize(3)
+            var movieList = Builder<Movie>.CreateListOfSize(3)
                                             .Random(1)
                                             .With(c => c.ProfileId = 2)
                                             .Build().ToList();
 
 
-            Mocker.GetMock<ISeriesService>().Setup(c => c.GetAllSeries()).Returns(seriesList);
+            Mocker.GetMock<IMovieService>().Setup(c => c.GetAllMovies()).Returns(movieList);
 
             Assert.Throws<ProfileInUseException>(() => Subject.Delete(2));
 
@@ -57,15 +57,15 @@ namespace NzbDrone.Core.Test.Profiles
 
 
         [Test]
-        public void should_delete_profile_if_not_assigned_to_series()
+        public void should_delete_profile_if_not_assigned_to_movie()
         {
-            var seriesList = Builder<Series>.CreateListOfSize(3)
+            var movieList = Builder<Movie>.CreateListOfSize(3)
                                             .All()
                                             .With(c => c.ProfileId = 2)
                                             .Build().ToList();
 
 
-            Mocker.GetMock<ISeriesService>().Setup(c => c.GetAllSeries()).Returns(seriesList);
+            Mocker.GetMock<IMovieService>().Setup(c => c.GetAllMovies()).Returns(movieList);
 
             Subject.Delete(1);
 

--- a/src/NzbDrone.Core/Profiles/ProfileService.cs
+++ b/src/NzbDrone.Core/Profiles/ProfileService.cs
@@ -22,13 +22,13 @@ namespace NzbDrone.Core.Profiles
     public class ProfileService : IProfileService, IHandle<ApplicationStartedEvent>
     {
         private readonly IProfileRepository _profileRepository;
-        private readonly ISeriesService _seriesService;
+        private readonly IMovieService _movieService;
         private readonly Logger _logger;
 
-        public ProfileService(IProfileRepository profileRepository, ISeriesService seriesService, Logger logger)
+        public ProfileService(IProfileRepository profileRepository, IMovieService movieService, Logger logger)
         {
             _profileRepository = profileRepository;
-            _seriesService = seriesService;
+            _movieService = movieService;
             _logger = logger;
         }
 
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.Profiles
 
         public void Delete(int id)
         {
-            if (_seriesService.GetAllSeries().Any(c => c.ProfileId == id))
+            if (_movieService.GetAllMovies().Any(c => c.ProfileId == id))
             {
                 throw new ProfileInUseException(id);
             }


### PR DESCRIPTION
Fix Check for Used Profile before Delete

#### Database Migration
NO

#### Description

Checks Movie repository for a used profile prior to deleting.
