### PR TITLE
Fixed: Wanted Cutoff Page filters

### DIFF
--- a/src/NzbDrone.Api/Wanted/MovieCutoffModule.cs
+++ b/src/NzbDrone.Api/Wanted/MovieCutoffModule.cs
@@ -26,11 +26,6 @@ namespace NzbDrone.Api.Wanted
 
             pagingSpec.FilterExpression = _movieService.ConstructFilterExpression(pagingResource.FilterKey, pagingResource.FilterValue);
 
-            if (pagingResource.FilterKey == null)
-            {
-                pagingSpec.FilterExpression = m => m.Monitored == true;
-            }
-
             var resource = ApplyToPage(_movieCutoffService.MoviesWhereCutoffUnmet, pagingSpec, v => MapToResource(v, true));
 
             return resource;

--- a/src/NzbDrone.Api/Wanted/MovieMissingModule.cs
+++ b/src/NzbDrone.Api/Wanted/MovieMissingModule.cs
@@ -30,10 +30,6 @@ namespace NzbDrone.Api.Wanted
             var pagingSpec = pagingResource.MapToPagingSpec<MovieResource, Core.Movies.Movie>("title", SortDirection.Descending);
 
             pagingSpec.FilterExpression = _movieService.ConstructFilterExpression(pagingResource.FilterKey, pagingResource.FilterValue);
-            if (pagingResource.FilterKey != "monitored")
-            {
-                pagingSpec.FilterExpression = m => m.Monitored == true;
-            }
 
             var resource = ApplyToPage(_movieService.MoviesWithoutFiles, pagingSpec, v => MapToResource(v, true));
 

--- a/src/NzbDrone.Integration.Test/ApiTests/WantedTests/CutoffUnmetFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/WantedTests/CutoffUnmetFixture.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
             var movie = EnsureMovie(680, "Pulp Fiction", false);
             EnsureMovieFile(movie, Quality.SDTV);
 
-            var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc");
+            var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "false");
 
             result.Records.Should().BeEmpty();
         }

--- a/src/NzbDrone.Integration.Test/ApiTests/WantedTests/CutoffUnmetFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/WantedTests/CutoffUnmetFixture.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
             var movie = EnsureMovie(680, "Pulp Fiction", true);
             EnsureMovieFile(movie, Quality.SDTV);
 
-            var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc");
+            var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "true");
 
             result.Records.Should().NotBeEmpty();
         }
@@ -27,7 +27,7 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
             var movie = EnsureMovie(680, "Pulp Fiction", false);
             EnsureMovieFile(movie, Quality.SDTV);
 
-            var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "false");
+            var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "true");
 
             result.Records.Should().BeEmpty();
         }

--- a/src/NzbDrone.Integration.Test/ApiTests/WantedTests/CutoffUnmetFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/WantedTests/CutoffUnmetFixture.cs
@@ -33,6 +33,18 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
         }
 
         [Test, Order(1)]
+        public void cutoff_should_not_have_released_items()
+        {
+            EnsureProfileCutoff(1, Quality.HDTV720p);
+            var movie = EnsureMovie(680, "Pulp Fiction", true);
+            EnsureMovieFile(movie, Quality.SDTV);
+
+            var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc", "status", "inCinemas");
+
+            result.Records.Should().BeEmpty();
+        }
+
+        [Test, Order(1)]
         public void cutoff_should_have_movie()
         {
             EnsureProfileCutoff(1, Quality.HDTV720p);
@@ -52,6 +64,18 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
             EnsureMovieFile(movie, Quality.SDTV);
 
             var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "false");
+
+            result.Records.Should().NotBeEmpty();
+        }
+        
+        [Test, Order(2)]
+        public void cutoff_should_have_released_items()
+        {
+            EnsureProfileCutoff(1, Quality.HDTV720p);
+            var movie = EnsureMovie(680, "Pulp Fiction", false);
+            EnsureMovieFile(movie, Quality.SDTV);
+
+            var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc", "status", "released");
 
             result.Records.Should().NotBeEmpty();
         }

--- a/src/NzbDrone.Integration.Test/ApiTests/WantedTests/MissingFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/WantedTests/MissingFixture.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
         {
             EnsureMovie(680, "Pulp Fiction", true);
 
-            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc");
+            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "true");
 
             result.Records.Should().NotBeEmpty();
         }
@@ -43,7 +43,17 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
         {
             EnsureMovie(680, "Pulp Fiction", false);
 
-            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc");
+            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "true");
+
+            result.Records.Should().BeEmpty();
+        }
+        
+        [Test, Order(1)]
+        public void missing_should_not_have_released_items()
+        {
+            EnsureMovie(680, "Pulp Fiction", false);
+
+            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc", "status", "inCinemas");
 
             result.Records.Should().BeEmpty();
         }
@@ -54,6 +64,16 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
             EnsureMovie(680, "Pulp Fiction", false);
 
             var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "false");
+
+            result.Records.Should().NotBeEmpty();
+        }
+        
+        [Test, Order(2)]
+        public void missing_should_have_released_items()
+        {
+            EnsureMovie(680, "Pulp Fiction", false);
+
+            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc", "status", "released");
 
             result.Records.Should().NotBeEmpty();
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
FilterExpression is set in MovieService by method above added lines, remove lines to un-break filtering on these pages. Need to update integration tests to suit.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR
#3605 
* #
