### PR TITLE
Update TMDbSettings.cs to allow OR separated Genre IDs Issue #2278

### DIFF
--- a/src/NzbDrone.Core/NetImport/TMDb/TMDbSettings.cs
+++ b/src/NzbDrone.Core/NetImport/TMDb/TMDbSettings.cs
@@ -36,19 +36,19 @@ namespace NzbDrone.Core.NetImport.TMDb
             RuleFor(c => c.Ceritification)
                 .Matches(@"^\bNR\b|\bG\b|\bPG\b|\bPG\-13\b|\bR\b|\bNC\-17\b$", RegexOptions.IgnoreCase)
                 .When(c => c.Ceritification.IsNotNullOrWhiteSpace())
-                .WithMessage("Not a valid cerification");
+                .WithMessage("Not a valid certification");
 
             // CSV of numbers
             RuleFor(c => c.IncludeGenreIds)
-                .Matches(@"^\d+([,]\d+)*$", RegexOptions.IgnoreCase)
+                .Matches(@"^\d+([,|]\d+)*$", RegexOptions.IgnoreCase)
                 .When(c => c.IncludeGenreIds.IsNotNullOrWhiteSpace())
-                .WithMessage("Genre Ids must be comma separated number ids");
+                .WithMessage("Genre Ids must be comma (,) or pipe (|) separated number ids");
 
             // CSV of numbers
             RuleFor(c => c.ExcludeGenreIds)
-                .Matches(@"^\d+([,]\d+)*$", RegexOptions.IgnoreCase)
+                .Matches(@"^\d+([,|]\d+)*$", RegexOptions.IgnoreCase)
                 .When(c => c.ExcludeGenreIds.IsNotNullOrWhiteSpace())
-                .WithMessage("Genre Ids must be comma separated number ids");
+                .WithMessage("Genre Ids must be comma (,) or pipe (|) separated number ids");
 
         }
     }


### PR DESCRIPTION
#### Database Migration
YES | NO

#### Description
This request changes the REGEX used to allow the pipe character to be used in Included and excluded Genre IDs.  The help popup has also been changed to include the change in function as well as a couple of spelling mistakes of the word certification. 

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR
https://github.com/Radarr/Radarr/issues/2278
* #
