### PR TITLE
Aphrodite fix update

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -52,6 +52,7 @@
   <PropertyGroup Condition="'$(RadarrOutputType)'=='Test'">
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <!-- Set the Product and Version info for our own projects -->

--- a/src/NzbDrone.Common.Test/ProcessProviderTests.cs
+++ b/src/NzbDrone.Common.Test/ProcessProviderTests.cs
@@ -66,9 +66,12 @@ namespace NzbDrone.Common.Test
         }
 
         [Test]
+        [Retry(3)]
         public void should_be_able_to_start_process()
         {
             var process = StartDummyProcess();
+
+            Thread.Sleep(500);
 
             var check = Subject.GetProcessById(process.Id);
             check.Should().NotBeNull();
@@ -87,6 +90,8 @@ namespace NzbDrone.Common.Test
         public void exists_should_find_running_process()
         {
             var process = StartDummyProcess();
+
+            Thread.Sleep(500);
 
             Subject.Exists(DummyApp.DUMMY_PROCCESS_NAME).Should()
                    .BeTrue("expected one dummy process to be already running");
@@ -147,11 +152,14 @@ namespace NzbDrone.Common.Test
         }
 
         [Test]
+        [Retry(3)]
         [Platform(Exclude="MacOsX")]
         public void kill_all_should_kill_all_process_with_name()
         {
             var dummy1 = StartDummyProcess();
             var dummy2 = StartDummyProcess();
+
+            Thread.Sleep(500);
 
             Subject.KillAll(DummyApp.DUMMY_PROCCESS_NAME);
 
@@ -181,7 +189,7 @@ namespace NzbDrone.Common.Test
                     }
                 });
 
-            if (!processStarted.Wait(2000))
+            if (!processStarted.Wait(5000))
             {
                 Assert.Fail("Failed to start process within 2 sec");
             }

--- a/src/NzbDrone.Common/Composition/ContainerBuilderBase.cs
+++ b/src/NzbDrone.Common/Composition/ContainerBuilderBase.cs
@@ -40,8 +40,10 @@ namespace NzbDrone.Common.Composition
                 _loadedTypes.AddRange(AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Combine(_startupPath, $"{assemblyName}.dll")).GetTypes());
             }
 
+            var toRegisterResolver = new List<string> { "System.Data.SQLite" };
+            toRegisterResolver.AddRange(assemblies.Intersect(new [] { "Radarr.Core" }));
+            RegisterNativeResolver(toRegisterResolver);
             AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(ContainerResolveEventHandler);
-            RegisterNativeResolver(new [] {"System.Data.SQLite.dll", "Radarr.Core.dll"});
 #endif
 
             Container = new Container(new TinyIoCContainer(), _loadedTypes);
@@ -70,7 +72,7 @@ namespace NzbDrone.Common.Composition
             foreach (var name in assemblyNames)
             {
                 var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(
-                    Path.Combine(AppDomain.CurrentDomain.BaseDirectory, name)
+                    Path.Combine(AppDomain.CurrentDomain.BaseDirectory, $"{name}.dll")
                     );
 
                 try

--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -9,7 +9,6 @@ using NzbDrone.Common.EnsureThat;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation;
-using System.Drawing;
 
 namespace NzbDrone.Common.Disk
 {

--- a/src/NzbDrone.Core/MediaCover/CoverAlreadyExistsSpecification.cs
+++ b/src/NzbDrone.Core/MediaCover/CoverAlreadyExistsSpecification.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using NzbDrone.Common.Disk;
+﻿using NzbDrone.Common.Disk;
 using NzbDrone.Common.Http;
-using System.Drawing;
 using NLog;
 
 namespace NzbDrone.Core.MediaCover

--- a/src/NzbDrone.Test.Common/AutoMoq/AutoMoqer.cs
+++ b/src/NzbDrone.Test.Common/AutoMoq/AutoMoqer.cs
@@ -143,7 +143,7 @@ namespace NzbDrone.Test.Common.AutoMoq
             AddTheAutoMockingContainerExtensionToTheContainer(container);
 
 #if NETCOREAPP3_0
-            ContainerBuilderBase.RegisterNativeResolver(new [] {"System.Data.SQLite.dll", "Radarr.Core.dll"});
+            ContainerBuilderBase.RegisterNativeResolver(new [] {"System.Data.SQLite", "Radarr.Core"});
 #endif
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Assorted fixes to .NET core aphrodite:
- Remove accidental dependency of `Radarr.Update` on `Radarr.Core.dll` (from the `NativeDependencyResolver`)
- Don't publish tests self contained - you need the SDK to run them anyway
- Make process provider tests more reliable
- Remove some old references to System.Drawing

#### Issues Fixed or Closed by this PR

* Fixes #3822 
