### PR TITLE
Add separate naming tags for AudioLanguage and SubtitleLanguage

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -844,11 +844,12 @@ namespace NzbDrone.Core.Organizer
             {
                 mediaInfoAudioLanguages = string.Format("[{0}]", mediaInfoAudioLanguages);
             }
-
+            var mediaInfoAudioLanguagesAll = mediaInfoAudioLanguages;
             if (mediaInfoAudioLanguages == "[EN]")
             {
                 mediaInfoAudioLanguages = string.Empty;
             }
+
 
             var mediaInfoSubtitleLanguages = GetLanguagesToken(movieFile.MediaInfo.Subtitles);
             if (!mediaInfoSubtitleLanguages.IsNullOrWhiteSpace())
@@ -872,6 +873,9 @@ namespace NzbDrone.Core.Organizer
             tokenHandlers["{MediaInfo Simple}"] = m => string.Format("{0} {1}", videoCodec, audioCodec);
 
             tokenHandlers["{MediaInfo Full}"] = m => string.Format("{0} {1}{2} {3}", videoCodec, audioCodec, mediaInfoAudioLanguages, mediaInfoSubtitleLanguages);
+            tokenHandlers["{MediaInfo AudioLanguages}"] = m => mediaInfoAudioLanguages;
+            tokenHandlers["{MediaInfo AudioLanguagesAll}"] = m => mediaInfoAudioLanguagesAll;
+            tokenHandlers["{MediaInfo SubtitleLanguages}"] = m => mediaInfoSubtitleLanguages;
         }
 
         private string GetLanguagesToken(string mediaInfoLanguages)

--- a/src/UI/Settings/MediaManagement/Naming/Partials/MediaInfoNamingPartial.hbs
+++ b/src/UI/Settings/MediaManagement/Naming/Partials/MediaInfoNamingPartial.hbs
@@ -7,5 +7,14 @@
         <li><a href="#" data-token="MediaInfo Full">MediaInfo Full</a></li>
         <li><a href="#" data-token="MediaInfo.Full">MediaInfo.Full</a></li>
         <li><a href="#" data-token="MediaInfo_Full">MediaInfo_Full</a></li>
+        <li><a href="#" data-token="MediaInfo AudioLanguages">MediaInfo AudioLanguages</a></li>
+        <li><a href="#" data-token="MediaInfo.AudioLanguages">MediaInfo.AudioLanguages</a></li>
+        <li><a href="#" data-token="MediaInfo_AudioLanguages">MediaInfo_AudioLanguages</a></li>
+        <li><a href="#" data-token="MediaInfo AudioLanguagesAll">MediaInfo AudioLanguagesAll</a></li>
+        <li><a href="#" data-token="MediaInfo.AudioLanguagesAll">MediaInfo.AudioLanguagesAll</a></li>
+        <li><a href="#" data-token="MediaInfo_AudioLanguagesAll">MediaInfo_AudioLanguagesAll</a></li>
+        <li><a href="#" data-token="MediaInfo SubtitleLanguages">MediaInfo SubtitleLanguages</a></li>
+        <li><a href="#" data-token="MediaInfo.SubtitleLanguages">MediaInfo.SubtitleLanguages</a></li>
+        <li><a href="#" data-token="MediaInfo_SubtitleLanguages">MediaInfo_SubtitleLanguages</a></li>
     </ul>
 </li>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add separate MediaInfo naming tags for AudioLanguage and SubtitleLanguage with the same behavior as in {MediaInfo Full}

AudioLanguageAll will include English even if it is the only language.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #2257
