### PR TITLE
Add message about adblockers preventing the log table from loading

### DIFF
--- a/src/UI/System/Logs/Table/LogsTableLayoutTemplate.hbs
+++ b/src/UI/System/Logs/Table/LogsTableLayoutTemplate.hbs
@@ -1,4 +1,8 @@
 <div id="x-toolbar"/>
+<div class="alert alert-warning alert-dismissable">
+    <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+    If the log viewer table does not load, please disable your adblocker and refresh the page.
+</div>
 <div class="row">
     <div class="col-md-12">
         <div id="x-grid" class="table-responsive"/>


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Looks like the `/api/log` request gets flagged by the EasyPrivacy list as a regex rule to block. This adds a dismissable alert on the page to inform the user of this.

![image](https://user-images.githubusercontent.com/8067792/31895485-35ae03e6-b809-11e7-97d8-cc4edfc10c8b.png)

Short term fix for now. Potentially the `/api/log` route could be renamed to something like `/api/syslog` to avoid the filter as a more long term fix.

#### Issues Fixed or Closed by this PR

* #2209 
