### PR TITLE
Fixed: Cannot Add ITA or ITALIAN custom format

### DIFF
--- a/src/NzbDrone.Core.Test/CustomFormat/QualityTagFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormat/QualityTagFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using NUnit.Framework;
@@ -23,6 +23,8 @@ namespace NzbDrone.Core.Test.CustomFormat
         [TestCase("S_WEBdL", TagType.Source, Source.WEBDL)]
         [TestCase("S_CAM", TagType.Source, Source.CAM)]
         [TestCase("L_English", TagType.Language, Language.English)]
+        [TestCase("L_Italian", TagType.Language, Language.Italian)]
+        [TestCase("L_iTa", TagType.Language, Language.Italian)]
         [TestCase("L_germaN", TagType.Language, Language.German)]
         [TestCase("E_Director", TagType.Edition, "director")]
         [TestCase("E_RX_Director('?s)?", TagType.Edition, "director('?s)?", TagModifier.Regex)]

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -13,7 +13,7 @@ namespace NzbDrone.Core.Parser
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(LanguageParser));
 
-        private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_)(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VOSTFR|VO|VFF|VFQ|VF2|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<dutch>nl\W?subs?)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<czech>\bCZ|SK\b)",
+        private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VOSTFR|VO|VFF|VFQ|VF2|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<dutch>nl\W?subs?)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<czech>\bCZ|SK\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})$", RegexOptions.Compiled | RegexOptions.IgnoreCase);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Modify language parser regex so that it will match on beginning of string as well, fixes custom format cases (ex. `italian` or `ita` match now). 

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
#3253 
* #
