### PR TITLE
Fix alignment and buttons position of Trakt Auth

### DIFF
--- a/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Options/NetImportOptionsViewTemplate.hbs
@@ -1,63 +1,67 @@
 <fieldset>
-		<legend>Options</legend>
+	<legend>Options</legend>
+	<div class="form-group">
+		<label class="col-sm-3 control-label">List Update Interval</label>
 
-		<div class="form-group">
-				<label class="col-sm-3 control-label">List Update Interval</label>
-
-				<div class="col-sm-1 col-sm-push-2 help-inline">
-						<i class="icon-sonarr-form-warning" title="This will apply to all lists, please follow the rules set forth by them."/>
-						<i class="icon-sonarr-form-info" title="Interval in minutes."/>
-				</div>
-
-				<div class="col-sm-2 col-sm-pull-1">
-						<input type="number" name="netImportSyncInterval" class="form-control" min="0" max="1440"/>
-				</div>
+		<div class="col-sm-1 col-sm-push-2 help-inline">
+			<i class="icon-sonarr-form-warning" title="This will apply to all lists, please follow the rules set forth by them."></i>
+			<i class="icon-sonarr-form-info" title="Interval in minutes."></i>
 		</div>
-		<div class="form-group">
-	              <label class="col-sm-3 control-label">Clean Library Level</label>
-                      <div class="col-sm-1 col-sm-push-2 help-inline">
-		      <i class="icon-sonarr-form-warning" title="Disable unless you are sure. Enabling Recycle bin before this is recommended"/>
-		      <i class="icon-sonarr-form-info" title="Movies in library will be removed or unmonitored if not found in your lists"/>
-		      </div>
 
-	              <div class="col-sm-2 col-sm-pull-1">
-	                  <select name="listSyncLevel" class="form-control">
-	                      <option value="disabled">Disabled</option>
-		                    <option value="logOnly">LogOnly</option>
-				    <option value="keepAndUnmonitor">Keep but Unmonitor</option>
-				    <option value="removeAndKeep">Remove & Keep Files</option>
-				    <option value="removeAndDelete">Remove & Delete Files</option>
-                    </select>
-	              </div>
-	          </div>
-		  <!--<div class="form-group">
-		                <label class="col-sm-3 control-label">Import Exclusions</label>
-				<div class="col-sm-1 col-sm-push-4 help-inline">
-				<i class="icon-sonarr-form-warning" title="Movies in this field will not be imported even if they exist on your lists."/>
-				<i class="icon-sonarr-form-info" title="Comma separated imdbid or tmdbid: tt0120915,216138,tt0121765"/>
-				</div>
-				<div class="col-sm-4 col-sm-pull-1">
-
-				                <input type="text" name="importExclusions" class="form-control x-import-exclusions"/>
-				</div>
-			</div>-->
-		<legend>Trakt Authentication</legend>
-		<div class="form-group">
-		    <label class="col-sm-1 control-label">Auth Token</label>
-				    <div class="col-sm-4">
-				        <input type="text" readonly="readonly" name="traktAuthToken" class="form-control x-trakt-auth-token"/>
-						    <input type="hidden" readonly="readonly" name="traktTokenExpiry" class="form-control x-trakt-token-expiry"/>
-		        </div>
+		<div class="col-sm-2 col-sm-pull-1">
+			<input type="number" name="netImportSyncInterval" class="form-control" min="0" max="1440">
 		</div>
-		<div class="form-group">
-		    <label class="col-sm-1 control-label">Refresh Token</label>
-				<div class="col-sm-4">
-				    <input type="text" readonly="readonly" name="traktRefreshToken" class="form-control x-trakt-refresh-token"/>
+	</div>
+    <div class="form-group">
+        <label class="col-sm-3 control-label">Clean Library Level</label>
+        <div class="col-sm-1 col-sm-push-2 help-inline">
+            <i class="icon-sonarr-form-warning" title="Disable unless you are sure. Enabling Recycle bin before this is recommended"></i>
+            <i class="icon-sonarr-form-info" title="Movies in library will be removed or unmonitored if not found in your lists"></i>
         </div>
-        <div class="input-group-btn">
-            <button class="btn btn-danger btn-icon-only x-reset-trakt-tokens" title="Reset Trakt Tokens"><i class="icon-sonarr-refresh"></i></button>
-	          <button class="btn btn-danger btn-icon-only x-revoke-trakt-tokens" title="Revoke Trakt Tokens"><i class="icon-sonarr-logout"></i></button>
-			  </div >
+        <div class="col-sm-2 col-sm-pull-1">
+            <select name="listSyncLevel" class="form-control">
+                <option value="disabled">Disabled</option>
+                <option value="logOnly">Log Only</option>
+                <option value="keepAndUnmonitor">Keep but Unmonitor</option>
+                <option value="removeAndKeep">Remove &amp; Keep Files</option>
+                <option value="removeAndDelete">Remove &amp; Delete Files</option>
+            </select>
+       </div>
     </div>
-
+    {{!--
+        <div class="form-group">
+            <label class="col-sm-3 control-label">Import Exclusions</label>
+            <div class="col-sm-1 col-sm-push-4 help-inline">
+                <i class="icon-sonarr-form-warning" title="Movies in this field will not be imported even if they exist on your lists."/>
+                <i class="icon-sonarr-form-info" title="Comma separated imdbid or tmdbid: tt0120915,216138,tt0121765"/>
+            </div>
+            <div class="col-sm-4 col-sm-pull-1">
+                <input type="text" name="importExclusions" class="form-control x-import-exclusions"/>
+            </div>
+        </div>
+    --}}
+	<legend>Trakt Authentication</legend>
+	<div class="form-group">
+	    <label class="col-sm-3 control-label">Auth Token</label>
+		<div class="col-sm-4">
+		    <input type="text" readonly="readonly" name="traktAuthToken" class="form-control x-trakt-auth-token">
+			<input type="hidden" readonly="readonly" name="traktTokenExpiry" class="form-control x-trakt-token-expiry">
+        </div>
+	</div>
+	<div class="form-group">
+	    <label class="col-sm-3 control-label">Refresh Token</label>
+		<div class="col-sm-4">
+            <div class="input-group">
+    			<input type="text" readonly="readonly" name="traktRefreshToken" class="form-control x-trakt-refresh-token">
+                <div class="input-group-btn">
+                    <button class="btn btn-danger btn-icon-only x-reset-trakt-tokens" title="Reset Trakt Tokens">
+                        <i class="icon-sonarr-refresh"></i>
+                    </button>
+                    <button class="btn btn-danger btn-icon-only x-revoke-trakt-tokens" title="Revoke Trakt Tokens">
+                        <i class="icon-sonarr-logout"></i>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
 </fieldset>


### PR DESCRIPTION
#### Database Migration
NO

#### Description

* Increase label size so text can fit on one line
* Fix alignment to the options section above (increase label col size)
* Ensure buttons are contained within col layout
* Add a space for the "Log Only" field option (value unchanged)
* Make Trakt buttons appear inline on the token input field
* Fix indents and HTML markup
* Stop commented out field appearing in the HTML output
* Encoded & as `&amp;`

New appearance in the settings section with these changes.

![image](https://user-images.githubusercontent.com/8067792/31353268-c7d91e4e-ad29-11e7-8f97-4d29135cc6e1.png)

