### PR TITLE
Fixed: TMDB Failing due to missing response header

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -86,11 +86,14 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             // The dude abides, so should us, Lets be nice to TMDb
             // var allowed = int.Parse(response.Headers.GetValues("X-RateLimit-Limit").First()); // get allowed
             // var reset = long.Parse(response.Headers.GetValues("X-RateLimit-Reset").First()); // get time when it resets
-            var remaining = int.Parse(response.Headers.GetValues("X-RateLimit-Remaining").First());
-            if (remaining <= 5)
+            if (response.Headers.ContainsKey("X-RateLimit-Remaining"))
             {
-                _logger.Trace("Waiting 5 seconds to get information for the next 35 movies");
-                Thread.Sleep(5000);
+                var remaining = int.Parse(response.Headers.GetValues("X-RateLimit-Remaining").First());
+                if (remaining <= 5)
+                {
+                    _logger.Trace("Waiting 5 seconds to get information for the next 35 movies");
+                    Thread.Sleep(5000);
+                }
             }
 
             var resource = response.Resource;
@@ -333,11 +336,14 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             // The dude abides, so should us, Lets be nice to TMDb
             // var allowed = int.Parse(response.Headers.GetValues("X-RateLimit-Limit").First()); // get allowed
             // var reset = long.Parse(response.Headers.GetValues("X-RateLimit-Reset").First()); // get time when it resets
-            var remaining = int.Parse(response.Headers.GetValues("X-RateLimit-Remaining").First());
-            if (remaining <= 5)
+            if (response.Headers.ContainsKey("X-RateLimit-Remaining"))
             {
-                _logger.Trace("Waiting 5 seconds to get information for the next 35 movies");
-                Thread.Sleep(5000);
+                var remaining = int.Parse(response.Headers.GetValues("X-RateLimit-Remaining").First());
+                if (remaining <= 5)
+                {
+                    _logger.Trace("Waiting 5 seconds to get information for the next 35 movies");
+                    Thread.Sleep(5000);
+                }
             }
 
             var resources = response.Resource;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Seems our friends at tmdb have changed something, and the rate limit headers are not always returned. This will check for header in response instead of assuming it will be there

#### Issues Fixed or Closed by this PR

* #
