### PR TITLE
Fixed: Incorrect Kodi nfo date format

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -130,7 +130,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 
                 if (movie.InCinemas.HasValue)
                 {
-                    details.Add(new XElement("premiered", movie.InCinemas.Value.ToString()));
+                    details.Add(new XElement("premiered", movie.InCinemas.Value.ToString("yyyy-MM-dd")));
                 }
 
                 foreach (var genre in movie.Genres)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Set Kodi date format to "yyyy-MM-dd" for premiered date in nfo file.

#### Issues Fixed or Closed by this PR
Fixes #2582 
