### PR TITLE
Trim filename from Kodi movie path before sending library scan request.

### DIFF
--- a/src/NzbDrone.Core/Notifications/Xbmc/JsonApiProvider.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/JsonApiProvider.cs
@@ -1,9 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
 using NzbDrone.Core.Notifications.Xbmc.Model;
 using NzbDrone.Core.Movies;
+using NzbDrone.Common.Disk;
+using System.IO;
 
 namespace NzbDrone.Core.Notifications.Xbmc
 {
@@ -85,6 +87,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
 
                 if (moviePath != null)
                 {
+                    moviePath = new OsPath(moviePath).Directory.FullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                     _logger.Debug("Updating movie {0} (Path: {1}) on XBMC host: {2}", movie, moviePath, settings.Address);
                 }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This fix trims the filename from the Kodi movie path before sending the library scan JSONRPC call.

This doesn't completely resolve the problem in the case where the folder structure the movie is in changes. To resolve this the call would need to have both the original and new path (which the code doesn't have at the point of the call).


#### Issues Fixed or Closed by this PR
Issue #2771 partially fixed

* #
