### PR TITLE
Add tags support to NetImport (Lists)

### DIFF
--- a/src/NzbDrone.Api/NetImport/NetImportModule.cs
+++ b/src/NzbDrone.Api/NetImport/NetImportModule.cs
@@ -24,6 +24,7 @@ namespace NzbDrone.Api.NetImport
             resource.RootFolderPath = definition.RootFolderPath;
             resource.ShouldMonitor = definition.ShouldMonitor;
             resource.MinimumAvailability = definition.MinimumAvailability;
+            resource.Tags = definition.Tags;
         }
 
         protected override void MapToModel(NetImportDefinition definition, NetImportResource resource)
@@ -36,6 +37,7 @@ namespace NzbDrone.Api.NetImport
             definition.RootFolderPath = resource.RootFolderPath;
             definition.ShouldMonitor = resource.ShouldMonitor;
             definition.MinimumAvailability = resource.MinimumAvailability;
+            definition.Tags = resource.Tags;
         }
 
         protected override void Validate(NetImportDefinition definition, bool includeWarnings)

--- a/src/NzbDrone.Api/NetImport/NetImportResource.cs
+++ b/src/NzbDrone.Api/NetImport/NetImportResource.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NzbDrone.Core.Movies;
 
 namespace NzbDrone.Api.NetImport
@@ -10,5 +11,6 @@ namespace NzbDrone.Api.NetImport
         public string RootFolderPath { get; set; }
         public int ProfileId { get; set; }
         public MovieStatusType MinimumAvailability { get; set; }
+        public HashSet<int> Tags { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/151_add_tags_to_net_import.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/151_add_tags_to_net_import.cs
@@ -1,0 +1,17 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(151)]
+    public class add_tags_to_net_import : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("NetImport")
+                 .AddColumn("Tags").AsString().Nullable();
+
+            Execute.Sql("UPDATE NetImport SET Tags = '[]'");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupUnusedTags.cs
+++ b/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupUnusedTags.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Housekeeping.Housekeepers
             using (var mapper = _database.GetDataMapper())
             {
 
-                var usedTags = new[] {"Movies", "Notifications", "DelayProfiles", "Restrictions"}
+                var usedTags = new[] {"Movies", "Notifications", "DelayProfiles", "Restrictions", "NetImport"}
                     .SelectMany(v => GetUsedTags(v, mapper))
                     .Distinct()
                     .ToArray();

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -701,6 +701,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 	            newMovie.Monitored = movie.Monitored;
 	            newMovie.MovieFile = movie.MovieFile;
 	            newMovie.MinimumAvailability = movie.MinimumAvailability;
+	            newMovie.Tags = movie.Tags;
 
 	            return newMovie;
 			}

--- a/src/NzbDrone.Core/NetImport/HttpNetImportBase.cs
+++ b/src/NzbDrone.Core/NetImport/HttpNetImportBase.cs
@@ -118,6 +118,7 @@ namespace NzbDrone.Core.NetImport
                 m.ProfileId = ((NetImportDefinition) Definition).ProfileId;
                 m.Monitored = ((NetImportDefinition) Definition).ShouldMonitor;
 		        m.MinimumAvailability = ((NetImportDefinition) Definition).MinimumAvailability;
+                m.Tags = ((NetImportDefinition) Definition).Tags;
                 return m;
             }).ToList();
         }
@@ -170,6 +171,5 @@ namespace NzbDrone.Core.NetImport
             return null;
         }
     }
-    
 
 }

--- a/src/NzbDrone.Core/NetImport/NetImportDefinition.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportDefinition.cs
@@ -1,4 +1,5 @@
-﻿using Marr.Data;
+﻿using System.Collections.Generic;
+using Marr.Data;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Movies;
@@ -15,5 +16,6 @@ namespace NzbDrone.Core.NetImport
         public LazyLoaded<Profile> Profile { get; set; }
         public string RootFolderPath { get; set; }
         public override bool Enable => Enabled;
+        public HashSet<int> Tags { get; set; }
     }
 }

