### PR TITLE
Fixed QBittorrent initial state paused

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
@@ -79,6 +79,11 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             {
                 request.AddFormParameter("category", settings.MovieCategory);
             }
+            
+            if ((QBittorrentState)settings.InitialState == QBittorrentState.Pause)
+            {
+                request.AddFormParameter("paused", true);
+            }
 
             var result = ProcessRequest(request, settings);
 
@@ -98,6 +103,11 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             if (settings.MovieCategory.IsNotNullOrWhiteSpace())
             {
                 request.AddFormParameter("category", settings.MovieCategory);
+            }
+            
+            if ((QBittorrentState)settings.InitialState == QBittorrentState.Pause)
+            {
+                request.AddFormParameter("paused", true);
             }
 
             var result = ProcessRequest(request, settings);


### PR DESCRIPTION
Copied the fix from https://github.com/Sonarr/Sonarr/commit/783c27a5840ae6c67afd63af6bf593a7f78e2269

Fixes issue #3422 
