### PR TITLE
TMDB: Added support for People Cast and People Crew lists

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/TMDBResources.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/TMDBResources.cs
@@ -18,6 +18,13 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public int total_pages { get; set; }
     }
 
+    public class PersonCreditsRoot
+    {
+        public MovieResult[] cast { get; set; }
+        public MovieResult[] crew { get; set; }
+        public int id { get; set; }
+    }
+
     public class MovieResult
     {
         public string poster_path { get; set; }
@@ -38,6 +45,9 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public string trailer_site { get; set; }
         public string physical_release { get; set; }
         public string physical_release_note { get; set; }
+        public string department { get; set; }
+        public string job { get; set; }
+        public string credit_id { get; set; }
     }
 
 

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/TMDBResources.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/TMDBResources.cs
@@ -20,8 +20,8 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
 
     public class PersonCreditsRoot
     {
-        public MovieResult[] cast { get; set; }
-        public MovieResult[] crew { get; set; }
+        public CreditsResult[] cast { get; set; }
+        public CreditsResult[] crew { get; set; }
         public int id { get; set; }
     }
 
@@ -45,9 +45,6 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public string trailer_site { get; set; }
         public string physical_release { get; set; }
         public string physical_release_note { get; set; }
-        public string department { get; set; }
-        public string job { get; set; }
-        public string credit_id { get; set; }
     }
 
 
@@ -185,6 +182,13 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public string[] origin_country { get; set; }
         public string name { get; set; }
         public string original_name { get; set; }
+    }
+
+    public class CreditsResult : MovieResult
+    {
+        public string department { get; set; }
+        public string job { get; set; }
+        public string credit_id { get; set; }
     }
 
 }

--- a/src/NzbDrone.Core/NetImport/TMDb/TMDbListType.cs
+++ b/src/NzbDrone.Core/NetImport/TMDb/TMDbListType.cs
@@ -14,9 +14,9 @@ namespace NzbDrone.Core.NetImport.TMDb
         Top = 3,
         [EnumMember(Value = "Upcoming")]
         Upcoming = 4,
-        [EnumMember(Value = "People Cast")]
-        PeopleCast = 5,
-        [EnumMember(Value = "People Crew")]
-        PeopleCrew = 6
+        [EnumMember(Value = "Person Cast")]
+        PersonCast = 5,
+        [EnumMember(Value = "Person Crew")]
+        PersonCrew = 6
     }
 }

--- a/src/NzbDrone.Core/NetImport/TMDb/TMDbListType.cs
+++ b/src/NzbDrone.Core/NetImport/TMDb/TMDbListType.cs
@@ -13,6 +13,10 @@ namespace NzbDrone.Core.NetImport.TMDb
         [EnumMember(Value = "Top Rated")]
         Top = 3,
         [EnumMember(Value = "Upcoming")]
-        Upcoming = 4
+        Upcoming = 4,
+        [EnumMember(Value = "People Cast")]
+        PeopleCast = 5,
+        [EnumMember(Value = "People Crew")]
+        PeopleCrew = 6
     }
 }

--- a/src/NzbDrone.Core/NetImport/TMDb/TMDbParser.cs
+++ b/src/NzbDrone.Core/NetImport/TMDb/TMDbParser.cs
@@ -40,10 +40,10 @@ namespace NzbDrone.Core.NetImport.TMDb
                 case (int)TMDbListType.List:
                     movies = ProcessListResponse();
                     break;
-                case (int)TMDbListType.PeopleCast:
+                case (int)TMDbListType.PersonCast:
                     movies = ProcessPersonCastListResponse();
                     break;
-                case (int)TMDbListType.PeopleCrew:
+                case (int)TMDbListType.PersonCrew:
                     movies = ProcessPersonCrewListResponse();
                     break;
                 default:

