### PR TITLE
Add configurable setting for "replace illegal characters" behavior

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,2 @@
+todo:
+  keyword: "TODO"

--- a/src/NzbDrone.Api/Config/NamingConfigResource.cs
+++ b/src/NzbDrone.Api/Config/NamingConfigResource.cs
@@ -7,7 +7,7 @@ namespace NzbDrone.Api.Config
     {
         public bool RenameEpisodes { get; set; }
         public bool ReplaceIllegalCharacters { get; set; }
-        public string ColonReplacementFormat { get; set; }
+        public int ColonReplacementFormat { get; set; }
         public string StandardMovieFormat { get; set; }
         public string MovieFolderFormat { get; set; }
         public int MultiEpisodeStyle { get; set; }

--- a/src/NzbDrone.Api/Config/NamingConfigResource.cs
+++ b/src/NzbDrone.Api/Config/NamingConfigResource.cs
@@ -7,6 +7,7 @@ namespace NzbDrone.Api.Config
     {
         public bool RenameEpisodes { get; set; }
         public bool ReplaceIllegalCharacters { get; set; }
+        public string ColonReplacementFormat { get; set; }
         public string StandardMovieFormat { get; set; }
         public string MovieFolderFormat { get; set; }
         public int MultiEpisodeStyle { get; set; }
@@ -28,6 +29,7 @@ namespace NzbDrone.Api.Config
 
                 RenameEpisodes = model.RenameEpisodes,
                 ReplaceIllegalCharacters = model.ReplaceIllegalCharacters,
+                ColonReplacementFormat = model.ColonReplacementFormat,
                 MultiEpisodeStyle = model.MultiEpisodeStyle,
                 StandardMovieFormat = model.StandardMovieFormat,
                 MovieFolderFormat = model.MovieFolderFormat
@@ -58,6 +60,7 @@ namespace NzbDrone.Api.Config
 
                 RenameEpisodes = resource.RenameEpisodes,
                 ReplaceIllegalCharacters = resource.ReplaceIllegalCharacters,
+                ColonReplacementFormat = resource.ColonReplacementFormat,
                 //MultiEpisodeStyle = resource.MultiEpisodeStyle,
                 //StandardEpisodeFormat = resource.StandardEpisodeFormat,
                 //DailyEpisodeFormat = resource.DailyEpisodeFormat,

--- a/src/NzbDrone.Common/NzbDrone.Common.csproj
+++ b/src/NzbDrone.Common/NzbDrone.Common.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Serializer\HttpUriConverter.cs" />
     <Compile Include="Serializer\IntConverter.cs" />
     <Compile Include="Serializer\Json.cs" />
+    <Compile Include="Serializer\UnderscoreStringEnumConverter.cs" />
     <Compile Include="ServiceFactory.cs" />
     <Compile Include="ServiceProvider.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />

--- a/src/NzbDrone.Common/Serializer/UnderscoreStringEnumConverter.cs
+++ b/src/NzbDrone.Common/Serializer/UnderscoreStringEnumConverter.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace NzbDrone.Common.Serializer
+{
+    public class UnderscoreStringEnumConverter : JsonConverter
+    {
+        public object UnknownValue { get; set; }
+
+        public UnderscoreStringEnumConverter(object unknownValue)
+        {
+            UnknownValue = unknownValue;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType.IsEnum;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var enumString = reader.Value.ToString().Replace("_", string.Empty);
+
+            try
+            {
+                return Enum.Parse(objectType, enumString, true);
+            }
+            catch
+            {
+                if (UnknownValue == null)
+                {
+                    throw;
+                }
+
+                return UnknownValue;
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var enumText = value.ToString();
+            var builder = new StringBuilder(enumText.Length + 4);
+            builder.Append(char.ToLower(enumText[0]));
+            for (int i = 1; i < enumText.Length; i++)
+            {
+                if (char.IsUpper(enumText[i]))
+                {
+                    builder.Append('_');
+                }
+                builder.Append(char.ToLower(enumText[i]));
+            }
+            enumText = builder.ToString();
+
+            writer.WriteValue(enumText);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/DownloadStationsTaskStatusJsonConverterFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/DownloadStationsTaskStatusJsonConverterFixture.cs
@@ -1,0 +1,49 @@
+﻿using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using NzbDrone.Core.Download.Clients.DownloadStation;
+
+namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
+{
+    [TestFixture]
+    public class DownloadStationsTaskStatusJsonConverterFixture
+    {
+        [TestCase("captcha_needed", DownloadStationTaskStatus.CaptchaNeeded)]
+        [TestCase("filehosting_waiting", DownloadStationTaskStatus.FilehostingWaiting)]
+        [TestCase("hash_checking", DownloadStationTaskStatus.HashChecking)]
+        [TestCase("error", DownloadStationTaskStatus.Error)]
+        [TestCase("downloading", DownloadStationTaskStatus.Downloading)]
+        public void should_parse_enum_correctly(string value, DownloadStationTaskStatus expected)
+        {
+            var task = "{\"Status\": \"" + value + "\"}";
+
+            var item = JsonConvert.DeserializeObject<DownloadStationTask>(task);
+
+            item.Status.Should().Be(expected);
+        }
+
+        [TestCase("captcha_needed", DownloadStationTaskStatus.CaptchaNeeded)]
+        [TestCase("filehosting_waiting", DownloadStationTaskStatus.FilehostingWaiting)]
+        [TestCase("hash_checking", DownloadStationTaskStatus.HashChecking)]
+        [TestCase("error", DownloadStationTaskStatus.Error)]
+        [TestCase("downloading", DownloadStationTaskStatus.Downloading)]
+        public void should_serialize_enum_correctly(string expected, DownloadStationTaskStatus value)
+        {
+            var task = new DownloadStationTask { Status = value };
+
+            var item = JsonConvert.SerializeObject(task);
+
+            item.Should().Contain(expected);
+        }
+
+        [Test]
+        public void should_return_unknown_if_unknown_enum_value()
+        {
+            var task = "{\"Status\": \"some_unknown_value\"}";
+
+            var item = JsonConvert.DeserializeObject<DownloadStationTask>(task);
+
+            item.Status.Should().Be(DownloadStationTaskStatus.Unknown);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
@@ -576,11 +576,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             items.Should().OnlyContain(v => !v.OutputPath.IsEmpty);
         }
 
-        [TestCase(DownloadStationTaskStatus.Downloading, DownloadItemStatus.Downloading, true)]
-        [TestCase(DownloadStationTaskStatus.Finished, DownloadItemStatus.Completed, false)]
-        [TestCase(DownloadStationTaskStatus.Seeding, DownloadItemStatus.Completed, true)]
-        [TestCase(DownloadStationTaskStatus.Waiting, DownloadItemStatus.Queued, true)]
-        public void GetItems_should_return_readonly_expected(DownloadStationTaskStatus apiStatus, DownloadItemStatus expectedItemStatus, bool readOnlyExpected)
+        [TestCase(DownloadStationTaskStatus.Downloading, false, false)]
+        [TestCase(DownloadStationTaskStatus.Finished, true, true)]
+        [TestCase(DownloadStationTaskStatus.Seeding,  true, false)]
+        [TestCase(DownloadStationTaskStatus.Waiting, false, false)]
+        public void GetItems_should_return_canBeMoved_and_canBeDeleted_as_expected(DownloadStationTaskStatus apiStatus, bool canMoveFilesExpected, bool canBeRemovedExpected)
         {
             GivenSerialNumber();
             GivenSharedFolder();
@@ -592,7 +592,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             var items = Subject.GetItems();
 
             items.Should().HaveCount(1);
-            items.First().IsReadOnly.Should().Be(readOnlyExpected);
+
+            var item = items.First();
+
+            item.CanBeRemoved.Should().Be(canBeRemovedExpected);
+            item.CanMoveFiles.Should().Be(canMoveFilesExpected);
         }
 
         [TestCase(DownloadStationTaskStatus.Downloading, DownloadItemStatus.Downloading)]
@@ -601,9 +605,12 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         [TestCase(DownloadStationTaskStatus.Finished, DownloadItemStatus.Completed)]
         [TestCase(DownloadStationTaskStatus.Finishing, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.HashChecking, DownloadItemStatus.Downloading)]
+        [TestCase(DownloadStationTaskStatus.CaptchaNeeded, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.Paused, DownloadItemStatus.Paused)]
         [TestCase(DownloadStationTaskStatus.Seeding, DownloadItemStatus.Completed)]
+        [TestCase(DownloadStationTaskStatus.FilehostingWaiting, DownloadItemStatus.Queued)]
         [TestCase(DownloadStationTaskStatus.Waiting, DownloadItemStatus.Queued)]
+        [TestCase(DownloadStationTaskStatus.Unknown, DownloadItemStatus.Queued)]
         public void GetItems_should_return_item_as_downloadItemStatus(DownloadStationTaskStatus apiStatus, DownloadItemStatus expectedItemStatus)
         {
             GivenSerialNumber();

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
@@ -408,32 +408,18 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             items.Should().OnlyContain(v => !v.OutputPath.IsEmpty);
         }
 
-        [TestCase(DownloadStationTaskStatus.Downloading, DownloadItemStatus.Downloading, true)]
-        [TestCase(DownloadStationTaskStatus.Finished, DownloadItemStatus.Completed, false)]
-        [TestCase(DownloadStationTaskStatus.Waiting, DownloadItemStatus.Queued, true)]
-        public void GetItems_should_return_readonly_expected(DownloadStationTaskStatus apiStatus, DownloadItemStatus expectedItemStatus, bool readOnlyExpected)
-        {
-            GivenSerialNumber();
-            GivenSharedFolder();
-
-            _queued.Status = apiStatus;
-
-            GivenTasks(new List<DownloadStationTask>() { _queued });
-
-            var items = Subject.GetItems();
-
-            items.Should().HaveCount(1);
-            items.First().IsReadOnly.Should().Be(readOnlyExpected);
-        }
-
         [TestCase(DownloadStationTaskStatus.Downloading, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.Error, DownloadItemStatus.Failed)]
         [TestCase(DownloadStationTaskStatus.Extracting, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.Finished, DownloadItemStatus.Completed)]
         [TestCase(DownloadStationTaskStatus.Finishing, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.HashChecking, DownloadItemStatus.Downloading)]
+        [TestCase(DownloadStationTaskStatus.CaptchaNeeded, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.Paused, DownloadItemStatus.Paused)]
+        [TestCase(DownloadStationTaskStatus.Seeding, DownloadItemStatus.Completed)]
+        [TestCase(DownloadStationTaskStatus.FilehostingWaiting, DownloadItemStatus.Queued)]
         [TestCase(DownloadStationTaskStatus.Waiting, DownloadItemStatus.Queued)]
+        [TestCase(DownloadStationTaskStatus.Unknown, DownloadItemStatus.Queued)]
         public void GetItems_should_return_item_as_downloadItemStatus(DownloadStationTaskStatus apiStatus, DownloadItemStatus expectedItemStatus)
         {
             GivenSerialNumber();

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -66,7 +66,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                     Detail = new Dictionary<string, string>
                     {
                         { "destination","shared/folder" },
-                        { "uri", FileNameBuilder.CleanFileName(_remoteEpisode.Release.Title) + ".nzb" }
+                        { "uri", CleanFileName(_remoteEpisode.Release.Title) }
                     },
                     Transfer = new Dictionary<string, string>
                     {
@@ -89,7 +89,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                     Detail = new Dictionary<string, string>
                     {
                         { "destination","shared/folder" },
-                        { "uri", FileNameBuilder.CleanFileName(_remoteEpisode.Release.Title) + ".nzb" }
+                        { "uri", CleanFileName(_remoteEpisode.Release.Title) }
                     },
                     Transfer = new Dictionary<string, string>
                     {
@@ -112,7 +112,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                     Detail = new Dictionary<string, string>
                     {
                         { "destination","shared/folder" },
-                        { "uri", FileNameBuilder.CleanFileName(_remoteEpisode.Release.Title) + ".nzb" }
+                        { "uri", CleanFileName(_remoteEpisode.Release.Title) }
                     },
                     Transfer = new Dictionary<string, string>
                     {
@@ -135,7 +135,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                     Detail = new Dictionary<string, string>
                     {
                         { "destination","shared/folder" },
-                        { "uri", FileNameBuilder.CleanFileName(_remoteEpisode.Release.Title) + ".nzb" }
+                        { "uri", CleanFileName(_remoteEpisode.Release.Title) }
                     },
                     Transfer = new Dictionary<string, string>
                     {
@@ -158,7 +158,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                     Detail = new Dictionary<string, string>
                     {
                         { "destination","shared/folder" },
-                        { "uri", FileNameBuilder.CleanFileName(_remoteEpisode.Release.Title) + ".nzb" }
+                        { "uri", CleanFileName(_remoteEpisode.Release.Title) }
                     },
                     Transfer = new Dictionary<string, string>
                     {
@@ -245,6 +245,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             Mocker.GetMock<IDownloadStationTaskProxy>()
                   .Setup(d => d.GetTasks(_settings))
                   .Returns(tasks);
+        }
+
+        protected static string CleanFileName(String name)
+        {
+            return FileNameBuilder.CleanFileName(name, NamingConfig.Default) + ".nzb";
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -311,7 +311,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         }
 
         [Test]
-        public void should_be_read_only_if_max_ratio_not_reached()
+        public void should_not_be_removable_and_should_not_allow_move_files_if_max_ratio_not_reached()
         {
             GivenMaxRatio(1.0f);
 
@@ -330,11 +330,12 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             GivenTorrents(new List<QBittorrentTorrent> { torrent });
 
             var item = Subject.GetItems().Single();
-            item.IsReadOnly.Should().BeTrue();
+            item.CanBeRemoved.Should().BeFalse();
+            item.CanMoveFiles.Should().BeFalse();
         }
 
         [Test]
-        public void should_be_read_only_if_max_ratio_reached_and_not_paused()
+        public void should_not_be_removable_and_should_not_allow_move_files_if_max_ratio_reached_and_not_paused()
         {
             GivenMaxRatio(1.0f);
 
@@ -353,11 +354,12 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             GivenTorrents(new List<QBittorrentTorrent> { torrent });
 
             var item = Subject.GetItems().Single();
-            item.IsReadOnly.Should().BeTrue();
+            item.CanBeRemoved.Should().BeFalse();
+            item.CanMoveFiles.Should().BeFalse();
         }
 
         [Test]
-        public void should_be_read_only_if_max_ratio_is_not_set()
+        public void should_not_be_removable_and_should_not_allow_move_files_if_max_ratio_is_not_set()
         {
             GivenMaxRatio(1.0f, false);
 
@@ -376,11 +378,12 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             GivenTorrents(new List<QBittorrentTorrent> { torrent });
 
             var item = Subject.GetItems().Single();
-            item.IsReadOnly.Should().BeTrue();
+            item.CanBeRemoved.Should().BeFalse();
+            item.CanMoveFiles.Should().BeFalse();
         }
 
         [Test]
-        public void should_not_be_read_only_if_max_ratio_reached_and_paused()
+        public void should_be_removable_and_should_allow_move_files_if_max_ratio_reached_and_paused()
         {
             GivenMaxRatio(1.0f);
 
@@ -399,7 +402,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             GivenTorrents(new List<QBittorrentTorrent> { torrent });
 
             var item = Subject.GetItems().Single();
-            item.IsReadOnly.Should().BeFalse();
+            item.CanBeRemoved.Should().BeTrue();
+            item.CanMoveFiles.Should().BeTrue();
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
@@ -41,6 +41,9 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
             PrepareClientToReturnCompletedItem();
             var item = Subject.GetItems().Single();
             VerifyCompleted(item);
+
+            item.CanBeRemoved.Should().BeTrue();
+            item.CanMoveFiles.Should().BeTrue();
         }
 
         [Test]
@@ -172,13 +175,13 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
             item.Status.Should().Be(expectedItemStatus);
         }
 
-        [TestCase(TransmissionTorrentStatus.Stopped, DownloadItemStatus.Completed, false)]
-        [TestCase(TransmissionTorrentStatus.CheckWait, DownloadItemStatus.Downloading, true)]
-        [TestCase(TransmissionTorrentStatus.Check, DownloadItemStatus.Downloading, true)]
-        [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Completed, true)]
-        [TestCase(TransmissionTorrentStatus.SeedingWait, DownloadItemStatus.Completed, true)]
-        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Completed, true)]
-        public void GetItems_should_return_completed_item_as_downloadItemStatus(TransmissionTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus, bool expectedReadOnly)
+        [TestCase(TransmissionTorrentStatus.Stopped, DownloadItemStatus.Completed, true)]
+        [TestCase(TransmissionTorrentStatus.CheckWait, DownloadItemStatus.Downloading, false)]
+        [TestCase(TransmissionTorrentStatus.Check, DownloadItemStatus.Downloading, false)]
+        [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Completed, false)]
+        [TestCase(TransmissionTorrentStatus.SeedingWait, DownloadItemStatus.Completed, false)]
+        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Completed, false)]
+        public void GetItems_should_return_completed_item_as_downloadItemStatus(TransmissionTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus, bool expectedValue)
         {
             _completed.Status = apiStatus;
 
@@ -187,7 +190,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
             var item = Subject.GetItems().Single();
 
             item.Status.Should().Be(expectedItemStatus);
-            item.IsReadOnly.Should().Be(expectedReadOnly);
+            item.CanBeRemoved.Should().Be(expectedValue);
+            item.CanMoveFiles.Should().Be(expectedValue);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/UTorrentTests/UTorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/UTorrentTests/UTorrentFixture.cs
@@ -222,6 +222,9 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.UTorrentTests
             PrepareClientToReturnCompletedItem();
             var item = Subject.GetItems().Single();
             VerifyCompleted(item);
+
+            item.CanBeRemoved.Should().BeTrue();
+            item.CanMoveFiles.Should().BeTrue();
         }
 
         [Test]
@@ -292,12 +295,12 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.UTorrentTests
             item.Status.Should().Be(expectedItemStatus);
         }
 
-        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checking, DownloadItemStatus.Queued, false)]
-        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked, DownloadItemStatus.Completed, false)]
-        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked | UTorrentTorrentStatus.Queued, DownloadItemStatus.Completed, true)]
-        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked | UTorrentTorrentStatus.Started, DownloadItemStatus.Completed, true)]
-        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked | UTorrentTorrentStatus.Queued | UTorrentTorrentStatus.Paused, DownloadItemStatus.Completed, true)]
-        public void GetItems_should_return_completed_item_as_downloadItemStatus(UTorrentTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus, bool expectedReadOnly)
+        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checking, DownloadItemStatus.Queued, true)]
+        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked, DownloadItemStatus.Completed, true)]
+        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked | UTorrentTorrentStatus.Queued, DownloadItemStatus.Completed, false)]
+        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked | UTorrentTorrentStatus.Started, DownloadItemStatus.Completed, false)]
+        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked | UTorrentTorrentStatus.Queued | UTorrentTorrentStatus.Paused, DownloadItemStatus.Completed, false)]
+        public void GetItems_should_return_completed_item_as_downloadItemStatus(UTorrentTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus, bool expectedValue)
         {
             _completed.Status = apiStatus;
 
@@ -306,7 +309,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.UTorrentTests
             var item = Subject.GetItems().Single();
 
             item.Status.Should().Be(expectedItemStatus);
-            item.IsReadOnly.Should().Be(expectedReadOnly);
+            item.CanBeRemoved.Should().Be(expectedValue);
+            item.CanMoveFiles.Should().Be(expectedValue);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
@@ -181,12 +181,12 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
             item.Status.Should().Be(expectedItemStatus);
         }
 
