### PR TITLE
Fallback to 'VideoCodec' if 'VideoFormat' is unavailable

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoCodecFixture.cs
@@ -8,10 +8,10 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
     [TestFixture]
     public class FormatVideoCodecFixture : TestBase
     {
-        [TestCase("AVC", null, "h264")]
+        [TestCase("AVC", null, "x264")]
         [TestCase("AVC", "source.title.x264.720p-Sonarr", "x264")]
         [TestCase("AVC", "source.title.h264.720p-Sonarr", "h264")]
-        [TestCase("V_MPEGH/ISO/HEVC", null, "h265")]
+        [TestCase("V_MPEGH/ISO/HEVC", null, "x265")]
         [TestCase("V_MPEGH/ISO/HEVC", "source.title.x265.720p-Sonarr", "x265")]
         [TestCase("V_MPEGH/ISO/HEVC", "source.title.h265.720p-Sonarr", "h265")]
         [TestCase("MPEG-2 Video", null, "MPEG2")]
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                VideoFormat = videoCodec
+                VideoCodec = videoCodec
             };
 
             MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, sceneName).Should().Be(expectedFormat);

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -331,7 +331,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
         public static string FormatVideoCodecLegacy(MediaInfoModel mediaInfo, string sceneName)
         {
-            var videoCodec = mediaInfo.VideoFormat;
+            var videoCodec = mediaInfo.VideoCodec;
 
             if (videoCodec.IsNullOrWhiteSpace())
             {

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
@@ -10,6 +10,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
     public class MediaInfoModel : IEmbeddedDocument
     {
         public string ContainerFormat { get; set; }
+        public string VideoCodec { get; set; }
         public string VideoFormat { get; set; }
         public string VideoCodecID { get; set; }
         public string VideoProfile { get; set; }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -17,8 +17,8 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         private readonly IDiskProvider _diskProvider;
         private readonly Logger _logger;
 
-        public const int MINIMUM_MEDIA_INFO_SCHEMA_REVISION = 3;
-        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 4;
+        public const int MINIMUM_MEDIA_INFO_SCHEMA_REVISION = 4;
+        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 5;
 
         public VideoFileInfoReader(IDiskProvider diskProvider, Logger logger)
         {

--- a/src/UI/Cells/MediaInfoCell.js
+++ b/src/UI/Cells/MediaInfoCell.js
@@ -12,7 +12,7 @@ module.exports = NzbDroneCell.extend({
           if (runtime) {
             runtime = runtime.split(".")[0];
           }
-          var video = "{0} ({1}x{2}) ({3})".format(info.videoFormat, info.width, info.height, runtime);
+          var video = "{0} ({1}x{2}) ({3})".format(info.videoFormat || info.videoCodec, info.width, info.height, runtime);
           var audio = "{0} ({1})".format(info.audioFormat, info.audioLanguages);
           this.$el.html(video + " " + audio);
         }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Fallback to `VideoCodec` property if `VideoFormat` is not found. Should solve issues with existing installations and already imported movies with MediaInfo data written with the legacy `VideoCodec`.