### PR TITLE
Customize Slack Channel

### DIFF
--- a/src/NzbDrone.Core/Notifications/Slack/Payloads/SlackPayload.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Payloads/SlackPayload.cs
@@ -15,6 +15,8 @@ namespace NzbDrone.Core.Notifications.Slack.Payloads
         [JsonProperty("icon_url")]
         public string IconUrl { get; set; }
 
+        public string Channel { get; set; }
+
         public List<Attachment> Attachments { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -109,6 +109,7 @@ namespace NzbDrone.Core.Notifications.Slack
         private SlackPayload CreatePayload(string message, List<Attachment> attachments = null)
         {
             var icon = Settings.Icon;
+            var channel = Settings.Channel;
 
             var payload = new SlackPayload
             {
@@ -128,6 +129,11 @@ namespace NzbDrone.Core.Notifications.Slack
                 {
                     payload.IconUrl = icon;
                 }
+            }
+
+            if (channel.IsNotNullOrWhiteSpace())
+            {
+                payload.Channel = channel;
             }
 
             return payload;

--- a/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
@@ -27,6 +27,9 @@ namespace NzbDrone.Core.Notifications.Slack
         [FieldDefinition(2, Label = "Icon", HelpText = "Change the icon that is used for messages from this integration (Emoji or URL)", Type = FieldType.Textbox, HelpLink = "http://www.emoji-cheat-sheet.com/")]
         public string Icon { get; set; }
 
+        [FieldDefinition(3, Label = "Channel", HelpText = "Overrides the default channel for the incoming webhook (#other-channel)", Type = FieldType.Textbox)]
+        public string Channel { get; set; }
+
         public NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));


### PR DESCRIPTION
Adds ability to specify Slack channel for incoming webhook.

#### Database Migration
NO

#### Description
Adds the ability to specify a channel for Slack incoming webhook. Reference [commit](https://github.com/Sonarr/Sonarr/commit/e11e8ad2722f848f034f7768fbb6227b5af065de) in Sonnar code solving the same issue.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #2298 
