### PR TITLE
Hotfix for parser error when using `(year) name` folder

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -84,6 +84,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Mission Impossible: Rogue Nation (2015)�[XviD - Ita Ac3 - SoftSub Ita]azione, spionaggio, thriller *Prima Visione* Team mulnic Tom Cruise", "Mission Impossible Rogue Nation")]
 		[TestCase("Scary.Movie.2000.FRENCH..BluRay.-AiRLiNE", "Scary Movie")]
 		[TestCase("My Movie 1999 German Bluray", "My Movie")]
+		[TestCase("(1995) Ghost in the Shell", "Ghost in the Shell")]
 		public void should_parse_movie_title(string postTitle, string title)
 		{
 			Parser.Parser.ParseMovieTitle(postTitle, true).MovieTitle.Should().Be(title);
@@ -92,6 +93,7 @@ namespace NzbDrone.Core.Test.ParserTests
 		[TestCase("1941.1979.EXTENDED.720p.BluRay.X264-AMIABLE", 1979)]
         [TestCase("Valana la Legende FRENCH BluRay 720p 2016 kjhlj", 2016)]
         [TestCase("Der.Soldat.James.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998", 1998)]
+        [TestCase("(1995) Ghost in the Shell", 1995)]
         public void should_parse_movie_year(string postTitle, int year)
 		{
 			Parser.Parser.ParseMovieTitle(postTitle, false).Year.Should().Be(year);

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -84,13 +84,18 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Mission Impossible: Rogue Nation (2015)�[XviD - Ita Ac3 - SoftSub Ita]azione, spionaggio, thriller *Prima Visione* Team mulnic Tom Cruise", "Mission Impossible Rogue Nation")]
 		[TestCase("Scary.Movie.2000.FRENCH..BluRay.-AiRLiNE", "Scary Movie")]
 		[TestCase("My Movie 1999 German Bluray", "My Movie")]
-		[TestCase("(1995) Ghost in the Shell", "Ghost in the Shell")]
 		public void should_parse_movie_title(string postTitle, string title)
 		{
-			Parser.Parser.ParseMovieTitle(postTitle, true).MovieTitle.Should().Be(title);
-		}
+		    Parser.Parser.ParseMovieTitle(postTitle, true).MovieTitle.Should().Be(title);
+        }
 
-		[TestCase("1941.1979.EXTENDED.720p.BluRay.X264-AMIABLE", 1979)]
+        [TestCase("(1995) Ghost in the Shell", "Ghost in the Shell")]
+        public void should_parse_movie_folder_name(string postTitle, string title)
+        {
+            Parser.Parser.ParseMovieTitle(postTitle, true, true).MovieTitle.Should().Be(title);
+        }
+
+        [TestCase("1941.1979.EXTENDED.720p.BluRay.X264-AMIABLE", 1979)]
         [TestCase("Valana la Legende FRENCH BluRay 720p 2016 kjhlj", 2016)]
         [TestCase("Der.Soldat.James.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998", 1998)]
         public void should_parse_movie_year(string postTitle, int year)

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -93,7 +93,6 @@ namespace NzbDrone.Core.Test.ParserTests
 		[TestCase("1941.1979.EXTENDED.720p.BluRay.X264-AMIABLE", 1979)]
         [TestCase("Valana la Legende FRENCH BluRay 720p 2016 kjhlj", 2016)]
         [TestCase("Der.Soldat.James.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998", 1998)]
-        [TestCase("(1995) Ghost in the Shell", 1995)]
         public void should_parse_movie_year(string postTitle, int year)
 		{
 			Parser.Parser.ParseMovieTitle(postTitle, false).Year.Should().Be(year);

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -848,7 +848,7 @@ namespace NzbDrone.Core.Parser
 
         private static ParsedMovieInfo ParseMovieMatchCollection(MatchCollection matchCollection)
         {
-            if (!matchCollection[0].Groups["title"].Success)
+            if (!matchCollection[0].Groups["title"].Success || matchCollection[0].Groups["title"].Value == "(")
             {
                 return null;
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Hotfix for parser regex error on folder name using `(year) name`

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
* #[1951](https://github.com/Radarr/Radarr/issues/1951)
