### PR TITLE
Solve ambiguous naming

### DIFF
--- a/src/UI/Settings/MediaManagement/FileManagement/FileManagementViewTemplate.hbs
+++ b/src/UI/Settings/MediaManagement/FileManagement/FileManagementViewTemplate.hbs
@@ -2,7 +2,7 @@
 		<legend>File Management</legend>
 
 		<div class="form-group">
-				<label class="col-sm-3 control-label">Ignore Deleted Movies</label>
+				<label class="col-sm-3 control-label">Unmonitor Deleted Movies</label>
 
 				<div class="col-sm-9">
 						<div class="input-group">


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The previous title: "Ignore Deleted Movies" is ambiguous. It can be interpreted as either:
-> If a movie is deleted, do nothing and ignore it.
-> If a movie is deleted, unmonitor the movie (and ignore future changes).

With this naming change, I hope to solve that issue, and it's more clear as to what the setting actually does.