### PR TITLE
Look for changes to package.json before using old build cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ artifacts:
 
 cache:
   - '%USERPROFILE%\.nuget\packages'
-  - node_modules
+  - node_modules -> package.json
   
 pull_requests:
   do_not_increment_build_number: true


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Tells appveyor not to use build cache if you have made changes to package.json

We spent a while chasing a build issue that turned out to be cache, figured you guys could benefit here as well. 
