### PR TITLE
New: Add Radarr_Download_Id and Radarr_Download_Client to PP scripts

### DIFF
--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -46,6 +46,8 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Radarr_Release_Quality", quality.Quality.Name);
             environmentVariables.Add("Radarr_Release_QualityVersion", quality.Revision.Version.ToString());
             environmentVariables.Add("Radarr_IndexerFlags", remoteMovie.Release.IndexerFlags.ToString());
+            environmentVariables.Add("Radarr_Download_Client", message.DownloadClient ?? string.Empty);
+            environmentVariables.Add("Radarr_Download_Id", message.DownloadId ?? string.Empty);
 
             ExecuteScript(environmentVariables);
         }

--- a/src/NzbDrone.Core/Notifications/GrabMessage.cs
+++ b/src/NzbDrone.Core/Notifications/GrabMessage.cs
@@ -1,4 +1,4 @@
-﻿using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Movies;
 
@@ -9,7 +9,9 @@ namespace NzbDrone.Core.Notifications
         public string Message { get; set; }
         public Movie Movie { get; set; }
         public RemoteMovie RemoteMovie { get; set; }
-        public QualityModel Quality { get; set; }   
+        public QualityModel Quality { get; set; }
+        public string DownloadClient { get; set; }
+        public string DownloadId { get; set; }
 
         public override string ToString()
         {

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -72,7 +72,9 @@ namespace NzbDrone.Core.Notifications
                 Message = GetMessage(message.Movie.Movie, message.Movie.ParsedMovieInfo.Quality),
                 Quality = message.Movie.ParsedMovieInfo.Quality,
                 Movie = message.Movie.Movie,
-                RemoteMovie = message.Movie
+                RemoteMovie = message.Movie,
+                DownloadClient = message.DownloadClient,
+                DownloadId = message.DownloadId
             };
 
             foreach (var notification in _notificationFactory.OnGrabEnabled())


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added Radarr_Download_Id and Radarr_Download_Client to the environment
variables passed to custom post-processing 'On Grab' scripts. In order to
do this, two new fields were introduced to the GrabMessage object
(DownloadClient and DownloadId). This reflects Sonarr's implementation.

#### Todos
- [ ] Tests
(tested successfully in my development environment)

#### Issues Fixed or Closed by this PR

* #3232 
