### PR TITLE
Added subdir to the defined TempFolder that is user specific

### DIFF
--- a/src/NzbDrone.Common/EnvironmentInfo/AppFolderInfo.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/AppFolderInfo.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Common.EnvironmentInfo
             }
 
             StartUpFolder = new FileInfo(Assembly.GetExecutingAssembly().Location).Directory.FullName;
-            TempFolder = Path.GetTempPath();
+            TempFolder = Path.Combine(Path.GetTempPath(), "Radarr_" + Environment.UserName);
         }
 
         public string AppDataFolder { get; private set; }


### PR DESCRIPTION
#### Description
Radarr is being increasingly added to seedbox's where users share the same '/tmp' folder in Linux. This causes issues of backups and updates failing (could affect other things). For example, when another user has already created a radarr_backup or radarr_update folder in the same tmp location and radarr is not allowed to modify their folders. This change will add a subdir such that /tmp will become /tmp/Radarr_{username} for each users radarr process to use. To the same effect for other platforms as well.

Todo:
Delete folder after use?