### PR TITLE
Stop commented out code appearing in HTML source in various places

### DIFF
--- a/src/UI/AddMovies/SearchResultViewTemplate.hbs
+++ b/src/UI/AddMovies/SearchResultViewTemplate.hbs
@@ -59,7 +59,7 @@
                         <label>Monitor <i class="icon-sonarr-form-info monitor-tooltip x-monitor-tooltip"></i></label>
                         <select class="form-control col-md-2 x-monitor">
                             <option value="all">Yes</option>
-                            <!-- <option value="missing">Missing</option> -->
+                            {{!--<option value="missing">Missing</option>--}}
                             <option value="none">No</option>
                         </select>
                     </div>
@@ -98,7 +98,6 @@
                 {{#unless existing}}
                     {{#if title}}
                     <div class="form-group col-md-2">
-                        <!--Uncomment if we need to add even more controls to add Movies-->
                         <label style="visibility: hidden">Add</label>
                         <div class="btn-group">
                             <button class="btn btn-success add x-add" title="Add">

--- a/src/UI/AddSeries/MonitoringTooltipTemplate.hbs
+++ b/src/UI/AddSeries/MonitoringTooltipTemplate.hbs
@@ -13,6 +13,6 @@
     <dd>Monitor all episodes of the latest season and future seasons</dd>
     <dt>None</dt>
     <dd>No episodes will be monitored.</dd>
-    <!--<dt>Latest Season</dt>-->
-    <!--<dd>Monitor all episodes the latest season only, previous seasons will be ignored</dd>-->
+    {{!--<dt>Latest Season</dt>-->
+    <dd>Monitor all episodes the latest season only, previous seasons will be ignored</dd>--}}
 </dl>

--- a/src/UI/AddSeries/SearchResultViewTemplate.hbs
+++ b/src/UI/AddSeries/SearchResultViewTemplate.hbs
@@ -77,8 +77,10 @@
                 {{#unless existing}}
                     {{#if title}}
                     <div class="form-group col-md-2 col-md-offset-10">
-                        <!--Uncomment if we need to add even more controls to add series-->
-                        <!--<label style="visibility: hidden">Add</label>-->
+                        {{!--
+                            Uncomment if we need to add even more controls to add series
+                            <label style="visibility: hidden">Add</label>
+                        --}}
                         <div class="btn-group">
                             <button class="btn btn-success add x-add" title="Add">
                                 <i class="icon-sonarr-add"></i>

--- a/src/UI/Navbar/NavbarLayoutTemplate.hbs
+++ b/src/UI/Navbar/NavbarLayoutTemplate.hbs
@@ -1,4 +1,4 @@
-<!-- Static navbar -->
+{{!-- Static navbar --}}
 <div class="navbar navbar-nzbdrone" role="navigation">
 	<div class="container-fluid">
         <div class="navbar-header">

--- a/src/UI/Series/Details/InfoViewTemplate.hbs
+++ b/src/UI/Series/Details/InfoViewTemplate.hbs
@@ -29,10 +29,10 @@
     </div>
     <div class="col-md-3">
         <span class="series-info-links">
-            <!--<a href="{{traktUrl}}" class="label label-info">Trakt</a>
-
-            <a href="{{tvdbUrl}}" class="label label-info">The TVDB</a>-->
-
+            {{!--
+                <a href="{{traktUrl}}" class="label label-info">Trakt</a>
+                <a href="{{tvdbUrl}}" class="label label-info">The TVDB</a>
+            --}}
             {{#if imdbId}}
                 <a href="{{imdbUrl}}" class="label label-info">IMDB</a>
             {{/if}}

--- a/src/UI/Wanted/WantedLayoutTemplate.hbs
+++ b/src/UI/Wanted/WantedLayoutTemplate.hbs
@@ -4,7 +4,9 @@
 </ul>
 
 <div class="tab-pane" id="content"></div>
-<!--<div class="tab-content">
-    <div class="tab-pane" id="missing"></div>
-    <div class="tab-pane" id="cutoff"></div>
-</div>-->
+{{!--
+    <div class="tab-content">
+        <div class="tab-pane" id="missing"></div>
+        <div class="tab-pane" id="cutoff"></div>
+    </div>
+--}}


### PR DESCRIPTION
#### Database Migration
NO

#### Description

We can use the `{{!-- --}}` comments in hbs files to comment out the code but not have it outputted in the HTML. Just a small optimisation but will cut the request size down slightly.

I've done a regex find for `<!--` in any .hbs file and this was picked up, others have been picked off in recent changes.
