### PR TITLE
Fix warning when QBittorrent torrents are in the "Downloading Metadata" state

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -164,6 +164,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                         item.Message = "The download is stalled with no connections";
                         break;
 
+                    case "metaDL": // torrent is downloading metadata
                     case "downloading": // torrent is being downloaded and data is being transfered
                         item.Status = DownloadItemStatus.Downloading;
                         break;


### PR DESCRIPTION
#### Database Migration
No.

#### Description
Resolves a warning shown during the completed download check task when a torrent on QBittorrent is in the "Downloading Metadata" task.

#### Todos
None.

#### Issues Fixed or Closed by this PR
Issue resolved as per description. No open issue for this.