### PR TITLE
Tweak style of movie path template on "bulk import movies" screen

### DIFF
--- a/src/UI/AddMovies/BulkImport/MoviePathTemplate.hbs
+++ b/src/UI/AddMovies/BulkImport/MoviePathTemplate.hbs
@@ -1,2 +1,4 @@
 {{path}}<br>
-<span title="{{#if movieFile.relativePath}}&nbsp;{{movieFile.relativePath}}{{/if}}" class="hint" style="font-size: 12px;">{{#if movieFile.relativePath}}&nbsp;{{movieFile.relativePath}}{{else}}&nbsp;Movie File Not Found{{/if}}</span>
+<span title="{{#if movieFile.relativePath}}&nbsp;{{movieFile.relativePath}}{{/if}}" class="hint path">
+{{#if movieFile.relativePath}}&#9493;&nbsp;{{movieFile.relativePath}}{{else}}&#9493;&nbsp;Movie File Not Found{{/if}}
+</span>

--- a/src/UI/AddMovies/addMovies.less
+++ b/src/UI/AddMovies/addMovies.less
@@ -1,3 +1,4 @@
+@import "../Content/Bootstrap/mixins";
 @import "../Shared/Styles/card.less";
 @import "../Shared/Styles/clickable.less";
 
@@ -130,6 +131,13 @@
   .hint {
     color      : #999999;
     font-style : italic;
+
+    &.path {
+      .text-overflow();
+
+      display: block;
+      font-size: 12px;
+    }
   }
 
   .monitor-tooltip-contents {


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Small style improvements to the movie path template on the "bulk import movies" screen:
- Fixed overflow ellipsis (different color, not italicized as the text).
- Added small character to better indicate the file is inside the respective folder.

#### Screenshot

![image](https://user-images.githubusercontent.com/96476/47147225-af863a80-d2c5-11e8-97bb-116b257d59af.png)

#### Issues Fixed or Closed by this PR

* Fixes #3106.
