### PR TITLE
removed hebrew ISO, since english movies are still in english.

### DIFF
--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -28,8 +28,8 @@ namespace NzbDrone.Core.Parser
 //                                                             new IsoLanguage("nl", "nld", Language.Flemish),
                                                                new IsoLanguage("el", "ell", Language.Greek),
                                                                new IsoLanguage("ko", "kor", Language.Korean),
-                                                               new IsoLanguage("hu", "hun", Language.Hungarian),
-                                                               new IsoLanguage("he", "heb", Language.Hebrew)
+                                                               new IsoLanguage("hu", "hun", Language.Hungarian)//,
+                                                               //new IsoLanguage("he", "heb", Language.Hebrew)
                                                            };
 
         public static IsoLanguage Find(string isoCode)


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Hebrew ISO will not find any movies. This had to be removed. 

- [x] Tests
Tested it manually also. It works great now.


