### PR TITLE
Bigger quality slider size for larger file limits

### DIFF
--- a/src/UI/Settings/Quality/Definition/QualityDefinitionItemView.js
+++ b/src/UI/Settings/Quality/Definition/QualityDefinitionItemView.js
@@ -9,7 +9,7 @@ var view = Marionette.ItemView.extend({
 
 		slider    : {
 				min  : 0,
-				max  : 200,
+				max  : 400,
 				step : 0.1
 		},
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
By default the UI only allows up to around 35 GB of file limit max. This is going to quickly become insufficient as resolutions and bitrates climb for source material. This change allows there to be more usability of the UI in changing file limits instead of having to use sqlite3 to directly edit the nzbdrone database.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* # https://github.com/Radarr/Radarr/issues/978
