### PR TITLE
Set a default name for Radarr.ics

### DIFF
--- a/src/NzbDrone.Api/Calendar/CalendarFeedModule.cs
+++ b/src/NzbDrone.Api/Calendar/CalendarFeedModule.cs
@@ -1,9 +1,10 @@
-﻿using Nancy;
+using Nancy;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ical.Net;
 using Ical.Net.DataTypes;
+using Ical.Net.General;
 using Ical.Net.Interfaces.Serialization;
 using Ical.Net.Serialization;
 using Ical.Net.Serialization.iCalendar.Factory;
@@ -81,10 +82,13 @@ namespace NzbDrone.Api.Calendar
             }
 
             var movies = _movieService.GetMoviesBetweenDates(start, end, unmonitored);
-            var calendar = new Ical.Net.Calendar
-            {
-                ProductId = "-//radarr.video//Radarr//EN"
-            };
+            var calendar = new Ical.Net.Calendar();
+
+            calendar.ProductId = "-//radarr.video//Radarr//EN";
+
+            var calendarName = "Radarr Movies Calendar";
+            calendar.AddProperty(new CalendarProperty("NAME", calendarName));
+            calendar.AddProperty(new CalendarProperty("X-WR-CALNAME", calendarName));
 
             foreach (var movie in movies.OrderBy(v => v.Added))
             {
@@ -114,8 +118,10 @@ namespace NzbDrone.Api.Calendar
                             occurrence.End = new CalDateTime(movie.InCinemas.Value.AddMinutes(movie.Runtime)) { HasTime = true };
                         }
                         break;
+
                     case MovieStatusType.Announced:
                         continue; // no date
+
                     default:
                         if (movie.PhysicalRelease != null)
                         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description

This sets a default name when the ics file is added to a calendar that supports iCal. It appears for compatibility, both the `NAME` and `X-WR-CALNAME` should be set.

Thought it might be better than using the rather long URL string for the default!