--- a/src/NzbDrone.Core/NetImport/NetImportDefinition.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportDefinition.cs
@@ -8,6 +8,11 @@ namespace NzbDrone.Core.NetImport
 {
     public class NetImportDefinition : ProviderDefinition
     {
+        public NetImportDefinition()
+        {
+            Tags = new HashSet<int>();
+        }
+
         public bool Enabled { get; set; }
         public bool EnableAuto { get; set; }
         public bool ShouldMonitor { get; set; }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Datastore\Migration\144_add_cookies_to_indexer_status.cs" />
     <Compile Include="Datastore\Migration\149_convert_regex_required_tags.cs" />
     <Compile Include="Datastore\Migration\150_fix_format_tags_double_underscore.cs" />
+    <Compile Include="Datastore\Migration\151_add_tags_to_net_import.cs" />
     <Compile Include="DecisionEngine\Specifications\CustomFormatAllowedByProfileSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\MaximumSizeSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RequiredIndexerFlagsSpecification.cs" />

--- a/src/UI/Settings/NetImport/Edit/NetImportEditView.js
+++ b/src/UI/Settings/NetImport/Edit/NetImportEditView.js
@@ -21,7 +21,8 @@ var view = Marionette.ItemView.extend({
 		ui : {
 				profile         : '.x-profile',
 				minimumAvailability : '.x-minimumavailability',
-				rootFolder      : '.x-root-folder',
+                rootFolder      : '.x-root-folder',
+                tags            : '.x-tags'
 			},
 
 		events : {
@@ -52,7 +53,11 @@ var view = Marionette.ItemView.extend({
 					if (RootFolders.get(defaultRoot)) {
 							this.ui.rootFolder.val(defaultRoot);
 					}
-				}
+                }
+                this.ui.tags.tagInput({
+                    model    : this.model,
+                    property : 'tags'
+                });
 		},
 
 		_onBeforeSave : function() {

--- a/src/UI/Settings/NetImport/Edit/NetImportEditView.js
+++ b/src/UI/Settings/NetImport/Edit/NetImportEditView.js
@@ -21,8 +21,8 @@ var view = Marionette.ItemView.extend({
 		ui : {
 				profile         : '.x-profile',
 				minimumAvailability : '.x-minimumavailability',
-                rootFolder      : '.x-root-folder',
-                tags            : '.x-tags'
+				rootFolder      : '.x-root-folder',
+				tags            : '.x-tags'
 			},
 
 		events : {
@@ -53,11 +53,11 @@ var view = Marionette.ItemView.extend({
 					if (RootFolders.get(defaultRoot)) {
 							this.ui.rootFolder.val(defaultRoot);
 					}
-                }
-                this.ui.tags.tagInput({
-                    model    : this.model,
-                    property : 'tags'
-                });
+				}
+				this.ui.tags.tagInput({
+					model    : this.model,
+					property : 'tags'
+				});
 		},
 
 		_onBeforeSave : function() {

--- a/src/UI/Settings/NetImport/Edit/NetImportEditViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Edit/NetImportEditViewTemplate.hbs
@@ -101,6 +101,14 @@
 							</div>
 						</div>
 
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">Tags</label>
+
+                            <div class="col-sm-5">
+                                <input type="text" class="form-control x-tags">
+                            </div>
+                        </div>
+
 						{{formBuilder}}
 				</div>
 		</div>

--- a/src/UI/Settings/NetImport/Edit/NetImportEditViewTemplate.hbs
+++ b/src/UI/Settings/NetImport/Edit/NetImportEditViewTemplate.hbs
@@ -101,13 +101,13 @@
 							</div>
 						</div>
 
-                        <div class="form-group">
-                            <label class="col-sm-3 control-label">Tags</label>
+						<div class="form-group">
+							<label class="col-sm-3 control-label">Tags</label>
 
-                            <div class="col-sm-5">
-                                <input type="text" class="form-control x-tags">
-                            </div>
-                        </div>
+							<div class="col-sm-5">
+								<input type="text" class="form-control x-tags">
+							</div>
+						</div>
 
 						{{formBuilder}}
 				</div>


### PR DESCRIPTION
#### Database Migration
YES

#### Description
Adds a `Tags` field to lists configuration so that one can associate tags with imported movies from network lists.

#### TODOS
- [x] Fix errors that are sometimes printed to the browser console when adding tags (https://github.com/Radarr/Radarr/blob/develop/src/UI/Mixins/TagInput.js#L184 - `tags` here is sometimes `undefined`).
- [x] Validate that tags added to the lists are actually saved to the imported movies (I don't think they are yet).

If anyone's interested in helping me solving the two issues above, I'd really appreciate it. Without them, especially the last one, this feature is not finished.
