### PR TITLE
changed: which event handler triggers movie search

### DIFF
--- a/src/UI/AddMovies/AddMoviesView.js
+++ b/src/UI/AddMovies/AddMoviesView.js
@@ -92,7 +92,7 @@ module.exports = Marionette.Layout.extend({
 
 				this.$el.addClass(this.className);
 
-				this.ui.moviesSearch.keyup(function(e) {
+				this.ui.moviesSearch.on('input', function(e) {
 
 						if (_.contains([
 										9,


### PR DESCRIPTION
Searching for a movie by name copy-pasted from somewhere looks like common scenario, and search is not triggered when text got pasted into input.
'Input' event works better then 'keyup' as it got triggered upon _any_ change of input's value (keypress, paste, text drag-n-drop).