### PR TITLE
Add preliminary support for seed ratio settings.

### DIFF
--- a/src/NzbDrone.Api/ClientSchema/SchemaBuilder.cs
+++ b/src/NzbDrone.Api/ClientSchema/SchemaBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -78,6 +78,18 @@ namespace NzbDrone.Api.ClientSchema
                     {
                         var value = field.Value.ToString().ParseInt32();
                         propertyInfo.SetValue(target, value ?? 0, null);
+                    }
+
+                    else if (propertyInfo.PropertyType == typeof(float))
+                    {
+                        var value = field.Value.ToString().ParseFloat();
+                        propertyInfo.SetValue(target, value ?? 0, null);
+                    }
+
+                    else if (propertyInfo.PropertyType == typeof(float?))
+                    {
+                        var value = field.Value.ToString().ParseFloat();
+                        propertyInfo.SetValue(target, value, null);
                     }
 
                     else if (propertyInfo.PropertyType == typeof(long))

--- a/src/NzbDrone.Common/Extensions/TryParseExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/TryParseExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace NzbDrone.Common.Extensions
 {
@@ -21,6 +21,17 @@ namespace NzbDrone.Common.Extensions
             long result = 0;
 
             if (long.TryParse(source, out result))
+            {
+                return result;
+            }
+
+            return null;
+        }
+
+        public static float? ParseFloat(this string source) {
+            float result = 0;
+
+            if (float.TryParse(source, out result))
             {
                 return result;
             }

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -89,6 +89,11 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
             _logger.Debug("Torrent Download succeeded, saved to: {0}", filepath);
 
             return null;
+        }
+
+        protected override void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfig)
+        {
+            throw new NotImplementedException();
         }
 
         public override string Name => "Torrent Blackhole";

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using NzbDrone.Common.Disk;
@@ -57,6 +57,11 @@ namespace NzbDrone.Core.Download.Clients.Deluge
             _proxy.SetTorrentConfiguration(actualHash, "remove_at_ratio", false, Settings);
 
             return actualHash.ToUpper();
+        }
+
+        protected override void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfig)
+        {
+            _proxy.SetTorrentSeedingConfiguration(hash, seedConfig, Settings);
         }
 
         protected override string AddFromMagnetLink(RemoteEpisode remoteEpisode, string hash, string magnetLink)

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -195,6 +195,10 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
             throw new DownloadClientException("Failed to add torrent task to Download Station");
         }
+        protected override void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfig)
+        {
+            throw new NotImplementedException();
+        }
 
         protected override void Test(List<ValidationFailure> failures)
         {

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation.Results;
@@ -169,6 +169,11 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
         protected override string AddFromTorrentFile(RemoteMovie remoteMovie, string hash, string filename, byte[] fileContent)
         {
             return _proxy.AddTorrentFile(Settings, fileContent).ToUpper();
+        }
+
+        protected override void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfig)
+        {
+            throw new NotImplementedException();
         }
 
         private ValidationFailure TestConnection()

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -69,6 +69,11 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             return hash;
         }
 
+        protected override void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfig)
+        {
+            throw new NotImplementedException();
+        }
+
         public override string Name => "qBittorrent";
 
         public override IEnumerable<DownloadClientItem> GetItems()

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -158,6 +158,10 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             return hash;
         }
 
+        protected override void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfig) {
+            _proxy.SetTorrentSeedingConfiguration(hash, seedConfig, Settings);
+        }
+
         protected override void Test(List<ValidationFailure> failures)
         {
             failures.AddIfNotNull(TestConnection());

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading;
@@ -79,6 +79,11 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
             }
 
             return hash;
+        }
+
+        protected override void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfig)
+        {
+            throw new NotImplementedException();
         }
 
         public override string Name => "rTorrent";

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
@@ -82,6 +82,11 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
             return hash;
         }
 
+        protected override void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfig)
+        {
+            _proxy.SetTorrentSeedingConfiguration(hash, seedConfig, Settings);
+        }
+
         public override string Name => "uTorrent";
 
         public override IEnumerable<DownloadClientItem> GetItems()

