### PR TITLE
Fix search for RARBG

### DIFF
--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
@@ -18,7 +18,6 @@ namespace NzbDrone.Core.Indexers.Rarbg
             }
         }
 
-
         public RarbgSettings Settings { get; set; }
 
         public RarbgRequestGenerator(IRarbgTokenProvider tokenProvider)

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.IndexerSearch.Definitions;
@@ -9,14 +10,6 @@ namespace NzbDrone.Core.Indexers.Rarbg
     public class RarbgRequestGenerator : IIndexerRequestGenerator
     {
         private readonly IRarbgTokenProvider _tokenProvider;
-
-        private string _categoryParam
-        {
-            get
-            {
-                return string.Join(";", Settings.Categories);
-            }
-        }
 
         public RarbgSettings Settings { get; set; }
 
@@ -68,7 +61,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
                 requestBuilder.AddQueryParam("ranked", "0");
             }
 
-            requestBuilder.AddQueryParam("category", _categoryParam);
+            requestBuilder.AddQueryParam("category", string.Join(";", Settings.Categories.Distinct()));
             requestBuilder.AddQueryParam("limit", "100");
             requestBuilder.AddQueryParam("token", _tokenProvider.GetToken(Settings));
             requestBuilder.AddQueryParam("format", "json_extended");
@@ -106,7 +99,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
                 requestBuilder.AddQueryParam("ranked", "0");
             }
 
-            requestBuilder.AddQueryParam("category", _categoryParam);
+            requestBuilder.AddQueryParam("category", string.Join(";", Settings.Categories.Distinct()));
             requestBuilder.AddQueryParam("limit", "100");
             requestBuilder.AddQueryParam("token", _tokenProvider.GetToken(Settings));
             requestBuilder.AddQueryParam("format", "json_extended");

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
             }
         }
 
+
         public RarbgSettings Settings { get; set; }
 
         public RarbgRequestGenerator(IRarbgTokenProvider tokenProvider)

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
@@ -8,6 +8,27 @@ namespace NzbDrone.Core.Indexers.Rarbg
 {
     public class RarbgRequestGenerator : IIndexerRequestGenerator
     {
+        static readonly public Dictionary<int, string> Categories = new Dictionary<int, string>()
+        {
+            {14, "Movies/XVID"},
+            {48, "Movies/XVID/720"},
+            {17, "Movies/x264"},
+            {44, "Movies/x264/1080"},
+            {45, "Movies/x264/720"},
+            {47, "Movies/x264/3D"},
+            {50, "Movies/x264/4k"},
+            {51, "Movies/x265/4k"},
+            {52, "Movs/x265/4k/HDR"},
+            {42, "Movies/Full BD"},
+            {46, "Movies/BD Remux"}
+        };
+        static private string _categoryParam
+        {
+            get
+            {
+                return string.Join(";", Categories.Keys);
+            }
+        }
         private readonly IRarbgTokenProvider _tokenProvider;
 
         public RarbgSettings Settings { get; set; }
@@ -60,7 +81,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
                 requestBuilder.AddQueryParam("ranked", "0");
             }
 
-            requestBuilder.AddQueryParam("category", "movies");
+            requestBuilder.AddQueryParam("category", _categoryParam);
             requestBuilder.AddQueryParam("limit", "100");
             requestBuilder.AddQueryParam("token", _tokenProvider.GetToken(Settings));
             requestBuilder.AddQueryParam("format", "json_extended");
@@ -91,14 +112,14 @@ namespace NzbDrone.Core.Indexers.Rarbg
             {
                 requestBuilder.AddQueryParam("search_string", $"{searchCriteria.Movie.Title} {searchCriteria.Movie.Year}");
             }
-            
+
 
             if (!Settings.RankedOnly)
             {
                 requestBuilder.AddQueryParam("ranked", "0");
             }
 
-            requestBuilder.AddQueryParam("category", "movies");
+            requestBuilder.AddQueryParam("category", _categoryParam);
             requestBuilder.AddQueryParam("limit", "100");
             requestBuilder.AddQueryParam("token", _tokenProvider.GetToken(Settings));
             requestBuilder.AddQueryParam("format", "json_extended");
@@ -106,7 +127,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
 
             yield return new IndexerRequest(requestBuilder.Build());
         }
