### PR TITLE
Added UHD, X265, WEB-DL etc. to NZB Finder

### DIFF
--- a/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
@@ -42,7 +42,6 @@ namespace NzbDrone.Core.Indexers.Newznab
             yield return GetDefinition("Nzb-Tortuga", GetSettings("https://www.nzb-tortuga.com"));
             yield return GetDefinition("Nzb.su", GetSettings("https://api.nzb.su"));
             yield return GetDefinition("NZBCat", GetSettings("https://nzb.cat"));
-            yield return GetDefinition("NZBFinder.ws", GetSettings("https://nzbfinder.ws"));
             yield return GetDefinition("NZBFinder.ws", GetSettings("https://nzbfinder.ws", categories: new[] { 2020,2030,2035,2040,2045,2050,2060,2070,2080,2090 }));
             yield return GetDefinition("NZBgeek", GetSettings("https://api.nzbgeek.info"));
             yield return GetDefinition("nzbplanet.net", GetSettings("https://api.nzbplanet.net"));

--- a/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             yield return GetDefinition("Nzb.su", GetSettings("https://api.nzb.su"));
             yield return GetDefinition("NZBCat", GetSettings("https://nzb.cat"));
             yield return GetDefinition("NZBFinder.ws", GetSettings("https://nzbfinder.ws"));
-            yield return GetDefinition("NZBFinder.ws", GetSettings("https://nzbfinder.ws", categories: new[] { 2000,2010,2020,2030,2035,2040,2045,2050,2060,2070,2080,2090 }));
+            yield return GetDefinition("NZBFinder.ws", GetSettings("https://nzbfinder.ws", categories: new[] { 2020,2030,2035,2040,2045,2050,2060,2070,2080,2090 }));
             yield return GetDefinition("NZBgeek", GetSettings("https://api.nzbgeek.info"));
             yield return GetDefinition("nzbplanet.net", GetSettings("https://api.nzbplanet.net"));
             yield return GetDefinition("Nzbs.org", GetSettings("http://nzbs.org"));

--- a/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
@@ -43,6 +43,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             yield return GetDefinition("Nzb.su", GetSettings("https://api.nzb.su"));
             yield return GetDefinition("NZBCat", GetSettings("https://nzb.cat"));
             yield return GetDefinition("NZBFinder.ws", GetSettings("https://nzbfinder.ws"));
+            yield return GetDefinition("NZBFinder.ws", GetSettings("https://nzbfinder.ws", categories: new[] { 2000,2010,2020,2030,2035,2040,2045,2050,2060,2070,2080,2090 }));
             yield return GetDefinition("NZBgeek", GetSettings("https://api.nzbgeek.info"));
             yield return GetDefinition("nzbplanet.net", GetSettings("https://api.nzbplanet.net"));
             yield return GetDefinition("Nzbs.org", GetSettings("http://nzbs.org"));


### PR DESCRIPTION
This works for Sonarr, can Radarr also add custom categories like this?

#### Database Migration
NO

#### Description
Added existing and future UHD, X265, WEB-DL categories to NZB Finder indexer.

#### Issues Fixed or Closed by this PR

* #Radarr not finding releases in the proper categories
