### PR TITLE
New: Same File Size MediaFile Specification

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/SameFileSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/SameFileSpecificationFixture.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Marr.Data;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.MediaFiles.EpisodeImport.Specifications;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
+{
+    [TestFixture]
+    public class SameFileSpecificationFixture : CoreTest<SameFileSpecification>
+    {
+        private LocalMovie _localMovie;
+
+        [SetUp]
+        public void Setup()
+        {
+            _localMovie = Builder<LocalMovie>.CreateNew()
+                                                 .With(l => l.Size = 150.Megabytes())
+                                                 .Build();
+        }
+
+        [Test]
+        public void should_be_accepted_if_no_existing_file()
+        {
+            _localMovie.Movie = Builder<Movie>.CreateNew()
+                                                     .With(e => e.MovieFileId = 0)
+                                                     .Build();
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_be_accepted_if_file_size_is_different()
+        {
+            _localMovie.Movie = Builder<Movie>.CreateNew()
+                .With(e => e.MovieFileId = 1)
+                .With(e => e.MovieFile = new LazyLoaded<MovieFile>(
+                    new MovieFile
+                    {
+                        Size = _localMovie.Size + 100.Megabytes()
+                    }))
+                .Build();
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_be_reject_if_file_size_is_the_same()
+        {
+            _localMovie.Movie = Builder<Movie>.CreateNew()
+                .With(e => e.MovieFileId = 1)
+                .With(e => e.MovieFile = new LazyLoaded<MovieFile>(
+                    new MovieFile
+                    {
+                        Size = _localMovie.Size
+                    }))
+                .Build();
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeFalse();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -283,6 +283,7 @@
     <Compile Include="MediaFiles\EpisodeImport\Specifications\MatchesFolderSpecificationFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\NotSampleSpecificationFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\NotUnpackingSpecificationFixture.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\Specifications\SameFileSpecificationFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\UpgradeSpecificationFixture.cs" />
     <Compile Include="MediaFiles\ImportApprovedEpisodesFixture.cs" />
     <Compile Include="MediaFiles\MediaFileRepositoryFixture.cs" />

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/SameFileSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/SameFileSpecification.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using NLog;
+using NzbDrone.Core.DecisionEngine;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
+{
+    public class SameFileSpecification : IImportDecisionEngineSpecification
+    {
+        private readonly Logger _logger;
+
+        public SameFileSpecification(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public Decision IsSatisfiedBy(LocalEpisode localEpisode)
+        {
+            return Decision.Accept();
+        }
+
+        public Decision IsSatisfiedBy(LocalMovie localMovie, DownloadClientItem downloadClientItem)
+        {
+            var movieFile = localMovie.Movie.MovieFile;
+
+            if (localMovie.Movie.MovieFileId == 0)
+            {
+                _logger.Debug("No existing movie file, skipping");
+                return Decision.Accept();
+            }
+
+            if (movieFile.Size == localMovie.Size)
+            {
+                _logger.Debug("'{0}' Has the same filesize as existing file", localMovie.Path);
+                return Decision.Reject("Has the same filesize as existing file");
+            }
+
+            return Decision.Accept();
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -131,6 +131,7 @@
     <Compile Include="DecisionEngine\Specifications\RequiredIndexerFlagsSpecification.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedAlternativeTitles.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\GrabbedReleaseQualitySpecification.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\Specifications\SameFileSpecification.cs" />
     <Compile Include="MediaFiles\Events\MovieFileUpdatedEvent.cs" />
     <Compile Include="Datastore\Migration\134_add_remux_qualities_for_the_wankers.cs" />
     <Compile Include="Datastore\Migration\129_add_parsed_movie_info_to_pending_release.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds same file size import specifications (files of same file size as the existing file for a given movie are rejected for import)

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
#2482 
* #
