### PR TITLE
Increase session expiry time

### DIFF
--- a/src/Radarr.Http/Authentication/AuthenticationModule.cs
+++ b/src/Radarr.Http/Authentication/AuthenticationModule.cs
@@ -34,7 +34,7 @@ namespace Radarr.Http.Authentication
 
             if (resource.RememberMe)
             {
-                expiry = DateTime.UtcNow.AddDays(7);
+                expiry = DateTime.UtcNow.AddYears(1);
             }
 
             return this.LoginAndRedirect(user.Identifier, expiry, _configFileProvider.UrlBase + "/");


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Increase session expiry time.

There's a compelling reason to have a short expiry on sites with
senstive information like a bank, but if I forget to lock my computer
and someone starts messing with radarr, there is very little damage they
can do.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR