### PR TITLE
Tweak NavbarLayoutTemplate.hbs

### DIFF
--- a/src/UI/Content/Overrides/bootstrap.less
+++ b/src/UI/Content/Overrides/bootstrap.less
@@ -80,3 +80,13 @@
 .table-responsive {
   overflow-x: visible;
 }
+
+.navbar-nav {
+  margin-bottom : 20px;
+}
+
+.navbar-brand {
+  @media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+    padding : 22px 15px !important;
+  }
+}

--- a/src/UI/Navbar/NavbarLayoutTemplate.hbs
+++ b/src/UI/Navbar/NavbarLayoutTemplate.hbs
@@ -1,46 +1,79 @@
 <!-- Static navbar -->
 <div class="navbar navbar-nzbdrone" role="navigation">
-		<div class="container-fluid">
-				<div class="navbar-header">
-						<button type="button" class="navbar-toggle navbar-inverse" data-toggle="collapse" data-target=".navbar-collapse">
-								<span class="sr-only">Toggle navigation</span>
-								<span class="icon-sonarr-navbar-collapsed fa-lg"></span>
-						</button>
-						<a class="navbar-brand" href="{{UrlBase}}/">
-								<!--<img src="{{UrlBase}}/Content/Images/logo.png?v=2" alt="Radarr">-->
-								<img src="{{UrlBase}}/Content/Images/logos/128.png" class="visible-lg"/>
-								<img src="{{UrlBase}}/Content/Images/logos/64.png" class="visible-md visible-sm"/>
-								<span class="visible-xs">
-										<img src="{{UrlBase}}/Content/Images/logos/32.png"/>
-										<span class="logo-text">Radarr</span>
-								</span>
-
-						</a>
+	<div class="container-fluid">
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle navbar-inverse" data-toggle="collapse" data-target=".navbar-collapse">
+				<span class="sr-only">Toggle navigation</span>
+				<span class="icon-sonarr-navbar-collapsed fa-lg"></span>
+			</button>
+			<a class="navbar-brand" href="{{UrlBase}}/">
+				<img src="{{UrlBase}}/Content/Images/logos/128.png" class="visible-md visible-lg">
+                <img src="{{UrlBase}}/Content/Images/logos/64.png" class="visible-sm">
+				<div class="visible-xs">
+					<img src="{{UrlBase}}/Content/Images/logos/32.png"/>
+					<span class="logo-text">Radarr</span>
 				</div>
-				<div class="navbar-collapse collapse x-navbar-collapse">
-						<ul class="nav navbar-nav">
-								<li><a href="{{UrlBase}}/addmovies" class="x-series-nav"><i class="icon-sonarr-navbar-icon icon-sonarr-add"></i> Add Movies</a></li>
-								<li><a href="{{UrlBase}}/" class="x-series-nav"><i class="icon-sonarr-navbar-icon icon-sonarr-navbar-series"></i> Movies</a></li>
-								
-								<li><a href="{{UrlBase}}/calendar" class="x-calendar-nav"><i class="icon-sonarr-navbar-icon icon-sonarr-navbar-calendar"></i> Calendar</a></li>
-								<li><a href="{{UrlBase}}/activity" class="x-activity-nav"><i class="icon-sonarr-navbar-icon icon-sonarr-navbar-activity"></i> Activity<span id="x-queue-count" class="navbar-info"></span></a></li>
-								<li><a href="{{UrlBase}}/wanted" class="x-wanted-nav"><i class="icon-sonarr-navbar-icon icon-sonarr-navbar-wanted"></i> Wanted</a></li>
-								<li><a href="{{UrlBase}}/settings" class="x-settings-nav"><i class="icon-sonarr-navbar-icon icon-sonarr-navbar-settings"></i> Settings</a></li>
-								<li><a href="{{UrlBase}}/system" class="x-system-nav"><i class="icon-sonarr-navbar-icon icon-sonarr-navbar-system"></i> System<span id="x-health" class="navbar-info"></span></a></li>
-								<li><a href="https://radarr.video/donate.html" target="_blank"><i class="icon-sonarr-navbar-icon icon-sonarr-navbar-donate"></i> Donate</a></li>
-						</ul>
-						<ul class="nav navbar-nav navbar-right">
-								<li class="active screen-size"></li>
-						</ul>
-				</div><!--/.nav-collapse -->
-		</div><!--/.container-fluid -->
-
-		<div class="col-md-12 search">
-				<div class="col-md-6 col-md-offset-3">
-						<div class="input-group">
-								<span class="input-group-addon"><i class="fa fa-search"></i></span>
-								<input type="text" class="col-md-6 form-control x-series-search" placeholder="Search the movies in your library">
-						</div>
-				</div>
+			</a>
+        </div>
+        <div class="navbar-collapse collapse x-navbar-collapse">
+            <ul class="nav navbar-nav">
+				<li>
+                    <a href="{{UrlBase}}/addmovies" class="x-series-nav">
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-add"></i>
+                        Add Movies
+                    </a>
+                </li>
+				<li>
+                    <a href="{{UrlBase}}/" class="x-series-nav">
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-series"></i>
+                        Movies
+                    </a>
+                </li>
+				<li>
+                    <a href="{{UrlBase}}/calendar" class="x-calendar-nav">
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-calendar"></i>
+                        Calendar
+                    </a>
+                </li>
+				<li>
+                    <a href="{{UrlBase}}/activity" class="x-activity-nav">
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-activity"></i>
+                        Activity <span id="x-queue-count" class="navbar-info"></span>
+                    </a>
+                </li>
+				<li>
+                    <a href="{{UrlBase}}/wanted" class="x-wanted-nav">
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-wanted"></i>
+                        Wanted
+                    </a>
+                </li>
+				<li>
+                    <a href="{{UrlBase}}/settings" class="x-settings-nav">
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-settings"></i>
+                        Settings
+                    </a>
+                </li>
+				<li>
+                    <a href="{{UrlBase}}/system" class="x-system-nav">
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-system"></i>
+                        System <span id="x-health" class="navbar-info"></span>
+                    </a>
+                </li>
+				<li>
+                    <a href="https://radarr.video/donate.html" target="_blank">
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-donate"></i>
+                        Donate
+                    </a>
+                </li>
+			</ul>
 		</div>
