### PR TITLE
Fix: Typo in UI dropdown for time format

### DIFF
--- a/frontend/src/Settings/UI/UISettings.js
+++ b/frontend/src/Settings/UI/UISettings.js
@@ -19,7 +19,7 @@ export const firstDayOfWeekOptions = [
 export const weekColumnOptions = [
   { key: 'ddd M/D', value: 'Tue 3/25' },
   { key: 'ddd MM/DD', value: 'Tue 03/25' },
-  { key: 'ddd D/M', value: 'Tue 25/03' },
+  { key: 'ddd D/M', value: 'Tue 25/3' },
   { key: 'ddd DD/MM', value: 'Tue 25/03' }
 ];
 


### PR DESCRIPTION
The time format was incorrectly showing the D/M format as DD/MM (25/03 instead of 25/3).

#### Database Migration
NO

#### Description
The time format was incorrectly showing the D/M format as DD/MM (25/03 instead of 25/3).

#### Todos
Nothing needed

#### Issues Fixed or Closed by this PR
Not aware of any issues for this