### PR TITLE
Apostrophe in movie titles cause indexer issues when searching for re…

### DIFF
--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -315,6 +315,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex WordDelimiterRegex = new Regex(@"(\s|\.|,|_|-|=|\|)+", RegexOptions.Compiled);
         private static readonly Regex SpecialCharRegex = new Regex(@"(\&|\:|\\|\/)+", RegexOptions.Compiled);
+        private static readonly Regex ApostropheRegex = new Regex(@"\'", RegexOptions.Compiled);
         private static readonly Regex PunctuationRegex = new Regex(@"[^\w\s]", RegexOptions.Compiled);
         private static readonly Regex CommonWordRegex = new Regex(@"\b(a|an|the|and|or|of)\b\s?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex SpecialEpisodeWordRegex = new Regex(@"\b(part|special|edition|christmas)\b\s?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -769,6 +770,7 @@ namespace NzbDrone.Core.Parser
         public static string NormalizeTitle(string title)
         {
             title = WordDelimiterRegex.Replace(title, " ");
+            title = ApostropheRegex.Replace(title, " ");
             title = PunctuationRegex.Replace(title, string.Empty);
             title = CommonWordRegex.Replace(title, string.Empty);
             title = DuplicateSpacesRegex.Replace(title, " ");


### PR DESCRIPTION
#### Database Migration
NO

#### Description

##### Example of the fix (with a french title)
Movie name : 'L'experience interdite'

Before fix : Raddar will search releases with : 'Lexperience interdite' => no releases found because 'Lexperience' isn't a correct world for french trackers (Torrent9 with Jackett)

After fix : Raddar will search releases with 'L experience interdite' (just replacing it by a space instead of string.Empty) => realeases on Torrent9 found correctly
