### PR TITLE
Fix task name of PreDB Sync task

### DIFF
--- a/src/NzbDrone.Api/System/Tasks/TaskModule.cs
+++ b/src/NzbDrone.Api/System/Tasks/TaskModule.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NzbDrone.Core.Datastore.Events;
@@ -12,7 +12,7 @@ namespace NzbDrone.Api.System.Tasks
     {
         private readonly ITaskManager _taskManager;
 
-        private static readonly Regex NameRegex = new Regex("(?<!^)[A-Z]", RegexOptions.Compiled);
+        private static readonly Regex NameRegex = new Regex("(?<!^)[A-Z][a-z]", RegexOptions.Compiled);
 
         public TaskModule(ITaskManager taskManager, IBroadcastSignalRMessage broadcastSignalRMessage)
             : base(broadcastSignalRMessage, "system/task")


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Currently the label of the PreDB Sync task in `/system/tasks` appears as "Pre D B Sync" due to the way the regex pattern matches the taskName string to be replaced. This modification allows the label to be displayed as "PreDB Sync" which is nicer.
