### PR TITLE
Skip movie search if movie was added as "unmonitored"

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/MoviesSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/MoviesSearchService.cs
@@ -46,6 +46,7 @@ namespace NzbDrone.Core.IndexerSearch
                 if (!movies.Monitored)
                 {
                     _logger.Debug("Movie {0} is not monitored, skipping search", movies.Title);
+                    continue;
                 }
 
                 var decisions = _nzbSearchService.MovieSearch(movieId, false);//_nzbSearchService.SeasonSearch(message.MovieId, season.SeasonNumber, false, message.Trigger == CommandTrigger.Manual);


### PR DESCRIPTION
#### Database Migration
NO

#### Description

When movies are added to Radarr through Net Import Sync (Lists) - not sure if this happens when added through other methods - with the option "Add Movies Monitored" set to `NO` (movies will be added as `unmonitored`), movies are still searched (Indexers APIs are still invoked) when they shouldn't. This fixes that.