### PR TITLE
Port fix from Sonarr for qBitTorrent 3.3.14 API change

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using NzbDrone.Common.Disk;
@@ -111,7 +111,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 {
                     case "error": // some error occurred, applies to paused torrents
                         item.Status = DownloadItemStatus.Failed;
-                        item.Message = "QBittorrent is reporting an error";
+                        item.Message = "qBittorrent is reporting an error";
                         break;
 
                     case "pausedDL": // torrent is paused and has NOT finished downloading
@@ -212,7 +212,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 var config = _proxy.GetConfig(Settings);
                 if (config.MaxRatioEnabled && config.RemoveOnMaxRatio)
                 {
-                    return new NzbDroneValidationFailure(String.Empty, "QBittorrent is configured to remove torrents when they reach their Share Ratio Limit")
+                    return new NzbDroneValidationFailure(String.Empty, "qBittorrent is configured to remove torrents when they reach their Share Ratio Limit")
                     {
                         DetailedDescription = "Radarr will be unable to perform Completed Download Handling as configured. You can fix this in qBittorrent ('Tools -> Options...' in the menu) by changing 'Options -> BitTorrent -> Share Ratio Limiting' from 'Remove them' to 'Pause them'."
                     };

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using NLog;
@@ -72,7 +72,13 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                                                 .Post()
                                                 .AddFormParameter("urls", torrentUrl);
 
-            ProcessRequest<object>(request, settings);
+            var result = ProcessRequest(request, settings);
+
+            // Note: Older qbit versions returned nothing, so we can't do != "Ok." here.
+            if (result == "Fails.")
+            {
+                throw new DownloadClientException("Download client failed to add torrent by url");
+            }
         }
 
         public void AddTorrentFromFile(string fileName, Byte[] fileContent, QBittorrentSettings settings)
@@ -81,7 +87,13 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                                                 .Post()
                                                 .AddFormUpload("torrents", fileName, fileContent);
 
-            ProcessRequest<object>(request, settings);
+            var result = ProcessRequest(request, settings);
+
+            // Note: Current qbit versions return nothing, so we can't do != "Ok." here.
+            if (result == "Fails.")
+            {
+                throw new DownloadClientException("Download client failed to add torrent");
+            }
         }
 
         public void RemoveTorrent(string hash, Boolean removeData, QBittorrentSettings settings)
@@ -90,7 +102,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                                                 .Post()
                                                 .AddFormParameter("hashes", hash);
 
-            ProcessRequest<object>(request, settings);
+            ProcessRequest(request, settings);
         }
 
         public void SetTorrentLabel(string hash, string label, QBittorrentSettings settings)
@@ -101,7 +113,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                                                         .AddFormParameter("category", label);
             try
             {
-                ProcessRequest<object>(setCategoryRequest, settings);
+                ProcessRequest(setCategoryRequest, settings);
             }
             catch(DownloadClientException ex)
             {
@@ -112,7 +124,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                                                                 .Post()
                                                                 .AddFormParameter("hashes", hash)
                                                                 .AddFormParameter("label", label);
-                    ProcessRequest<object>(setLabelRequest, settings);
+
+                    ProcessRequest(setLabelRequest, settings);
                 }
             }
         }
@@ -125,7 +138,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
             try
             {
-                var response = ProcessRequest<object>(request, settings);
+                ProcessRequest(request, settings);
             }
             catch (DownloadClientException ex)
             {
@@ -153,9 +166,17 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         private TResult ProcessRequest<TResult>(HttpRequestBuilder requestBuilder, QBittorrentSettings settings)
             where TResult : new()
         {
+            var responseContent = ProcessRequest(requestBuilder, settings);
+
+            return Json.Deserialize<TResult>(responseContent);
+        }
+
+        private string ProcessRequest(HttpRequestBuilder requestBuilder, QBittorrentSettings settings)
+        {
             AuthenticateClient(requestBuilder, settings);
 
             var request = requestBuilder.Build();
+            request.LogResponseContent = true;
 
             HttpResponse response;
             try
@@ -184,7 +205,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 throw new DownloadClientException("Failed to connect to qBitTorrent, please check your settings.", ex);
             }
 
-            return Json.Deserialize<TResult>(response.Content);
+            return response.Content;
         }
 
         private void AuthenticateClient(HttpRequestBuilder requestBuilder, QBittorrentSettings settings, bool reauthenticate = false)

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
@@ -197,12 +197,12 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 }
                 else
                 {
-                    throw new DownloadClientException("Failed to connect to qBitTorrent, check your settings.", ex);
+                    throw new DownloadClientException("Failed to connect to qBittorrent, check your settings.", ex);
                 }
             }
             catch (WebException ex)
             {
-                throw new DownloadClientException("Failed to connect to qBitTorrent, please check your settings.", ex);
+                throw new DownloadClientException("Failed to connect to qBittorrent, please check your settings.", ex);
             }
 
             return response.Content;
@@ -239,23 +239,23 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     _logger.Debug("qbitTorrent authentication failed.");
                     if (ex.Response.StatusCode == HttpStatusCode.Forbidden)
                     {
-                        throw new DownloadClientAuthenticationException("Failed to authenticate with qbitTorrent.", ex);
+                        throw new DownloadClientAuthenticationException("Failed to authenticate with qBittorrent.", ex);
                     }
 
-                    throw new DownloadClientException("Failed to connect to qBitTorrent, please check your settings.", ex);
+                    throw new DownloadClientException("Failed to connect to qBittorrent, please check your settings.", ex);
                 }
                 catch (WebException ex)
                 {
-                    throw new DownloadClientException("Failed to connect to qBitTorrent, please check your settings.", ex);
+                    throw new DownloadClientException("Failed to connect to qBittorrent, please check your settings.", ex);
                 }
 
                 if (response.Content != "Ok.") // returns "Fails." on bad login
                 {
                     _logger.Debug("qbitTorrent authentication failed.");
-                    throw new DownloadClientAuthenticationException("Failed to authenticate with qbitTorrent.");
+                    throw new DownloadClientAuthenticationException("Failed to authenticate with qBittorrent.");
                 }
 
-                _logger.Debug("qbitTorrent authentication succeeded.");
+                _logger.Debug("qBittorrent authentication succeeded.");
 
                 cookies = response.GetCookies();
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description

This is ported from Sonarr to fix a [recent upstream change](https://github.com/qbittorrent/qBittorrent/commit/7cf1d844b05a275a51472fc93de3ce33aa750f0b) to the qBitTorrent 3.3.14 API where the return value is different. In addition, a logging change has also been ported over.

As a bonus, some inconsistent naming references to "qBittorrent" have been fixed for when exceptions or log events occur. 

#### Issues Fixed or Closed by this PR

* #1842
