### PR TITLE
Fixed: When refreshing info about a movie, the alt titles should now correctly be deleted / updated, even from TMDB.

### DIFF
--- a/src/NzbDrone.Core.Test/MovieTests/AlternativeTitleServiceTests/AlternativeTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/AlternativeTitleServiceTests/AlternativeTitleFixture.cs
@@ -1,0 +1,32 @@
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Movies.AlternativeTitles;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.MovieTests.AlternativeTitleServiceTests
+{
+    [TestFixture]
+    public class AlternativeTitleFixture : CoreTest
+    {
+        private AlternativeTitle CreateFakeTitle(SourceType source, int votes)
+        {
+            return Builder<AlternativeTitle>.CreateNew().With(t => t.SourceType = source).With(t => t.Votes = votes)
+                .Build();
+        }
+
+        [TestCase(SourceType.TMDB, -1, true)]
+        [TestCase(SourceType.TMDB, 1000, true)]
+        [TestCase(SourceType.Mappings, 0, false)]
+        [TestCase(SourceType.Mappings, 4, true)]
+        [TestCase(SourceType.Mappings, -1, false)]
+        [TestCase(SourceType.Indexer, 0, true)]
+        [TestCase(SourceType.User, 0, true)]
+        public void should_be_trusted(SourceType source, int votes, bool trusted)
+        {
+            var fakeTitle = CreateFakeTitle(source, votes);
+
+            fakeTitle.IsTrusted().Should().Be(trusted);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MovieTests/AlternativeTitleServiceTests/AlternativeTitleServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/AlternativeTitleServiceTests/AlternativeTitleServiceFixture.cs
@@ -4,6 +4,7 @@ using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.AlternativeTitles;
 using NzbDrone.Core.Test.Framework;
@@ -85,6 +86,19 @@ namespace NzbDrone.Core.Test.MovieTests.AlternativeTitleServiceTests
 
             _title1.MovieId.Should().Be(_movie.Id);
             _title2.MovieId.Should().Be(_movie.Id);
+        }
+
+        [Test]
+        public void should_update_with_correct_id()
+        {
+            var existingTitle = Builder<AlternativeTitle>.CreateNew().With(t => t.Id = 2).Build();
+            GivenExistingTitles(existingTitle);
+            var updateTitle = existingTitle.JsonClone();
+            updateTitle.Id = 0;
+
+            Subject.UpdateTitles(new List<AlternativeTitle> {updateTitle}, _movie);
+
+            Mocker.GetMock<IAlternativeTitleRepository>().Verify(r => r.UpdateMany(It.Is<IList<AlternativeTitle>>(list => list.First().Id == existingTitle.Id)), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MovieTests/AlternativeTitleServiceTests/AlternativeTitleServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/AlternativeTitleServiceTests/AlternativeTitleServiceFixture.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.AlternativeTitles;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.MovieTests.AlternativeTitleServiceTests
+{
+    [TestFixture]
+    public class AlternativeTitleServiceFixture : CoreTest<AlternativeTitleService>
+    {
+        private AlternativeTitle _title1;
+        private AlternativeTitle _title2;
+        private AlternativeTitle _title3;
+
+        private Movie _movie;
+
+        [SetUp]
+        public void Setup()
+        {
+            var titles = Builder<AlternativeTitle>.CreateListOfSize(3).All().With(t => t.MovieId = 0).Build();
+            _title1 = titles[0];
+            _title2 = titles[1];
+            _title3 = titles[2];
+            _movie = Builder<Movie>.CreateNew().With(m => m.CleanTitle = "myothertitle").With(m => m.Id = 1).Build();
+        }
+
+        private void GivenExistingTitles(params AlternativeTitle[] titles)
+        {
+            Mocker.GetMock<IAlternativeTitleRepository>().Setup(r => r.FindByMovieId(_movie.Id))
+                .Returns(titles.ToList());
+        }
+
+        [Test]
+        public void should_update_insert_remove_titles()
+        {
+            var titles = new List<AlternativeTitle> {_title2, _title3};
+            var updates = new List<AlternativeTitle> {_title2};
+            var deletes = new List<AlternativeTitle> {_title1};
+            var inserts = new List<AlternativeTitle> {_title3};
+            GivenExistingTitles(_title1, _title2);
+
+            Subject.UpdateTitles(titles, _movie);
+
+            Mocker.GetMock<IAlternativeTitleRepository>().Verify(r => r.InsertMany(inserts), Times.Once());
+            Mocker.GetMock<IAlternativeTitleRepository>().Verify(r => r.UpdateMany(updates), Times.Once());
+            Mocker.GetMock<IAlternativeTitleRepository>().Verify(r => r.DeleteMany(deletes), Times.Once());
+        }
+
+        [Test]
+        public void should_not_insert_duplicates()
+        {
+            GivenExistingTitles();
+            var titles = new List<AlternativeTitle> {_title1, _title1};
+            var inserts = new List<AlternativeTitle>{ _title1 };
+
+            Subject.UpdateTitles(titles, _movie);
+
+            Mocker.GetMock<IAlternativeTitleRepository>().Verify(r => r.InsertMany(inserts), Times.Once());
+        }
+
+        [Test]
+        public void should_not_insert_main_title()
+        {
+            GivenExistingTitles();
+            var titles = new List<AlternativeTitle>{_title1};
+            var movie = Builder<Movie>.CreateNew().With(m => m.CleanTitle = _title1.CleanTitle).Build();
+
+            Subject.UpdateTitles(titles, movie);
+
+            Mocker.GetMock<IAlternativeTitleRepository>().Verify(r => r.InsertMany(new List<AlternativeTitle>()), Times.Once());
+        }
+
+        [Test]
+        public void should_update_movie_id()
+        {
+            GivenExistingTitles();
+            var titles = new List<AlternativeTitle> {_title1, _title2};
+
+            Subject.UpdateTitles(titles, _movie);
+
+            _title1.MovieId.Should().Be(_movie.Id);
+            _title2.MovieId.Should().Be(_movie.Id);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -296,6 +296,7 @@
     <Compile Include="MetadataSource\SkyHook\SkyHookProxySearchFixture.cs" />
     <Compile Include="MetadataSource\SearchMovieComparerFixture.cs" />
     <Compile Include="MetadataSource\SkyHook\SkyHookProxyFixture.cs" />
+    <Compile Include="MovieTests\AlternativeTitleServiceTests\AlternativeTitleServiceFixture.cs" />
     <Compile Include="NetImport\CouchPotato\CouchPotatoParserFixture.cs" />
     <Compile Include="NetImport\RSSImportFixture.cs" />
     <Compile Include="NetImport\RSSImportParserFixture.cs" />

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -296,6 +296,7 @@
     <Compile Include="MetadataSource\SkyHook\SkyHookProxySearchFixture.cs" />
     <Compile Include="MetadataSource\SearchMovieComparerFixture.cs" />
     <Compile Include="MetadataSource\SkyHook\SkyHookProxyFixture.cs" />
+    <Compile Include="MovieTests\AlternativeTitleServiceTests\AlternativeTitleFixture.cs" />
     <Compile Include="MovieTests\AlternativeTitleServiceTests\AlternativeTitleServiceFixture.cs" />
     <Compile Include="NetImport\CouchPotato\CouchPotatoParserFixture.cs" />
     <Compile Include="NetImport\RSSImportFixture.cs" />

--- a/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitle.cs
+++ b/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitle.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.Movies.AlternativeTitles
         {
             switch (SourceType)
             {
-                case SourceType.TMDB:
+                case SourceType.Mappings:
                     return Votes >= minVotes;
                 default:
                     return true;

--- a/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitle.cs
+++ b/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitle.cs
@@ -17,22 +17,22 @@ namespace NzbDrone.Core.Movies.AlternativeTitles
         public int VoteCount { get; set; }
         public Language Language { get; set; }
         public LazyLoaded<Movie> Movie { get; set; }
-        
-        public AlternativeTitle() 
-        { 
-             
-        } 
- 
-        public AlternativeTitle(string title, SourceType sourceType = SourceType.TMDB, int sourceId = 0, Language language = Language.English) 
-        { 
-            Title = title; 
-            CleanTitle = title.CleanSeriesTitle(); 
-            SourceType = sourceType;
-            SourceId = sourceId;
-            Language = language; 
+
+        public AlternativeTitle()
+        {
+
         }
 
-        public bool IsTrusted(int minVotes = 3)
+        public AlternativeTitle(string title, SourceType sourceType = SourceType.TMDB, int sourceId = 0, Language language = Language.English)
+        {
+            Title = title;
+            CleanTitle = title.CleanSeriesTitle();
+            SourceType = sourceType;
+            SourceId = sourceId;
+            Language = language;
+        }
+
+        public bool IsTrusted(int minVotes = 4)
         {
             switch (SourceType)
             {
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Movies.AlternativeTitles
                     return Votes >= minVotes;
                 default:
                     return true;
-            }   
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitleRepository.cs
+++ b/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitleRepository.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
+using Marr.Data;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Messaging.Events;

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -116,9 +116,8 @@ namespace NzbDrone.Core.Movies
                 mappingsTitles = mappingsTitles.Where(t => t.IsTrusted()).ToList();
 
                 movieInfo.AlternativeTitles.AddRange(mappingsTitles);
-
-                _titleService.UpdateTitles(movieInfo.AlternativeTitles, movie);
-                movie.AlternativeTitles = movieInfo.AlternativeTitles;
+                
+                movie.AlternativeTitles = _titleService.UpdateTitles(movieInfo.AlternativeTitles, movie);
 
                 if (mappings.Item2 != null)
                 {

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -108,26 +108,17 @@ namespace NzbDrone.Core.Movies
                 _logger.Warn(e, "Couldn't update movie path for " + movie.Path);
             }
 
-            movieInfo.AlternativeTitles = movieInfo.AlternativeTitles.Where(t => t.CleanTitle != movie.CleanTitle)
-                .DistinctBy(t => t.CleanTitle)
-                .ExceptBy(t => t.CleanTitle, movie.AlternativeTitles, t => t.CleanTitle, EqualityComparer<string>.Default).ToList();
-
             try
             {
-                movie.AlternativeTitles.AddRange(_titleService.AddAltTitles(movieInfo.AlternativeTitles, movie));
-                
                 var mappings = _apiClient.AlternativeTitlesAndYearForMovie(movieInfo.TmdbId);
                 var mappingsTitles = mappings.Item1;
 
-                _titleService.DeleteNotEnoughVotes(mappingsTitles);
+                mappingsTitles = mappingsTitles.Where(t => t.IsTrusted()).ToList();
 
-                mappingsTitles = mappingsTitles.ExceptBy(t => t.CleanTitle, movie.AlternativeTitles,
-                    t => t.CleanTitle, EqualityComparer<string>.Default).ToList();
+                movieInfo.AlternativeTitles.AddRange(mappingsTitles);
 
-
-                mappingsTitles = mappingsTitles.Where(t => t.Votes > 3).ToList();
-
-                movie.AlternativeTitles.AddRange(_titleService.AddAltTitles(mappingsTitles, movie));
+                _titleService.UpdateTitles(movieInfo.AlternativeTitles, movie);
+                movie.AlternativeTitles = movieInfo.AlternativeTitles;
 
                 if (mappings.Item2 != null)
                 {


### PR DESCRIPTION
Not sure if we should add more tests, I think they should cover most of it.
Fixes #3542

#### Database Migration
NO

#### Description


#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #3542
