### PR TITLE
Fix missing icon preventing detailed info for validation errors from appearing

### DIFF
--- a/src/UI/jQuery/jquery.validation.js
+++ b/src/UI/jQuery/jquery.validation.js
@@ -92,9 +92,9 @@ module.exports = function() {
 
         if (error.infoLink) {
             if (error.detailedDescription) {
-                errorMessage += ' <a class="no-router" target="_blank" href="' + error.infoLink + '"><i class="icon-sonarr-external-link" title="' + error.detailedDescription + '"></i></a>';
+                errorMessage += ' <a class="no-router" target="_blank" href="' + error.infoLink + '"><i class="icon-sonarr-form-external-link" title="' + error.detailedDescription + '"></i></a>';
             } else {
-                errorMessage += ' <a class="no-router" target="_blank" href="' + error.infoLink + '"><i class="icon-sonarr-external-link"></i></a>';
+                errorMessage += ' <a class="no-router" target="_blank" href="' + error.infoLink + '"><i class="icon-sonarr-form-external-link"></i></a>';
             }
         } else if (error.detailedDescription) {
             errorMessage += ' <i class="icon-sonarr-form-info" title="' + error.detailedDescription + '"></i>';


### PR DESCRIPTION
(cherry picked from commit 3749f3e2e5e80de0637188fca949fd90b2a95ceb) from Sonarr.

#### Database Migration
NO

#### Description

The icon for extended error info for various error messages on fields are not appearing, here's the current output on an example error with extended detail info.

![radarr_error_icon_broke](https://user-images.githubusercontent.com/8067792/29333113-8302a0f6-81fa-11e7-9e93-af43200e3b94.PNG)

This fixed output, where the icon should appear

![radarr_fixed_error_icon](https://user-images.githubusercontent.com/8067792/29333112-830034ba-81fa-11e7-9e9d-d5bfd60cc330.PNG)
