### PR TITLE
Update CustomFormatService.cs

### DIFF
--- a/src/NzbDrone.Core/CustomFormats/CustomFormatService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatService.cs
@@ -191,8 +191,8 @@ namespace NzbDrone.Core.CustomFormats
                     {
                         "Easy", new List<CustomFormat>
                         {
-                            new CustomFormat("x264", @"C_RX_(x|h\.?)264"),
-                            new CustomFormat("x265", @"C_RX_(((x|h\.?)265)|(HEVC))"),
+                            new CustomFormat("x264", @"C_RX_(x|h)\.?264"),
+                            new CustomFormat("x265", @"C_RX_(((x|h)\.?265)|(HEVC))"),
                             new CustomFormat("Simple Hardcoded Subs", "C_RX_subs?"),
                             new CustomFormat("Multi Language", "L_English", "L_French")
                         }

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatService.cs
@@ -191,8 +191,8 @@ namespace NzbDrone.Core.CustomFormats
                     {
                         "Easy", new List<CustomFormat>
                         {
-                            new CustomFormat("x264", "C_RX_(x|h)264"),
-                            new CustomFormat("x265", "C_RX_(((x|h)265)|(HEVC))"),
+                            new CustomFormat("x264", "C_RX_(x|h\.?)264"),
+                            new CustomFormat("x265", "C_RX_(((x|h\.?)265)|(HEVC))"),
                             new CustomFormat("Simple Hardcoded Subs", "C_RX_subs?"),
                             new CustomFormat("Multi Language", "L_English", "L_French")
                         }

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatService.cs
@@ -191,8 +191,8 @@ namespace NzbDrone.Core.CustomFormats
                     {
                         "Easy", new List<CustomFormat>
                         {
-                            new CustomFormat("x264", "C_RX_(x|h\.?)264"),
-                            new CustomFormat("x265", "C_RX_(((x|h\.?)265)|(HEVC))"),
+                            new CustomFormat("x264", @"C_RX_(x|h\.?)264"),
+                            new CustomFormat("x265", @"C_RX_(((x|h\.?)265)|(HEVC))"),
                             new CustomFormat("Simple Hardcoded Subs", "C_RX_subs?"),
                             new CustomFormat("Multi Language", "L_English", "L_French")
                         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Releases using a dotted h.264 format for the codec are being missed by the CF tag so have added the dot in the template regex

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR
resolves #3419 