-        [TestCase(TransmissionTorrentStatus.Stopped, DownloadItemStatus.Completed, false)]
-        [TestCase(TransmissionTorrentStatus.CheckWait, DownloadItemStatus.Downloading, true)]
-        [TestCase(TransmissionTorrentStatus.Check, DownloadItemStatus.Downloading, true)]
-        [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Queued, true)]
-        [TestCase(TransmissionTorrentStatus.SeedingWait, DownloadItemStatus.Completed, true)]
-        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Completed, true)]
+        [TestCase(TransmissionTorrentStatus.Stopped, DownloadItemStatus.Completed, true)]
+        [TestCase(TransmissionTorrentStatus.CheckWait, DownloadItemStatus.Downloading, false)]
+        [TestCase(TransmissionTorrentStatus.Check, DownloadItemStatus.Downloading, false)]
+        [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Queued, false)]
+        [TestCase(TransmissionTorrentStatus.SeedingWait, DownloadItemStatus.Completed, false)]
+        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Completed, false)]
         public void GetItems_should_return_completed_item_as_downloadItemStatus(TransmissionTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus, bool expectedReadOnly)
         {
             _completed.Status = apiStatus;
@@ -196,7 +196,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
             var item = Subject.GetItems().Single();
 
             item.Status.Should().Be(expectedItemStatus);
-            item.IsReadOnly.Should().Be(expectedReadOnly);
+            item.CanBeRemoved.Should().Be(expectedReadOnly);
+            item.CanMoveFiles.Should().Be(expectedReadOnly);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/HistoryTests/HistoryServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/HistoryTests/HistoryServiceFixture.cs
@@ -81,7 +81,7 @@ namespace NzbDrone.Core.Test.HistoryTests
                                    Path = @"C:\Test\Unsorted\Movie.2011.mkv"
                                };
 
-            Subject.Handle(new MovieImportedEvent(localMovie, movieFile, true, "sab", "abcd", true));
+            Subject.Handle(new MovieImportedEvent(localMovie, movieFile, true, "sab", "abcd"));
 
             Mocker.GetMock<IHistoryRepository>()
                 .Verify(v => v.Insert(It.Is<History.History>(h => h.SourceTitle == Path.GetFileNameWithoutExtension(localMovie.Path))));

--- a/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedEpisodesFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedEpisodesFixture.cs
@@ -218,9 +218,9 @@ namespace NzbDrone.Core.Test.MediaFiles
         }
 
         [Test]
