### PR TITLE
Fixed: Movies not getting unmonitored when folder gets deleted

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -165,12 +165,7 @@ namespace NzbDrone.Core.MediaFiles
                 if (movie.MovieFileId != 0)
                 {
                     //Since there is no folder, there can't be any files right?
-                    // Delete Movie from MovieFiles
-                    _movieFileRepository.Delete(movie.MovieFileId);
-
-                    // Update Movie
-                    movie.MovieFileId = 0;
-                    _movieService.UpdateMovie(movie);
+                    _mediaFileTableCleanupService.Clean(movie, new List<string>());
 
                     _logger.Debug("Movies folder doesn't exist: {0}", movie.Path);
                 }


### PR DESCRIPTION
#### Database Migration
 NO

#### Description

The previously committed fix to the listed issues didn't appear to work, at least for me, so I did some digging and comparisons with Sonarr's behaviour and think this fix should work. It sends the movie through the same route as it does when just the file is deleted - MediaFileTableCleanupService -> MediaFileService -> MovieService, which ends up doing the unmonitor config option check.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #1191 and #1590
