### PR TITLE
Update 256.png to include transparency

### DIFF
--- a/Logo/256 (replacement).png
+++ b/Logo/256 (replacement).png
@@ -1,0 +1,6 @@
+// See comment
+// I apologize - I'm not at all familiar with GitHub. I'd like to propose replacing the 256.png logo image with this one: https://i.imgur.com/WfcxC8g.png
+// 
+// The new image image has transparency, which will look better in Android notifications. See this issue for some more info: https://github.com/Radarr/Radarr/issues/2518
+// 
+// I couldn't figure out how to submit the new file. Please let me know if anything more is needed. 


### PR DESCRIPTION
I apologize - I'm not at all familiar with GitHub. I'd like to propose replacing the 256.png logo image with this one: https://i.imgur.com/WfcxC8g.png

The new image image has transparency, which will look better in Android notifications. See this issue for some more info: https://github.com/Radarr/Radarr/issues/2518

I couldn't figure out how to submit the new file. Please let me know if anything more is needed.

#### Database Migration
YES | NO

#### Description


#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #
