### PR TITLE
Fixed: Pin Cake and Addin Versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,8 +148,9 @@ _temp_*/**/*
 Thumbs.db
 
 # AppVeyor
-/tools-cake/
+/tools/cake/
 /_artifacts/
 
 # Cake
 /tools/Addins/*
+packages.config.md5sum

--- a/build-appveyor.cake
+++ b/build-appveyor.cake
@@ -1,6 +1,6 @@
-#addin "Cake.Npm"
-#addin "SharpZipLib"
-#addin "Cake.Compression"
+#addin nuget:?package=Cake.Npm&version=0.12.1
+#addin nuget:?package=SharpZipLib&version=0.86.0
+#addin nuget:?package=Cake.Compression&version=0.1.4
 
 // Build variables
 var outputFolder = "./_output";

--- a/build-appveyor.ps1
+++ b/build-appveyor.ps1
@@ -81,8 +81,8 @@ if(!$PSScriptRoot){
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
 
-$TOOLS_DIR = Join-Path $PSScriptRoot "tools-cake"
-$NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
+$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$NUGET_EXE = Join-Path $TOOLS_DIR "nuget/nuget.exe"
 $CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
 $NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
@@ -156,7 +156,12 @@ if(-Not $SkipToolPackageRestore.IsPresent) {
     if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
       ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
         Write-Verbose -Message "Missing or changed package.config hash..."
-        Remove-Item * -Recurse -Exclude packages.config,nuget.exe
+        Get-ChildItem -Path $TOOLS_DIR -Recurse -Exclude packages.config |
+        Select -ExpandProperty FullName |
+        Where {$_ -notlike (Join-Path $TOOLS_DIR "pdb2mdb*")} |
+        Where {$_ -notlike (Join-Path $TOOLS_DIR "nuget*")} |
+        sort length -Descending |
+        Remove-Item -Recurse 
     }
 
     Write-Verbose -Message "Restoring tools from NuGet..."
@@ -180,5 +185,5 @@ if (!(Test-Path $CAKE_EXE)) {
 
 # Start Cake
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -settings_skipverification=true -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
 exit $LASTEXITCODE

--- a/build-appveyor.ps1
+++ b/build-appveyor.ps1
@@ -180,5 +180,5 @@ if (!(Test-Path $CAKE_EXE)) {
 
 # Start Cake
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -settings_skipverification=true -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
 exit $LASTEXITCODE

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.25.0" />
+</packages>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Workaround Appveyor builds failing due to Cake version/verification checks (Cake.npm doesn't reference latest version 0.26)

Option two is we change our reference to cake packages.config to `https://raw.githubusercontent.com/cake-build/example/9fb63124abc90e5e9cf925355353a877c9dc9d54/tools/packages.config` which is package.config for v0.25.0. This would pin us to that version instead of always getting the latest (which may or may not play well with our cake packages (cake.npm, cake.compression). 

Option 2 appears to be recommendation by devs: https://github.com/cake-contrib/Cake.Npm/issues/70