### PR TITLE
Set category when adding torrent to qBittorrent

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
@@ -75,6 +75,11 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                                                 .Post()
                                                 .AddFormParameter("urls", torrentUrl);
 
+            if (settings.MovieCategory.IsNotNullOrWhiteSpace())
+            {
+                request.AddFormParameter("category", settings.MovieCategory);
+            }
+
             var result = ProcessRequest(request, settings);
 
             // Note: Older qbit versions returned nothing, so we can't do != "Ok." here.
@@ -105,6 +110,11 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                                                 .Post()
                                                 .AddFormParameter("hashes", hash);
 
+            if (settings.MovieCategory.IsNotNullOrWhiteSpace())
+            {
+                request.AddFormParameter("category", settings.MovieCategory);
+            }
+            
             ProcessRequest(request, settings);
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This incorporates [a change from Sonarr](https://github.com/Sonarr/Sonarr/commit/bcf45bb68a72e73df57ac1ccf3ca2a8da4a4d78b) that attempts to fix a bug with adding categories to torrents sent to qBittorrent.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #2200 