+	</div>
+	<div class="col-md-12 search">
+		<div class="col-md-6 col-md-offset-3">
+			<div class="input-group">
+				<span class="input-group-addon"><i class="fa fa-search"></i></span>
+				<input type="text" class="col-md-6 form-control x-series-search" placeholder="Search the movies in your library">
+			</div>
+		</div>
+	</div>
 </div>

--- a/src/UI/Navbar/NavbarLayoutTemplate.hbs
+++ b/src/UI/Navbar/NavbarLayoutTemplate.hbs
@@ -19,49 +19,49 @@
             <ul class="nav navbar-nav">
 				<li>
                     <a href="{{UrlBase}}/addmovies" class="x-series-nav">
-                        <i class="icon-sonarr-navbar-icon icon-sonarr-add"></i>
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-add" aria-hidden="true"></i>
                         Add Movies
                     </a>
                 </li>
 				<li>
                     <a href="{{UrlBase}}/" class="x-series-nav">
-                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-series"></i>
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-series" aria-hidden="true"></i>
                         Movies
                     </a>
                 </li>
 				<li>
                     <a href="{{UrlBase}}/calendar" class="x-calendar-nav">
-                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-calendar"></i>
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-calendar" aria-hidden="true"></i>
                         Calendar
                     </a>
                 </li>
 				<li>
                     <a href="{{UrlBase}}/activity" class="x-activity-nav">
-                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-activity"></i>
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-activity" aria-hidden="true"></i>
                         Activity <span id="x-queue-count" class="navbar-info"></span>
                     </a>
                 </li>
 				<li>
                     <a href="{{UrlBase}}/wanted" class="x-wanted-nav">
-                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-wanted"></i>
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-wanted" aria-hidden="true"></i>
                         Wanted
                     </a>
                 </li>
 				<li>
                     <a href="{{UrlBase}}/settings" class="x-settings-nav">
-                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-settings"></i>
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-settings" aria-hidden="true"></i>
                         Settings
                     </a>
                 </li>
 				<li>
                     <a href="{{UrlBase}}/system" class="x-system-nav">
-                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-system"></i>
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-system" aria-hidden="true"></i>
                         System <span id="x-health" class="navbar-info"></span>
                     </a>
                 </li>
 				<li>
                     <a href="https://radarr.video/donate.html" target="_blank">
-                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-donate"></i>
+                        <i class="icon-sonarr-navbar-icon icon-sonarr-navbar-donate" aria-hidden="true"></i>
                         Donate
                     </a>
                 </li>
@@ -71,7 +71,9 @@
 	<div class="col-md-12 search">
 		<div class="col-md-6 col-md-offset-3">
 			<div class="input-group">
-				<span class="input-group-addon"><i class="fa fa-search"></i></span>
+				<span class="input-group-addon">
+                    <i class="fa fa-search"></i>
+                </span>
 				<input type="text" class="col-md-6 form-control x-series-search" placeholder="Search the movies in your library">
 			</div>
 		</div>


### PR DESCRIPTION
#### Database Migration
NO

#### Description

* Allows for larger logo to be displayed in the medium breakpoint, because it can fit.
* Remove empty unordered list element and added the margin with CSS
* Added `aria-hidden` to nav icons because of the text label already present

Existing logo appearance in medium breakpoint:

![image](https://user-images.githubusercontent.com/8067792/29690255-2719f606-891e-11e7-92c6-5c4d585acb0c.png)

Logo appearance with modifications in medium breakpoint:

![image](https://user-images.githubusercontent.com/8067792/29690189-e237e0f2-891d-11e7-8db9-33b301dd2af1.png)

