### PR TITLE
Include the URL to the TMDB page for the movie

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -207,6 +207,9 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 
             }
 
+            xmlResult += "https://www.themoviedb.org/movie/" + movie.TmdbId;
+            xmlResult += Environment.NewLine;
+
             var metadataFileName = GetMovieMetadataFilename(movieFile.RelativePath);
 
             if (Settings.UseMovieNfo)


### PR DESCRIPTION
This change makes Radarr produce the [Combination Nfo format documented on the Kodi wiki](https://kodi.wiki/view/NFO_files#Combination_nfo). It directs Kodi to the correct page to parse any info that's not available in the metadata nfo file.

I found that when I turned on the production of nfo files for Kodi, Kodi used these solely and didn't fetch any missing information via it's own scraper. I ran a few tests and found that including the parsing nfo (the url to the TMDB page) at the bottom of the nfo file allowed Kodi to scrape missing data and ensured it was getting it for the correct movie.

A concrete example was missing cast info. After adding this in, cast info shows up.

The code change is pretty trivial. One thing I'm not sure about is whether everyone would want this behaviour. I can't see why not, but to err on the safe side it could be put behind an (advanced?) option in the Kodi metadata settings UI. I've not looked at the UI at all yet, but I'm happy to investigate if this is seen as a desirable feature.