### PR TITLE
Added: Remote poster and fanart references to Kodi metadata file (#2837)

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -121,7 +121,9 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
             using (var xw = XmlWriter.Create(sb, xws))
             {
                 var doc = new XDocument();
-                var image = movie.Images.SingleOrDefault(i => i.CoverType == MediaCoverTypes.Screenshot);
+                var thumbnail = movie.Images.SingleOrDefault(i => i.CoverType == MediaCoverTypes.Screenshot);
+                var posters = movie.Images.Where(i => i.CoverType == MediaCoverTypes.Poster);
+                var fanarts = movie.Images.Where(i => i.CoverType == MediaCoverTypes.Fanart);
 
                 var details = new XElement("movie");
 
@@ -148,14 +150,29 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 
                 details.Add(new XElement("studio", movie.Studio));
 
-                if (image == null)
+                if (thumbnail == null)
                 {
                     details.Add(new XElement("thumb"));
                 }
 
                 else
                 {
-                    details.Add(new XElement("thumb", image.Url));
+                    details.Add(new XElement("thumb", thumbnail.Url));
+                }
+
+                foreach (var poster in posters)
+                {                    
+                    details.Add(new XElement("thumb", new XAttribute("aspect", "poster"), poster.Url));
+                }
+
+                if (fanarts.Count() > 0)
+                {
+                    var fanartElement = new XElement("fanart");
+                    foreach (var fanart in fanarts)
+                    {
+                        fanartElement.Add(new XElement("thumb", fanart.Url));
+                    }
+                    details.Add(fanartElement);
                 }
 
                 details.Add(new XElement("watched", watched));

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -162,7 +162,10 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 
                 foreach (var poster in posters)
                 {                    
-                    details.Add(new XElement("thumb", new XAttribute("aspect", "poster"), poster.Url));
+                    if (poster != null && poster.Url != null)
+                    {
+                        details.Add(new XElement("thumb", new XAttribute("aspect", "poster"), poster.Url));
+                    }
                 }
 
                 if (fanarts.Count() > 0)
@@ -170,7 +173,10 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                     var fanartElement = new XElement("fanart");
                     foreach (var fanart in fanarts)
                     {
-                        fanartElement.Add(new XElement("thumb", fanart.Url));
+                        if (fanart != null && fanart.Url != null)
+                        {
+                            fanartElement.Add(new XElement("thumb", fanart.Url));
+                        }
                     }
                     details.Add(fanartElement);
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added remote poster and fanart references to the output of Kodi metadata files. Including these tags allows Kodi to properly differentiate video thumbnails from posters and fixes the issue that some skins would show a video thumbnail instead of the poster because of the empty `<thumb>` tag. Fanart entries were included as an extra for completeness.

#### Notes
The metadata file now refers to the remote images from TheMovieDB. Therefore, this solution will not provide the intended result (i.e., using the local image files), but does fix the issue that no posters or fanart are shown in Kodi. 

#### Issues Fixed or Closed by this PR

* Fixes #2837
