### PR TITLE
Fix mask-icon and other resources when UrlBase is in use

### DIFF
--- a/src/NzbDrone.Api/Frontend/Mappers/IndexHtmlMapper.cs
+++ b/src/NzbDrone.Api/Frontend/Mappers/IndexHtmlMapper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Text.RegularExpressions;
 using Nancy;
@@ -17,7 +17,7 @@ namespace NzbDrone.Api.Frontend.Mappers
         private readonly IAnalyticsService _analyticsService;
         private readonly Func<ICacheBreakerProvider> _cacheBreakProviderFactory;
         private readonly string _indexPath;
-        private static readonly Regex ReplaceRegex = new Regex(@"(?:(?<attribute>href|src)=\"")(?<path>.*?(?<extension>css|js|png|ico|ics))(?:\"")(?:\s(?<nohash>data-no-hash))?", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ReplaceRegex = new Regex(@"(?:(?<attribute>href|src)=\"")(?<path>.*?(?<extension>css|js|png|ico|ics|svg))(?:\"")(?:\s(?<nohash>data-no-hash))?", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static string API_KEY;
         private static string URL_BASE;

--- a/src/NzbDrone.Api/Frontend/Mappers/IndexHtmlMapper.cs
+++ b/src/NzbDrone.Api/Frontend/Mappers/IndexHtmlMapper.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Api.Frontend.Mappers
         private readonly IAnalyticsService _analyticsService;
         private readonly Func<ICacheBreakerProvider> _cacheBreakProviderFactory;
         private readonly string _indexPath;
-        private static readonly Regex ReplaceRegex = new Regex(@"(?:(?<attribute>href|src)=\"")(?<path>.*?(?<extension>css|js|png|ico|ics|svg))(?:\"")(?:\s(?<nohash>data-no-hash))?", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ReplaceRegex = new Regex(@"(?:(?<attribute>href|src|content)=\"")(?<path>.*?(?<extension>css|js|png|ico|ics|svg|json|xml))(?:\"")(?:\s(?<nohash>data-no-hash))?", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static string API_KEY;
         private static string URL_BASE;


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Rather trivial thing, but mask-icon path is broken when UrlBase is in use. In addition, other paths are not rewritten when UrlBase is in use, so I've added further rules in addition to the Sonarr fix.
