### PR TITLE
Add: Always Move Files When Importing 

### DIFF
--- a/src/NzbDrone.Api/Config/MediaManagementConfigResource.cs
+++ b/src/NzbDrone.Api/Config/MediaManagementConfigResource.cs
@@ -22,6 +22,7 @@ namespace NzbDrone.Api.Config
 
         public bool SkipFreeSpaceCheckWhenImporting { get; set; }
         public bool CopyUsingHardlinks { get; set; }
+        public bool AlwaysMoveFilesWhenImporting { get; set; }
         public bool ImportExtraFiles { get; set; }
         public string ExtraFileExtensions { get; set; }
         public bool EnableMediaInfo { get; set; }
@@ -48,7 +49,9 @@ namespace NzbDrone.Api.Config
                 ChownGroup = model.ChownGroup,
 
                 SkipFreeSpaceCheckWhenImporting = model.SkipFreeSpaceCheckWhenImporting,
+
                 CopyUsingHardlinks = model.CopyUsingHardlinks,
+                AlwaysMoveFilesWhenImporting = model.AlwaysMoveFilesWhenImporting,
                 ImportExtraFiles = model.ImportExtraFiles,
                 ExtraFileExtensions = model.ExtraFileExtensions,
                 EnableMediaInfo = model.EnableMediaInfo

--- a/src/NzbDrone.Api/Config/MediaManagementConfigResource.cs
+++ b/src/NzbDrone.Api/Config/MediaManagementConfigResource.cs
@@ -49,7 +49,6 @@ namespace NzbDrone.Api.Config
                 ChownGroup = model.ChownGroup,
 
                 SkipFreeSpaceCheckWhenImporting = model.SkipFreeSpaceCheckWhenImporting,
-
                 CopyUsingHardlinks = model.CopyUsingHardlinks,
                 AlwaysMoveFilesWhenImporting = model.AlwaysMoveFilesWhenImporting,
                 ImportExtraFiles = model.ImportExtraFiles,

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -302,6 +302,12 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("CopyUsingHardlinks", value); }
         }
 
