### PR TITLE
Fixed: MediaInfo Unit Test Failing due to AudioAdditionalFeatures after MediaInfo update

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/VideoFileInfoReaderFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/VideoFileInfoReaderFixture.cs
@@ -53,7 +53,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
             info.AudioBitrate.Should().Be(128000);
             info.AudioChannels.Should().Be(2);
             info.AudioLanguages.Should().Be("English");
-            info.AudioAdditionalFeatures.Should().Be("");
+            info.AudioAdditionalFeatures.Should().Be("LC");
             info.Height.Should().Be(320);
             info.RunTime.Seconds.Should().Be(10);
             info.ScanType.Should().Be("Progressive");
@@ -90,7 +90,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
             info.AudioBitrate.Should().Be(128000);
             info.AudioChannels.Should().Be(2);
             info.AudioLanguages.Should().Be("English");
-            info.AudioAdditionalFeatures.Should().Be("");
+            info.AudioAdditionalFeatures.Should().Be("LC");
             info.Height.Should().Be(320);
             info.RunTime.Seconds.Should().Be(10);
             info.ScanType.Should().Be("Progressive");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes unit tests failing due to "LC" being read from AudioAdditionalFeatures

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* #
