### PR TITLE
Adjust ambiguous date options

### DIFF
--- a/src/UI/Settings/UI/UiViewTemplate.hbs
+++ b/src/UI/Settings/UI/UiViewTemplate.hbs
@@ -45,10 +45,10 @@
 
             <div class="col-sm-4 col-sm-pull-1">
                 <select name="calendarWeekColumnHeader" class="form-control">
-                    <option value="ddd M/D">Tue 3/5</option>
-                    <option value="ddd MM/DD">Tue 03/05</option>
-                    <option value="ddd D/M">Tue 5/3</option>
-                    <option value="ddd DD/MM">Tue 05/03</option>
+                    <option value="ddd M/D">Tue 3/25</option>
+                    <option value="ddd MM/DD">Tue 03/25</option>
+                    <option value="ddd D/M">Tue 25/3</option>
+                    <option value="ddd DD/MM">Tue 25/03</option>
                 </select>
             </div>
         </div>
@@ -62,12 +62,12 @@
 
             <div class="col-sm-4">
                 <select name="shortDateFormat" class="form-control">
-                    <option value="MMM D YYYY">Mar 5 2014</option>
-                    <option value="DD MMM YYYY">05 Mar 2014</option>
-                    <option value="MM/D/YYYY">03/5/2014</option>
-                    <option value="MM/DD/YYYY">03/05/2014</option>
-                    <option value="DD/MM/YYYY">05/03/2014</option>
-                    <option value="YYYY-MM-DD">2014-03-05</option>
+                    <option value="MMM D YYYY">Mar 25 2014</option>
+                    <option value="DD MMM YYYY">25 Mar 2014</option>
+                    <option value="MM/D/YYYY">03/25/2014</option>
+                    <option value="MM/DD/YYYY">03/25/2014</option>
+                    <option value="DD/MM/YYYY">25/03/2014</option>
+                    <option value="YYYY-MM-DD">2014-03-25</option>
                 </select>
             </div>
         </div>
@@ -77,8 +77,8 @@
 
             <div class="col-sm-4">
                 <select name="longDateFormat" class="form-control">
-                    <option value="dddd, MMMM D YYYY">Tuesday, March 5, 2014</option>
-                    <option value="dddd, D MMMM YYYY">Tuesday, 5 March, 2014</option>
+                    <option value="dddd, MMMM D YYYY">Tuesday, March 25, 2014</option>
+                    <option value="dddd, D MMMM YYYY">Tuesday, 25 March, 2014</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
(cherry picked from commit 00c307421666b55a6d08ff1c69c1871ccb541314)

#### Database Migration
NO

#### Description

Adjusts the example labels for setting the date in the UI. I'm inclined to agree with original author @franga2000 of the PR on Sonarr, that its not obvious and can be ambiguous here.

https://github.com/Sonarr/Sonarr/commit/00c307421666b55a6d08ff1c69c1871ccb541314
