### PR TITLE
New: Added reposting groups as exclusions into CleanReleaseGroupRegex

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -29,6 +29,16 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("The.Middle.720p.HEVC.x265-MeGusta-Pre", "MeGusta")]
         [TestCase("Haunted.Hayride.2018.720p.WEBRip.DDP5.1.x264-NTb-postbot", "NTb")]
         [TestCase("Haunted.Hayride.2018.720p.WEBRip.DDP5.1.x264-NTb-xpost", "NTb")]
+        [TestCase("Men.in.Black.International.2019.BluRay.1080p.AVC.DTS-HD.MA5.1-CHDBits-RakuvArrow", "CHDBits")]
+        [TestCase("Aladdin.2019.1080p.BluRay.x264-SPARKS-WhiteRev", "SPARKS")]
+        [TestCase("Elvis.Presley.The.Searcher.2018.1080p.BluRay.x264-HANDJOB-BUYMORE", "HANDJOB")]
+        [TestCase("Kill.Bill.Vol.2.2004.1080p.BluRay.DTS.x264-CyTSuNee-AsRequested", "CyTSuNee")]
+        [TestCase("The.Good.Doctor.S02E17.Breakdown.1080p.AMZN.WEB-DL.DDP5.1.H.264-SiGMA-AlternativeToRequested", "SiGMA")]
+        [TestCase("Mandy.2018.NORDiC.1080p.BluRay.x264-EGEN-GEROV", "EGEN")]
+        [TestCase("TheEqualizer.2.2018.1080p.BluRay.DTS.X264-CMRG-Z0iDS3N", "CMRG")]
+        [TestCase("Ghosthouse.1988.720p.BluRay.x264-SADPANDA-Chamele0n", "SADPANDA")]
+        [TestCase("The.Walking.Dead.S08E08.1080p.BluRay.x264-ROVERS-4P", "ROVERS")]
+        [TestCase("Stranger.Things.S01E02.720p.BluRay.X264-REWARD-4Planet", "REWARD")]
         //[TestCase("", "")]
         public void should_parse_release_group(string title, string expected)
         {

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -112,7 +112,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex SixDigitAirDateRegex = new Regex(@"(?<=[_.-])(?<airdate>(?<!\d)(?<airyear>[1-9]\d{1})(?<airmonth>[0-1][0-9])(?<airday>[0-3][0-9]))(?=[_.-])",
                                                                         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex CleanReleaseGroupRegex = new Regex(@"^(.*?[-._ ](S\d+E\d+)[-._ ])|(-(RP|1|NZBGeek|Obfuscated|sample|Pre|postbot|xpost))+$",
+        private static readonly Regex CleanReleaseGroupRegex = new Regex(@"^(.*?[-._ ](S\d+E\d+)[-._ ])|(-(RP|1|NZBGeek|Obfuscated|sample|Pre|postbot|xpost|Rakuv[a-z0-9]*|WhiteRev|BUYMORE|AsRequested|AlternativeToRequested|GEROV|Z0iDS3N|Chamele0n|4P|4Planet))+$",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex CleanTorrentSuffixRegex = new Regex(@"\[(?:ettv|rartv|rarbg|cttv)\]$",


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Added names of groups who repost releases, and add their names to the end, into CleanReleaseGroupRegex.

Similar groups were added into [Sonarr](https://github.com/Sonarr/Sonarr/commit/fa8b8cebf9c142348124e57342913c6ff3873fd2#diff-23ff1526865b238134cc108b0cf2acd3) as well. 

Tried to find movie releases with these scenarios as test examples. For the ones I couldnt find, I used TV releases (this was also done previously on tests/inclusions made by others).

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* n/a