--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using MonoTorrent;
 using NzbDrone.Common.Disk;
@@ -13,6 +13,7 @@ using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Configuration;
 using NLog;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Download.Clients;
 
 namespace NzbDrone.Core.Download
 {
@@ -48,6 +49,7 @@ namespace NzbDrone.Core.Download
         {
             throw new NotImplementedException();
         }
+        protected abstract void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfig);
 
         public override string Download(RemoteMovie remoteMovie)
         {
@@ -270,6 +272,16 @@ namespace NzbDrone.Core.Download
             var hash = _torrentFileInfoReader.GetHashFromTorrentFile(torrentFile);
             var actualHash = AddFromTorrentFile(remoteEpisode, hash, filename, torrentFile);
 
+            if (actualHash.IsNotNullOrWhiteSpace() && hash == actualHash && remoteEpisode.Release.SeedConfiguration != null) {
+                try { SetTorrentSeedingConfiguration(actualHash, remoteEpisode.Release.SeedConfiguration); }
+                catch (Exception ex) {
+                    _logger.Debug(
+                        "SetTorrentSeedingConfiguration failed for {0} with hash {1}, error {2}",
+                        Definition.Implementation, actualHash, ex.Message
+                    );
+                }
+            }
+
             if (actualHash.IsNotNullOrWhiteSpace() && hash != actualHash)
             {
                 _logger.Debug(
@@ -299,6 +311,16 @@ namespace NzbDrone.Core.Download
             if (hash != null)
             {
                 actualHash = AddFromMagnetLink(remoteEpisode, hash, magnetUrl);
+            }
+
+            if (actualHash.IsNotNullOrWhiteSpace() && hash == actualHash && remoteEpisode.Release.SeedConfiguration != null) {
+                try { SetTorrentSeedingConfiguration(actualHash, remoteEpisode.Release.SeedConfiguration); }
+                catch (Exception ex) {
+                    _logger.Debug(
+                        "SetTorrentSeedingConfiguration failed for {0} with hash {1}, error {2}",
+                        Definition.Implementation, actualHash, ex.Message
+                    );
+                }
             }
 
             if (actualHash.IsNotNullOrWhiteSpace() && hash != actualHash)
@@ -372,6 +394,16 @@ namespace NzbDrone.Core.Download
             var hash = _torrentFileInfoReader.GetHashFromTorrentFile(torrentFile);
             var actualHash = AddFromTorrentFile(remoteEpisode, hash, filename, torrentFile);
 
+            if (actualHash.IsNotNullOrWhiteSpace() && hash == actualHash && remoteEpisode.Release.SeedConfiguration != null) {
+                try { SetTorrentSeedingConfiguration(actualHash, remoteEpisode.Release.SeedConfiguration); }
+                catch (Exception ex) {
+                    _logger.Debug(
+                        "SetTorrentSeedingConfiguration failed for {0} with hash {1}, error {2}",
+                        Definition.Implementation, actualHash, ex.Message
+                    );
+                }
+            }
+
             if (actualHash.IsNotNullOrWhiteSpace() && hash != actualHash)
             {
                 _logger.Debug(
@@ -401,6 +433,16 @@ namespace NzbDrone.Core.Download
             if (hash != null)
             {
                 actualHash = AddFromMagnetLink(remoteEpisode, hash, magnetUrl);
+            }
+
+            if (actualHash.IsNotNullOrWhiteSpace() && hash == actualHash && remoteEpisode.Release.SeedConfiguration != null) {
+                try { SetTorrentSeedingConfiguration(actualHash, remoteEpisode.Release.SeedConfiguration); }
+                catch (Exception ex) {
+                    _logger.Debug(
+                        "SetTorrentSeedingConfiguration failed for {0} with hash {1}, error {2}",
+                        Definition.Implementation, actualHash, ex.Message
+                    );
+                }
             }
 
             if (actualHash.IsNotNullOrWhiteSpace() && hash != actualHash)

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -13,6 +13,7 @@ using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Download.Clients;
 
 namespace NzbDrone.Core.Indexers
 {
@@ -25,6 +26,8 @@ namespace NzbDrone.Core.Indexers
 
         public override bool SupportsRss => true;
         public override bool SupportsSearch => true;
+        public override TorrentSeedConfiguration SeedConfiguration => null;
+
         public bool SupportsPaging => PageSize > 0;
 
         public virtual int PageSize => 0;

--- a/src/NzbDrone.Core/Indexers/IndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation.Results;
@@ -9,6 +9,7 @@ using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Download.Clients;
 
 namespace NzbDrone.Core.Indexers
 {
@@ -22,6 +23,7 @@ namespace NzbDrone.Core.Indexers
 
         public abstract string Name { get; }
         public abstract DownloadProtocol Protocol { get; }
+        public abstract TorrentSeedConfiguration SeedConfiguration { get; }
 
         public abstract bool SupportsRss { get; }
         public abstract bool SupportsSearch { get; }
@@ -75,6 +77,7 @@ namespace NzbDrone.Core.Indexers
                 c.IndexerId = Definition.Id;
                 c.Indexer = Definition.Name;
                 c.DownloadProtocol = Protocol;
+                c.SeedConfiguration = SeedConfiguration;
             });
 
             return result;

--- a/src/NzbDrone.Core/Indexers/TorrentPotato/TorrentPotato.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentPotato/TorrentPotato.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using NLog;
 using NzbDrone.Common.Extensions;
@@ -10,6 +10,7 @@ using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Http.CloudFlare;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Validation;
+using NzbDrone.Core.Download.Clients;
 
 namespace NzbDrone.Core.Indexers.TorrentPotato
 {
@@ -19,11 +20,11 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
 
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override TimeSpan RateLimit => TimeSpan.FromSeconds(2);
+        public override TorrentSeedConfiguration SeedConfiguration => Settings.SeedRatio.HasValue ? new TorrentSeedConfiguration { Ratio = Settings.SeedRatio, SeedTime = null } : null;
 
         public TorrentPotato(IHttpClient httpClient, IIndexerStatusService indexerStatusService, IConfigService configService, IParsingService parsingService, Logger logger)
             : base(httpClient, indexerStatusService, configService, parsingService, logger)
         {
-
         }
 
         private IndexerDefinition GetDefinition(string name, TorrentPotatoSettings settings)

--- a/src/NzbDrone.Core/Indexers/TorrentPotato/TorrentPotatoSettings.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentPotato/TorrentPotatoSettings.cs
@@ -21,6 +21,7 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
         {
             BaseUrl = "http://127.0.0.1";
             MinimumSeeders = IndexerDefaults.MINIMUM_SEEDERS;
+            SeedRatio = (float?)null;
         }
 
         [FieldDefinition(0, Label = "API URL", HelpText = "URL to TorrentPotato api.")]
@@ -34,6 +35,9 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
 
         [FieldDefinition(3, Type = FieldType.Textbox, Label = "Minimum Seeders", HelpText = "Minimum number of seeders required.", Advanced = true)]
         public int MinimumSeeders { get; set; }
+
+        [FieldDefinition(4, Type = FieldType.Textbox, Label = "Seed ratio", HelpText = "Set seed ratio before completed, blank for downloader default", Advanced = true)]
+        public float? SeedRatio { get; set; }
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Parser/Model/ReleaseInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ReleaseInfo.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Text;
 using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Download.Clients;
 
 namespace NzbDrone.Core.Parser.Model
 {
@@ -25,6 +26,8 @@ namespace NzbDrone.Core.Parser.Model
         public string Container { get; set; }
         public string Codec { get; set; }
         public string Resolution { get; set; }
+
+        public TorrentSeedConfiguration SeedConfiguration { get; set; }
 
 	public IndexerFlags IndexerFlags { get; set; }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added seed ratio for TorrentPotato (as it is the only one i use and know).
A new advanced option is available on TorrentPotato settings where you can define a "Seed ratio".
That seed ratio is added to the RemoteMovie.Release as SeedConfiguration.
When the file gets added to a Torrent downloader it will set the ratio if the downloader supports it.

#### Todos
- [ ] Tests, need help with this. Tips on how and where ?

#### Issues Fixed or Closed by this PR