-        public void should_copy_readonly_downloads()
+        public void should_copy_when_cannot_move_files_downloads()
         {
-            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, new DownloadClientItem { Title = "30.Rock.S01E01", IsReadOnly = true });
+            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, new DownloadClientItem { Title = "30.Rock.S01E01", CanMoveFiles = false});
 
             Mocker.GetMock<IUpgradeMediaFiles>()
                   .Verify(v => v.UpgradeMovieFile(It.IsAny<MovieFile>(), _approvedDecisions.First().LocalMovie, true), Times.Once());
@@ -229,7 +229,7 @@ namespace NzbDrone.Core.Test.MediaFiles
         [Test]
         public void should_use_override_importmode()
         {
-            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, new DownloadClientItem { Title = "30.Rock.S01E01", IsReadOnly = true }, ImportMode.Move);
+            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, new DownloadClientItem { Title = "30.Rock.S01E01", CanMoveFiles = false }, ImportMode.Move);
 
             Mocker.GetMock<IUpgradeMediaFiles>()
                   .Verify(v => v.UpgradeMovieFile(It.IsAny<MovieFile>(), _approvedDecisions.First().LocalMovie, false), Times.Once());

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Download\DownloadClientTests\Blackhole\UsenetBlackholeFixture.cs" />
     <Compile Include="Download\DownloadClientTests\DelugeTests\DelugeFixture.cs" />
     <Compile Include="Download\DownloadClientTests\DownloadClientFixtureBase.cs" />
+    <Compile Include="Download\DownloadClientTests\DownloadStationTests\DownloadStationsTaskStatusJsonConverterFixture.cs" />
     <Compile Include="Download\DownloadClientTests\HadoukenTests\HadoukenFixture.cs" />
     <Compile Include="Download\DownloadClientTests\NzbgetTests\NzbgetFixture.cs" />
     <Compile Include="Download\DownloadClientTests\NzbVortexTests\NzbVortexFixture.cs" />

--- a/src/NzbDrone.Core.Test/OrganizerTests/CleanFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/CleanFixture.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.Test.OrganizerTests
             "Mission Impossible - no [HDTV-720p]")]
         public void CleanFileName(string name, string expectedName)
         {
-            FileNameBuilder.CleanFileName(name).Should().Be(expectedName);
+            FileNameBuilder.CleanFileName(name, NamingConfig.Default).Should().Be(expectedName);
         }
 
     }

--- a/src/NzbDrone.Core/Datastore/Migration/146_naming_config_colon_replacement_format.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/146_naming_config_colon_replacement_format.cs
@@ -1,0 +1,15 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(146)]
+    public class naming_config_colon_action : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("NamingConfig").AddColumn("ColonReplacementFormat").AsString().WithDefaultValue("");
+            Update.Table("NamingConfig").Set(new { ColonReplacementFormat = "" }).AllRows();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/146_naming_config_colon_replacement_format.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/146_naming_config_colon_replacement_format.cs
@@ -8,8 +8,7 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            Alter.Table("NamingConfig").AddColumn("ColonReplacementFormat").AsString().WithDefaultValue("");
-            Update.Table("NamingConfig").Set(new { ColonReplacementFormat = "" }).AllRows();
+            Alter.Table("NamingConfig").AddColumn("ColonReplacementFormat").AsInt32().NotNullable().WithDefaultValue(0);
         }
     }
 }

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
@@ -28,10 +28,11 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
                                 ITorrentFileInfoReader torrentFileInfoReader,
                                 IHttpClient httpClient,
                                 IConfigService configService,
+                                INamingConfigService namingConfigService,
                                 IDiskProvider diskProvider,
                                 IRemotePathMappingService remotePathMappingService,
                                 Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _scanWatchFolder = scanWatchFolder;
 
@@ -47,7 +48,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
 
             var title = remoteMovie.Release.Title;
 
-            title = FileNameBuilder.CleanFileName(title);
+            title = CleanFileName(title);
 
             var filepath = Path.Combine(Settings.TorrentFolder, string.Format("{0}.magnet", title));
 
@@ -66,7 +67,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
         {
             var title = remoteMovie.Release.Title;
 
-            title = FileNameBuilder.CleanFileName(title);
+            title = CleanFileName(title);
 
             var filepath = Path.Combine(Settings.TorrentFolder, string.Format("{0}.torrent", title));
 

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
@@ -103,7 +103,8 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
 
                     Status = item.Status,
 
-                    IsReadOnly = Settings.ReadOnly
+                    CanMoveFiles = !Settings.ReadOnly,
+                    CanBeRemoved = !Settings.ReadOnly
                 };
             }
         }

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackhole.cs
@@ -22,10 +22,11 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
         public UsenetBlackhole(IScanWatchFolder scanWatchFolder,
                                IHttpClient httpClient,
                                IConfigService configService,
+                               INamingConfigService namingConfigService,
                                IDiskProvider diskProvider,
                                IRemotePathMappingService remotePathMappingService,
                                Logger logger)
-            : base(httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _scanWatchFolder = scanWatchFolder;
 
@@ -36,7 +37,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
         {
             var title = remoteMovie.Release.Title;
 
-            title = FileNameBuilder.CleanFileName(title);
+            title = CleanFileName(title);
 
             var filepath = Path.Combine(Settings.NzbFolder, title + ".nzb");
 

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -122,14 +122,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
                 }
 
                 // Here we detect if Deluge is managing the torrent and whether the seed criteria has been met. This allows drone to delete the torrent as appropriate.
-                if (torrent.IsAutoManaged && torrent.StopAtRatio && torrent.Ratio >= torrent.StopRatio && torrent.State == DelugeTorrentStatus.Paused)
-                {
-                    item.IsReadOnly = false;
-                }
-                else
-                {
-                    item.IsReadOnly = true;
-                }
+                item.CanMoveFiles = item.CanBeRemoved = (torrent.IsAutoManaged && torrent.StopAtRatio && torrent.Ratio >= torrent.StopRatio && torrent.State == DelugeTorrentStatus.Paused);
 
                 items.Add(item);
             }

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -12,6 +12,7 @@ using NLog;
 using FluentValidation.Results;
 using System.Net;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.Deluge
 {
@@ -23,10 +24,11 @@ namespace NzbDrone.Core.Download.Clients.Deluge
                       ITorrentFileInfoReader torrentFileInfoReader,
                       IHttpClient httpClient,
                       IConfigService configService,
+                      INamingConfigService namingConfigService,
                       IDiskProvider diskProvider,
                       IRemotePathMappingService remotePathMappingService,
                       Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationTask.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationTask.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using NzbDrone.Common.Serializer;
 
 namespace NzbDrone.Core.Download.Clients.DownloadStation
 {
@@ -23,7 +22,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         [JsonProperty(PropertyName = "status_extra")]
         public Dictionary<string, string> StatusExtra { get; set; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(UnderscoreStringEnumConverter), DownloadStationTaskStatus.Unknown)]
         public DownloadStationTaskStatus Status { get; set; }
 
         public DownloadStationTaskAdditional Additional { get; set; }
@@ -41,6 +40,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
     public enum DownloadStationTaskStatus
     {
+        Unknown,
         Waiting,
         Downloading,
         Paused,
@@ -48,9 +48,10 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         Finished,
         HashChecking,
         Seeding,
-        FileHostingWaiting,
+        FilehostingWaiting,
         Extracting,
-        Error
+        Error,
+        CaptchaNeeded
     }
 
     public enum DownloadStationPriority

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs
@@ -72,7 +72,20 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
                                                          DownloadStationSettings settings) where T : new()
         {
             var request = requestBuilder.Build();
-            var response = _httpClient.Execute(request);
+            HttpResponse response;
+
+            try
+            {
+                response = _httpClient.Execute(request);
+            }
+            catch (HttpException ex)
+            {
+                throw new DownloadClientException("Unable to connect to Diskstation, please check your settings", ex);
+            }
+            catch (WebException ex)
+            {
+                throw new DownloadClientException("Unable to connect to Diskstation, please check your settings", ex);
+            }
 
             _logger.Debug("Trying to {0}", operation);
 

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -90,7 +90,8 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                     RemainingTime = GetRemainingTime(torrent),
                     Status = GetStatus(torrent),
                     Message = GetMessage(torrent),
-                    IsReadOnly = !IsFinished(torrent)
+                    CanMoveFiles = IsCompleted(torrent),
+                    CanBeRemoved = IsFinished(torrent)
                 };
 
                 if (item.Status == DownloadItemStatus.Completed || item.Status == DownloadItemStatus.Failed)
@@ -199,6 +200,11 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             return torrent.Status == DownloadStationTaskStatus.Finished;
         }
 
+        protected bool IsCompleted(DownloadStationTask torrent)
+        {
+            return torrent.Status == DownloadStationTaskStatus.Seeding || IsFinished(torrent) ||  (torrent.Status == DownloadStationTaskStatus.Waiting && torrent.Size != 0 && GetRemainingSize(torrent) <= 0);
+        }
+
         protected string GetMessage(DownloadStationTask torrent)
         {
             if (torrent.StatusExtra != null)
@@ -221,7 +227,9 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         {
             switch (torrent.Status)
             {
+                case DownloadStationTaskStatus.Unknown:
                 case DownloadStationTaskStatus.Waiting:
+                case DownloadStationTaskStatus.FilehostingWaiting:
                     return torrent.Size == 0 || GetRemainingSize(torrent) > 0 ? DownloadItemStatus.Queued : DownloadItemStatus.Completed;
                 case DownloadStationTaskStatus.Paused:
                     return DownloadItemStatus.Paused;
@@ -314,12 +322,12 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             }
             catch (DownloadClientAuthenticationException ex) // User could not have permission to access to downloadstation
             {
-                _logger.Error(ex);
+                _logger.Error(ex, ex.Message);
                 return new NzbDroneValidationFailure(string.Empty, ex.Message);
             }
             catch (Exception ex)
             {
-                _logger.Error(ex);
+                _logger.Error(ex, "Error testing Torrent Download Station");
                 return new NzbDroneValidationFailure(string.Empty, $"Unknown exception: {ex.Message}");
             }
         }
@@ -340,7 +348,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             }
             catch (WebException ex)
             {
-                _logger.Error(ex);
+                _logger.Error(ex, "Unable to connect to Torrent Download Station");
 
                 if (ex.Status == WebExceptionStatus.ConnectFailure)
                 {
@@ -353,7 +361,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             }
             catch (Exception ex)
             {
-                _logger.Error(ex);
+                _logger.Error(ex, "Error testing Torrent Download Station");
                 return new NzbDroneValidationFailure(string.Empty, $"Unknown exception: {ex.Message}");
             }
         }

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -11,6 +11,7 @@ using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.DownloadStation.Proxies;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Core.Validation;
@@ -33,10 +34,11 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                                       ITorrentFileInfoReader torrentFileInfoReader,
                                       IHttpClient httpClient,
                                       IConfigService configService,
+                                      INamingConfigService namingConfigService,
                                       IDiskProvider diskProvider,
                                       IRemotePathMappingService remotePathMappingService,
                                       Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _dsInfoProxy = dsInfoProxy;
             _dsTaskProxy = dsTaskProxy;

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -9,6 +9,7 @@ using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.DownloadStation.Proxies;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Core.Validation;
@@ -30,11 +31,12 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                                      IDownloadStationTaskProxy dsTaskProxy,
                                      IHttpClient httpClient,
                                      IConfigService configService,
