### PR TITLE
Add a handler for MovieDeletedEvent so that the underlying files will…

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/RecycleBinProvider.cs
+++ b/src/NzbDrone.Core/MediaFiles/RecycleBinProvider.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.MediaFiles
         void Cleanup();
     }
 
-    public class RecycleBinProvider : IHandleAsync<SeriesDeletedEvent>, IExecute<CleanUpRecycleBinCommand>, IRecycleBinProvider
+    public class RecycleBinProvider : IHandleAsync<SeriesDeletedEvent>, IExecute<CleanUpRecycleBinCommand>, IRecycleBinProvider, IHandleAsync<MovieDeletedEvent>
     {
         private readonly IDiskTransferService _diskTransferService;
         private readonly IDiskProvider _diskProvider;
@@ -197,6 +197,17 @@ namespace NzbDrone.Core.MediaFiles
                 if (_diskProvider.FolderExists(message.Series.Path))
                 {
                     DeleteFolder(message.Series.Path);
+                }
+            }
+        }
+
+        public void HandleAsync(MovieDeletedEvent message)
+        {
+            if (message.DeleteFiles)
+            {
+                if (_diskProvider.FolderExists(message.Movie.Path))
+                {
+                    DeleteFolder(message.Movie.Path);
                 }
             }
         }


### PR DESCRIPTION
… be deleted when specified.

#### Database Migration
NO

#### Description
Added a handler for MovieDeletedEvent so that when deleteFiles=true the underlying folder will be removed in addition to the metadata. My main motivation for this was so that I can bulk delete movies using the API but I have also tested the front end and it now works properly there too. 

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #694