-        
+
         public Func<IDictionary<string, string>> GetCookies { get; set; }
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
@@ -8,28 +8,15 @@ namespace NzbDrone.Core.Indexers.Rarbg
 {
     public class RarbgRequestGenerator : IIndexerRequestGenerator
     {
-        static readonly public Dictionary<int, string> Categories = new Dictionary<int, string>()
-        {
-            {14, "Movies/XVID"},
-            {48, "Movies/XVID/720"},
-            {17, "Movies/x264"},
-            {44, "Movies/x264/1080"},
-            {45, "Movies/x264/720"},
-            {47, "Movies/x264/3D"},
-            {50, "Movies/x264/4k"},
-            {51, "Movies/x265/4k"},
-            {52, "Movs/x265/4k/HDR"},
-            {42, "Movies/Full BD"},
-            {46, "Movies/BD Remux"}
-        };
-        static private string _categoryParam
+        private readonly IRarbgTokenProvider _tokenProvider;
+
+        private string _categoryParam
         {
             get
             {
-                return string.Join(";", Categories.Keys);
+                return string.Join(";", Settings.Categories);
             }
         }
-        private readonly IRarbgTokenProvider _tokenProvider;
 
         public RarbgSettings Settings { get; set; }
 
@@ -112,7 +99,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
             {
                 requestBuilder.AddQueryParam("search_string", $"{searchCriteria.Movie.Title} {searchCriteria.Movie.Year}");
             }
-
+            
 
             if (!Settings.RankedOnly)
             {
@@ -127,7 +114,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
 
             yield return new IndexerRequest(requestBuilder.Build());
         }
-
+        
         public Func<IDictionary<string, string>> GetCookies { get; set; }
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgSettings.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Parser;
@@ -12,6 +12,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
         public RarbgSettingsValidator()
         {
             RuleFor(c => c.BaseUrl).ValidRootUrl();
+            RuleFor(c => c.Categories).NotEmpty();
         }
     }
 
@@ -24,6 +25,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
             BaseUrl = "https://torrentapi.org";
             RankedOnly = false;
             MinimumSeeders = IndexerDefaults.MINIMUM_SEEDERS;
+            Categories = new[] { 14, 48, 17, 44, 45, 47, 50, 51, 52, 42, 46 };
         }
 
         [FieldDefinition(0, Label = "API URL", HelpText = "URL to Rarbg api, not the website.")]
@@ -43,6 +45,9 @@ namespace NzbDrone.Core.Indexers.Rarbg
 
         [FieldDefinition(5, Type = FieldType.Tag, SelectOptions = typeof(IndexerFlags), Label = "Required Flags", HelpText = "What indexer flags are required?", HelpLink = "https://github.com/Radarr/Radarr/wiki/Indexer-Flags#1-required-flags", Advanced = true)]
         public IEnumerable<int> RequiredFlags { get; set; }
+
+        [FieldDefinition(6, Type = FieldType.Textbox, Label = "Categories", HelpText = "Comma Separated list, you can retrieve the ID by checking the URL behind the category on the website (i.e. Movie/x264/1080 = 44)", HelpLink = "https://rarbgmirror.org/torrents.php?category=movies", Advanced = true)]
+        public IEnumerable<int> Categories { get; set; }
 
         public NzbDroneValidationResult Validate()
         {


### PR DESCRIPTION
Movie in category "Movs/x265/4k/HDR" were not returned

#### Database Migration
NO

#### Description
Movies in category "Movs/x265/4k/HDR" were not returned - certainly because it is named differently (all other categories but this one care called "Movies/..."). I tried to use movs as a criteria (category=movs) but it is not working - this is why I had no choice but to expand the list. 

This is exactly how Jackett does it.

Values are stored in a Dict for readability. The name of the category is never used. I could change that to an array of int with the name in comment if you feel more like it.

#### Issues Fixed or Closed by this PR

* https://github.com/Radarr/Radarr/issues/3543
