### PR TITLE
#3514 fix library shown as empty after filter returns no movies and page is refreshed

### DIFF
--- a/src/UI/Movies/Index/MoviesIndexLayout.js
+++ b/src/UI/Movies/Index/MoviesIndexLayout.js
@@ -370,7 +370,7 @@ module.exports = Marionette.Layout.extend({
     },
 
     _renderView : function() {
-        if (MoviesCollection.length === 0) {
+        if (MoviesCollection.length === 0 && !this.moviesCollection.isFiltered()) {
             this.moviesRegion.show(new EmptyView());
 
             this.toolbar.close();

--- a/src/UI/Movies/MoviesCollection.js
+++ b/src/UI/Movies/MoviesCollection.js
@@ -261,6 +261,10 @@ var Collection = PageableCollection.extend({
       this.fetch();
     },
 
+    isFiltered : function() {
+        return this.state.filterKey && this.state.filterKey !== 'all';
+    },
+
     comparator: function (model) {
 		return model.get('sortTitle');
     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Only show the empty page view, when the unfiltered movies collection is actually empty.
When there are movies that are currently filtered out, show the filter toolbars so users can change the view.

[Screenshot](https://i.imgur.com/F4OfSPu.png)

#### Issues Fixed or Closed by this PR

* #3514
