### PR TITLE
Replace GitHub wiki references to Radarr's wiki paths

### DIFF
--- a/src/NzbDrone.Core.Test/HealthCheck/HealthCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/HealthCheckFixture.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.Test.HealthCheck
     [TestFixture]
     public class HealthCheckFixture : CoreTest
     {
-        private const string WikiRoot = "https://github.com/Sonarr/Sonarr/wiki/";
+        private const string WikiRoot = "https://github.com/Radarr/Radarr/wiki/";
 
         [TestCase("I blew up because of some weird user mistake", null, WikiRoot + "Health-checks#i-blew-up-because-of-some-weird-user-mistake")]
         [TestCase("I blew up because of some weird user mistake", "#my-health-check", WikiRoot + "Health-checks#my-health-check")]

--- a/src/NzbDrone.Core/Datastore/DbFactory.cs
+++ b/src/NzbDrone.Core/Datastore/DbFactory.cs
@@ -110,10 +110,10 @@ namespace NzbDrone.Core.Datastore
                 {
                     if (OsInfo.IsOsx)
                     {
-                        throw new CorruptDatabaseException("Database file: {0} is corrupt, restore from backup if available. See: https://github.com/Sonarr/Sonarr/wiki/FAQ#i-use-sonarr-on-a-mac-and-it-suddenly-stopped-working-what-happened", ex, fileName);
+                        throw new CorruptDatabaseException("Database file: {0} is corrupt, restore from backup if available. See: https://github.com/Radarr/Radarr/wiki/FAQ#i-use-radarr-on-a-mac-and-it-suddenly-stopped-working-what-happened", ex, fileName);
                     }
 
-                    throw new CorruptDatabaseException("Database file: {0} is corrupt, restore from backup if available. See: https://github.com/Sonarr/Sonarr/wiki/FAQ#i-am-getting-an-error-database-disk-image-is-malformed", ex, fileName);
+                    throw new CorruptDatabaseException("Database file: {0} is corrupt, restore from backup if available. See: https://github.com/Radarr/Radarr/wiki/FAQ#i-am-getting-an-error-database-disk-image-is-malformed", ex, fileName);
                 }
             }
 

--- a/src/NzbDrone.Core/HealthCheck/HealthCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/HealthCheck.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.HealthCheck
 
         private static HttpUri MakeWikiUrl(string fragment)
         {
-            return new HttpUri("https://github.com/Sonarr/Sonarr/wiki/Health-checks") + new HttpUri(fragment);
+            return new HttpUri("https://github.com/Radarr/Radarr/wiki/Health-checks") + new HttpUri(fragment);
         }
     }
 

--- a/src/NzbDrone.Core/Notifications/Twitter/TwitterSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/TwitterSettings.cs
@@ -37,10 +37,10 @@ namespace NzbDrone.Core.Notifications.Twitter
             AuthorizeNotification = "step1";
         }
 
-        [FieldDefinition(0, Label = "Consumer Key", HelpText = "Consumer key from a Twitter application", HelpLink = "https://github.com/Sonarr/Sonarr/wiki/Twitter-Notifications")]
+        [FieldDefinition(0, Label = "Consumer Key", HelpText = "Consumer key from a Twitter application", HelpLink = "https://github.com/Radarr/Radarr/wiki/Twitter-Notifications")]
         public string ConsumerKey { get; set; }
 
-        [FieldDefinition(1, Label = "Consumer Secret", HelpText = "Consumer secret from a Twitter application", HelpLink = "https://github.com/Sonarr/Sonarr/wiki/Twitter-Notifications")]
+        [FieldDefinition(1, Label = "Consumer Secret", HelpText = "Consumer secret from a Twitter application", HelpLink = "https://github.com/Radarr/Radarr/wiki/Twitter-Notifications")]
         public string ConsumerSecret { get; set; }
 
         [FieldDefinition(2, Label = "Access Token", Advanced = true)]

--- a/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             _service = service;
         }
 
-        public override string Link => "https://github.com/Sonarr/Sonarr/wiki/Webhook";
+        public override string Link => "https://github.com/Radarr/Radarr/wiki/Webhook";
 
         public override void OnGrab(GrabMessage message)
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description

This replaces any GitHub wiki references currently pointing at Sonarr to Radarr.

Pages have been created in Radarr's wiki and modified in a basic sense. Wiki content may need more work. I have left the webhook wiki entry blank for know as its structure differs from Sonarr in terms of Episode vs Movie etc.