### PR TITLE
Bulk Impoprt - Remove sorting on Monitor/Profile

### DIFF
--- a/src/UI/AddMovies/BulkImport/BulkImportView.js
+++ b/src/UI/AddMovies/BulkImport/BulkImportView.js
@@ -94,13 +94,15 @@ module.exports = Marionette.Layout.extend({
 					name :'monitor',
 					label: 'Monitor',
 					cell : MonitorCell,
-					cellValue : 'this'
+					cellValue : 'this',
+					sortable : false,
 				},
 				{
 					name : 'profileId',
 					label : 'Profile',
 					cell  : ProfileCell,
 					cellValue : "this",
+					sortable : false,
 				},
 				{
 					name     : 'quality',


### PR DESCRIPTION
Remove sorting on Monitor/Profile columns to prevent unexpected results until sorting can properly be handled. Quick Fix for #2540