### PR TITLE
Initial state option for torrents added to qBittorrent

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -50,6 +50,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 _proxy.SetTorrentLabel(hash.ToLower(), Settings.MovieCategory, Settings);
             }
 
+            SetInitialState(hash.ToLower());
+
             return hash;
         }
 
@@ -61,6 +63,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             {
                 _proxy.SetTorrentLabel(hash.ToLower(), Settings.MovieCategory, Settings);
             }
+
+            SetInitialState(hash);
 
             return hash;
         }
@@ -260,6 +264,29 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             }
 
             return null;
+        }
+
+        private void SetInitialState(string hash)
+        {
+            try
+            {
+                switch ((QBittorrentState)Settings.InitialState)
+                {
+                    case QBittorrentState.ForceStart:
+                        _proxy.SetForceStart(hash, true, Settings);
+                        break;
+                    case QBittorrentState.Start:
+                        _proxy.ResumeTorrent(hash, Settings);
+                        break;
+                    case QBittorrentState.Pause:
+                        _proxy.PauseTorrent(hash, Settings);
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn(ex, "Failed to set inital state for {0}.", hash);
+            }
         }
     }
 }

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
@@ -23,6 +23,9 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         void RemoveTorrent(string hash, Boolean removeData, QBittorrentSettings settings);
         void SetTorrentLabel(string hash, string label, QBittorrentSettings settings);
         void MoveTorrentToTopInQueue(string hash, QBittorrentSettings settings);
+        void PauseTorrent(string hash, QBittorrentSettings settings);
+        void ResumeTorrent(string hash, QBittorrentSettings settings);
+        void SetForceStart(string hash, bool enabled, QBittorrentSettings settings);
     }
 
     public class QBittorrentProxy : IQBittorrentProxy
@@ -152,6 +155,34 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 throw;
             }
 
+        }
+
+        public void PauseTorrent(string hash, QBittorrentSettings settings)
+        {
+            var request = BuildRequest(settings).Resource("/command/pause")
+                                                .Post()
+                                                .AddFormParameter("hash", hash);
+
+            ProcessRequest(request, settings);
+        }
+
+        public void ResumeTorrent(string hash, QBittorrentSettings settings)
+        {
+            var request = BuildRequest(settings).Resource("/command/resume")
+                                                .Post()
+                                                .AddFormParameter("hash", hash);
+
+            ProcessRequest(request, settings);
+        }
+
+        public void SetForceStart(string hash, bool enabled, QBittorrentSettings settings)
+        {
+            var request = BuildRequest(settings).Resource("/command/setForceStart")
+                                                .Post()
+                                                .AddFormParameter("hashes", hash)
+                                                .AddFormParameter("value", enabled ? "true": "false");
+
+            ProcessRequest(request, settings);
         }
 
         private HttpRequestBuilder BuildRequest(QBittorrentSettings settings)

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
@@ -40,7 +40,10 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         [FieldDefinition(4, Label = "Category", Type = FieldType.Textbox, HelpText = "Adding a category specific to Radarr avoids conflicts with unrelated downloads, but it's optional")]
         public string MovieCategory { get; set; }
 
-        [FieldDefinition(5, Label = "Use SSL", Type = FieldType.Checkbox, HelpText = "Use a secure connection. See Options -> Web UI -> 'Use HTTPS instead of HTTP' in qBittorrent.")]
+        [FieldDefinition(5, Label = "Initial State", Type = FieldType.Select, SelectOptions = typeof(QBittorrentState), HelpText = "Initial state for torrents added to qBittorrent")]
+        public int InitialState { get; set; }
+
+        [FieldDefinition(6, Label = "Use SSL", Type = FieldType.Checkbox, HelpText = "Use a secure connection. See Options -> Web UI -> 'Use HTTPS instead of HTTP' in qBittorrent.")]
         public bool UseSsl { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentState.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentState.cs
@@ -1,0 +1,9 @@
+namespace NzbDrone.Core.Download.Clients.QBittorrent
+{
+    public enum QBittorrentState
+    {
+        Start = 0,
+        ForceStart = 1,
+        Pause = 2
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -504,6 +504,7 @@
     <Compile Include="Download\Clients\Pneumatic\Pneumatic.cs" />
     <Compile Include="Download\Clients\Pneumatic\PneumaticSettings.cs" />
     <Compile Include="Download\Clients\QBittorrent\QBittorrentPreferences.cs" />
+    <Compile Include="Download\Clients\QBittorrent\QBittorrentState.cs" />
     <Compile Include="Download\Clients\rTorrent\RTorrentDirectoryValidator.cs" />
     <Compile Include="Download\Clients\QBittorrent\QBittorrent.cs" />
     <Compile Include="Download\Clients\QBittorrent\QBittorrentPriority.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Port initial state when adding torrents for qBittorent, implemented in Sonarr in September.

https://github.com/Sonarr/Sonarr/commit/ef8b882258786ed99cc04f81e9414d039bfb0357
