### PR TITLE
Fixed: Bump default version to prevent update running from source

### DIFF
--- a/src/Common/CommonVersionInfo.cs
+++ b/src/Common/CommonVersionInfo.cs
@@ -2,4 +2,4 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("0.1.0.*")]
+[assembly: AssemblyVersion("10.0.0.*")]

--- a/src/NzbDrone.Common/Properties/SharedAssemblyInfo.cs
+++ b/src/NzbDrone.Common/Properties/SharedAssemblyInfo.cs
@@ -1,10 +1,10 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("radarr.tv")]
-[assembly: AssemblyProduct("NzbDrone")]
-[assembly: AssemblyVersion("0.1.0.*")]
+[assembly: AssemblyCompany("radarr.video")]
+[assembly: AssemblyProduct("Radarr")]
+[assembly: AssemblyVersion("10.0.0.*")]
 [assembly: AssemblyCopyright("GNU General Public v3")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This sets default assembly version back to 10.0.0.build. When default version is less than or equal to current release version Radarr tries to update to latest release when running from source. This should not affect building as assembly version is set by Appveyor during build. 

#### Issues Fixed or Closed by this PR

* #
