### PR TITLE
Use proper cursor for text and linked labels

### DIFF
--- a/src/UI/Movies/movies.less
+++ b/src/UI/Movies/movies.less
@@ -156,6 +156,10 @@
       width   : 170px;
 
       :hover {
+        cursor : default;
+      }
+
+      a:hover {
         cursor : pointer;
       }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I made a small mistake on my previous pull request and I'm here fixing it. The idea is to have the `pointer` cursor for labels which are links (like links to Trakt, IMDb, Trailer, etc...) and the `default` cursor for non-link labels (which are just informational).

Hopefully this finally fixes that for the poster view.