### PR TITLE
Add configurable setting for "replace illegal characters" behavior

### DIFF
--- a/src/NzbDrone.Api/Config/NamingConfigResource.cs
+++ b/src/NzbDrone.Api/Config/NamingConfigResource.cs
@@ -7,6 +7,7 @@ namespace NzbDrone.Api.Config
     {
         public bool RenameEpisodes { get; set; }
         public bool ReplaceIllegalCharacters { get; set; }
+        public string ColonAction { get; set; }
         public string StandardMovieFormat { get; set; }
         public string MovieFolderFormat { get; set; }
         public int MultiEpisodeStyle { get; set; }
@@ -28,6 +29,7 @@ namespace NzbDrone.Api.Config
 
                 RenameEpisodes = model.RenameEpisodes,
                 ReplaceIllegalCharacters = model.ReplaceIllegalCharacters,
+                ColonAction = model.ColonAction,
                 MultiEpisodeStyle = model.MultiEpisodeStyle,
                 StandardMovieFormat = model.StandardMovieFormat,
                 MovieFolderFormat = model.MovieFolderFormat
@@ -58,6 +60,7 @@ namespace NzbDrone.Api.Config
 
                 RenameEpisodes = resource.RenameEpisodes,
                 ReplaceIllegalCharacters = resource.ReplaceIllegalCharacters,
+                ColonAction = resource.ColonAction,
                 //MultiEpisodeStyle = resource.MultiEpisodeStyle,
                 //StandardEpisodeFormat = resource.StandardEpisodeFormat,
                 //DailyEpisodeFormat = resource.DailyEpisodeFormat,

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -66,7 +66,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                     Detail = new Dictionary<string, string>
                     {
                         { "destination","shared/folder" },
-                        { "uri", FileNameBuilder.CleanFileName(_remoteEpisode.Release.Title) + ".nzb" }
+                        { "uri", CleanFileName(_remoteEpisode.Release.Title) }
                     },
                     Transfer = new Dictionary<string, string>
                     {
@@ -89,7 +89,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                     Detail = new Dictionary<string, string>
                     {
                         { "destination","shared/folder" },
-                        { "uri", FileNameBuilder.CleanFileName(_remoteEpisode.Release.Title) + ".nzb" }
+                        { "uri", CleanFileName(_remoteEpisode.Release.Title) }
                     },
                     Transfer = new Dictionary<string, string>
                     {
@@ -112,7 +112,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                     Detail = new Dictionary<string, string>
                     {
                         { "destination","shared/folder" },
-                        { "uri", FileNameBuilder.CleanFileName(_remoteEpisode.Release.Title) + ".nzb" }
+                        { "uri", CleanFileName(_remoteEpisode.Release.Title) }
                     },
                     Transfer = new Dictionary<string, string>
                     {
@@ -135,7 +135,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                     Detail = new Dictionary<string, string>
                     {
                         { "destination","shared/folder" },
-                        { "uri", FileNameBuilder.CleanFileName(_remoteEpisode.Release.Title) + ".nzb" }
+                        { "uri", CleanFileName(_remoteEpisode.Release.Title) }
                     },
                     Transfer = new Dictionary<string, string>
                     {
@@ -158,7 +158,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                     Detail = new Dictionary<string, string>
                     {
                         { "destination","shared/folder" },
-                        { "uri", FileNameBuilder.CleanFileName(_remoteEpisode.Release.Title) + ".nzb" }
+                        { "uri", CleanFileName(_remoteEpisode.Release.Title) }
                     },
                     Transfer = new Dictionary<string, string>
                     {
@@ -245,6 +245,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             Mocker.GetMock<IDownloadStationTaskProxy>()
                   .Setup(d => d.GetTasks(_settings))
                   .Returns(tasks);
+        }
+
+        protected string CleanFileName(String name)
+        {
+            return FileNameBuilder.CleanFileName(name, NamingConfig.Default) + ".nzb";
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/OrganizerTests/CleanFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/CleanFixture.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.Test.OrganizerTests
             "Mission Impossible - no [HDTV-720p]")]
         public void CleanFileName(string name, string expectedName)
         {
-            FileNameBuilder.CleanFileName(name).Should().Be(expectedName);
+            FileNameBuilder.CleanFileName(name, NamingConfig.Default).Should().Be(expectedName);
         }
 
     }

--- a/src/NzbDrone.Core/Datastore/Migration/144_naming_config_colon_action.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/144_naming_config_colon_action.cs
@@ -1,0 +1,15 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(144)]
+    public class naming_config_colon_action : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("NamingConfig").AddColumn("ColonAction").AsString().WithDefaultValue("");
+            Update.Table("NamingConfig").Set(new { ColonAction = "" }).AllRows();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
@@ -28,10 +28,11 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
                                 ITorrentFileInfoReader torrentFileInfoReader,
                                 IHttpClient httpClient,
                                 IConfigService configService,
+                                INamingConfigService namingConfigService,
                                 IDiskProvider diskProvider,
                                 IRemotePathMappingService remotePathMappingService,
                                 Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _scanWatchFolder = scanWatchFolder;
 
@@ -47,7 +48,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
 
             var title = remoteMovie.Release.Title;
 
-            title = FileNameBuilder.CleanFileName(title);
+            title = CleanFileName(title);
 
             var filepath = Path.Combine(Settings.TorrentFolder, string.Format("{0}.magnet", title));
 
@@ -66,7 +67,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
         {
             var title = remoteMovie.Release.Title;
 
-            title = FileNameBuilder.CleanFileName(title);
+            title = CleanFileName(title);
 
             var filepath = Path.Combine(Settings.TorrentFolder, string.Format("{0}.torrent", title));
 

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackhole.cs
@@ -22,10 +22,11 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
         public UsenetBlackhole(IScanWatchFolder scanWatchFolder,
                                IHttpClient httpClient,
                                IConfigService configService,
+                               INamingConfigService namingConfigService,
                                IDiskProvider diskProvider,
                                IRemotePathMappingService remotePathMappingService,
                                Logger logger)
-            : base(httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _scanWatchFolder = scanWatchFolder;
 
@@ -36,7 +37,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
         {
             var title = remoteMovie.Release.Title;
 
-            title = FileNameBuilder.CleanFileName(title);
+            title = CleanFileName(title);
 
             var filepath = Path.Combine(Settings.NzbFolder, title + ".nzb");
 

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -12,6 +12,7 @@ using NLog;
 using FluentValidation.Results;
 using System.Net;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.Deluge
 {
@@ -23,10 +24,11 @@ namespace NzbDrone.Core.Download.Clients.Deluge
                       ITorrentFileInfoReader torrentFileInfoReader,
                       IHttpClient httpClient,
                       IConfigService configService,
+                      INamingConfigService namingConfigService,
                       IDiskProvider diskProvider,
                       IRemotePathMappingService remotePathMappingService,
                       Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -11,6 +11,7 @@ using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.DownloadStation.Proxies;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Core.Validation;
@@ -33,10 +34,11 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                                       ITorrentFileInfoReader torrentFileInfoReader,
                                       IHttpClient httpClient,
                                       IConfigService configService,
+                                      INamingConfigService namingConfigService,
                                       IDiskProvider diskProvider,
                                       IRemotePathMappingService remotePathMappingService,
                                       Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _dsInfoProxy = dsInfoProxy;
             _dsTaskProxy = dsTaskProxy;

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -9,6 +9,7 @@ using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.DownloadStation.Proxies;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Core.Validation;
@@ -30,11 +31,12 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                                      IDownloadStationTaskProxy dsTaskProxy,
                                      IHttpClient httpClient,
                                      IConfigService configService,
+                                     INamingConfigService namingConfigService,
                                      IDiskProvider diskProvider,
                                      IRemotePathMappingService remotePathMappingService,
                                      Logger logger
                                      )
-            : base(httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _dsInfoProxy = dsInfoProxy;
             _dsTaskProxy = dsTaskProxy;

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
@@ -9,6 +9,7 @@ using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.Hadouken.Models;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Core.Validation;
@@ -23,10 +24,11 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
                         ITorrentFileInfoReader torrentFileInfoReader,
                         IHttpClient httpClient,
                         IConfigService configService,
+                        INamingConfigService namingConfigService,
                         IDiskProvider diskProvider,
                         IRemotePathMappingService remotePathMappingService,
                         Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortex.cs
+++ b/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortex.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.NzbVortex
 {
@@ -21,10 +22,11 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
         public NzbVortex(INzbVortexProxy proxy,
                        IHttpClient httpClient,
                        IConfigService configService,
+                       INamingConfigService namingConfigService,
                        IDiskProvider diskProvider,
                        IRemotePathMappingService remotePathMappingService,
                        Logger logger)
-            : base(httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.Nzbget
 {
@@ -23,10 +24,11 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
         public Nzbget(INzbgetProxy proxy,
                       IHttpClient httpClient,
                       IConfigService configService,
+                      INamingConfigService namingConfigService,
                       IDiskProvider diskProvider,
                       IRemotePathMappingService remotePathMappingService,
                       Logger logger)
-            : base(httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
+++ b/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
@@ -20,10 +20,11 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
 
         public Pneumatic(IHttpClient httpClient,
                          IConfigService configService,
+                         INamingConfigService namingConfigService,
                          IDiskProvider diskProvider,
                          IRemotePathMappingService remotePathMappingService,
                          Logger logger)
-            : base(configService, diskProvider, remotePathMappingService, logger)
+            : base(configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _httpClient = httpClient;
         }
@@ -43,7 +44,7 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
             //    throw new NotSupportedException("Full season releases are not supported with Pneumatic.");
             //}
 
-            title = FileNameBuilder.CleanFileName(title);
+            title = CleanFileName(title);
 
             //Save to the Pneumatic directory (The user will need to ensure its accessible by XBMC)
             var nzbFile = Path.Combine(Settings.NzbFolder, title + ".nzb");
@@ -70,7 +71,7 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
                     continue;
                 }
 
-                var title = FileNameBuilder.CleanFileName(Path.GetFileName(file));
+                var title = CleanFileName(Path.GetFileName(file));
 
                 var historyItem = new DownloadClientItem
                 {

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -12,6 +12,7 @@ using FluentValidation.Results;
 using System.Net;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.QBittorrent
 {
@@ -23,10 +24,11 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                            ITorrentFileInfoReader torrentFileInfoReader,
                            IHttpClient httpClient,
                            IConfigService configService,
+                           INamingConfigService namingConfigService,
                            IDiskProvider diskProvider,
                            IRemotePathMappingService remotePathMappingService,
                            Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.Sabnzbd
 {
@@ -21,10 +22,11 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
         public Sabnzbd(ISabnzbdProxy proxy,
                        IHttpClient httpClient,
                        IConfigService configService,
+                       INamingConfigService namingConfigService,
                        IDiskProvider diskProvider,
                        IRemotePathMappingService remotePathMappingService,
                        Logger logger)
-            : base(httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Transmission/Transmission.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/Transmission.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Http;
@@ -7,6 +7,7 @@ using NLog;
 using FluentValidation.Results;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.Transmission
 {
@@ -16,10 +17,11 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                             ITorrentFileInfoReader torrentFileInfoReader,
                             IHttpClient httpClient,
                             IConfigService configService,
+                            INamingConfigService namingConfigService,
                             IDiskProvider diskProvider,
                             IRemotePathMappingService remotePathMappingService,
                             Logger logger)
-            : base(proxy, torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(proxy, torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
         }
 

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -9,6 +9,7 @@ using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Core.Validation;
@@ -23,10 +24,11 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             ITorrentFileInfoReader torrentFileInfoReader,
             IHttpClient httpClient,
             IConfigService configService,
+            INamingConfigService namingConfigService,
             IDiskProvider diskProvider,
             IRemotePathMappingService remotePathMappingService,
             Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
+++ b/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
@@ -1,10 +1,11 @@
-﻿using FluentValidation.Results;
+using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.Transmission;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.RemotePathMappings;
 
 namespace NzbDrone.Core.Download.Clients.Vuze
@@ -17,10 +18,11 @@ namespace NzbDrone.Core.Download.Clients.Vuze
                     ITorrentFileInfoReader torrentFileInfoReader,
                     IHttpClient httpClient,
                     IConfigService configService,
+                    INamingConfigService namingConfigService,
                     IDiskProvider diskProvider,
                     IRemotePathMappingService remotePathMappingService,
                     Logger logger)
-            : base(proxy, torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(proxy, torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
         }
 

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -15,6 +15,7 @@ using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.RTorrent
 {
@@ -27,11 +28,12 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
                         ITorrentFileInfoReader torrentFileInfoReader,
                         IHttpClient httpClient,
                         IConfigService configService,
+                        INamingConfigService namingConfigService,
                         IDiskProvider diskProvider,
                         IRemotePathMappingService remotePathMappingService,
                         IRTorrentDirectoryValidator rTorrentDirectoryValidator,
                         Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
             _rTorrentDirectoryValidator = rTorrentDirectoryValidator;

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
@@ -13,6 +13,7 @@ using System.Net;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Common.Cache;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.UTorrent
 {
@@ -26,10 +27,11 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
                         ITorrentFileInfoReader torrentFileInfoReader,
                         IHttpClient httpClient,
                         IConfigService configService,
+                        INamingConfigService namingConfigService,
                         IDiskProvider diskProvider,
                         IRemotePathMappingService remotePathMappingService,
                         Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
 

--- a/src/NzbDrone.Core/Download/DownloadClientBase.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientBase.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download
 {
@@ -18,6 +19,7 @@ namespace NzbDrone.Core.Download
         where TSettings : IProviderConfig, new()
     {
         protected readonly IConfigService _configService;
+        protected readonly INamingConfigService _namingConfigService;
         protected readonly IDiskProvider _diskProvider;
         protected readonly IRemotePathMappingService _remotePathMappingService;
         protected readonly Logger _logger;
@@ -39,12 +41,14 @@ namespace NzbDrone.Core.Download
 
         protected TSettings Settings => (TSettings)Definition.Settings;
 
-        protected DownloadClientBase(IConfigService configService, 
+        protected DownloadClientBase(IConfigService configService,
+            INamingConfigService namingConfigService,
             IDiskProvider diskProvider, 
             IRemotePathMappingService remotePathMappingService,
             Logger logger)
         {
             _configService = configService;
+            _namingConfigService = namingConfigService;
             _diskProvider = diskProvider;
             _remotePathMappingService = remotePathMappingService;
             _logger = logger;
@@ -151,6 +155,13 @@ namespace NzbDrone.Core.Download
             return null;
         }
 
+        // proxy method to pass in our naming config
+        protected String CleanFileName(string name)
+        {
+            // get a fresh naming config each time, in case the user has made changes
+            NamingConfig namingConfig = _namingConfigService.GetConfig();
+            return FileNameBuilder.CleanFileName(name, namingConfig);
+        }
         
     }
 }

--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -25,10 +25,11 @@ namespace NzbDrone.Core.Download
         protected TorrentClientBase(ITorrentFileInfoReader torrentFileInfoReader,
                                     IHttpClient httpClient,
                                     IConfigService configService,
+                                    INamingConfigService namingConfigService,
                                     IDiskProvider diskProvider,
                                     IRemotePathMappingService remotePathMappingService,
                                     Logger logger)
-            : base(configService, diskProvider, remotePathMappingService, logger)
+            : base(configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _httpClient = httpClient;
             _torrentFileInfoReader = torrentFileInfoReader;
@@ -178,7 +179,7 @@ namespace NzbDrone.Core.Download
                 throw new ReleaseDownloadException(remoteMovie.Release, "Downloading torrent failed", ex);
             }
 
-            var filename = string.Format("{0}.torrent", FileNameBuilder.CleanFileName(remoteMovie.Release.Title));
+            var filename = string.Format("{0}.torrent", CleanFileName(remoteMovie.Release.Title));
             var hash = _torrentFileInfoReader.GetHashFromTorrentFile(torrentFile);
             var actualHash = AddFromTorrentFile(remoteMovie, hash, filename, torrentFile);
 

--- a/src/NzbDrone.Core/Download/UsenetClientBase.cs
+++ b/src/NzbDrone.Core/Download/UsenetClientBase.cs
@@ -20,10 +20,11 @@ namespace NzbDrone.Core.Download
 
         protected UsenetClientBase(IHttpClient httpClient,
                                    IConfigService configService,
+                                   INamingConfigService namingConfigService,
                                    IDiskProvider diskProvider,
                                    IRemotePathMappingService remotePathMappingService,
                                    Logger logger)
-            : base(configService, diskProvider, remotePathMappingService, logger)
+            : base(configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _httpClient = httpClient;
         }
@@ -35,7 +36,7 @@ namespace NzbDrone.Core.Download
         public override string Download(RemoteMovie remoteMovie)
         {
             var url = remoteMovie.Release.DownloadUrl;
-            var filename = FileNameBuilder.CleanFileName(remoteMovie.Release.Title) + ".nzb";
+            var filename = CleanFileName(remoteMovie.Release.Title) + ".nzb";
 
             byte[] nzbData;
 

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Authentication\UserRepository.cs" />
     <Compile Include="Authentication\UserService.cs" />
     <Compile Include="Datastore\Migration\123_create_netimport_table.cs" />
+    <Compile Include="Datastore\Migration\144_naming_config_colon_action.cs" />
     <Compile Include="Datastore\Migration\143_clean_core_tv.cs" />
     <Compile Include="Datastore\Migration\142_movie_extras.cs" />
     <Compile Include="Datastore\Migration\140_add_alternative_titles_table.cs" />

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -248,8 +248,9 @@ namespace NzbDrone.Core.Organizer
             {
                 AddMovieFileTokens(tokenHandlers, new MovieFile { SceneName = $"{movie.Title} {movie.Year}", RelativePath = $"{movie.Title} {movie.Year}"});
             }
-                
-            return CleanFolderName(ReplaceTokens(namingConfig.MovieFolderFormat, tokenHandlers, namingConfig));
+
+            string name = ReplaceTokens(namingConfig.MovieFolderFormat, tokenHandlers, namingConfig);
+            return CleanFolderName(name, namingConfig);
         }
 
         public static string CleanTitle(string title)
@@ -283,11 +284,14 @@ namespace NzbDrone.Core.Organizer
             return title.Trim();
         }
 
-        public static string CleanFileName(string name, bool replace = true)
+        public static string CleanFileName(string name, NamingConfig namingConfig)
         {
+            bool replace = namingConfig.ReplaceIllegalCharacters;
+            string colonAction = namingConfig.ColonAction;
+
             string result = name;
             string[] badCharacters = { "\\", "/", "<", ">", "?", "*", ":", "|", "\"" };
-            string[] goodCharacters = { "+", "+", "", "", "!", "-", "", "", "" };
+            string[] goodCharacters = { "+", "+", "", "", "!", "-", colonAction, "", "" };
 
             for (int i = 0; i < badCharacters.Length; i++)
             {
@@ -297,12 +301,12 @@ namespace NzbDrone.Core.Organizer
             return result.Trim();
         }
 
-        public static string CleanFolderName(string name)
+        public static string CleanFolderName(string name, NamingConfig namingConfig)
         {
             name = FileNameCleanupRegex.Replace(name, match => match.Captures[0].Value[0].ToString());
             name = name.Trim(' ', '.');
 
-            return CleanFileName(name);
+            return CleanFileName(name, namingConfig);
         }
 
         private void AddMovieTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Movie movie)
@@ -557,7 +561,7 @@ namespace NzbDrone.Core.Organizer
                 replacementText = replacementText.Replace(" ", tokenMatch.Separator);
             }
 
-            replacementText = CleanFileName(replacementText, namingConfig.ReplaceIllegalCharacters);
+            replacementText = CleanFileName(replacementText, namingConfig);
 
             if (!replacementText.IsNullOrWhiteSpace())
             {

--- a/src/NzbDrone.Core/Organizer/NamingConfig.cs
+++ b/src/NzbDrone.Core/Organizer/NamingConfig.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.Organizer
         {
             RenameEpisodes = false,
             ReplaceIllegalCharacters = true,
+            ColonAction = "",
             MultiEpisodeStyle = 0,
             MovieFolderFormat = "{Movie Title} ({Release Year})",
             StandardMovieFormat = "{Movie Title} ({Release Year}) {Quality Full}",
@@ -15,6 +16,7 @@ namespace NzbDrone.Core.Organizer
 
         public bool RenameEpisodes { get; set; }
         public bool ReplaceIllegalCharacters { get; set; }
+        public string ColonAction { get; set; }
         public int MultiEpisodeStyle { get; set; }
         public string StandardMovieFormat { get; set; }
         public string MovieFolderFormat { get; set; }

--- a/src/UI/Settings/MediaManagement/Naming/NamingView.js
+++ b/src/UI/Settings/MediaManagement/Naming/NamingView.js
@@ -11,6 +11,8 @@ module.exports = (function() {
         ui                                  : {
             namingOptions            : '.x-naming-options',
             renameEpisodesCheckbox   : '.x-rename-episodes',
+            replacingOptions         : '.x-replacing-options',
+            replaceIllegalChars      : '.x-replace-illegal-chars',
             singleEpisodeExample     : '.x-single-episode-example',
             multiEpisodeExample      : '.x-multi-episode-example',
             dailyEpisodeExample      : '.x-daily-episode-example',
@@ -24,7 +26,8 @@ module.exports = (function() {
             movieFolderExample       : '.x-movie-folder-example'
         },
         events                              : {
-            "change .x-rename-episodes"      : '_setFailedDownloadOptionsVisibility',
+            "change .x-rename-episodes"      : '_setRenameEpisodesVisibility',
+            "change .x-replace-illegal-chars": '_setReplaceIllegalCharsVisibility',
             "click .x-show-wizard"           : '_showWizard',
             "click .x-naming-token-helper a" : '_addToken',
             "change .x-multi-episode-style"  : '_multiEpisodeFomatChanged'
@@ -34,6 +37,9 @@ module.exports = (function() {
             if (!this.model.get('renameEpisodes')) {
                 this.ui.namingOptions.hide();
             }
+            if (!this.model.get('replaceIllegalCharacters')) {
+                this.ui.replacingOptions.hide();
+            }
             var basicNamingView = new BasicNamingView({ model : this.model });
             this.basicNamingRegion.show(basicNamingView);
             this.namingSampleModel = new NamingSampleModel();
@@ -41,12 +47,20 @@ module.exports = (function() {
             this.listenTo(this.namingSampleModel, 'sync', this._showSamples);
             this._updateSamples();
         },
-        _setFailedDownloadOptionsVisibility : function() {
+        _setRenameEpisodesVisibility : function() {
             var checked = this.ui.renameEpisodesCheckbox.prop('checked');
             if (checked) {
                 this.ui.namingOptions.slideDown();
             } else {
                 this.ui.namingOptions.slideUp();
+            }
+        },
+        _setReplaceIllegalCharsVisibility : function() {
+            var checked = this.ui.replaceIllegalChars.prop('checked');
+            if (checked) {
+                this.ui.replacingOptions.slideDown();
+            } else {
+                this.ui.replacingOptions.slideUp();
             }
         },
         _updateSamples                      : function() {

--- a/src/UI/Settings/MediaManagement/Naming/NamingViewTemplate.hbs
+++ b/src/UI/Settings/MediaManagement/Naming/NamingViewTemplate.hbs
@@ -24,31 +24,49 @@
         </div>
     </div>
 
-    <div class="form-group advanced-setting">
-        <label class="col-sm-3 control-label">Replace Illegal Characters</label>
-
-        <div class="col-sm-8">
-            <div class="input-group">
-                <label class="checkbox toggle well">
-                    <input type="checkbox" name="replaceIllegalCharacters" />
-
-                    <p>
-                        <span>Yes</span>
-                        <span>No</span>
-                    </p>
-
-                    <div class="btn btn-primary slide-button"/>
-                </label>
-
-                <span class="help-inline-checkbox">
-                    <i class="icon-sonarr-form-info" title="Replace or Remove illegal characters"/>
-                </span>
-            </div>
-        </div>
-    </div>
-
     <div class="x-naming-options">
         <div class="basic-setting x-basic-naming"></div>
+
+        <div class="form-group advanced-setting">
+            <label class="col-sm-3 control-label">Replace Illegal Characters</label>
+
+            <div class="col-sm-8">
+                <div class="input-group">
+                    <label class="checkbox toggle well">
+                        <input type="checkbox" name="replaceIllegalCharacters" class="x-replace-illegal-chars"/>
+
+                        <p>
+                            <span>Yes</span>
+                            <span>No</span>
+                        </p>
+
+                        <div class="btn btn-primary slide-button"/>
+                    </label>
+
+                    <span class="help-inline-checkbox">
+                        <i class="icon-sonarr-form-info" title="Replace or Remove illegal characters"/>
+                    </span>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group advanced-setting x-replacing-options">
+
+            <label class="col-sm-3 control-label">Colon Action</label>
+
+            <span class="col-sm-1 col-sm-push-8 help-inline">
+                <i class="icon-sonarr-form-info" title="Colons are illegal characters; Radarr will delete them by default" />
+            </span>
+
+            <div class="col-sm-8 col-sm-pull-1">
+                <select class="form-control" name="colonAction">
+                    <option value="">Delete</option>
+                    <option value="-">Replace with Dash</option>
+                    <option value=" -">Replace with Space Dash</option>
+                    <option value=" - ">Replace with Space Dash Space</option>
+                </select>
+            </div>
+        </div>
 
         <div class="form-group advanced-setting">
             <label class="col-sm-3 control-label">Standard Movie Format</label>


### PR DESCRIPTION
The default functionality is to delete colon characters. However,
there are several other ways that various media software expects
these characters to be resolved (dash, space dash, or space dash
space). This commit adds the ability to choose one of those
settings from a "Colon Action" select control in the "Movie Naming"
section of the "Media Management" Settings tab.

Also, this changes behavior for the "Rename Movies" switch so that
when it is disabled it also hides the "Replace Illegal Characters"
setting. This is in line with how these two settings interoperate.

I only resolved two issues with a single commit because these both
modify the same UI elements.

#### Database Migration
YES

#### Description

Added the `Colon Action` input in the *Movie Naming* settings section:
____
![image](https://user-images.githubusercontent.com/5295965/37695600-e2df0788-2ca6-11e8-9383-6fa7a5ab178e.png)
____
Note, the default value is `Delete` (which corresponds to an empty string value), to stay consistent with current Radarr functionality.

#### Issues Fixed or Closed by this PR

* #2140 
* #2657 