+        public bool AlwaysMoveFilesWhenImporting
+        {
+            get { return GetValueBoolean("AlwaysMoveFilesWhenImporting", false); }
+
+            set { SetValue("AlwaysMoveFilesWhenImporting", value); }
+        }
         public bool EnableMediaInfo
         {
             get { return GetValueBoolean("EnableMediaInfo", true); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -33,6 +33,7 @@ namespace NzbDrone.Core.Configuration
         FileDateType FileDate { get; set; }
         bool SkipFreeSpaceCheckWhenImporting { get; set; }
         bool CopyUsingHardlinks { get; set; }
+        bool AlwaysMoveFilesWhenImporting { get; set; }
         bool EnableMediaInfo { get; set; }
         bool ImportExtraFiles { get; set; }
         string ExtraFileExtensions { get; set; }

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser;
@@ -28,6 +29,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
         private readonly IExtraService _extraService;
         private readonly IDiskProvider _diskProvider;
         private readonly IEventAggregator _eventAggregator;
+        private readonly IConfigService _configService;
         private readonly Logger _logger;
 
         public ImportApprovedMovie(IUpgradeMediaFiles movieFileUpgrader,
@@ -35,6 +37,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
                                       IExtraService extraService,
                                       IDiskProvider diskProvider,
                                       IEventAggregator eventAggregator,
+                                      IConfigService configService,
                                       Logger logger)
         {
             _movieFileUpgrader = movieFileUpgrader;
@@ -42,6 +45,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
             _extraService = extraService;
             _diskProvider = diskProvider;
             _eventAggregator = eventAggregator;
+            _configService = configService;
             _logger = logger;
         }
 
@@ -92,7 +96,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
                     {
                         default:
                         case ImportMode.Auto:
-                            copyOnly = downloadClientItem != null && !downloadClientItem.CanMoveFiles;
+                            copyOnly = downloadClientItem != null && !downloadClientItem.CanMoveFiles && !_configService.AlwaysMoveFilesWhenImporting;
                             break;
                         case ImportMode.Move:
                             copyOnly = false;

--- a/src/UI/Settings/MediaManagement/Sorting/SortingViewTemplate.hbs
+++ b/src/UI/Settings/MediaManagement/Sorting/SortingViewTemplate.hbs
@@ -74,30 +74,30 @@
 <fieldset>
     <legend>Importing</legend>
 
-    {{#if_mono}}
+{{#if_mono}}
     <div class="form-group advanced-setting">
         <label class="col-sm-3 control-label">Skip Free Space Check</label>
 
         <div class="col-sm-9">
             <div class="input-group">
                 <label class="checkbox toggle well">
-                    <input type="checkbox" name="skipFreeSpaceCheckWhenImporting" />
+                    <input type="checkbox" name="skipFreeSpaceCheckWhenImporting"/>
 
                     <p>
                         <span>Yes</span>
                         <span>No</span>
                     </p>
 
-                    <div class="btn btn-primary slide-button" />
+                    <div class="btn btn-primary slide-button"/>
                 </label>
 
                 <span class="help-inline-checkbox">
-                    <i class="icon-radarr-form-info" title="Use when drone is unable to detect free space from your movies root folder" />
+                    <i class="icon-radarr-form-info" title="Use when drone is unable to detect free space from your movies root folder"/>
                 </span>
             </div>
         </div>
     </div>
-    {{/if_mono}}
+{{/if_mono}}
 
     <div class="form-group advanced-setting">
         <label class="col-sm-3 control-label">Use Hardlinks instead of Copy</label>
@@ -105,19 +105,19 @@
         <div class="col-sm-9">
             <div class="input-group">
                 <label class="checkbox toggle well">
-                    <input type="checkbox" name="copyUsingHardlinks" />
+                    <input type="checkbox" name="copyUsingHardlinks"/>
 
                     <p>
                         <span>Yes</span>
                         <span>No</span>
                     </p>
 
-                    <div class="btn btn-primary slide-button" />
+                    <div class="btn btn-primary slide-button"/>
                 </label>
 
                 <span class="help-inline-checkbox">
-                    <i class="icon-radarr-form-info" title="Use Hardlinks when trying to copy files from torrents that are still being seeded" />
-                    <i class="icon-radarr-form-warning" title="Occasionally, file locks may prevent renaming files that are being seeded. You may temporarily disable seeding and use Radarr's rename function as a work around." />
+                    <i class="icon-radarr-form-info" title="Use Hardlinks when trying to copy files from torrents that are still being seeded"/>
+                    <i class="icon-radarr-form-warning" title="Occasionally, file locks may prevent renaming files that are being seeded. You may temporarily disable seeding and use Radarr's rename function as a work around."/>
                 </span>
             </div>
         </div>
@@ -129,19 +129,19 @@
         <div class="col-sm-9">
             <div class="input-group">
                 <label class="checkbox toggle well">
-                    <input type="checkbox" name="alwaysMoveFilesWhenImporting" />
+                    <input type="checkbox" name="alwaysMoveFilesWhenImporting"/>
 
                     <p>
                         <span>Yes</span>
                         <span>No</span>
                     </p>
 
-                    <div class="btn btn-primary slide-button" />
+                    <div class="btn btn-primary slide-button"/>
                 </label>
 
                 <span class="help-inline-checkbox">
-                    <i class="icon-radarr-form-info" title="As the title implies, always move file on import." />
-                    <i class="icon-radarr-form-warning" title="This option should only be used with downloaders that copy the files to a remote storage from which Radarr will import" />
+                    <i class="icon-radarr-form-info" title="As the title implies, always move file on import."/>
+                    <i class="icon-radarr-form-warning" title="This option should only be used with downloaders that copy the files to a remote storage from which Radarr will import"/>
                 </span>
             </div>
         </div>
@@ -153,18 +153,18 @@
         <div class="col-sm-9">
             <div class="input-group">
                 <label class="checkbox toggle well">
-                    <input type="checkbox" name="importExtraFiles" class="x-import-extra-files" />
+                    <input type="checkbox" name="importExtraFiles" class="x-import-extra-files"/>
 
                     <p>
                         <span>Yes</span>
                         <span>No</span>
                     </p>
 
-                    <div class="btn btn-primary slide-button" />
+                    <div class="btn btn-primary slide-button"/>
                 </label>
 
                 <span class="help-inline-checkbox">
-                    <i class="icon-radarr-form-info" title="Import matching extra files (subtitles, nfo, etc) after importing a movie file" />
+                    <i class="icon-radarr-form-info" title="Import matching extra files (subtitles, nfo, etc) after importing a movie file"/>
                 </span>
             </div>
         </div>
@@ -174,11 +174,11 @@
         <label class="col-sm-3 control-label">Extra File Extensions</label>
 
         <div class="col-sm-1 col-sm-push-5 help-inline">
-            <i class="icon-radarr-form-info" title="Comma separated list of extra files to import, ie sub,nfo (.nfo will be imported as .nfo-orig)" />
+            <i class="icon-radarr-form-info" title="Comma separated list of extra files to import, ie sub,nfo (.nfo will be imported as .nfo-orig)"/>
         </div>
 
         <div class="col-sm-5 col-sm-pull-1">
-            <input type="text" name="extraFileExtensions" class="form-control" />
+            <input type="text" name="extraFileExtensions" class="form-control"/>
         </div>
     </div>
 </fieldset>

--- a/src/UI/Settings/MediaManagement/Sorting/SortingViewTemplate.hbs
+++ b/src/UI/Settings/MediaManagement/Sorting/SortingViewTemplate.hbs
@@ -140,7 +140,7 @@
                 </label>
 
                 <span class="help-inline-checkbox">
-                    <i class="icon-radarr-form-info" title="As the title implies, always move file on import."/>
+                    <i class="icon-radarr-form-info" title="As the title implies, always move files on import."/>
                     <i class="icon-radarr-form-warning" title="This option should only be used with downloaders that copy the files to a remote storage from which Radarr will import"/>
                 </span>
             </div>

--- a/src/UI/Settings/MediaManagement/Sorting/SortingViewTemplate.hbs
+++ b/src/UI/Settings/MediaManagement/Sorting/SortingViewTemplate.hbs
@@ -74,30 +74,30 @@
 <fieldset>
     <legend>Importing</legend>
 
-{{#if_mono}}
+    {{#if_mono}}
     <div class="form-group advanced-setting">
         <label class="col-sm-3 control-label">Skip Free Space Check</label>
 
         <div class="col-sm-9">
             <div class="input-group">
                 <label class="checkbox toggle well">
-                    <input type="checkbox" name="skipFreeSpaceCheckWhenImporting"/>
+                    <input type="checkbox" name="skipFreeSpaceCheckWhenImporting" />
 
                     <p>
                         <span>Yes</span>
                         <span>No</span>
                     </p>
 
-                    <div class="btn btn-primary slide-button"/>
+                    <div class="btn btn-primary slide-button" />
                 </label>
 
                 <span class="help-inline-checkbox">
-                    <i class="icon-radarr-form-info" title="Use when drone is unable to detect free space from your movies root folder"/>
+                    <i class="icon-radarr-form-info" title="Use when drone is unable to detect free space from your movies root folder" />
                 </span>
             </div>
         </div>
     </div>
-{{/if_mono}}
+    {{/if_mono}}
 
     <div class="form-group advanced-setting">
         <label class="col-sm-3 control-label">Use Hardlinks instead of Copy</label>
@@ -105,19 +105,43 @@
         <div class="col-sm-9">
             <div class="input-group">
                 <label class="checkbox toggle well">
-                    <input type="checkbox" name="copyUsingHardlinks"/>
+                    <input type="checkbox" name="copyUsingHardlinks" />
 
                     <p>
                         <span>Yes</span>
                         <span>No</span>
                     </p>
 
-                    <div class="btn btn-primary slide-button"/>
+                    <div class="btn btn-primary slide-button" />
                 </label>
 
                 <span class="help-inline-checkbox">
-                    <i class="icon-radarr-form-info" title="Use Hardlinks when trying to copy files from torrents that are still being seeded"/>
-                    <i class="icon-radarr-form-warning" title="Occasionally, file locks may prevent renaming files that are being seeded. You may temporarily disable seeding and use Radarr's rename function as a work around."/>
+                    <i class="icon-radarr-form-info" title="Use Hardlinks when trying to copy files from torrents that are still being seeded" />
+                    <i class="icon-radarr-form-warning" title="Occasionally, file locks may prevent renaming files that are being seeded. You may temporarily disable seeding and use Radarr's rename function as a work around." />
+                </span>
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group advanced-setting">
+        <label class="col-sm-3 control-label">Always Move Files</label>
+
+        <div class="col-sm-9">
+            <div class="input-group">
+                <label class="checkbox toggle well">
+                    <input type="checkbox" name="alwaysMoveFilesOnImport" />
+
+                    <p>
+                        <span>Yes</span>
+                        <span>No</span>
+                    </p>
+
+                    <div class="btn btn-primary slide-button" />
+                </label>
+
+                <span class="help-inline-checkbox">
+                    <i class="icon-radarr-form-info" title="As the title implies, always move file on import." />
+                    <i class="icon-radarr-form-warning" title="This option should only be used with downloaders that copy the files to a remote storage from which Radarr will import" />
                 </span>
             </div>
         </div>
@@ -129,18 +153,18 @@
         <div class="col-sm-9">
             <div class="input-group">
                 <label class="checkbox toggle well">
-                    <input type="checkbox" name="importExtraFiles" class="x-import-extra-files"/>
+                    <input type="checkbox" name="importExtraFiles" class="x-import-extra-files" />
 
                     <p>
                         <span>Yes</span>
                         <span>No</span>
                     </p>
 
-                    <div class="btn btn-primary slide-button"/>
+                    <div class="btn btn-primary slide-button" />
                 </label>
 
                 <span class="help-inline-checkbox">
-                    <i class="icon-radarr-form-info" title="Import matching extra files (subtitles, nfo, etc) after importing a movie file"/>
+                    <i class="icon-radarr-form-info" title="Import matching extra files (subtitles, nfo, etc) after importing a movie file" />
                 </span>
             </div>
         </div>
@@ -150,11 +174,11 @@
         <label class="col-sm-3 control-label">Extra File Extensions</label>
 
         <div class="col-sm-1 col-sm-push-5 help-inline">
-            <i class="icon-radarr-form-info" title="Comma separated list of extra files to import, ie sub,nfo (.nfo will be imported as .nfo-orig)"/>
+            <i class="icon-radarr-form-info" title="Comma separated list of extra files to import, ie sub,nfo (.nfo will be imported as .nfo-orig)" />
         </div>
 
         <div class="col-sm-5 col-sm-pull-1">
-            <input type="text" name="extraFileExtensions" class="form-control"/>
+            <input type="text" name="extraFileExtensions" class="form-control" />
         </div>
     </div>
 </fieldset>

--- a/src/UI/Settings/MediaManagement/Sorting/SortingViewTemplate.hbs
+++ b/src/UI/Settings/MediaManagement/Sorting/SortingViewTemplate.hbs
@@ -129,7 +129,7 @@
         <div class="col-sm-9">
             <div class="input-group">
                 <label class="checkbox toggle well">
-                    <input type="checkbox" name="alwaysMoveFilesOnImport" />
+                    <input type="checkbox" name="alwaysMoveFilesWhenImporting" />
 
                     <p>
                         <span>Yes</span>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I have a non standard setup. All my media is stored with a cloud provider. 
The download clients are on different instances and upload after the download is finished to the cloud provider.
I have recently added a torrent client to my setup and I noticed that on import it copies the files.
As you can imagine, copying the files has a very huge impact on performance and on the limits imposed by the cloud provider.

This PR adds a global switch that will always move files regardless of the type of client.