### PR TITLE
Add deprecation warning about Drone Factory to front end

### DIFF
--- a/src/UI/Settings/DownloadClient/DroneFactory/DroneFactoryViewTemplate.hbs
+++ b/src/UI/Settings/DownloadClient/DroneFactory/DroneFactoryViewTemplate.hbs
@@ -1,5 +1,8 @@
 <fieldset class="advanced-setting">
     <legend>Drone Factory Options</legend>
+    <div class="alert alert-warning">
+        Drone Factory is deprecated and should be disabled, use Wanted -> Manual Import to manually import arbitrary directories. See <a href="https://github.com/Radarr/Radarr/wiki/Health-Checks#drone-factory-is-deprecated">the wiki for further details</a>.
+    </div>
     <div class="form-group">
         <label class="col-sm-3 control-label">Drone Factory</label>
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description

@weirdcrap raised a good point in the linked issue about Drone Factory. Sonarr is deprecating it, therefore at minimum we should be also displaying the message on the front end as well.

In addition there is the HealthCheck for Drone Factory, but looking through the commits, getting it merged in will require a bit more work as a fair bit of rework was done on HealthChecks and associated code and will likely have merge conflicts with Radarr changes.

For now, this just adds the message to the front end.

#### Issues Fixed or Closed by this PR

#1936
