### PR TITLE
Fixed: Multiple History Issues

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/HistorySpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/HistorySpecificationFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using FizzWare.NBuilder;
 using FluentAssertions;
@@ -72,7 +72,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
         private void GivenMostRecentForEpisode(int episodeId, string downloadId, QualityModel quality, DateTime date, HistoryEventType eventType)
         {
-            Mocker.GetMock<IHistoryService>().Setup(s => s.MostRecentForEpisode(episodeId))
+            Mocker.GetMock<IHistoryService>().Setup(s => s.MostRecentForMovie(episodeId))
                   .Returns(new History.History { DownloadId = downloadId, Quality = quality, Date = date, EventType = eventType });
         }
 
@@ -92,7 +92,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         [Test]
         public void should_return_true_if_latest_history_item_is_null()
         {
-            Mocker.GetMock<IHistoryService>().Setup(s => s.MostRecentForEpisode(It.IsAny<int>())).Returns((History.History)null);
+            Mocker.GetMock<IHistoryService>().Setup(s => s.MostRecentForMovie(It.IsAny<int>())).Returns((History.History)null);
             _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
         }
 

--- a/src/NzbDrone.Core.Test/HistoryTests/HistoryRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/HistoryTests/HistoryRepositoryFixture.cs
@@ -1,4 +1,4 @@
-﻿using FizzWare.NBuilder;
+using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.History;
@@ -32,13 +32,13 @@ namespace NzbDrone.Core.Test.HistoryTests
         {
             var historyBluray = Builder<History.History>.CreateNew()
                 .With(c => c.Quality = new QualityModel(Quality.Bluray1080p))
-                .With(c => c.SeriesId = 12)
+                .With(c => c.MovieId = 12)
                 .With(c => c.EventType = HistoryEventType.Grabbed)
                 .BuildNew();
 
             var historyDvd = Builder<History.History>.CreateNew()
                 .With(c => c.Quality = new QualityModel(Quality.DVD))
-                .With(c => c.SeriesId = 12)
+                .With(c => c.MovieId = 12)
                 .With(c => c.EventType = HistoryEventType.Grabbed)
              .BuildNew();
 

--- a/src/NzbDrone.Core.Test/HistoryTests/HistoryServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/HistoryTests/HistoryServiceFixture.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Linq;
 using FizzWare.NBuilder;
 using Moq;
@@ -68,23 +68,23 @@ namespace NzbDrone.Core.Test.HistoryTests
         [Test]
         public void should_use_file_name_for_source_title_if_scene_name_is_null()
         {
-            var series = Builder<Series>.CreateNew().Build();
-            var episodes = Builder<Episode>.CreateListOfSize(1).Build().ToList();
-            var episodeFile = Builder<EpisodeFile>.CreateNew()
+            // Test fails becuase Radarr is using movie.title in historyService with no fallback
+
+            var movie = Builder<Movie>.CreateNew().Build();
+            var movieFile = Builder<MovieFile>.CreateNew()
                                                   .With(f => f.SceneName = null)
                                                   .Build();
 
-            var localEpisode = new LocalEpisode
+            var localMovie = new LocalMovie()
                                {
-                                   Series = series,
-                                   Episodes = episodes,
-                                   Path = @"C:\Test\Unsorted\Series.s01e01.mkv"
+                                   Movie = movie,
+                                   Path = @"C:\Test\Unsorted\Movie.2011.mkv"
                                };
 
-            Subject.Handle(new EpisodeImportedEvent(localEpisode, episodeFile, true, "sab", "abcd", true));
+            Subject.Handle(new MovieImportedEvent(localMovie, movieFile, true, "sab", "abcd", true));
 
             Mocker.GetMock<IHistoryRepository>()
-                .Verify(v => v.Insert(It.Is<History.History>(h => h.SourceTitle == Path.GetFileNameWithoutExtension(localEpisode.Path))));
+                .Verify(v => v.Insert(It.Is<History.History>(h => h.SourceTitle == Path.GetFileNameWithoutExtension(localMovie.Path))));
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
@@ -80,54 +80,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
-            if (searchCriteria != null)
-            {
-                _logger.Debug("Skipping history check during search");
-                return Decision.Accept();
-            }
-
-            var cdhEnabled = _configService.EnableCompletedDownloadHandling;
-
-            _logger.Debug("Performing history status check on report");
-            foreach (var episode in subject.Episodes)
-            {
-                _logger.Debug("Checking current status of episode [{0}] in history", episode.Id);
-                var mostRecent = _historyService.MostRecentForEpisode(episode.Id);
-
-                if (mostRecent != null && mostRecent.EventType == HistoryEventType.Grabbed)
-                {
-                    var recent = mostRecent.Date.After(DateTime.UtcNow.AddHours(-12));
-                    var cutoffUnmet = _qualityUpgradableSpecification.CutoffNotMet(subject.Series.Profile, mostRecent.Quality, subject.ParsedEpisodeInfo.Quality);
-                    var upgradeable = _qualityUpgradableSpecification.IsUpgradable(subject.Series.Profile, mostRecent.Quality, subject.ParsedEpisodeInfo.Quality);
-
-                    if (!recent && cdhEnabled)
-                    {
-                        continue;
-                    }
-
-                    if (!cutoffUnmet)
-                    {
-                        if (recent)
-                        {
-                            return Decision.Reject("Recent grab event in history already meets cutoff: {0}", mostRecent.Quality);  
-                        }
-
-                        return Decision.Reject("CDH is disabled and grab event in history already meets cutoff: {0}", mostRecent.Quality);
-                    }
-
-                    if (!upgradeable)
-                    {
-                        if (recent)
-                        {
-                            return Decision.Reject("Recent grab event in history is of equal or higher quality: {0}", mostRecent.Quality);
-                        }
-
-                        return Decision.Reject("CDH is disabled and grab event in history is of equal or higher quality: {0}", mostRecent.Quality);
-                    }
-                }
-            }
-
-            return Decision.Accept();
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/NzbDrone.Core/History/HistoryRepository.cs
+++ b/src/NzbDrone.Core/History/HistoryRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Marr.Data.QGen;
@@ -11,12 +11,10 @@ namespace NzbDrone.Core.History
 {
     public interface IHistoryRepository : IBasicRepository<History>
     {
-        List<QualityModel> GetBestQualityInHistory(int episodeId);
-        History MostRecentForEpisode(int episodeId);
+        List<QualityModel> GetBestQualityInHistory(int movieId);
         History MostRecentForDownloadId(string downloadId);
         List<History> FindByDownloadId(string downloadId);
-        List<History> FindDownloadHistory(int idSeriesId, QualityModel quality);
-        void DeleteForSeries(int seriesId);
+        List<History> FindDownloadHistory(int idMovieId, QualityModel quality);
         void DeleteForMovie(int movieId);
         History MostRecentForMovie(int movieId);
     }
@@ -29,19 +27,11 @@ namespace NzbDrone.Core.History
         {
         }
 
-
-        public List<QualityModel> GetBestQualityInHistory(int episodeId)
+        public List<QualityModel> GetBestQualityInHistory(int movieId)
         {
-            var history = Query.Where(c => c.EpisodeId == episodeId);
+            var history = Query.Where(c => c.MovieId == movieId);
 
             return history.Select(h => h.Quality).ToList();
-        }
-
-        public History MostRecentForEpisode(int episodeId)
-        {
-            return Query.Where(h => h.EpisodeId == episodeId)
-                        .OrderByDescending(h => h.Date)
-                        .FirstOrDefault();
         }
 
         public History MostRecentForDownloadId(string downloadId)
@@ -56,20 +46,15 @@ namespace NzbDrone.Core.History
             return Query.Where(h => h.DownloadId == downloadId);
         }
 
-        public List<History> FindDownloadHistory(int idSeriesId, QualityModel quality)
+        public List<History> FindDownloadHistory(int idMovieId, QualityModel quality)
         {
             return Query.Where(h =>
-                 h.SeriesId == idSeriesId &&
+                 h.MovieId == idMovieId &&
                  h.Quality == quality &&
                  (h.EventType == HistoryEventType.Grabbed ||
                  h.EventType == HistoryEventType.DownloadFailed ||
                  h.EventType == HistoryEventType.DownloadFolderImported)
                  ).ToList();
-        }
-
-        public void DeleteForSeries(int seriesId)
-        {
-            Delete(c => c.SeriesId == seriesId);
         }
 
         public void DeleteForMovie(int movieId)

--- a/src/NzbDrone.Core/History/HistoryService.cs
+++ b/src/NzbDrone.Core/History/HistoryService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -21,7 +21,6 @@ namespace NzbDrone.Core.History
         QualityModel GetBestQualityInHistory(Profile profile, int episodeId);
         PagingSpec<History> Paged(PagingSpec<History> pagingSpec);
         History MostRecentForMovie(int movieId);
-        History MostRecentForEpisode(int episodeId);
         History MostRecentForDownloadId(string downloadId);
         History Get(int historyId);
         List<History> Find(string downloadId, HistoryEventType eventType);
@@ -29,14 +28,11 @@ namespace NzbDrone.Core.History
     }
 
     public class HistoryService : IHistoryService,
-                                  IHandle<EpisodeGrabbedEvent>,
                                   IHandle<MovieGrabbedEvent>,
                                   IHandle<MovieImportedEvent>,
-                                  IHandle<EpisodeImportedEvent>,
                                   IHandle<DownloadFailedEvent>,
-                                  IHandle<EpisodeFileDeletedEvent>,
                                   IHandle<MovieFileDeletedEvent>,
-                                  IHandle<SeriesDeletedEvent>
+                                  IHandle<MovieDeletedEvent>
     {
         private readonly IHistoryRepository _historyRepository;
         private readonly Logger _logger;
@@ -50,11 +46,6 @@ namespace NzbDrone.Core.History
         public PagingSpec<History> Paged(PagingSpec<History> pagingSpec)
         {
             return _historyRepository.GetPaged(pagingSpec);
-        }
-
-        public History MostRecentForEpisode(int episodeId)
-        {
-            return _historyRepository.MostRecentForEpisode(episodeId);
         }
 
         public History MostRecentForMovie(int movieId)
@@ -205,10 +196,7 @@ namespace NzbDrone.Core.History
 
             var movieId = trackedDownload.MovieInfo.Movie.Id;
 
-            var allHistory = _historyRepository.FindDownloadHistory(movieId, trackedDownload.ImportedMovie.Quality);
-
-            //Find download related items for this movie
-            var movieHistory = allHistory.Where(h => movieId == h.MovieId).ToList();
+            var movieHistory = _historyRepository.FindDownloadHistory(movieId, trackedDownload.ImportedMovie.Quality);
 
             var processedDownloadId = movieHistory
                 .Where(c => c.EventType != HistoryEventType.Grabbed && c.DownloadId != null)
@@ -244,136 +232,6 @@ namespace NzbDrone.Core.History
             return downloadId;
         }
 
-        private string FindDownloadId(EpisodeImportedEvent trackedDownload)
-        {
-            _logger.Debug("Trying to find downloadId for {0} from history", trackedDownload.ImportedEpisode.Path);
-
-            var episodeIds = trackedDownload.EpisodeInfo.Episodes.Select(c => c.Id).ToList();
-
-            var allHistory = _historyRepository.FindDownloadHistory(trackedDownload.EpisodeInfo.Series.Id, trackedDownload.ImportedEpisode.Quality);
-
-
-            //Find download related items for these episdoes
-            var episodesHistory = allHistory.Where(h => episodeIds.Contains(h.EpisodeId)).ToList();
-
-            var processedDownloadId = episodesHistory
-                .Where(c => c.EventType != HistoryEventType.Grabbed && c.DownloadId != null)
-                .Select(c => c.DownloadId);
-
-            var stillDownloading = episodesHistory.Where(c => c.EventType == HistoryEventType.Grabbed && !processedDownloadId.Contains(c.DownloadId)).ToList();
-
-            string downloadId = null;
-
-            if (stillDownloading.Any())
-            {
-                foreach (var matchingHistory in trackedDownload.EpisodeInfo.Episodes.Select(e => stillDownloading.Where(c => c.EpisodeId == e.Id).ToList()))
-                {
-                    if (matchingHistory.Count != 1)
-                    {
-                        return null;
-                    }
-
-                    var newDownloadId = matchingHistory.Single().DownloadId;
-
-                    if (downloadId == null || downloadId == newDownloadId)
-                    {
-                        downloadId = newDownloadId;
-                    }
-                    else
-                    {
-                        return null;
-                    }
-                }
-            }
-
-            return downloadId;
-        }
-
-        public void Handle(EpisodeGrabbedEvent message)
-        {
-            foreach (var episode in message.Episode.Episodes)
-            {
-                var history = new History
-                {
-                    EventType = HistoryEventType.Grabbed,
-                    Date = DateTime.UtcNow,
-                    Quality = message.Episode.ParsedEpisodeInfo.Quality,
-                    SourceTitle = message.Episode.Release.Title,
-                    SeriesId = episode.SeriesId,
-                    EpisodeId = episode.Id,
-                    DownloadId = message.DownloadId,
-                    MovieId = 0
-                };
-
-                history.Data.Add("Indexer", message.Episode.Release.Indexer);
-                history.Data.Add("NzbInfoUrl", message.Episode.Release.InfoUrl);
-                history.Data.Add("ReleaseGroup", message.Episode.ParsedEpisodeInfo.ReleaseGroup);
-                history.Data.Add("Age", message.Episode.Release.Age.ToString());
-                history.Data.Add("AgeHours", message.Episode.Release.AgeHours.ToString());
-                history.Data.Add("AgeMinutes", message.Episode.Release.AgeMinutes.ToString());
-                history.Data.Add("PublishedDate", message.Episode.Release.PublishDate.ToString("s") + "Z");
-                history.Data.Add("DownloadClient", message.DownloadClient);
-                history.Data.Add("Size", message.Episode.Release.Size.ToString());
-                history.Data.Add("DownloadUrl", message.Episode.Release.DownloadUrl);
-                history.Data.Add("Guid", message.Episode.Release.Guid);
-                history.Data.Add("TvdbId", message.Episode.Release.TvdbId.ToString());
-                history.Data.Add("TvRageId", message.Episode.Release.TvRageId.ToString());
-                history.Data.Add("Protocol", ((int)message.Episode.Release.DownloadProtocol).ToString());
-
-                if (!message.Episode.ParsedEpisodeInfo.ReleaseHash.IsNullOrWhiteSpace())
-                {
-                    history.Data.Add("ReleaseHash", message.Episode.ParsedEpisodeInfo.ReleaseHash);
-                }
-
-                var torrentRelease = message.Episode.Release as TorrentInfo;
-
-                if (torrentRelease != null)
-                {
-                    history.Data.Add("TorrentInfoHash", torrentRelease.InfoHash);
-                }
-
-                _historyRepository.Insert(history);
-            }
-        }
-
-        public void Handle(EpisodeImportedEvent message)
-        {
-            if (!message.NewDownload)
-            {
-                return;
-            }
-
-            var downloadId = message.DownloadId;
-
-            if (downloadId.IsNullOrWhiteSpace())
-            {
-                downloadId = FindDownloadId(message);
-            }
-
-            foreach (var episode in message.EpisodeInfo.Episodes)
-            {
-                var history = new History
-                {
-                    EventType = HistoryEventType.DownloadFolderImported,
-                    Date = DateTime.UtcNow,
-                    Quality = message.EpisodeInfo.Quality,
-                    SourceTitle = message.ImportedEpisode.SceneName ?? Path.GetFileNameWithoutExtension(message.EpisodeInfo.Path),
-                    SeriesId = message.ImportedEpisode.SeriesId,
-                    EpisodeId = episode.Id,
-                    DownloadId = downloadId,
-                    MovieId = 0,
-                };
-
-                //Won't have a value since we publish this event before saving to DB.
-                //history.Data.Add("FileId", message.ImportedEpisode.Id.ToString());
-                history.Data.Add("DroppedPath", message.EpisodeInfo.Path);
-                history.Data.Add("ImportedPath", Path.Combine(message.EpisodeInfo.Series.Path, message.ImportedEpisode.RelativePath));
-                history.Data.Add("DownloadClient", message.DownloadClient);
-
-                _historyRepository.Insert(history);
-            }
-        }
-
         public void Handle(DownloadFailedEvent message)
         {
             var history = new History
@@ -392,38 +250,6 @@ namespace NzbDrone.Core.History
             history.Data.Add("Message", message.Message);
 
             _historyRepository.Insert(history);
-        }
-
-        public void Handle(EpisodeFileDeletedEvent message)
-        {
-            if (message.Reason == DeleteMediaFileReason.NoLinkedEpisodes)
-            {
-                _logger.Debug("Removing episode file from DB as part of cleanup routine, not creating history event.");
-                return;
-            }
-
-            foreach (var episode in message.EpisodeFile.Episodes.Value)
-            {
-                var history = new History
-                {
-                    EventType = HistoryEventType.EpisodeFileDeleted,
-                    Date = DateTime.UtcNow,
-                    Quality = message.EpisodeFile.Quality,
-                    SourceTitle = message.EpisodeFile.Path,
-                    SeriesId = message.EpisodeFile.SeriesId,
-                    EpisodeId = episode.Id,
-                    MovieId = 0
-                };
-
-                history.Data.Add("Reason", message.Reason.ToString());
-
-                _historyRepository.Insert(history);
-            }
-        }
-
-        public void Handle(SeriesDeletedEvent message)
-        {
-            _historyRepository.DeleteForSeries(message.Series.Id);
         }
     }
 }

