### PR TITLE
punctuation replaced by space when parsing title

### DIFF
--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -769,7 +769,7 @@ namespace NzbDrone.Core.Parser
         public static string NormalizeTitle(string title)
         {
             title = WordDelimiterRegex.Replace(title, " ");
-            title = PunctuationRegex.Replace(title, string.Empty);
+            title = PunctuationRegex.Replace(title, " ");
             title = CommonWordRegex.Replace(title, string.Empty);
             title = DuplicateSpacesRegex.Replace(title, " ");
             title = SpecialCharRegex.Replace(title, string.Empty);


### PR DESCRIPTION
To take into account titles like "Rock'n Roll" where "rockn roll" did not return anything, replace punctuation with space instead of empty string. So when looking for "Rock'n Roll", we are looking for "rock n roll".

#### Database Migration
NO

#### Issues Fixed or Closed by this PR
#245757

* #
