### PR TITLE
Add in last and in next filter types

### DIFF
--- a/frontend/src/Helpers/Props/filterTypePredicates.js
+++ b/frontend/src/Helpers/Props/filterTypePredicates.js
@@ -1,4 +1,6 @@
 import * as filterTypes from './filterTypes';
+import isAfter from 'Utilities/Date/isAfter';
+import isBefore from 'Utilities/Date/isBefore';
 
 const filterTypePredicates = {
   [filterTypes.CONTAINS]: function(itemValue, filterValue) {
@@ -39,6 +41,20 @@ const filterTypePredicates = {
 
   [filterTypes.NOT_EQUAL]: function(itemValue, filterValue) {
     return itemValue !== filterValue;
+  },
+
+  [filterTypes.IN_LAST]: function(itemValue, filterValue) {
+    return (
+      isAfter(itemValue, { [filterValue.time]: filterValue.value * -1 }) &&
+      isBefore(itemValue)
+    );
+  },
+
+  [filterTypes.IN_NEXT]: function(itemValue, filterValue) {
+    return (
+      isAfter(itemValue) &&
+      isBefore(itemValue, { [filterValue.time]: filterValue.value })
+    );
   }
 };
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds the `IN_NEXT` and `IN_LAST` filter types to `filterTypePredicates.js` in the same way they're done [here](https://github.com/Radarr/Radarr/blob/8bbec88b6fe88b89a229bb09bfa00525b3806de8/frontend/src/Utilities/Date/dateFilterPredicate.js), this fixes #3885.

In Sonarr the `IN_NEXT` and `IN_LAST` filters are handled in [this block](https://github.com/Radarr/Radarr/blob/8bbec88b6fe88b89a229bb09bfa00525b3806de8/frontend/src/Store/Selectors/createClientSideCollectionSelector.js#L44) where as in Radarr they end up being handled in [this block](https://github.com/Radarr/Radarr/blob/8bbec88b6fe88b89a229bb09bfa00525b3806de8/frontend/src/Store/Selectors/createClientSideCollectionSelector.js#L52) as `filterPredicates` does not contain keys for as many types of filter as in Sonarr

This could probably be done a different way but my knowledge of react and this project aren't enough I'd be confident to go right ahead and do it so if you want it changed just let me know where and I'll happily shuffle some stuff around 

#### Issues Fixed or Closed by this PR
* #3885