### PR TITLE
Fix FontAwesome font path

### DIFF
--- a/src/UI/Content/FontAwesome/variables.less
+++ b/src/UI/Content/FontAwesome/variables.less
@@ -1,7 +1,7 @@
 // Variables
 // --------------------------
 
-@fa-font-path:        "../fonts";
+@fa-font-path:        "../Content/FontAwesome";
 @fa-font-size-base:   14px;
 @fa-line-height-base: 1;
 //@fa-font-path:        "//netdna.bootstrapcdn.com/font-awesome/4.7.0/fonts"; // for referencing Bootstrap CDN font files directly


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Apologies. Recent update to FontAwesome nuked the original set font path in `variables.less` this corrects it!
