### PR TITLE
Add Download_Id to On Download/On Upgrade

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedMovie.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedMovie.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -131,7 +131,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
 
                     if (newDownload)
                     {
-                        _eventAggregator.PublishEvent(new MovieDownloadedEvent(localMovie, movieFile, oldFiles));
+                        _eventAggregator.PublishEvent(new MovieDownloadedEvent(localMovie, movieFile, oldFiles, downloadClientItem));
                     }
                 }
                 catch (Exception e)

--- a/src/NzbDrone.Core/MediaFiles/Events/MovieDownloadedEvent.cs
+++ b/src/NzbDrone.Core/MediaFiles/Events/MovieDownloadedEvent.cs
@@ -10,14 +10,14 @@ namespace NzbDrone.Core.MediaFiles.Events
         public LocalMovie Movie { get; private set; }
         public MovieFile MovieFile { get; private set; }
         public List<MovieFile> OldFiles { get; private set; }
-		public string DownloadId { get; private set; }
+        public string DownloadId { get; private set; }
 
         public MovieDownloadedEvent(LocalMovie episode, MovieFile episodeFile, List<MovieFile> oldFiles, DownloadClientItem downloadClientItem)
         {
             Movie = episode;
             MovieFile = episodeFile;
             OldFiles = oldFiles;
-			if (downloadClientItem != null)
+            if (downloadClientItem != null)
             {
                 DownloadId = downloadClientItem.DownloadId;
             }

--- a/src/NzbDrone.Core/MediaFiles/Events/MovieDownloadedEvent.cs
+++ b/src/NzbDrone.Core/MediaFiles/Events/MovieDownloadedEvent.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using NzbDrone.Common.Messaging;
 using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Download;
 
 namespace NzbDrone.Core.MediaFiles.Events
 {
@@ -9,12 +10,17 @@ namespace NzbDrone.Core.MediaFiles.Events
         public LocalMovie Movie { get; private set; }
         public MovieFile MovieFile { get; private set; }
         public List<MovieFile> OldFiles { get; private set; }
+		public string DownloadId { get; private set; }
 
-        public MovieDownloadedEvent(LocalMovie episode, MovieFile episodeFile, List<MovieFile> oldFiles)
+        public MovieDownloadedEvent(LocalMovie episode, MovieFile episodeFile, List<MovieFile> oldFiles, DownloadClientItem downloadClientItem)
         {
             Movie = episode;
             MovieFile = episodeFile;
             OldFiles = oldFiles;
+			if (downloadClientItem != null)
+            {
+                DownloadId = downloadClientItem.DownloadId;
+            }
         }
     }
 }

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -72,7 +72,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Radarr_MovieFile_SceneName", movieFile.SceneName ?? string.Empty);
             environmentVariables.Add("Radarr_MovieFile_SourcePath", sourcePath);
             environmentVariables.Add("Radarr_MovieFile_SourceFolder", Path.GetDirectoryName(sourcePath));
-			environmentVariables.Add("Radarr_Download_Id", message.DownloadId ?? string.Empty);
+            environmentVariables.Add("Radarr_Download_Id", message.DownloadId ?? string.Empty);
 
             if (message.OldMovieFiles.Any())
             {

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -72,6 +72,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Radarr_MovieFile_SceneName", movieFile.SceneName ?? string.Empty);
             environmentVariables.Add("Radarr_MovieFile_SourcePath", sourcePath);
             environmentVariables.Add("Radarr_MovieFile_SourceFolder", Path.GetDirectoryName(sourcePath));
+			environmentVariables.Add("Radarr_Download_Id", message.DownloadId ?? string.Empty);
 
             if (message.OldMovieFiles.Any())
             {

--- a/src/NzbDrone.Core/Notifications/DownloadMessage.cs
+++ b/src/NzbDrone.Core/Notifications/DownloadMessage.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Notifications
         public MovieFile MovieFile { get; set; }
         public List<MovieFile> OldMovieFiles { get; set; }
         public string SourcePath { get; set; }
-		public string DownloadId { get; set; }
+        public string DownloadId { get; set; }
 
         public override string ToString()
         {

--- a/src/NzbDrone.Core/Notifications/DownloadMessage.cs
+++ b/src/NzbDrone.Core/Notifications/DownloadMessage.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Tv;
 
@@ -14,6 +14,7 @@ namespace NzbDrone.Core.Notifications
         public MovieFile MovieFile { get; set; }
         public List<MovieFile> OldMovieFiles { get; set; }
         public string SourcePath { get; set; }
+		public string DownloadId { get; set; }
 
         public override string ToString()
         {

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -221,7 +221,7 @@ namespace NzbDrone.Core.Notifications
             downloadMessage.OldFiles = null;
             downloadMessage.OldMovieFiles = message.OldFiles;
             downloadMessage.SourcePath = message.Movie.Path;
-			downloadMessage.DownloadId = message.DownloadId;
+            downloadMessage.DownloadId = message.DownloadId;
 
             foreach (var notification in _notificationFactory.OnDownloadEnabled())
             {

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
@@ -221,6 +221,7 @@ namespace NzbDrone.Core.Notifications
             downloadMessage.OldFiles = null;
             downloadMessage.OldMovieFiles = message.OldFiles;
             downloadMessage.SourcePath = message.Movie.Path;
+			downloadMessage.DownloadId = message.DownloadId;
 
             foreach (var notification in _notificationFactory.OnDownloadEnabled())
             {


### PR DESCRIPTION
#### Description
Feature based on equivalent Sonarr feature. Add an additional enviornment variable for the download id from the torrent client for the custom post processing script feature. The variable name is 'Radarr_Download_Id' with the description 'The hash of the torrent/NZB file downloaded (used to uniquely identify the download in the download client).

* #
