### PR TITLE
Convert backticks in package.sh

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -17,10 +17,10 @@ case "$(uname -s)" in
 esac
 
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-  VERSION="`date +%H:%M:%S`"
-  YEAR="`date +%Y`"
-  MONTH="`date +%m`"
-  DAY="`date +%d`"
+  VERSION="$(date +%H:%M:%S)"
+  YEAR="$(date +%Y)"
+  MONTH="$(date +%m)"
+  DAY="$(date +%d)"
 else
   VERSION=$1
   BRANCH=$2


### PR DESCRIPTION
#### Database Migration
NO

#### Description

To be consistent, I replaced backticks with `$()`. It is generally noted as the more favourable method with shell.
