### PR TITLE
Don't return unmapped folders on rootfolder API call

### DIFF
--- a/src/NzbDrone.Api/RootFolders/RootFolderModule.cs
+++ b/src/NzbDrone.Api/RootFolders/RootFolderModule.cs
@@ -52,7 +52,7 @@ namespace NzbDrone.Api.RootFolders
 
         private List<RootFolderResource> GetRootFolders()
         {
-            return _rootFolderService.AllWithUnmappedFolders().ToResource();
+            return _rootFolderService.AllWithSpace().ToResource();
         }
 
         private void DeleteFolder(int id)

--- a/src/NzbDrone.Core/RootFolders/RootFolderService.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolderService.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.RootFolders
     public interface IRootFolderService
     {
         List<RootFolder> All();
-        List<RootFolder> AllWithUnmappedFolders();
+        List<RootFolder> AllWithSpace();
         RootFolder Add(RootFolder rootDir);
         void Remove(int id);
         RootFolder Get(int id);
@@ -62,10 +62,10 @@ namespace NzbDrone.Core.RootFolders
             return rootFolders;
         }
 
-        public List<RootFolder> AllWithUnmappedFolders()
+        public List<RootFolder> AllWithSpace()
         {
             var rootFolders = _rootFolderRepository.All().ToList();
-
+            
             rootFolders.ForEach(folder =>
             {
                 try
@@ -74,15 +74,13 @@ namespace NzbDrone.Core.RootFolders
                     {
                         folder.FreeSpace = _diskProvider.GetAvailableSpace(folder.Path);
                         folder.TotalSpace = _diskProvider.GetTotalSize(folder.Path);
-                        folder.UnmappedFolders = GetUnmappedFolders(folder.Path);
                     }
                 }
                 //We don't want an exception to prevent the root folders from loading in the UI, so they can still be deleted
                 catch (Exception ex)
                 {
                     folder.FreeSpace = 0;
-                    _logger.Error(ex, "Unable to get free space and unmapped folders for root folder {0}", folder.Path);
-                    folder.UnmappedFolders = new List<UnmappedFolder>();
+                    _logger.Error(ex, "Unable to get free space for root folder {0}", folder.Path);
                 }
             });
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This removes the unmapped folders from the rootfolder API call.

They are simply not used at all. Even folder bulk import returns them in an extra call.

Beside this, retrieving them with the current implementation takes ~410ms per rootfolder on my end. This is mainly because of the call for `_movieRepository.All().ToList()`, which stored instead of calling it for every rootfolder. But even then it still takes ~60ms:
```
[Info] RootFolderService: /mnt/data/Movies/Stirb Langsam (1988-2013) [Collection]
[Info] RootFolderService: TimeToGetMoviesList=00:00:00.3465284
[Info] RootFolderService: TimeToCompleteUnmappedFolders=00:00:00.4105930
```

This might not be much for users with a single rootfolder, but for me this sums up to 8 seconds for this simple API request (or up to a full minute without the list-fix).

### Tested
* Searching movies
* Adding new movies
* Adding existing movies by folder bulk import