--- a/src/NzbDrone.Core/NetImport/TMDb/TMDbRequestGenerator.cs
+++ b/src/NzbDrone.Core/NetImport/TMDb/TMDbRequestGenerator.cs
@@ -59,10 +59,10 @@ namespace NzbDrone.Core.NetImport.TMDb
                 case (int)TMDbListType.Upcoming:
                     tmdbParams = $"/3/discover/movie?primary_release_date.gte={todaysDate}&primary_release_date.lte={threeMonthsFromNow}&vote_count.gte={minVoteCount}&vote_average.gte={minVoteAverage}{ceritification}&with_genres={includeGenreIds}&without_genres={excludeGenreIds}&with_original_language={languageCode}";
                     break;
-                case (int)TMDbListType.PeopleCast:
+                case (int)TMDbListType.PersonCast:
                     tmdbParams = $"/3/person/{personId}/movie_credits?language={languageCode}";
                     break;
-                case (int)TMDbListType.PeopleCrew:
+                case (int)TMDbListType.PersonCrew:
                     tmdbParams = $"/3/person/{personId}/movie_credits?language={languageCode}";
                     break;
             }
@@ -112,8 +112,8 @@ namespace NzbDrone.Core.NetImport.TMDb
             var doesntPage = new List<int>
             {
                 (int)TMDbListType.List,
-                (int)TMDbListType.PeopleCast,
-                (int)TMDbListType.PeopleCrew
+                (int)TMDbListType.PersonCast,
+                (int)TMDbListType.PersonCrew
             };
 
             var baseUrl = $"{Settings.Link.TrimEnd("/")}{tmdbParams}";

--- a/src/NzbDrone.Core/NetImport/TMDb/TMDbSettings.cs
+++ b/src/NzbDrone.Core/NetImport/TMDb/TMDbSettings.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.NetImport.TMDb
             // Greater than 0
             RuleFor(c => c.PersonId)
                 .Matches(@"^[1-9][0-9]*$", RegexOptions.IgnoreCase)
-                .When(c => c.ListType == (int)TMDbListType.PeopleCast || c.ListType == (int)TMDbListType.PeopleCrew)
+                .When(c => c.ListType == (int)TMDbListType.PersonCast || c.ListType == (int)TMDbListType.PersonCrew)
                 .WithMessage("Person ID required when selecting people lists");
 
             // Range 0.0 - 10.0
@@ -104,25 +104,25 @@ namespace NzbDrone.Core.NetImport.TMDb
         [FieldDefinition(9, Label = "Person ID", HelpText = "Used when a People* list is selected.  for the url https://www.themoviedb.org/person/6384-keanu-reeves, the person id is '6384'. Only one person per list ")]
         public string PersonId { get; set; }
 
