### PR TITLE
Fixed: SSL certificate import

### DIFF
--- a/src/NzbDrone.Host/WebHost/WebHostController.cs
+++ b/src/NzbDrone.Host/WebHost/WebHostController.cs
@@ -72,8 +72,7 @@ namespace Radarr.Host
                     {
                         options.ConfigureHttpsDefaults(configureOptions =>
                         {
-                            var certificate = new X509Certificate2();
-                            certificate.Import(_configFileProvider.SslCertPath, _configFileProvider.SslCertPassword, X509KeyStorageFlags.DefaultKeySet);
+                            var certificate = new X509Certificate2(_configFileProvider.SslCertPath, _configFileProvider.SslCertPassword, X509KeyStorageFlags.DefaultKeySet);
 
                             configureOptions.ServerCertificate = certificate;
                         });


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes cert import using X509Certificate2 constructor [(MSDN)](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2.-ctor?view=netframework-4.8#System_Security_Cryptography_X509Certificates_X509Certificate2__ctor_System_String_System_String_System_Security_Cryptography_X509Certificates_X509KeyStorageFlags_).
(Info to same issue: [Link 1](https://stackoverflow.com/questions/47756451/load-x509-certificate-from-disk-net-core) and [Link 2](https://www.cloudnotes.io/x509certificate-is-immutable-on-this-platform-use-the-equivalent-constructor-instead/))

Error message before: `Unable to start Kestrel.: X509Certificate is immutable on this platform. Use the equivalent constructor instead.`

with Exception: 
```
System.PlatformNotSupportedException: X509Certificate is immutable on this platform. Use the equivalent constructor instead.
   at System.Security.Cryptography.X509Certificates.X509Certificate.Import(String fileName, String password, X509KeyStorageFlags keyStorageFlags)
   at System.Security.Cryptography.X509Certificates.X509Certificate2.Import(String fileName, String password, X509KeyStorageFlags keyStorageFlags)
   at Radarr.Host.WebHostController.<>c__DisplayClass7_0.<StartServer>b__5(HttpsConnectionAdapterOptions configureOptions) in d:\a\1\s\src\NzbDrone.Host\WebHost\WebHostController.cs:line 78
   at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ApplyHttpsDefaults(HttpsConnectionAdapterOptions httpsOptions)
   at Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(ListenOptions listenOptions, Action`1 configureOptions)
   at Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(ListenOptions listenOptions)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.AddressBinder.AddressesStrategy.BindAsync(AddressBindContext context)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.AddressBinder.BindAsync(IServerAddressesFeature addresses, KestrelServerOptions serverOptions, ILogger logger, Func`2 createBinding)
   at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer.StartAsync[TContext](IHttpApplication`1 application, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Hosting.WebHost.StartAsync(CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Hosting.WebHost.Start()
   at Radarr.Host.WebHostController.StartServer() in d:\a\1\s\src\NzbDrone.Host\WebHost\WebHostController.cs:line 130
   at Radarr.Host.NzbDroneConsoleFactory.Start() in d:\a\1\s\src\NzbDrone.Host\ApplicationServer.cs:line 96
   at Radarr.Host.Router.Route(ApplicationModes applicationModes) in d:\a\1\s\src\NzbDrone.Host\Router.cs:line 58
   at Radarr.Host.Bootstrap.Start(ApplicationModes applicationModes, StartupContext startupContext) in d:\a\1\s\src\NzbDrone.Host\Bootstrap.cs:line 77
   at Radarr.Host.Bootstrap.Start(StartupContext startupContext, IUserAlert userAlert, Action`1 startCallback) in d:\a\1\s\src\NzbDrone.Host\Bootstrap.cs:line 40
   at NzbDrone.WindowsApp.Main(String[] args) in d:\a\1\s\src\NzbDrone\WindowsApp.cs:line 23
```

