### PR TITLE
Fix hanging form-group div in Basic Naming Viewing Template

### DIFF
--- a/src/UI/Settings/MediaManagement/Naming/Basic/BasicNamingViewTemplate.hbs
+++ b/src/UI/Settings/MediaManagement/Naming/Basic/BasicNamingViewTemplate.hbs
@@ -1,5 +1,5 @@
-<div class="form-group">
-    {{!--<label class="col-sm-3 control-label">Include Series Title</label>
+﻿{{!--<div class="form-group">
+    <label class="col-sm-3 control-label">Include Series Title</label>
 
     <div class="col-sm-9">
         <div class="input-group">


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Looks like when these Sonarr related fields were commented out, the `form-group` div from one of the commented out fields was left in the code still. This will probably cause weird layout results as its a hanging div as far as I can tell.