### PR TITLE
Fixed: Replaced episode with movie in UpgradeSpecification

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Specifications/UpgradeSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Specifications/UpgradeSpecification.cs
@@ -21,8 +21,8 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Specifications
             var qualityComparer = new QualityModelComparer(localMovie.Movie.Profile);
             if (localMovie.Movie.MovieFile != null && qualityComparer.Compare(localMovie.Movie.MovieFile.Quality, localMovie.Quality) > 0)
             {
-                _logger.Debug("This file isn't an upgrade for all episodes. Skipping {0}", localMovie.Path);
-                return Decision.Reject("Not an upgrade for existing episode file(s)");
+                _logger.Debug("This file isn't an upgrade for movie. Skipping {0}", localMovie.Path);
+                return Decision.Reject("Not an upgrade for existing movie file");
             }
 
             return Decision.Accept();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
A string has been bugging me. A simple change of replacing the word episode with movie in the UpgradeSpecification

#### Todos
- [ x ] Tests
None should be needed 

#### Issues Fixed or Closed by this PR

* #
