### PR TITLE
Fix typo on margin-bottom property hotkeys.less

### DIFF
--- a/src/UI/Hotkeys/hotkeys.less
+++ b/src/UI/Hotkeys/hotkeys.less
@@ -1,7 +1,7 @@
 .hotkeys-modal {
   h3 {
     margin-top    : 0;
-    margin-botton : 0;
+    margin-bottom : 0;
   }
 
   .hotkey-group {


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Typo on `margin-bottom`