### PR TITLE
add this code back since it can vastly improve netimport performance

### DIFF
--- a/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
@@ -125,6 +125,12 @@ namespace NzbDrone.Core.NetImport
                 CleanLibrary(listedMovies);
             }
 
+            listedMovies = listedMovies.Where(x => !_movieService.MovieExists(x)).ToList();
+            if (listedMovies.Any())
+            {
+                _logger.Info($"Found {listedMovies.Count()} movies on your auto enabled lists not in your library");
+            }
+
             var importExclusions = new List<string>();
             var moviesToAdd = new List<Movie>();
 


### PR DESCRIPTION
having this code there shouldnt reintroduce the problem
however it will allow us to substantially reduce the amount of time netimport takes when running

#### Database Migration
NO

#### Description
I think having this code in there vastly improves performance but doesnt reintroduce the bug regarding duplicates.

It just means we chop a ton of movies off the list from the begining, if there were some that we didnt catch they will be caught in the subsequent code that was introduced when this was removed.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #
