### PR TITLE
Fixed: Parse UHDRemux as Remux and not as WEB-DL

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -251,6 +251,7 @@ namespace NzbDrone.Core.Test.ParserTests
 
         [TestCase("Contract.to.Kill.2016.REMUX.2160p.BluRay.AVC.DTS-HD.MA.5.1-iFT")]
         [TestCase("27.Dresses.2008.REMUX.2160p.Bluray.AVC.DTS-HR.MA.5.1-LEGi0N")]
+        [TestCase("Los Vengadores (2012) [UHDRemux HDR HEVC 2160p][Dolby Atmos TrueHD 7 1 Eng DTS 5 1 Esp]")]
         public void should_parse_remux2160p_quality(string title)
         {
             ParseAndVerifyQuality(title, Source.BLURAY, false, Resolution.R2160P, Modifier.REMUX);

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex HardcodedSubsRegex = new Regex(@"\b(?<hcsub>(\w+SUBS?)\b)|(?<hc>(HC|SUBBED))\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
-        private static readonly Regex RemuxRegex = new Regex(@"\b(?<remux>(BD)?Remux)\b",
+        private static readonly Regex RemuxRegex = new Regex(@"\b(?<remux>(BD|UHD)?Remux)\b",
                                                         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex BRDISKRegex = new Regex(@"\b(COMPLETE|ISO|BDISO|BD25|BD50|BR.?DISK)\b",


### PR DESCRIPTION
#### Database Migration
 NO

#### Description

HDCity names 2160p Remux releases as UHDRemux, which currently Radarr parses as WEB-DL instead of Remux

#### Todos
- [ X] Tests

#### Issues Fixed or Closed by this PR

Fixes #3694
