### PR TITLE
Add GB as English language when fetching alternative titles

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -156,7 +156,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 {
                     altTitles.Add(new AlternativeTitle(alternativeTitle.title, SourceType.TMDB, TmdbId, IsoLanguages.Find(alternativeTitle.iso_3166_1.ToLower())?.Language ?? Language.English));
                 }
-                else if (alternativeTitle.iso_3166_1.ToLower() == "us")
+                else if (alternativeTitle.iso_3166_1.ToLower() == "us" || alternativeTitle.iso_3166_1.ToLower() == "gb")
                 {
                     altTitles.Add(new AlternativeTitle(alternativeTitle.title, SourceType.TMDB, TmdbId, Language.English));
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Movies with different titles in US and GB would not parse correctly. For example Chuck (US) <-> The Bleeder (GB) (found with GB name on indexer: The Bleeder 2016 1080p BluRay DD5.1 x264-VietHD)

https://api.themoviedb.org/3/movie/373546/alternative_titles?api_key=1a7373301961d03f97f853a876dd1212

#### Todos

#### Issues Fixed or Closed by this PR
