### PR TITLE
Add "Add Paused" option to Deluge and Transmission

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeProxy.cs
@@ -84,21 +84,31 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
         public string AddTorrentFromMagnet(string magnetLink, DelugeSettings settings)
         {
-            var response = ProcessRequest<string>(settings, "core.add_torrent_magnet", magnetLink, new JObject());
+            var options = new
+                          {
+                              add_paused = settings.AddPaused,
+                              remove_at_ratio = false
+                          };
+            var response = ProcessRequest<string>(settings, "core.add_torrent_magnet", magnetLink, options);
 
             return response;
         }
 
         public string AddTorrentFromFile(string filename, byte[] fileContent, DelugeSettings settings)
         {
-            var response = ProcessRequest<string>(settings, "core.add_torrent_file", filename, fileContent, new JObject());
+            var options = new
+                          {
+                              add_paused = settings.AddPaused,
+                              remove_at_ratio = false
+                          };
+            var response = ProcessRequest<string>(settings, "core.add_torrent_file", filename, fileContent, options);
 
             return response;
         }
 
-        public bool RemoveTorrent(string hashString, bool removeData, DelugeSettings settings)
+        public bool RemoveTorrent(string hash, bool removeData, DelugeSettings settings)
         {
-            var response = ProcessRequest<bool>(settings, "core.remove_torrent", hashString, removeData);
+            var response = ProcessRequest<bool>(settings, "core.remove_torrent", hash, removeData);
 
             return response;
         }

--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
@@ -49,7 +49,10 @@ namespace NzbDrone.Core.Download.Clients.Deluge
         [FieldDefinition(6, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(DelugePriority), HelpText = "Priority to use when grabbing movies that released over 21 days ago")]
         public int OlderMoviePriority { get; set; }
 
-        [FieldDefinition(7, Label = "Use SSL", Type = FieldType.Checkbox)]
+        [FieldDefinition(7, Label = "Add Paused", Type = FieldType.Checkbox)]
+        public bool AddPaused { get; set; }
+
+        [FieldDefinition(8, Label = "Use SSL", Type = FieldType.Checkbox)]
         public bool UseSsl { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
@@ -51,6 +51,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         {
             var arguments = new Dictionary<string, object>();
             arguments.Add("filename", torrentUrl);
+            arguments.Add("paused", settings.AddPaused);
 
             if (!downloadDirectory.IsNullOrWhiteSpace())
             {
@@ -64,6 +65,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         {
             var arguments = new Dictionary<string, object>();
             arguments.Add("metainfo", Convert.ToBase64String(torrentData));
+            arguments.Add("paused", settings.AddPaused);
 
             if (!downloadDirectory.IsNullOrWhiteSpace())
             {

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
@@ -63,7 +63,10 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         [FieldDefinition(8, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(TransmissionPriority), HelpText = "Priority to use when grabbing movies that released over 21 days ago")]
         public int OlderMoviePriority { get; set; }
 
-        [FieldDefinition(9, Label = "Use SSL", Type = FieldType.Checkbox)]
+        [FieldDefinition(9, Label = "Add Paused", Type = FieldType.Checkbox)]
+        public bool AddPaused { get; set; }
+        
+        [FieldDefinition(10, Label = "Use SSL", Type = FieldType.Checkbox)]
         public bool UseSsl { get; set; }
 
         public NzbDroneValidationResult Validate()


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Adds an `add paused` option to deluge and transmission clients. Based on a [similar commit](https://github.com/Sonarr/Sonarr/commit/5663eb527b7160c3e13d87eb6b1399194b5e0463) in Sonarr.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* https://github.com/Radarr/Radarr/issues/2186
