### PR TITLE
Fixed: Don't add category when removing torrent from qBittorrent

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
@@ -97,6 +97,11 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
             var result = ProcessRequest(request, settings);
 
+            if (settings.MovieCategory.IsNotNullOrWhiteSpace())
+            {
+                request.AddFormParameter("category", settings.MovieCategory);
+            }
+
             // Note: Current qbit versions return nothing, so we can't do != "Ok." here.
             if (result == "Fails.")
             {
@@ -109,11 +114,6 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             var request = BuildRequest(settings).Resource(removeData ? "/command/deletePerm" : "/command/delete")
                                                 .Post()
                                                 .AddFormParameter("hashes", hash);
-
-            if (settings.MovieCategory.IsNotNullOrWhiteSpace())
-            {
-                request.AddFormParameter("category", settings.MovieCategory);
-            }
             
             ProcessRequest(request, settings);
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
https://github.com/Sonarr/Sonarr/commit/ac379e3b84a68b5a895bcaeb24056be4c8918887

#### Issues Fixed or Closed by this PR
Fixes #2655 
* #
