### PR TITLE
Fixed: Register Growl as Radarr to avoid issues with Sonarr

### DIFF
--- a/src/NzbDrone.Core/Notifications/Growl/GrowlService.cs
+++ b/src/NzbDrone.Core/Notifications/Growl/GrowlService.cs
@@ -20,9 +20,8 @@ namespace NzbDrone.Core.Notifications.Growl
     public class GrowlService : IGrowlService
     {
         private readonly Logger _logger;
-
-        //TODO: Change this to Sonarr, but it is a breaking change (v3)
-        private readonly Application _growlApplication = new Application("NzbDrone");
+        
+        private readonly Application _growlApplication = new Application("Radarr");
         private readonly NotificationType[] _notificationTypes;
 
         private class GrowlRequestState


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Register growl notification application as Radarr to avoid conflict with Sonarr.

#### Issues Fixed or Closed by this PR
#1232 

* #
