### PR TITLE
Change default port of qBittorrent download client config

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         public QBittorrentSettings()
         {
             Host = "localhost";
-            Port = 9091;
+            Port = 8080;
             MovieCategory = "radarr";
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description

New installs of qBittorrent set `8080` as the default port, so this sets the default indexer config with that port.
