### PR TITLE
Added: Fallback to Bitrate_Nominal for MediaInfo

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.IO;
 using NLog;
@@ -96,6 +96,10 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                     int.TryParse(mediaInfo.Get(StreamKind.Video, 0, "Width"), out width);
                     int.TryParse(mediaInfo.Get(StreamKind.Video, 0, "Height"), out height);
                     int.TryParse(mediaInfo.Get(StreamKind.Video, 0, "BitRate"), out videoBitRate);
+                    if (videoBitRate <= 0)
+                    {
+                        int.TryParse(mediaInfo.Get(StreamKind.Video, 0, "BitRate_Nominal"), out videoBitRate);
+                    }
                     decimal.TryParse(mediaInfo.Get(StreamKind.Video, 0, "FrameRate"), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out videoFrameRate);
                     int.TryParse(mediaInfo.Get(StreamKind.Video, 0, "BitDepth"), out videoBitDepth);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When `Bitrate` property cannot be parsed from movie file mediainfo, fallback to look for `Bitrate_Nominal` when available.

#### Issues Fixed or Closed by this PR
Fixes #2860