+                                     INamingConfigService namingConfigService,
                                      IDiskProvider diskProvider,
                                      IRemotePathMappingService remotePathMappingService,
                                      Logger logger
                                      )
-            : base(httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _dsInfoProxy = dsInfoProxy;
             _dsTaskProxy = dsTaskProxy;

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
@@ -9,6 +9,7 @@ using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.Hadouken.Models;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Core.Validation;
@@ -23,10 +24,11 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
                         ITorrentFileInfoReader torrentFileInfoReader,
                         IHttpClient httpClient,
                         IConfigService configService,
+                        INamingConfigService namingConfigService,
                         IDiskProvider diskProvider,
                         IRemotePathMappingService remotePathMappingService,
                         Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
@@ -97,14 +97,7 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
                     item.Status = DownloadItemStatus.Downloading;
                 }
 
-                if (torrent.IsFinished && torrent.State == HadoukenTorrentState.Paused)
-                {
-                    item.IsReadOnly = false;
-                }
-                else
-                {
-                    item.IsReadOnly = true;
-                }
+                item.CanMoveFiles = item.CanBeRemoved = (torrent.IsFinished && torrent.State == HadoukenTorrentState.Paused);
 
                 items.Add(item);
             }

--- a/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortex.cs
+++ b/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortex.cs
@@ -72,7 +72,9 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
                 queueItem.TotalSize = vortexQueueItem.TotalDownloadSize;
                 queueItem.RemainingSize = vortexQueueItem.TotalDownloadSize - vortexQueueItem.DownloadedSize;
                 queueItem.RemainingTime = null;
