### PR TITLE
Use subfolder inside recycle bin when deleting

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Subject.UpgradeMovieFile(_movieFile, _localMovie);
 
-            Mocker.GetMock<IRecycleBinProvider>().Verify(v => v.DeleteFile(It.IsAny<string>()), Times.Once());
+            Mocker.GetMock<IRecycleBinProvider>().Verify(v => v.DeleteFile(It.IsAny<string>(), It.IsAny<string>()), Times.Once());
         }
 
 
@@ -95,7 +95,7 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Subject.UpgradeMovieFile(_movieFile, _localMovie);
 
-            Mocker.GetMock<IRecycleBinProvider>().Verify(v => v.DeleteFile(It.IsAny<string>()), Times.Never());
+            Mocker.GetMock<IRecycleBinProvider>().Verify(v => v.DeleteFile(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
         }
 
         [Test]

--- a/src/NzbDrone.Core/Extras/Files/ExtraFileService.cs
+++ b/src/NzbDrone.Core/Extras/Files/ExtraFileService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using NLog;
 using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
@@ -120,7 +121,8 @@ namespace NzbDrone.Core.Extras.Files
                     if (_diskProvider.FileExists(path))
                     {
                         // Send to the recycling bin so they can be recovered if necessary
-                        _recycleBinProvider.DeleteFile(path);
+                        var subfolder = _diskProvider.GetParentFolder(movie.Path).GetRelativePath(_diskProvider.GetParentFolder(path));
+                        _recycleBinProvider.DeleteFile(path, subfolder);
                     }
                 }
             }

--- a/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
@@ -312,7 +312,8 @@ namespace NzbDrone.Core.Extras.Metadata
 
                 _logger.Debug("Removing duplicate Metadata file: {0}", path);
 
-                _recycleBinProvider.DeleteFile(path);
+                var subfolder = _diskProvider.GetParentFolder(movie.Path).GetRelativePath(_diskProvider.GetParentFolder(path));
+                _recycleBinProvider.DeleteFile(path, subfolder);
                 _metadataFileService.Delete(file.Id);
             }
 

--- a/src/NzbDrone.Core/Extras/Others/OtherExtraFileRenamer.cs
+++ b/src/NzbDrone.Core/Extras/Others/OtherExtraFileRenamer.cs
@@ -74,7 +74,8 @@ namespace NzbDrone.Core.Extras.Others
             var otherExtraFile = _otherExtraFileService.FindByPath(relativePath);
             if (otherExtraFile != null)
             {
-                _recycleBinProvider.DeleteFile(path);
+                var subfolder = Path.GetDirectoryName(relativePath);
+                _recycleBinProvider.DeleteFile(path, subfolder);
             }
         }
     }

--- a/src/NzbDrone.Core/MediaFiles/RecycleBinProvider.cs
+++ b/src/NzbDrone.Core/MediaFiles/RecycleBinProvider.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.MediaFiles
     public interface IRecycleBinProvider
     {
         void DeleteFolder(string path);
-        void DeleteFile(string path);
+        void DeleteFile(string path, string subfolder = "");
         void Empty();
         void Cleanup();
     }
@@ -73,7 +73,7 @@ namespace NzbDrone.Core.MediaFiles
             }
         }
 
-        public void DeleteFile(string path)
+        public void DeleteFile(string path, string subfolder = "")
         {
             _logger.Debug("Attempting to send '{0}' to recycling bin", path);
             var recyclingBin = _configService.RecycleBin;
@@ -94,7 +94,10 @@ namespace NzbDrone.Core.MediaFiles
             else
             {
                 var fileInfo = new FileInfo(path);
-                var destination = Path.Combine(recyclingBin, fileInfo.Name);
+                var destinationFolder = Path.Combine(recyclingBin, subfolder);
+                var destination = Path.Combine(destinationFolder, fileInfo.Name);
+
+                _diskProvider.CreateFolder(destinationFolder);
 
                 var index = 1;
                 while (_diskProvider.FileExists(destination))
@@ -102,11 +105,11 @@ namespace NzbDrone.Core.MediaFiles
                     index++;
                     if (fileInfo.Extension.IsNullOrWhiteSpace())
                     {
-                        destination = Path.Combine(recyclingBin, fileInfo.Name + "_" + index);
+                        destination = Path.Combine(destinationFolder, fileInfo.Name + "_" + index);
                     }
                     else
                     {
-                        destination = Path.Combine(recyclingBin, Path.GetFileNameWithoutExtension(fileInfo.Name) + "_" + index + fileInfo.Extension);
+                        destination = Path.Combine(destinationFolder, Path.GetFileNameWithoutExtension(fileInfo.Name) + "_" + index + fileInfo.Extension);
                     }
                 }
 
@@ -121,7 +124,7 @@ namespace NzbDrone.Core.MediaFiles
                     _logger.Error(e, message);
                     throw;
                 }
-                
+
                 //TODO: Better fix than this for non-Windows?
                 if (OsInfo.IsWindows)
                 {

--- a/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Linq;
 using NLog;
 using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.MediaFiles
@@ -38,18 +39,21 @@ namespace NzbDrone.Core.MediaFiles
         public MovieFileMoveResult UpgradeMovieFile(MovieFile movieFile, LocalMovie localMovie, bool copyOnly = false)
         {
             _logger.Trace("Upgrading existing movie file.");
-            var moveFileResult = new MovieFileMoveResult();
 
+            var moveFileResult = new MovieFileMoveResult();
             var existingFile = localMovie.Movie.MovieFile;
 
+            var rootFolder = _diskProvider.GetParentFolder(localMovie.Movie.Path);
+
             if (existingFile != null)
-            {
+            {                
                 var movieFilePath = Path.Combine(localMovie.Movie.Path, existingFile.RelativePath);
+                var subfolder = rootFolder.GetRelativePath(_diskProvider.GetParentFolder(movieFilePath));
 
                 if (_diskProvider.FileExists(movieFilePath))
                 {
                     _logger.Debug("Removing existing movie file: {0}", existingFile);
-                    _recycleBinProvider.DeleteFile(movieFilePath);
+                    _recycleBinProvider.DeleteFile(movieFilePath, subfolder);
                 }
 
                 moveFileResult.OldFiles.Add(existingFile);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When using the recycle bin, create a subfolder and move the files there. Since some things like backdrops or themes have the same file names, this helps prevent needed to suffix numbers to files and makes it much easier if you need to restore the changes.

This code is based on the same functionality inside Sonarr

#### Issues Fixed or Closed by this PR

* #
