### PR TITLE
Added: Monitor Toggle on Movies Editor Page

### DIFF
--- a/src/UI/Movies/Editor/MovieEditorLayout.js
+++ b/src/UI/Movies/Editor/MovieEditorLayout.js
@@ -6,6 +6,7 @@ var EmptyView = require('../Index/EmptyView');
 var FullMovieCollection = require ('../FullMovieCollection');
 var MoviesCollection = require('../MoviesCollection');
 var MovieTitleCell = require('../../Cells/MovieTitleCell');
+var MovieMonitoredCell = require('../../Cells/ToggleCell');
 var DownloadedQualityCell = require('../../Cells/DownloadedQualityCell');
 var ProfileCell = require('../../Cells/ProfileCell');
 var SelectAllCell = require('../../Cells/SelectAllCell');
@@ -44,6 +45,15 @@ module.exports = Marionette.Layout.extend({
             name       : '',
             cell       : SelectAllCell,
             headerCell : 'select-all',
+            sortable   : false
+        },
+        {
+            name       : 'monitored',
+            label      : '',
+            cell       : MovieMonitoredCell,
+            trueClass  : 'icon-sonarr-monitored',
+            falseClass : 'icon-sonarr-unmonitored',
+            tooltip    : 'Toggle movie monitored status',
             sortable   : false
         },
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds Monitored toggle for each row in Movie Editor page (Combines functionality for Season Pass into Series Editor in Sonarr speak.)

#610 mentions adding this to the main page, but seems to fit better here to avoid rouge changes. Thoughts?

I'll fix all the icon names in another PR after this.

#### Issues Fixed or Closed by this PR
Fixes #610
* #
