### PR TITLE
Add support for Homebrew-installed mono

### DIFF
--- a/osx/Radarr
+++ b/osx/Radarr
@@ -9,7 +9,11 @@ APPNAME="Radarr"
 
 #set up environment
 if [[ -x '/opt/local/bin/mono' ]]; then
+    # Macports and mono-supplied installer path
     export PATH="/opt/local/bin:$PATH"
+elif [[ -x '/usr/local/bin/mono' ]]; then
+    # Homebrew-supplied path to mono
+    export PATH="/usr/local/bin:$PATH"
 fi
 
 export DYLD_FALLBACK_LIBRARY_PATH="$DIR"


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Lots of macOS users use Homebrew to manage things like Mono and other libraries. This ensures Radarr is compatible out-of-the-box, and does not require installing multiple copies of Mono.

Mirrors Sonarr/Sonarr#2728

#### Todos

- [x] Tests

#### Issues Fixed or Closed by this PR

None