--- a/src/UI/Activity/History/Details/HistoryDetailsLayoutTemplate.hbs
+++ b/src/UI/Activity/History/Details/HistoryDetailsLayoutTemplate.hbs
@@ -7,7 +7,7 @@
                 {{#if_eq eventType compare="grabbed"}}Grabbed{{/if_eq}}
                 {{#if_eq eventType compare="downloadFailed"}}Download Failed{{/if_eq}}
                 {{#if_eq eventType compare="downloadFolderImported"}}Movie Imported{{/if_eq}}
-                {{#if_eq eventType compare="episodeFileDeleted"}}Movie File Deleted{{/if_eq}}
+                {{#if_eq eventType compare="movieFileDeleted"}}Movie File Deleted{{/if_eq}}
             </h3>
 
         </div>

--- a/src/UI/Activity/History/Details/HistoryDetailsViewTemplate.hbs
+++ b/src/UI/Activity/History/Details/HistoryDetailsViewTemplate.hbs
@@ -77,7 +77,7 @@
 </dl>
 {{/if_eq}}
 
-{{#if_eq eventType compare="episodeFileDeleted"}}
+{{#if_eq eventType compare="movieFileDeleted"}}
 <dl class="dl-horizontal">
 
     <dt>Path:</dt>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes multiple issues with history classes as well as some cleanup:

- Correctly show tooltip for movieFileDeleted events in UI
- Add EventHandler definition for MovieDeletedEvent in HistoryService (was not hooked up)
- Cleanup TV Events in History Service
- Update `FindDownloadHistory` method so that it looks for movie history instead of series history when searching for downloaded items.
- Update `GetBestQualityInHistory` method to work for movies.

This does not remove the series fields from the history model as that would also require a DB migration and it may be best to do one migration for the entire series cleanup from all tables after more of the core is cleaned up. 

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
Not sure if this fixes any current github issues?
* #
