### PR TITLE
Fixed: TitleThe doesn't handle separators

### DIFF
--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -300,6 +300,7 @@
     <Compile Include="NetImport\RSSImportParserFixture.cs" />
     <Compile Include="NotificationTests\SynologyIndexerFixture.cs" />
     <Compile Include="OrganizerTests\FileNameBuilderTests\CleanTitleFixture.cs" />
+    <Compile Include="OrganizerTests\FileNameBuilderTests\TitleTheFixture.cs" />
     <Compile Include="OrganizerTests\GetMovieFolderFixture.cs" />
     <Compile Include="ParserTests\ParsingServiceTests\AugmentersTests\AugmentMovieInfoFixture.cs" />
     <Compile Include="ParserTests\ParsingServiceTests\AugmentersTests\AugmentWithFileSizeFixture.cs" />

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TitleTheFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TitleTheFixture.cs
@@ -1,0 +1,86 @@
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Movies;
+
+namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
+{
+    [TestFixture]
+    public class TitleTheFixture : CoreTest<FileNameBuilder>
+    {
+        private Movie _movie;
+        private MovieFile _movieFile;
+        private NamingConfig _namingConfig;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movie = Builder<Movie>
+                    .CreateNew()
+                    .Build();
+
+
+            _movieFile = new MovieFile { Quality = new QualityModel(Quality.HDTV720p), ReleaseGroup = "RadarrTest" };
+
+            _namingConfig = NamingConfig.Default;
+            _namingConfig.RenameEpisodes = true;
+
+            Mocker.GetMock<INamingConfigService>()
+                  .Setup(c => c.GetConfig()).Returns(_namingConfig);
+
+            Mocker.GetMock<IQualityDefinitionService>()
+                .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
+                .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+        }
+
+        [TestCase("The Mist", "Mist, The")]
+        [TestCase("A Place to Call Home", "Place to Call Home, A")]
+        [TestCase("An Adventure in Space and Time", "Adventure in Space and Time, An")]
+        [TestCase("The Flash (2010)", "Flash, The (2010)")]
+        [TestCase("A League Of Their Own (AU)", "League Of Their Own, A (AU)")]
+        [TestCase("The Fixer (ZH) (2015)", "Fixer, The (ZH) (2015)")]
+        [TestCase("The Sixth Sense 2 (Thai)", "Sixth Sense 2, The (Thai)")]
+        [TestCase("The Amazing Race (Latin America)", "Amazing Race, The (Latin America)")]
+        [TestCase("The Rat Pack (A&E)", "Rat Pack, The (A&E)")]
+        [TestCase("The Climax: I (Almost) Got Away With It (2016)", "Climax I (Almost) Got Away With It, The (2016)")]
+        //[TestCase("", "")]
+        public void should_get_expected_title_back(string title, string expected)
+        {
+            _movie.Title = title;
+            _namingConfig.StandardMovieFormat = "{Movie TitleThe}";
+
+            Subject.BuildFileName(_movie , _movieFile)
+                   .Should().Be(expected);
+        }
+
+        [TestCase("The Mist", "Mist,The")]
+        [TestCase("A Place to Call Home", "Place.to.Call.Home,A")]
+        //[TestCase("", "")]
+        public void should_get_expected_dot_title_back(string title, string expected)
+        {
+            _movie.Title = title;
+            _namingConfig.StandardMovieFormat = "{Movie.TitleThe}";
+
+            Subject.BuildFileName(_movie , _movieFile)
+                .Should().Be(expected);
+        }
+
+        [TestCase("A")]
+        [TestCase("Anne")]
+        [TestCase("Theodore")]
+        [TestCase("3%")]
+        public void should_not_change_title(string title)
+        {
+            _movie.Title = title;
+            _namingConfig.StandardMovieFormat = "{Movie TitleThe}";
+
+            Subject.BuildFileName(_movie, _movieFile)
+                   .Should().Be(title);
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Adds unit tests for TitleThe
- Fixes cases where title contains year
- Fixes handling of separators with TitleThe

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
Fixes #3201 
* #
