### PR TITLE
Fixed: Radarr Changes every file due to timezones

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/UpdateMovieFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpdateMovieFileService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -79,21 +79,24 @@ namespace NzbDrone.Core.MediaFiles
 
         private bool ChangeFileDate(string filePath, DateTime date)
         {
-            DateTime oldDateTime = _diskProvider.FileGetLastWrite(filePath);
+            DateTime oldDateTime;
 
-            if (!DateTime.Equals(date, oldDateTime))
+            if (DateTime.TryParse(_diskProvider.FileGetLastWrite(filePath).ToLongDateString(), out oldDateTime))
             {
-                try
+                if (!DateTime.Equals(date, oldDateTime))
                 {
-                    _diskProvider.FileSetLastWriteTime(filePath, date);
-                    _logger.Debug("Date of file [{0}] changed from '{1}' to '{2}'", filePath, oldDateTime, date);
+                    try
+                    {
+                        _diskProvider.FileSetLastWriteTime(filePath, date);
+                        _logger.Debug("Date of file [{0}] changed from '{1}' to '{2}'", filePath, oldDateTime, date);
 
-                    return true;
-                }
+                        return true;
+                    }
 
-                catch (Exception ex)
-                {
-                    _logger.Warn(ex, "Unable to set date of file [" + filePath + "]");
+                    catch (Exception ex)
+                    {
+                        _logger.Warn(ex, "Unable to set date of file [" + filePath + "]");
+                    }
                 }
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Parses in last modified date for file as a UTC date and ignores the time during the parse. This creates a DateTime object with 12:00AM UTC which is the format Radarr uses for the release DateTime. 

#### Issues Fixed or Closed by this PR
fixes #1741
* #