-                
+                queueItem.CanBeRemoved = true;
+                queueItem.CanMoveFiles = true;
+
                 if (vortexQueueItem.IsPaused)
                 {
                     queueItem.Status = DownloadItemStatus.Paused;

--- a/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortex.cs
+++ b/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortex.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.NzbVortex
 {
@@ -21,10 +22,11 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
         public NzbVortex(INzbVortexProxy proxy,
                        IHttpClient httpClient,
                        IConfigService configService,
+                       INamingConfigService namingConfigService,
                        IDiskProvider diskProvider,
                        IRemotePathMappingService remotePathMappingService,
                        Logger logger)
-            : base(httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.Nzbget
 {
@@ -23,10 +24,11 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
         public Nzbget(INzbgetProxy proxy,
                       IHttpClient httpClient,
                       IConfigService configService,
+                      INamingConfigService namingConfigService,
                       IDiskProvider diskProvider,
                       IRemotePathMappingService remotePathMappingService,
                       Logger logger)
-            : base(httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
@@ -77,14 +77,15 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
 
                 var droneParameter = item.Parameters.SingleOrDefault(p => p.Name == "drone");
 
-                var queueItem = new DownloadClientItem()
-                {
-                    DownloadId = droneParameter == null ? item.NzbId.ToString() : droneParameter.Value.ToString(),
-                    Title = item.NzbName,
-                    TotalSize = totalSize,
-                    Category = item.Category,
-                    DownloadClient = Definition.Name
-                };
+                var queueItem = new DownloadClientItem();
+                queueItem.DownloadId = droneParameter == null ? item.NzbId.ToString() : droneParameter.Value.ToString();
+                queueItem.Title = item.NzbName;
+                queueItem.TotalSize = totalSize;
+                queueItem.Category = item.Category;
+                queueItem.DownloadClient = Definition.Name;
+                queueItem.CanMoveFiles = true;
+                queueItem.CanBeRemoved = true;
+
                 if (globalStatus.DownloadPaused || remainingSize == pausedSize && remainingSize != 0)
                 {
                     queueItem.Status = DownloadItemStatus.Paused;
@@ -136,18 +137,19 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
             {
                 var droneParameter = item.Parameters.SingleOrDefault(p => p.Name == "drone");
 
-                var historyItem = new DownloadClientItem()
-                {
-                    DownloadClient = Definition.Name,
-                    DownloadId = droneParameter == null ? item.Id.ToString() : droneParameter.Value.ToString(),
-                    Title = item.Name,
-                    TotalSize = MakeInt64(item.FileSizeHi, item.FileSizeLo),
-                    OutputPath = _remotePathMappingService.RemapRemoteToLocal(Settings.Host, new OsPath(item.DestDir)),
-                    Category = item.Category,
-                    Message = $"PAR Status: {item.ParStatus} - Unpack Status: {item.UnpackStatus} - Move Status: {item.MoveStatus} - Script Status: {item.ScriptStatus} - Delete Status: {item.DeleteStatus} - Mark Status: {item.MarkStatus}",
-                    Status = DownloadItemStatus.Completed,
-                    RemainingTime = TimeSpan.Zero
-                };
+                var historyItem = new DownloadClientItem();
+                historyItem.DownloadClient = Definition.Name;
+                historyItem.DownloadId = droneParameter == null ? item.Id.ToString() : droneParameter.Value.ToString();
+                historyItem.Title = item.Name;
+                historyItem.TotalSize = MakeInt64(item.FileSizeHi, item.FileSizeLo);
+                historyItem.OutputPath = _remotePathMappingService.RemapRemoteToLocal(Settings.Host, new OsPath(item.DestDir));
+                historyItem.Category = item.Category;
+                historyItem.Message = $"PAR Status: {item.ParStatus} - Unpack Status: {item.UnpackStatus} - Move Status: {item.MoveStatus} - Script Status: {item.ScriptStatus} - Delete Status: {item.DeleteStatus} - Mark Status: {item.MarkStatus}";
+                historyItem.Status = DownloadItemStatus.Completed;
+                historyItem.RemainingTime = TimeSpan.Zero;
+                historyItem.CanMoveFiles = true;
+                historyItem.CanBeRemoved = true;
+
                 if (item.DeleteStatus == "MANUAL")
                 {
                     continue;

--- a/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
+++ b/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
@@ -78,6 +78,9 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
                     DownloadId = GetDownloadClientId(file),
                     Title = title,
 
+                    CanBeRemoved = true,
+                    CanMoveFiles = true,
+
                     TotalSize = _diskProvider.GetFileSize(file),
 
                     OutputPath = new OsPath(file)

--- a/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
+++ b/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
@@ -20,10 +20,11 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
 
         public Pneumatic(IHttpClient httpClient,
                          IConfigService configService,
+                         INamingConfigService namingConfigService,
                          IDiskProvider diskProvider,
                          IRemotePathMappingService remotePathMappingService,
                          Logger logger)
-            : base(configService, diskProvider, remotePathMappingService, logger)
+            : base(configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _httpClient = httpClient;
         }
@@ -43,7 +44,7 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
             //    throw new NotSupportedException("Full season releases are not supported with Pneumatic.");
             //}
 
-            title = FileNameBuilder.CleanFileName(title);
+            title = CleanFileName(title);
 
             //Save to the Pneumatic directory (The user will need to ensure its accessible by XBMC)
             var nzbFile = Path.Combine(Settings.NzbFolder, title + ".nzb");
@@ -70,7 +71,7 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
                     continue;
                 }
 
-                var title = FileNameBuilder.CleanFileName(Path.GetFileName(file));
+                var title = CleanFileName(Path.GetFileName(file));
 
                 var historyItem = new DownloadClientItem
                 {

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -94,7 +94,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
                 // Avoid removing torrents that haven't reached the global max ratio.
                 // Removal also requires the torrent to be paused, in case a higher max ratio was set on the torrent itself (which is not exposed by the api).
-                item.IsReadOnly = (config.MaxRatioEnabled && config.MaxRatio > torrent.Ratio) || torrent.State != "pausedUP";
+                item.CanMoveFiles = item.CanBeRemoved = (!config.MaxRatioEnabled || config.MaxRatio <= torrent.Ratio) && torrent.State == "pausedUP";
 
                 if (!item.OutputPath.IsEmpty && item.OutputPath.FileName != torrent.Name)
                 {

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -12,6 +12,7 @@ using FluentValidation.Results;
 using System.Net;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.QBittorrent
 {
@@ -23,10 +24,11 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                            ITorrentFileInfoReader torrentFileInfoReader,
                            IHttpClient httpClient,
                            IConfigService configService,
+                           INamingConfigService namingConfigService,
                            IDiskProvider diskProvider,
                            IRemotePathMappingService remotePathMappingService,
                            Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.Sabnzbd
 {
@@ -21,10 +22,11 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
         public Sabnzbd(ISabnzbdProxy proxy,
                        IHttpClient httpClient,
                        IConfigService configService,
+                       INamingConfigService namingConfigService,
                        IDiskProvider diskProvider,
                        IRemotePathMappingService remotePathMappingService,
                        Logger logger)
-            : base(httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -78,6 +78,8 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
                 queueItem.TotalSize = (long)(sabQueueItem.Size * 1024 * 1024);
                 queueItem.RemainingSize = (long)(sabQueueItem.Sizeleft * 1024 * 1024);
                 queueItem.RemainingTime = sabQueueItem.Timeleft;
+                queueItem.CanBeRemoved = true;
+                queueItem.CanMoveFiles = true;
 
                 if (sabQueue.Paused || sabQueueItem.Status == SabnzbdDownloadStatus.Paused)
                 {
@@ -142,7 +144,10 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
                     RemainingSize = 0,
                     RemainingTime = TimeSpan.Zero,
 
-                    Message = sabHistoryItem.FailMessage
+                    Message = sabHistoryItem.FailMessage,
+
+                    CanBeRemoved = true,
+                    CanMoveFiles = true
                 };
 
                 if (sabHistoryItem.Status == SabnzbdDownloadStatus.Failed)

--- a/src/NzbDrone.Core/Download/Clients/Transmission/Transmission.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/Transmission.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Http;
@@ -7,6 +7,7 @@ using NLog;
 using FluentValidation.Results;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.Transmission
 {
@@ -16,10 +17,11 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                             ITorrentFileInfoReader torrentFileInfoReader,
                             IHttpClient httpClient,
                             IConfigService configService,
+                            INamingConfigService namingConfigService,
                             IDiskProvider diskProvider,
                             IRemotePathMappingService remotePathMappingService,
                             Logger logger)
-            : base(proxy, torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(proxy, torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
         }
 

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -9,6 +9,7 @@ using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Core.Validation;
@@ -23,10 +24,11 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             ITorrentFileInfoReader torrentFileInfoReader,
             IHttpClient httpClient,
             IConfigService configService,
+            INamingConfigService namingConfigService,
             IDiskProvider diskProvider,
             IRemotePathMappingService remotePathMappingService,
             Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -106,7 +106,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                     item.Status = DownloadItemStatus.Downloading;
                 }
 
-                item.IsReadOnly = torrent.Status != TransmissionTorrentStatus.Stopped;
+                item.CanMoveFiles = item.CanBeRemoved = torrent.Status == TransmissionTorrentStatus.Stopped;
 
                 items.Add(item);
             }

--- a/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
+++ b/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
@@ -1,10 +1,11 @@
-﻿using FluentValidation.Results;
+using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.Transmission;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.RemotePathMappings;
 
 namespace NzbDrone.Core.Download.Clients.Vuze
@@ -17,10 +18,11 @@ namespace NzbDrone.Core.Download.Clients.Vuze
                     ITorrentFileInfoReader torrentFileInfoReader,
                     IHttpClient httpClient,
                     IConfigService configService,
+                    INamingConfigService namingConfigService,
                     IDiskProvider diskProvider,
                     IRemotePathMappingService remotePathMappingService,
                     Logger logger)
-            : base(proxy, torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(proxy, torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
         }
 

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -115,7 +115,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
                     else if (!torrent.IsActive) item.Status = DownloadItemStatus.Paused;
 
                     // No stop ratio data is present, so do not delete
-                    item.IsReadOnly = true;
+                    item.CanMoveFiles = item.CanBeRemoved = false;
 
                     items.Add(item);
                 }

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -15,6 +15,7 @@ using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.RTorrent
 {
@@ -27,11 +28,12 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
                         ITorrentFileInfoReader torrentFileInfoReader,
                         IHttpClient httpClient,
                         IConfigService configService,
+                        INamingConfigService namingConfigService,
                         IDiskProvider diskProvider,
                         IRemotePathMappingService remotePathMappingService,
                         IRTorrentDirectoryValidator rTorrentDirectoryValidator,
                         Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
             _rTorrentDirectoryValidator = rTorrentDirectoryValidator;

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
@@ -169,7 +169,7 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
                 }
 
                 // 'Started' without 'Queued' is when the torrent is 'forced seeding'
-                item.IsReadOnly = torrent.Status.HasFlag(UTorrentTorrentStatus.Queued) || torrent.Status.HasFlag(UTorrentTorrentStatus.Started);
+                item.CanMoveFiles = item.CanBeRemoved = (!torrent.Status.HasFlag(UTorrentTorrentStatus.Queued) && !torrent.Status.HasFlag(UTorrentTorrentStatus.Started));
 
                 queueItems.Add(item);
             }

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
@@ -13,6 +13,7 @@ using System.Net;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Common.Cache;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.UTorrent
 {
@@ -26,10 +27,11 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
                         ITorrentFileInfoReader torrentFileInfoReader,
                         IHttpClient httpClient,
                         IConfigService configService,
+                        INamingConfigService namingConfigService,
                         IDiskProvider diskProvider,
                         IRemotePathMappingService remotePathMappingService,
                         Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _proxy = proxy;
 

--- a/src/NzbDrone.Core/Download/DownloadClientBase.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientBase.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download
 {
@@ -18,6 +19,7 @@ namespace NzbDrone.Core.Download
         where TSettings : IProviderConfig, new()
     {
         protected readonly IConfigService _configService;
+        protected readonly INamingConfigService _namingConfigService;
         protected readonly IDiskProvider _diskProvider;
         protected readonly IRemotePathMappingService _remotePathMappingService;
         protected readonly Logger _logger;
@@ -39,12 +41,14 @@ namespace NzbDrone.Core.Download
 
         protected TSettings Settings => (TSettings)Definition.Settings;
 
-        protected DownloadClientBase(IConfigService configService, 
+        protected DownloadClientBase(IConfigService configService,
+            INamingConfigService namingConfigService,
             IDiskProvider diskProvider, 
             IRemotePathMappingService remotePathMappingService,
             Logger logger)
         {
             _configService = configService;
+            _namingConfigService = namingConfigService;
             _diskProvider = diskProvider;
             _remotePathMappingService = remotePathMappingService;
             _logger = logger;
@@ -151,6 +155,13 @@ namespace NzbDrone.Core.Download
             return null;
         }
 
+        // proxy method to pass in our naming config
+        protected String CleanFileName(string name)
+        {
+            // get a fresh naming config each time, in case the user has made changes
+            NamingConfig namingConfig = _namingConfigService.GetConfig();
+            return FileNameBuilder.CleanFileName(name, namingConfig);
+        }
         
     }
 }

--- a/src/NzbDrone.Core/Download/DownloadClientItem.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientItem.cs
@@ -21,7 +21,9 @@ namespace NzbDrone.Core.Download
 
         public DownloadItemStatus Status { get; set; }
         public bool IsEncrypted { get; set; }
-        public bool IsReadOnly { get; set; }
+
+        public bool CanMoveFiles { get; set; }
+        public bool CanBeRemoved { get; set; }
 
         public bool Removed { get; set; }
     }

--- a/src/NzbDrone.Core/Download/DownloadEventHub.cs
+++ b/src/NzbDrone.Core/Download/DownloadEventHub.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Download
         {
             if (!_configService.RemoveCompletedDownloads ||
                 message.TrackedDownload.DownloadItem.Removed ||
-                message.TrackedDownload.DownloadItem.IsReadOnly ||
+                !message.TrackedDownload.DownloadItem.CanBeRemoved ||
                 message.TrackedDownload.DownloadItem.Status == DownloadItemStatus.Downloading)
             {
                 return;
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.Download
         {
             var trackedDownload = message.TrackedDownload;
 
-            if (trackedDownload == null || trackedDownload.DownloadItem.IsReadOnly || _configService.RemoveFailedDownloads == false)
+            if (trackedDownload == null || !trackedDownload.DownloadItem.CanBeRemoved || _configService.RemoveFailedDownloads == false)
             {
                 return;
             }

--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -25,10 +25,11 @@ namespace NzbDrone.Core.Download
         protected TorrentClientBase(ITorrentFileInfoReader torrentFileInfoReader,
                                     IHttpClient httpClient,
                                     IConfigService configService,
+                                    INamingConfigService namingConfigService,
                                     IDiskProvider diskProvider,
                                     IRemotePathMappingService remotePathMappingService,
                                     Logger logger)
-            : base(configService, diskProvider, remotePathMappingService, logger)
+            : base(configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _httpClient = httpClient;
             _torrentFileInfoReader = torrentFileInfoReader;
@@ -178,7 +179,7 @@ namespace NzbDrone.Core.Download
                 throw new ReleaseDownloadException(remoteMovie.Release, "Downloading torrent failed", ex);
             }
 
-            var filename = string.Format("{0}.torrent", FileNameBuilder.CleanFileName(remoteMovie.Release.Title));
+            var filename = string.Format("{0}.torrent", CleanFileName(remoteMovie.Release.Title));
             var hash = _torrentFileInfoReader.GetHashFromTorrentFile(torrentFile);
             var actualHash = AddFromTorrentFile(remoteMovie, hash, filename, torrentFile);
 

--- a/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
         private void RemoveCompletedDownloads(List<TrackedDownload> trackedDownloads)
         {
-            foreach (var trackedDownload in trackedDownloads.Where(c => !c.DownloadItem.IsReadOnly && c.State == TrackedDownloadStage.Imported))
+            foreach (var trackedDownload in trackedDownloads.Where(c => c.DownloadItem.CanBeRemoved && c.State == TrackedDownloadStage.Imported))
             {
                 _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload));
             }

--- a/src/NzbDrone.Core/Download/UsenetClientBase.cs
+++ b/src/NzbDrone.Core/Download/UsenetClientBase.cs
@@ -20,10 +20,11 @@ namespace NzbDrone.Core.Download
 
         protected UsenetClientBase(IHttpClient httpClient,
                                    IConfigService configService,
+                                   INamingConfigService namingConfigService,
                                    IDiskProvider diskProvider,
                                    IRemotePathMappingService remotePathMappingService,
                                    Logger logger)
-            : base(configService, diskProvider, remotePathMappingService, logger)
+            : base(configService, namingConfigService, diskProvider, remotePathMappingService, logger)
         {
             _httpClient = httpClient;
         }
@@ -35,7 +36,7 @@ namespace NzbDrone.Core.Download
         public override string Download(RemoteMovie remoteMovie)
         {
             var url = remoteMovie.Release.DownloadUrl;
-            var filename = FileNameBuilder.CleanFileName(remoteMovie.Release.Title) + ".nzb";
+            var filename = CleanFileName(remoteMovie.Release.Title) + ".nzb";
 
             byte[] nzbData;
 

--- a/src/NzbDrone.Core/MediaFiles/DownloadedMovieImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DownloadedMovieImportService.cs
@@ -191,7 +191,7 @@ namespace NzbDrone.Core.MediaFiles
             var decisions = _importDecisionMaker.GetImportDecisions(videoFiles.ToList(), movie, null, folderInfo, true, false);
             var importResults = _importApprovedMovie.Import(decisions, true, downloadClientItem, importMode);
 
-            if ((downloadClientItem == null || !downloadClientItem.IsReadOnly) &&
+            if ((downloadClientItem == null || downloadClientItem.CanBeRemoved) &&
                 importResults.Any(i => i.Result == ImportResultType.Imported) &&
                 ShouldDeleteFolder(directoryInfo, movie))
             {

--- a/src/NzbDrone.Core/MediaFiles/Events/MovieImportedEvent.cs
+++ b/src/NzbDrone.Core/MediaFiles/Events/MovieImportedEvent.cs
@@ -9,8 +9,7 @@ namespace NzbDrone.Core.MediaFiles.Events
         public MovieFile ImportedMovie { get; private set; }
         public bool NewDownload { get; private set; }
         public string DownloadClient { get; private set; }
-        public string DownloadId { get; private set; }
-        public bool IsReadOnly { get; set; }
+        public string DownloadId { get; private set; }        
 
         public MovieImportedEvent(LocalMovie movieInfo, MovieFile importedMovie, bool newDownload)
         {
@@ -19,14 +18,13 @@ namespace NzbDrone.Core.MediaFiles.Events
             NewDownload = newDownload;
         }
 
-        public MovieImportedEvent(LocalMovie movieInfo, MovieFile importedMovie, bool newDownload, string downloadClient, string downloadId, bool isReadOnly)
+        public MovieImportedEvent(LocalMovie movieInfo, MovieFile importedMovie, bool newDownload, string downloadClient, string downloadId)
         {
             MovieInfo = movieInfo;
             ImportedMovie = importedMovie;
             NewDownload = newDownload;
             DownloadClient = downloadClient;
             DownloadId = downloadId;
-            IsReadOnly = isReadOnly;
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
@@ -93,7 +93,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
                     {
                         default:
                         case ImportMode.Auto:
-                            copyOnly = downloadClientItem != null && downloadClientItem.IsReadOnly;
+                            copyOnly = downloadClientItem != null && !downloadClientItem.CanMoveFiles;
                             break;
                         case ImportMode.Move:
                             copyOnly = false;
@@ -125,7 +125,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
 
                     if (downloadClientItem != null)
                     {
-                        _eventAggregator.PublishEvent(new MovieImportedEvent(localMovie, movieFile, newDownload, downloadClientItem.DownloadClient, downloadClientItem.DownloadId, downloadClientItem.IsReadOnly));
+                        _eventAggregator.PublishEvent(new MovieImportedEvent(localMovie, movieFile, newDownload, downloadClientItem.DownloadClient, downloadClientItem.DownloadId));
                     }
                     else
                     {

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
@@ -268,7 +268,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
                 {
                     if (_downloadedMovieImportService.ShouldDeleteFolder(
                             new DirectoryInfo(trackedDownload.DownloadItem.OutputPath.FullPath),
-                            trackedDownload.RemoteMovie.Movie) && !trackedDownload.DownloadItem.IsReadOnly)
+                            trackedDownload.RemoteMovie.Movie) && trackedDownload.DownloadItem.CanMoveFiles)
                     {
                         _diskProvider.DeleteFolder(trackedDownload.DownloadItem.OutputPath.FullPath, true);
                     }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Authentication\UserRepository.cs" />
     <Compile Include="Authentication\UserService.cs" />
     <Compile Include="Datastore\Migration\123_create_netimport_table.cs" />
+    <Compile Include="Datastore\Migration\146_naming_config_colon_replacement_format.cs" />
     <Compile Include="Datastore\Migration\143_clean_core_tv.cs" />
     <Compile Include="Datastore\Migration\142_movie_extras.cs" />
     <Compile Include="Datastore\Migration\140_add_alternative_titles_table.cs" />

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -248,8 +248,9 @@ namespace NzbDrone.Core.Organizer
             {
                 AddMovieFileTokens(tokenHandlers, new MovieFile { SceneName = $"{movie.Title} {movie.Year}", RelativePath = $"{movie.Title} {movie.Year}"});
             }
-                
-            return CleanFolderName(ReplaceTokens(namingConfig.MovieFolderFormat, tokenHandlers, namingConfig));
+
+            string name = ReplaceTokens(namingConfig.MovieFolderFormat, tokenHandlers, namingConfig);
+            return CleanFolderName(name, namingConfig);
         }
 
         public static string CleanTitle(string title)
@@ -283,11 +284,14 @@ namespace NzbDrone.Core.Organizer
             return title.Trim();
         }
 
-        public static string CleanFileName(string name, bool replace = true)
+        public static string CleanFileName(string name, NamingConfig namingConfig)
         {
+            bool replace = namingConfig.ReplaceIllegalCharacters;
+            string colonReplacementFormat = namingConfig.ColonReplacementFormat;
+
             string result = name;
             string[] badCharacters = { "\\", "/", "<", ">", "?", "*", ":", "|", "\"" };
-            string[] goodCharacters = { "+", "+", "", "", "!", "-", "", "", "" };
+            string[] goodCharacters = { "+", "+", "", "", "!", "-", colonReplacementFormat, "", "" };
 
             for (int i = 0; i < badCharacters.Length; i++)
             {
@@ -297,12 +301,12 @@ namespace NzbDrone.Core.Organizer
             return result.Trim();
         }
 
-        public static string CleanFolderName(string name)
+        public static string CleanFolderName(string name, NamingConfig namingConfig)
         {
             name = FileNameCleanupRegex.Replace(name, match => match.Captures[0].Value[0].ToString());
             name = name.Trim(' ', '.');
 
-            return CleanFileName(name);
+            return CleanFileName(name, namingConfig);
         }
 
         private void AddMovieTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Movie movie)
@@ -557,7 +561,7 @@ namespace NzbDrone.Core.Organizer
                 replacementText = replacementText.Replace(" ", tokenMatch.Separator);
             }
 
-            replacementText = CleanFileName(replacementText, namingConfig.ReplaceIllegalCharacters);
+            replacementText = CleanFileName(replacementText, namingConfig);
 
             if (!replacementText.IsNullOrWhiteSpace())
             {

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -287,7 +287,26 @@ namespace NzbDrone.Core.Organizer
         public static string CleanFileName(string name, NamingConfig namingConfig)
         {
             bool replace = namingConfig.ReplaceIllegalCharacters;
-            string colonReplacementFormat = namingConfig.ColonReplacementFormat;
+            string colonReplacementFormat;
+
+            switch ((ColonReplacementFormat) namingConfig.ColonReplacementFormat)
+            {
+                case ColonReplacementFormat.Delete:
+                    colonReplacementFormat = "";
+                    break;
+                case ColonReplacementFormat.Dash:
+                    colonReplacementFormat = "-";
+                    break;
+                case ColonReplacementFormat.SpaceDash:
+                    colonReplacementFormat = " -";
+                    break;
+                case ColonReplacementFormat.SpaceDashSpace:
+                    colonReplacementFormat = " - ";
+                    break;
+                default:
+                    colonReplacementFormat = "";
+                    break;
+            }
 
             string result = name;
             string[] badCharacters = { "\\", "/", "<", ">", "?", "*", ":", "|", "\"" };
@@ -662,5 +681,13 @@ namespace NzbDrone.Core.Organizer
         Scene = 3,
         Range = 4,
         PrefixedRange = 5
+    }
+
+    public enum ColonReplacementFormat
+    {
+        Delete = 0,
+        Dash = 1,
+        SpaceDash = 2,
+        SpaceDashSpace = 3
     }
 }

--- a/src/NzbDrone.Core/Organizer/NamingConfig.cs
+++ b/src/NzbDrone.Core/Organizer/NamingConfig.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.Organizer
         {
             RenameEpisodes = false,
             ReplaceIllegalCharacters = true,
-            ColonReplacementFormat = "",
+            ColonReplacementFormat = 0,
             MultiEpisodeStyle = 0,
             MovieFolderFormat = "{Movie Title} ({Release Year})",
             StandardMovieFormat = "{Movie Title} ({Release Year}) {Quality Full}",
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Organizer
 
         public bool RenameEpisodes { get; set; }
         public bool ReplaceIllegalCharacters { get; set; }
-        public string ColonReplacementFormat { get; set; }
+        public int ColonReplacementFormat { get; set; }
         public int MultiEpisodeStyle { get; set; }
         public string StandardMovieFormat { get; set; }
         public string MovieFolderFormat { get; set; }

--- a/src/NzbDrone.Core/Organizer/NamingConfig.cs
+++ b/src/NzbDrone.Core/Organizer/NamingConfig.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.Organizer
         {
             RenameEpisodes = false,
             ReplaceIllegalCharacters = true,
+            ColonReplacementFormat = "",
             MultiEpisodeStyle = 0,
             MovieFolderFormat = "{Movie Title} ({Release Year})",
             StandardMovieFormat = "{Movie Title} ({Release Year}) {Quality Full}",
@@ -15,6 +16,7 @@ namespace NzbDrone.Core.Organizer
 
         public bool RenameEpisodes { get; set; }
         public bool ReplaceIllegalCharacters { get; set; }
+        public string ColonReplacementFormat { get; set; }
         public int MultiEpisodeStyle { get; set; }
         public string StandardMovieFormat { get; set; }
         public string MovieFolderFormat { get; set; }

--- a/src/UI/Settings/MediaManagement/Naming/NamingView.js
+++ b/src/UI/Settings/MediaManagement/Naming/NamingView.js
@@ -1,54 +1,46 @@
-var _ = require("underscore");
-var Marionette = require("marionette");
-var NamingSampleModel = require("./NamingSampleModel");
-var BasicNamingView = require("./Basic/BasicNamingView");
-var AsModelBoundView = require("../../../Mixins/AsModelBoundView");
-var AsValidatedView = require("../../../Mixins/AsValidatedView");
+var _ = require('underscore');
+var Marionette = require('marionette');
+var NamingSampleModel = require('./NamingSampleModel');
+var BasicNamingView = require('./Basic/BasicNamingView');
+var AsModelBoundView = require('../../../Mixins/AsModelBoundView');
+var AsValidatedView = require('../../../Mixins/AsValidatedView');
 
 module.exports = (function() {
     var view = Marionette.Layout.extend({
-        template                            : "Settings/MediaManagement/Naming/NamingViewTemplate",
+        template                            : 'Settings/MediaManagement/Naming/NamingViewTemplate',
         ui                                  : {
-            namingOptions            : ".x-naming-options",
-            renameEpisodesCheckbox   : ".x-rename-episodes",
-            replacingOptions         : ".x-replacing-options",
-            replaceIllegalChars      : ".x-replace-illegal-chars",
-            singleEpisodeExample     : ".x-single-episode-example",
-            multiEpisodeExample      : ".x-multi-episode-example",
-            dailyEpisodeExample      : ".x-daily-episode-example",
-            animeEpisodeExample      : ".x-anime-episode-example",
-            animeMultiEpisodeExample : ".x-anime-multi-episode-example",
-            namingTokenHelper        : ".x-naming-token-helper",
-            multiEpisodeStyle        : ".x-multi-episode-style",
-            seriesFolderExample      : ".x-series-folder-example",
-            seasonFolderExample      : ".x-season-folder-example",
-            movieExample             : ".x-movie-example",
-            movieFolderExample       : ".x-movie-folder-example"
+            namingOptions            : '.x-naming-options',
+            renameEpisodesCheckbox   : '.x-rename-episodes',
+            replacingOptions         : '.x-replacing-options',
+            replaceIllegalChars      : '.x-replace-illegal-chars',
+            namingTokenHelper        : '.x-naming-token-helper',
+            movieExample             : '.x-movie-example',
+            movieFolderExample       : '.x-movie-folder-example'
         },
         events                              : {
-            "change .x-rename-episodes"      : "_setRenameEpisodesVisibility",
-            "change .x-replace-illegal-chars": "_setReplaceIllegalCharsVisibility",
-            "click .x-show-wizard"           : "_showWizard",
-            "click .x-naming-token-helper a" : "_addToken",
-            "change .x-multi-episode-style"  : "_multiEpisodeFomatChanged"
+            'change .x-rename-episodes'      : '_setRenameEpisodesVisibility',
+            'change .x-replace-illegal-chars': '_setReplaceIllegalCharsVisibility',
+            'click .x-show-wizard'           : '_showWizard',
+            'click .x-naming-token-helper a' : '_addToken',
+            'change .x-multi-episode-style'  : '_multiEpisodeFomatChanged'
         },
-        regions                             : { basicNamingRegion : ".x-basic-naming" },
+        regions                             : { basicNamingRegion : '.x-basic-naming' },
         onRender                            : function() {
-            if (!this.model.get("renameEpisodes")) {
+            if (!this.model.get('renameEpisodes')) {
                 this.ui.namingOptions.hide();
             }
-            if (!this.model.get("replaceIllegalCharacters")) {
+            if (!this.model.get('replaceIllegalCharacters')) {
                 this.ui.replacingOptions.hide();
             }
             var basicNamingView = new BasicNamingView({ model : this.model });
             this.basicNamingRegion.show(basicNamingView);
             this.namingSampleModel = new NamingSampleModel();
-            this.listenTo(this.model, "change", this._updateSamples);
-            this.listenTo(this.namingSampleModel, "sync", this._showSamples);
+            this.listenTo(this.model, 'change', this._updateSamples);
+            this.listenTo(this.namingSampleModel, 'sync', this._showSamples);
             this._updateSamples();
         },
         _setRenameEpisodesVisibility : function() {
-            var checked = this.ui.renameEpisodesCheckbox.prop("checked");
+            var checked = this.ui.renameEpisodesCheckbox.prop('checked');
             if (checked) {
                 this.ui.namingOptions.slideDown();
             } else {
@@ -56,7 +48,7 @@ module.exports = (function() {
             }
         },
         _setReplaceIllegalCharsVisibility : function() {
-            var checked = this.ui.replaceIllegalChars.prop("checked");
+            var checked = this.ui.replaceIllegalChars.prop('checked');
             if (checked) {
                 this.ui.replacingOptions.slideDown();
             } else {
@@ -67,34 +59,27 @@ module.exports = (function() {
             this.namingSampleModel.fetch({ data : this.model.toJSON() });
         },
         _showSamples                        : function() {
-            this.ui.singleEpisodeExample.html(this.namingSampleModel.get("singleEpisodeExample"));
-            this.ui.multiEpisodeExample.html(this.namingSampleModel.get("multiEpisodeExample"));
-            this.ui.dailyEpisodeExample.html(this.namingSampleModel.get("dailyEpisodeExample"));
-            this.ui.animeEpisodeExample.html(this.namingSampleModel.get("animeEpisodeExample"));
-            this.ui.animeMultiEpisodeExample.html(this.namingSampleModel.get("animeMultiEpisodeExample"));
-            this.ui.seriesFolderExample.html(this.namingSampleModel.get("seriesFolderExample"));
-            this.ui.seasonFolderExample.html(this.namingSampleModel.get("seasonFolderExample"));
-            this.ui.movieExample.html(this.namingSampleModel.get("movieExample"));
-            this.ui.movieFolderExample.html(this.namingSampleModel.get("movieFolderExample"));
+            this.ui.movieExample.html(this.namingSampleModel.get('movieExample'));
+            this.ui.movieFolderExample.html(this.namingSampleModel.get('movieFolderExample'));
         },
         _addToken                           : function(e) {
             e.preventDefault();
             e.stopPropagation();
             var target = e.target;
-            var token = "";
-            var input = this.$(target).closest(".x-helper-input").children("input");
-            if (this.$(target).attr("data-token")) {
-                token = "{{0}}".format(this.$(target).attr("data-token"));
+            var token = '';
+            var input = this.$(target).closest('.x-helper-input').children('input');
+            if (this.$(target).attr('data-token')) {
+                token = '{{0}}'.format(this.$(target).attr('data-token'));
             } else {
-                token = this.$(target).attr("data-separator");
+                token = this.$(target).attr('data-separator');
             }
             input.val(input.val() + token);
             input.change();
-            this.ui.namingTokenHelper.removeClass("open");
+            this.ui.namingTokenHelper.removeClass('open');
             input.focus();
         },
         multiEpisodeFormatChanged           : function() {
-            this.model.set("multiEpisodeStyle", this.ui.multiEpisodeStyle.val());
+            this.model.set('multiEpisodeStyle', this.ui.multiEpisodeStyle.val());
         }
     });
     AsModelBoundView.call(view);

--- a/src/UI/Settings/MediaManagement/Naming/NamingView.js
+++ b/src/UI/Settings/MediaManagement/Naming/NamingView.js
@@ -1,86 +1,100 @@
-var _ = require('underscore');
-var Marionette = require('marionette');
-var NamingSampleModel = require('./NamingSampleModel');
-var BasicNamingView = require('./Basic/BasicNamingView');
-var AsModelBoundView = require('../../../Mixins/AsModelBoundView');
-var AsValidatedView = require('../../../Mixins/AsValidatedView');
+var _ = require("underscore");
+var Marionette = require("marionette");
+var NamingSampleModel = require("./NamingSampleModel");
+var BasicNamingView = require("./Basic/BasicNamingView");
+var AsModelBoundView = require("../../../Mixins/AsModelBoundView");
+var AsValidatedView = require("../../../Mixins/AsValidatedView");
 
 module.exports = (function() {
     var view = Marionette.Layout.extend({
-        template                            : 'Settings/MediaManagement/Naming/NamingViewTemplate',
+        template                            : "Settings/MediaManagement/Naming/NamingViewTemplate",
         ui                                  : {
-            namingOptions            : '.x-naming-options',
-            renameEpisodesCheckbox   : '.x-rename-episodes',
-            singleEpisodeExample     : '.x-single-episode-example',
-            multiEpisodeExample      : '.x-multi-episode-example',
-            dailyEpisodeExample      : '.x-daily-episode-example',
-            animeEpisodeExample      : '.x-anime-episode-example',
-            animeMultiEpisodeExample : '.x-anime-multi-episode-example',
-            namingTokenHelper        : '.x-naming-token-helper',
-            multiEpisodeStyle        : '.x-multi-episode-style',
-            seriesFolderExample      : '.x-series-folder-example',
-            seasonFolderExample      : '.x-season-folder-example',
-            movieExample             : '.x-movie-example',
-            movieFolderExample       : '.x-movie-folder-example'
+            namingOptions            : ".x-naming-options",
+            renameEpisodesCheckbox   : ".x-rename-episodes",
+            replacingOptions         : ".x-replacing-options",
+            replaceIllegalChars      : ".x-replace-illegal-chars",
+            singleEpisodeExample     : ".x-single-episode-example",
+            multiEpisodeExample      : ".x-multi-episode-example",
+            dailyEpisodeExample      : ".x-daily-episode-example",
+            animeEpisodeExample      : ".x-anime-episode-example",
+            animeMultiEpisodeExample : ".x-anime-multi-episode-example",
+            namingTokenHelper        : ".x-naming-token-helper",
+            multiEpisodeStyle        : ".x-multi-episode-style",
+            seriesFolderExample      : ".x-series-folder-example",
+            seasonFolderExample      : ".x-season-folder-example",
+            movieExample             : ".x-movie-example",
+            movieFolderExample       : ".x-movie-folder-example"
         },
         events                              : {
-            "change .x-rename-episodes"      : '_setFailedDownloadOptionsVisibility',
-            "click .x-show-wizard"           : '_showWizard',
-            "click .x-naming-token-helper a" : '_addToken',
-            "change .x-multi-episode-style"  : '_multiEpisodeFomatChanged'
+            "change .x-rename-episodes"      : "_setRenameEpisodesVisibility",
+            "change .x-replace-illegal-chars": "_setReplaceIllegalCharsVisibility",
+            "click .x-show-wizard"           : "_showWizard",
+            "click .x-naming-token-helper a" : "_addToken",
+            "change .x-multi-episode-style"  : "_multiEpisodeFomatChanged"
         },
-        regions                             : { basicNamingRegion : '.x-basic-naming' },
+        regions                             : { basicNamingRegion : ".x-basic-naming" },
         onRender                            : function() {
-            if (!this.model.get('renameEpisodes')) {
+            if (!this.model.get("renameEpisodes")) {
                 this.ui.namingOptions.hide();
+            }
+            if (!this.model.get("replaceIllegalCharacters")) {
+                this.ui.replacingOptions.hide();
             }
             var basicNamingView = new BasicNamingView({ model : this.model });
             this.basicNamingRegion.show(basicNamingView);
             this.namingSampleModel = new NamingSampleModel();
-            this.listenTo(this.model, 'change', this._updateSamples);
-            this.listenTo(this.namingSampleModel, 'sync', this._showSamples);
+            this.listenTo(this.model, "change", this._updateSamples);
+            this.listenTo(this.namingSampleModel, "sync", this._showSamples);
             this._updateSamples();
         },
-        _setFailedDownloadOptionsVisibility : function() {
-            var checked = this.ui.renameEpisodesCheckbox.prop('checked');
+        _setRenameEpisodesVisibility : function() {
+            var checked = this.ui.renameEpisodesCheckbox.prop("checked");
             if (checked) {
                 this.ui.namingOptions.slideDown();
             } else {
                 this.ui.namingOptions.slideUp();
             }
         },
+        _setReplaceIllegalCharsVisibility : function() {
+            var checked = this.ui.replaceIllegalChars.prop("checked");
+            if (checked) {
+                this.ui.replacingOptions.slideDown();
+            } else {
+                this.ui.replacingOptions.slideUp();
+            }
+        },
         _updateSamples                      : function() {
             this.namingSampleModel.fetch({ data : this.model.toJSON() });
         },
         _showSamples                        : function() {
-            this.ui.singleEpisodeExample.html(this.namingSampleModel.get('singleEpisodeExample'));
-            this.ui.multiEpisodeExample.html(this.namingSampleModel.get('multiEpisodeExample'));
-            this.ui.dailyEpisodeExample.html(this.namingSampleModel.get('dailyEpisodeExample'));
-            this.ui.animeEpisodeExample.html(this.namingSampleModel.get('animeEpisodeExample'));
-            this.ui.animeMultiEpisodeExample.html(this.namingSampleModel.get('animeMultiEpisodeExample'));
-            this.ui.seriesFolderExample.html(this.namingSampleModel.get('seriesFolderExample'));
-            this.ui.seasonFolderExample.html(this.namingSampleModel.get('seasonFolderExample'));
-            this.ui.movieExample.html(this.namingSampleModel.get('movieExample'));
-            this.ui.movieFolderExample.html(this.namingSampleModel.get('movieFolderExample'));
+            this.ui.singleEpisodeExample.html(this.namingSampleModel.get("singleEpisodeExample"));
+            this.ui.multiEpisodeExample.html(this.namingSampleModel.get("multiEpisodeExample"));
+            this.ui.dailyEpisodeExample.html(this.namingSampleModel.get("dailyEpisodeExample"));
+            this.ui.animeEpisodeExample.html(this.namingSampleModel.get("animeEpisodeExample"));
+            this.ui.animeMultiEpisodeExample.html(this.namingSampleModel.get("animeMultiEpisodeExample"));
+            this.ui.seriesFolderExample.html(this.namingSampleModel.get("seriesFolderExample"));
+            this.ui.seasonFolderExample.html(this.namingSampleModel.get("seasonFolderExample"));
+            this.ui.movieExample.html(this.namingSampleModel.get("movieExample"));
+            this.ui.movieFolderExample.html(this.namingSampleModel.get("movieFolderExample"));
         },
         _addToken                           : function(e) {
             e.preventDefault();
             e.stopPropagation();
             var target = e.target;
-            var token = '';
-            var input = this.$(target).closest('.x-helper-input').children('input');
-            if (this.$(target).attr('data-token')) {
-                token = '{{0}}'.format(this.$(target).attr('data-token'));
+            var token = "";
+            var input = this.$(target).closest(".x-helper-input").children("input");
+            if (this.$(target).attr("data-token")) {
+                token = "{{0}}".format(this.$(target).attr("data-token"));
             } else {
-                token = this.$(target).attr('data-separator');
+                token = this.$(target).attr("data-separator");
             }
             input.val(input.val() + token);
             input.change();
-            this.ui.namingTokenHelper.removeClass('open');
+            this.ui.namingTokenHelper.removeClass("open");
             input.focus();
         },
         multiEpisodeFormatChanged           : function() {
-            this.model.set('multiEpisodeStyle', this.ui.multiEpisodeStyle.val());
+            this.model.set("multiEpisodeStyle", this.ui.multiEpisodeStyle.val());
         }
     });
     AsModelBoundView.call(view);

--- a/src/UI/Settings/MediaManagement/Naming/NamingViewTemplate.hbs
+++ b/src/UI/Settings/MediaManagement/Naming/NamingViewTemplate.hbs
@@ -24,31 +24,51 @@
         </div>
     </div>
 
-    <div class="form-group advanced-setting">
-        <label class="col-sm-3 control-label">Replace Illegal Characters</label>
-
-        <div class="col-sm-8">
-            <div class="input-group">
-                <label class="checkbox toggle well">
-                    <input type="checkbox" name="replaceIllegalCharacters" />
-
-                    <p>
-                        <span>Yes</span>
-                        <span>No</span>
-                    </p>
-
-                    <div class="btn btn-primary slide-button"/>
-                </label>
-
-                <span class="help-inline-checkbox">
-                    <i class="icon-sonarr-form-info" title="Replace or Remove illegal characters"/>
-                </span>
-            </div>
-        </div>
-    </div>
-
     <div class="x-naming-options">
         <div class="basic-setting x-basic-naming"></div>
+
+        <div class="form-group advanced-setting">
+            <label class="col-sm-3 control-label">Replace Illegal Characters</label>
+
+            <div class="col-sm-8">
+                <div class="input-group">
+                    <label class="checkbox toggle well">
+                        <input type="checkbox" name="replaceIllegalCharacters" class="x-replace-illegal-chars"/>
+
+                        <p>
+                            <span>Yes</span>
+                            <span>No</span>
+                        </p>
+
+                        <div class="btn btn-primary slide-button"/>
+                    </label>
+
+                    <span class="help-inline-checkbox">
+                        <i class="icon-sonarr-form-info" title="Replace or Remove illegal characters"/>
+                    </span>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group advanced-setting">
+            <div class="x-replacing-options">
+
+                <label class="col-sm-3 control-label">Colon Replacement Format</label>
+
+                <span class="col-sm-1 col-sm-push-8 help-inline">
+                    <i class="icon-sonarr-form-info" title="Colons are illegal characters; Radarr will delete them by default" />
+                </span>
+
+                <div class="col-sm-8 col-sm-pull-1">
+                    <select class="form-control" name="colonReplacementFormat">
+                        <option value="">Delete</option>
+                        <option value="-">Replace with Dash</option>
+                        <option value=" -">Replace with Space Dash</option>
+                        <option value=" - ">Replace with Space Dash Space</option>
+                    </select>
+                </div>
+            </div>
+        </div>
 
         <div class="form-group advanced-setting">
             <label class="col-sm-3 control-label">Standard Movie Format</label>

--- a/src/UI/Settings/MediaManagement/Naming/NamingViewTemplate.hbs
+++ b/src/UI/Settings/MediaManagement/Naming/NamingViewTemplate.hbs
@@ -61,10 +61,11 @@
 
                 <div class="col-sm-8 col-sm-pull-1">
                     <select class="form-control" name="colonReplacementFormat">
-                        <option value="">Delete</option>
-                        <option value="-">Replace with Dash</option>
-                        <option value=" -">Replace with Space Dash</option>
-                        <option value=" - ">Replace with Space Dash Space</option>
+                        <option value="0">Delete</option>
+                        <option value="1">Replace with Dash</option>
+                        <option value="2">Replace with Space Dash</option>
+                        <option value="3">Replace with Space Dash Space</option>
+
                     </select>
                 </div>
             </div>
@@ -100,71 +101,6 @@
             </div>
         </div>
 
-        {{!--<div class="form-group advanced-setting">
-            <label class="col-sm-3 control-label">Daily Episode Format</label>
-
-            <div class="col-sm-1 col-sm-push-8 help-inline">
-                <i class="icon-sonarr-form-info" title="" data-original-title="All caps or all lower-case can also be used"></i>
-                <a href="https://github.com/NzbDrone/NzbDrone/wiki/Sorting-and-Renaming" class="help-link" title="More information"><i class="icon-sonarr-form-info-link"/></a>
-            </div>
-
-            <div class="col-sm-8 col-sm-pull-1">
-                <div class="input-group x-helper-input">
-                    <input type="text" class="form-control naming-format" name="dailyEpisodeFormat" data-onkeyup="true" />
-                    <div class="input-group-btn btn-group x-naming-token-helper">
-                        <button class="btn btn-icon-only dropdown-toggle" data-toggle="dropdown">
-                            <i class="icon-sonarr-add"></i>
-                        </button>
-                        <ul class="dropdown-menu">
-                            {{> SeriesTitleNamingPartial}}
-                            {{> AirDateNamingPartial}}
-                            {{> SeasonNamingPartial}}
-                            {{> EpisodeNamingPartial}}
-                            {{> EpisodeTitleNamingPartial}}
-                            {{> QualityNamingPartial}}
-                            {{> MediaInfoNamingPartial}}
-                            {{> ReleaseGroupNamingPartial}}
-                            {{> OriginalTitleNamingPartial}}
-                            {{> SeparatorNamingPartial}}
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </div>--}}
-
-        {{!--<div class="form-group advanced-setting">
-            <label class="col-sm-3 control-label">Anime Episode Format</label>
-
-            <div class="col-sm-1 col-sm-push-8 help-inline">
-                <i class="icon-sonarr-form-info" title="" data-original-title="All caps or all lower-case can also be used"></i>
-                <a href="https://github.com/NzbDrone/NzbDrone/wiki/Sorting-and-Renaming" class="help-link" title="More information"><i class="icon-sonarr-form-info-link"/></a>
-            </div>
-
-            <div class="col-sm-8 col-sm-pull-1">
-                <div class="input-group x-helper-input">
-                    <input type="text" class="form-control naming-format" name="animeEpisodeFormat" data-onkeyup="true" />
-                    <div class="input-group-btn btn-group x-naming-token-helper">
-                        <button class="btn btn-icon-only dropdown-toggle" data-toggle="dropdown">
-                            <i class="icon-sonarr-add"></i>
-                        </button>
-                        <ul class="dropdown-menu">
-                            {{> SeriesTitleNamingPartial}}
-                            {{> AbsoluteEpisodeNamingPartial}}
-                            {{> SeasonNamingPartial}}
-                            {{> EpisodeNamingPartial}}
-                            {{> EpisodeTitleNamingPartial}}
-                            {{> QualityNamingPartial}}
-                            {{> MediaInfoNamingPartial}}
-                            {{> ReleaseGroupNamingPartial}}
-                            {{> OriginalTitleNamingPartial}}
-                            {{> SeparatorNamingPartial}}
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>--}}
-
     <div class="form-group advanced-setting">
         <label class="col-sm-3 control-label">Movie Folder Format</label>
 
@@ -193,43 +129,6 @@
         </div>
     </div>
 
-    {{!--<div class="form-group">
-        <label class="col-sm-3 control-label">Season Folder Format</label>
-
-        <div class="col-sm-8">
-            <div class="input-group x-helper-input">
-                <input type="text" class="form-control naming-format" name="seasonFolderFormat" data-onkeyup="true"/>
-                <div class="input-group-btn btn-group x-naming-token-helper">
-                    <button class="btn btn-icon-only dropdown-toggle" data-toggle="dropdown">
-                        <i class="icon-sonarr-add"></i>
-                    </button>
-                    <ul class="dropdown-menu">
-                        {{> SeriesTitleNamingPartial}}
-                        {{> SeasonNamingPartial}}
-                        {{> SeparatorNamingPartial}}
-                    </ul>
-                </div>
-            </div>
-        </div>
-    </div>--}}
-
-    {{!--<div class="x-naming-options">
-        <div class="form-group">
-            <label class="col-sm-3 control-label">Multi-Episode Style</label>
-
-            <div class="col-sm-2">
-                <select class="form-control x-multi-episode-style" name="multiEpisodeStyle">
-                    <option value="0">Extend</option>
-                    <option value="1">Duplicate</option>
-                    <option value="2">Repeat</option>
-                    <option value="3">Scene</option>
-                    <option value="4">Range</option>
-                    <option value="5">Prefixed Range</option>
-                </select>
-            </div>
-        </div>
-    </div>--}}
-
     <div class="form-group">
         <label class="col-sm-3 control-label">Movie Example</label>
 
@@ -238,37 +137,6 @@
         </div>
     </div>
 
-    {{!--<div class="form-group">
-        <label class="col-sm-3 control-label">Multi-Episode Example</label>
-
-        <div class="col-sm-8">
-            <p class="form-control-static x-multi-episode-example naming-example"></p>
-        </div>
-    </div>
-
-    <div class="form-group">
-        <label class="col-sm-3 control-label">Daily-Episode Example</label>
-
-        <div class="col-sm-8">
-            <p class="form-control-static x-daily-episode-example naming-example"></p>
-        </div>
-    </div>
-
-    <div class="form-group">
-        <label class="col-sm-3 control-label">Anime Episode Example</label>
-        <div class="col-sm-8">
-            <p class="form-control-static x-anime-episode-example naming-example"></p>
-        </div>
-    </div>
-
-    <div class="form-group">
-        <label class="col-sm-3 control-label">Anime Multi-Episode Example</label>
-
-        <div class="col-sm-8">
-            <p class="form-control-static x-anime-multi-episode-example naming-example"></p>
-        </div>
-    </div>--}}
-
     <div class="form-group">
         <label class="col-sm-3 control-label">Movie Folder Example</label>
 
@@ -276,12 +144,4 @@
             <p class="form-control-static x-movie-folder-example naming-example"></p>
         </div>
     </div>
-
-    {{!--<div class="form-group">
-        <label class="col-sm-3 control-label">Season Folder Example</label>
-
-        <div class="col-sm-8">
-            <p class="form-control-static x-season-folder-example naming-example"></p>
-        </div>
-    </div>--}}
 </fieldset>


### PR DESCRIPTION
The default functionality is to delete colon characters. However,
there are several other ways that various media software expects
these characters to be resolved (dash, space dash, or space dash
space). This commit adds the ability to choose one of those
settings from a "Colon Replacement Format" select control in the
"Movie Naming" section of the "Media Management" Settings tab.

Also, this changes behavior for the "Rename Movies" switch so that
when it is disabled it also hides the "Replace Illegal Characters"
setting. This is in line with how these two settings interoperate.

I only resolved two issues with a single commit because these both
modify the same UI elements.

Finally, since I changed NamingViewTemplate.hbs, I had to reformat
it (replace single quotes with double quotes) to pass the Codacy
scan for code quality.

#### Database Migration
YES

I added the `ColonReplacementFormat` string value, see the migration file: [146_naming_config_colon_replacement_format.cs](https://github.com/jportner/Radarr/blob/7b51ae15e10c6d31cd91a064c2a7ef9df0b49208/src/NzbDrone.Core/Datastore/Migration/146_naming_config_colon_replacement_format.cs)

#### Description

Added the `Colon Replacement Format` input in the *Movie Naming* settings section.
Note, the default value for this input is  `Delete` (which corresponds to an empty string value), to stay consistent with current Radarr functionality.

____
#### Screenshot 1
![image](https://user-images.githubusercontent.com/5295965/38229085-e3c6d4fe-36d4-11e8-9e55-2a4aded64cca.png)
____
#### Screenshot 2
![image](https://user-images.githubusercontent.com/5295965/38229090-f0b75ba2-36d4-11e8-81fb-73a9f77f44b9.png)
____
#### Screenshot 3
![image](https://user-images.githubusercontent.com/5295965/38229097-03b17882-36d5-11e8-8664-25025cffecf5.png)
____

#### Issues Fixed or Closed by this PR

* Supersedes #2658 
* Resolves #2140 
* Resolves #2657 

