### PR TITLE
Fix icon not being hidden on Discover New Movies button in X-Small

### DIFF
--- a/src/UI/AddMovies/AddMoviesLayoutTemplate.hbs
+++ b/src/UI/AddMovies/AddMoviesLayoutTemplate.hbs
@@ -1,10 +1,22 @@
 <div class="row">
 		<div class="col-md-12">
 				<div class="btn-group add-movies-btn-group btn-group-lg btn-block btn-group-collapse">
-						<button class="btn btn-default col-md-3 col-xs-12 x-bulk-import"><i class="icon-sonarr-view-list hidden-xs"></i> Bulk Import Movies</button>
-						<button type="button" class="btn btn-default col-md-4 col-xs-12 add-movies-import-btn x-discover"><i class="icon-sonarr-star"/> Discover new movies</button>
-						<button class="btn btn-default col-md-2 col-xs-12 x-add-new"><i class="icon-sonarr-active hidden-xs"></i> Add New Movie</button>
-						<button class="btn btn-default col-md-3 col-xs-12 x-add-lists"><i class="icon-sonarr-active hidden-xs"></i> Add Movies from Lists</button>
+						<button class="btn btn-default col-md-3 col-xs-12 x-bulk-import">
+                            <i class="icon-sonarr-view-list hidden-xs" aria-hidden="true"></i>
+                            Bulk Import Movies
+                        </button>
+						<button type="button" class="btn btn-default col-md-4 col-xs-12 add-movies-import-btn x-discover">
+                            <i class="icon-sonarr-star hidden-xs" aria-hidden="true"></i>
+                            Discover New movies
+                        </button>
+						<button class="btn btn-default col-md-2 col-xs-12 x-add-new">
+                            <i class="icon-sonarr-active hidden-xs" aria-hidden="true"></i>
+                            Add New Movie
+                        </button>
+						<button class="btn btn-default col-md-3 col-xs-12 x-add-lists">
+                            <i class="icon-sonarr-active hidden-xs" aria-hidden="true"></i>
+                            Add Movies from Lists
+                        </button>
 				</div>
 		</div>
 </div>
@@ -28,7 +40,7 @@
 							</label>
 
 							<span class="help-inline-checkbox">
-								<i class="icon-sonarr-form-info" title="Should Radarr display movies already in your collection?"/>
+                                <i class="icon-sonarr-form-info" title="Should Radarr display movies already in your collection?"></i>
 							</span>
 						</div>
 					</div>


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Currently in X-Small, the Discover New Movies button still has its icon showing when the other buttons have them hidden, causing a bit of inconsistency, this fixes that and also improves the accessibility with `aria-hidden`.

![image](https://user-images.githubusercontent.com/8067792/30780575-ed264166-a105-11e7-9d67-2bbe806f3cc4.png)

