### PR TITLE
Allow toolbar buttons to be full width on x-small and small breakpoints

### DIFF
--- a/src/UI/Activity/Blacklist/BlacklistLayout.js
+++ b/src/UI/Activity/Blacklist/BlacklistLayout.js
@@ -80,6 +80,7 @@ module.exports = Marionette.Layout.extend({
         var leftSideButtons = {
             type       : 'default',
             storeState : false,
+            collapse: true,
             items      : [
                 {
                     title   : 'Clear blacklist',

--- a/src/UI/Content/theme.less
+++ b/src/UI/Content/theme.less
@@ -47,6 +47,16 @@
       display : inline-block;
     }
 
+    @media (max-width: @screen-sm-max) {
+      .x-toolbar-left-1 {
+        display: block;
+      }
+
+      .btn-group {
+        display: block;
+      }
+    }
+
     .sorting-buttons {
       .sorting-title {
         display : inline-block;

--- a/src/UI/Movies/Editor/MovieEditorLayout.js
+++ b/src/UI/Movies/Editor/MovieEditorLayout.js
@@ -97,16 +97,17 @@ module.exports = Marionette.Layout.extend({
 		this.leftSideButtons = {
             type       : 'default',
                 storeState : false,
+                collapse: true,
                 items      : [
                 {
-                    title          : 'Update Library',
+                    title          : 'Update library',
                     icon           : 'icon-sonarr-refresh',
                     command        : 'refreshmovie',
                     successMessage : 'Library was updated!',
                     errorMessage   : 'Library update failed!'
                 },
                 {
-                    title : 'Delete Selected',
+                    title : 'Delete selected',
                     icon : 'icon-radarr-delete-white',
                     className: 'btn-danger',
                     callback : this._deleteSelected

--- a/src/UI/System/Backup/BackupLayout.js
+++ b/src/UI/System/Backup/BackupLayout.js
@@ -41,7 +41,7 @@ module.exports = Marionette.Layout.extend({
     leftSideButtons : {
         type       : 'default',
         storeState : false,
-        collapse   : false,
+        collapse   : true,
         items      : [
             {
                 title          : 'Backup',

--- a/src/UI/Wanted/Cutoff/CutoffUnmetLayout.js
+++ b/src/UI/Wanted/Cutoff/CutoffUnmetLayout.js
@@ -97,6 +97,7 @@ module.exports = Marionette.Layout.extend({
         var leftSideButtons = {
             type       : 'default',
             storeState : false,
+            collapse: true,
             items      : [
                 {
                     title        : 'Search Selected',


### PR DESCRIPTION
#### Database Migration
NO

#### Description

So this is something that's always bothered me, but currently the toolbar buttons layout don't really scale on mobile, a lot of wasted space on larger devices in the small breakpoint.

Currently:

![image](https://user-images.githubusercontent.com/8067792/29498133-c8ec52fa-85ed-11e7-89e2-c21d30029c47.png)

With some changes:

![image](https://user-images.githubusercontent.com/8067792/29498140-e3b4e2b4-85ed-11e7-94e1-559a24282b66.png)

It is a little hacky override the classes, but I don't think there is any simpler way to do it, outside of implementing it JS but having to detect the breakpoint size and adding classes conditionally like `.btn-block` etc.

Its a fairly simply override, I've specifically targeted `x-toolbar-left-1` because it looks to be the single class used on these button toolbars only i.e. they always appear first on the page.

This modifies the look and feel of the buttons on:

* Movies
  * Index
  * Movie editor
* Activity
  * Blacklist
* Wanted section
  * Missing
  * Cutoff unmet
* System
  * Backup

As far as I'm aware these are the only places the toolbar setup is used where one or more buttons appear at the very top.
  