-        [FieldDefinition(10, Label = "Person Director",
+        [FieldDefinition(10, Label = "Person Director Credits",
             HelpText =
                 "Used when a PeopleCrew list is selected.  Select if you want to include Director credits in the result"
             , Type = FieldType.Checkbox)]
         public bool PersonCastDirector { get; set; }
 
-        [FieldDefinition(11, Label = "Person Producer",
+        [FieldDefinition(11, Label = "Person Producer Credits",
             HelpText =
                 "Used when a PeopleCrew list is selected.  Select if you want to include Producer credits in the result"
             , Type = FieldType.Checkbox)]
         public bool PersonCastProducer { get; set; }
 
-        [FieldDefinition(12, Label = "Person Sound",
+        [FieldDefinition(12, Label = "Person Sound Credits",
             HelpText =
                 "Used when a PeopleCrew list is selected.  Select if you want to include Sound credits in the result"
             , Type = FieldType.Checkbox)]
         public bool PersonCastSound { get; set; }
 
-        [FieldDefinition(113, Label = "Person Writing",
+        [FieldDefinition(113, Label = "Person Writing Credits",
             HelpText =
                 "Used when a PeopleCrew list is selected.  Select if you want to include Writing credits in the result"
             , Type = FieldType.Checkbox)]

--- a/src/NzbDrone.Core/NetImport/TMDb/TMDbSettings.cs
+++ b/src/NzbDrone.Core/NetImport/TMDb/TMDbSettings.cs
@@ -1,4 +1,6 @@
-﻿using FluentValidation;
+﻿using System;
+using System.Collections.Generic;
+using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
@@ -19,6 +21,12 @@ namespace NzbDrone.Core.NetImport.TMDb
                 .Matches(@"^[1-9][0-9]*$", RegexOptions.IgnoreCase)
                 .When(c => c.ListType == (int)TMDbListType.List)
                 .WithMessage("List Id is required when using TMDb Lists");
+
+            // Greater than 0
+            RuleFor(c => c.PersonId)
+                .Matches(@"^[1-9][0-9]*$", RegexOptions.IgnoreCase)
+                .When(c => c.ListType == (int)TMDbListType.PeopleCast || c.ListType == (int)TMDbListType.PeopleCrew)
+                .WithMessage("Person ID required when selecting people lists");
 
             // Range 0.0 - 10.0
             RuleFor(c => c.MinVoteAverage)
@@ -93,9 +101,63 @@ namespace NzbDrone.Core.NetImport.TMDb
         [FieldDefinition(8, Label = "Original Language", Type = FieldType.Select, SelectOptions = typeof(TMDbLanguageCodes), HelpText = "Filter by Language")]
         public int LanguageCode { get; set; }
 
+        [FieldDefinition(9, Label = "Person ID", HelpText = "Used when a People* list is selected.  for the url https://www.themoviedb.org/person/6384-keanu-reeves, the person id is '6384'. Only one person per list ")]
+        public string PersonId { get; set; }
+
+        [FieldDefinition(10, Label = "Person Director",
+            HelpText =
+                "Used when a PeopleCrew list is selected.  Select if you want to include Director credits in the result"
+            , Type = FieldType.Checkbox)]
+        public bool PersonCastDirector { get; set; }
+
+        [FieldDefinition(11, Label = "Person Producer",
+            HelpText =
+                "Used when a PeopleCrew list is selected.  Select if you want to include Producer credits in the result"
+            , Type = FieldType.Checkbox)]
+        public bool PersonCastProducer { get; set; }
+
+        [FieldDefinition(12, Label = "Person Sound",
+            HelpText =
+                "Used when a PeopleCrew list is selected.  Select if you want to include Sound credits in the result"
+            , Type = FieldType.Checkbox)]
+        public bool PersonCastSound { get; set; }
+
+        [FieldDefinition(113, Label = "Person Writing",
+            HelpText =
+                "Used when a PeopleCrew list is selected.  Select if you want to include Writing credits in the result"
+            , Type = FieldType.Checkbox)]
+        public bool PersonCastWriting { get; set; }
+
         public NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
+        }
+
+        public List<String> GetCrewDepartments()
+        {
+            var creditsDepartment = new List<String>();
+
+            if (PersonCastDirector)
+            {
+                creditsDepartment.Add("Directing");
+            }
+
+            if (PersonCastProducer)
+            {
+                creditsDepartment.Add("Production");
+            }
+
+            if (PersonCastSound)
+            {
+                creditsDepartment.Add("Sound");
+            }
+
+            if (PersonCastWriting)
+            {
+                creditsDepartment.Add("Writing");
+            }
+
+            return creditsDepartment;
         }
     }
 


### PR DESCRIPTION
#### Database Migration
No

#### Description
This PR adds the ability to add lists for people.  So if you want a list of all the movies John Wayne was in, you can now add a new TMDB list, Select "PersonCast" as a list type, add John Waynes person ID lower in the screen, and save.  The list will work normally after that and you can import all movies that John wayne was in.

Same with crew.  There are now checkboxes at the bottom of the config where you can choose the role that the person had in the crew.  So if you only want movies where Clint Eastwood did the Music, you would create a new list, PersonCrew as the list type, then select "Person Sound Credits" checkbox.  From there, the list works normally and it will only include movies where Clint Eastwood did the music score.

This is designed for one person for each personcast/personcrew list.  The way TMDB's API works, its really the only way it can be done

It is possible to combine these into one list type, and then choose if you want things from the cast, crew, or both.  I tried it out and since the config screen system is so simplistic, it got really confusing as to what you were supposed to select when.  Thats why i chose different lists for different roles.

#### Todos
- It seems field validation doesn't work.  I have my validator in correctly, but it doesn't seem to be firing at all, not sure if it ever worked

#### Issues Fixed or Closed by this PR

* #1685
