### PR TITLE
Added a EAC3 Atmos option

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         [TestCase("DTS, A_DTS, , , XBR", "DTSHD-HRA", "DTS-HD HRA")]
         [TestCase("DTS, A_DTS, , , DTS", "DTS", "DTS")]
         [TestCase("E-AC-3, A_EAC3, , , JOC", "EAC3.Atmos", "EAC3 Atmos")]
-        [TestCase("E-AC-3, A_EAC3, , , ", "DD5.1", "EAC3")]
+        [TestCase("E-AC-3, A_EAC3, , , ", "DDP5.1", "EAC3")]
         [TestCase("AC-3, A_AC3, , , ", "DD5.1", "AC3")]
         [TestCase("A_QUICKTIME, A_QUICKTIME, , , ", "", "")]
         [TestCase("ADPCM, 2, , , ", "Custom?", "PCM")]

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         [TestCase("DTS, A_DTS, , , ES XXCH", "DTS", "DTS-ES")]
         [TestCase("DTS, A_DTS, , , XBR", "DTSHD-HRA", "DTS-HD HRA")]
         [TestCase("DTS, A_DTS, , , DTS", "DTS", "DTS")]
-        [TestCase("E-AC-3, A_EAC3, , , JOC", "EAC3", "EAC3")]
+        [TestCase("E-AC-3, A_EAC3, , , JOC", "EAC3.Atmos", "EAC3 Atmos")]
         [TestCase("E-AC-3, A_EAC3, , , ", "DD5.1", "EAC3")]
         [TestCase("AC-3, A_AC3, , , ", "DD5.1", "AC3")]
         [TestCase("A_QUICKTIME, A_QUICKTIME, , , ", "", "")]

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioFormat.ContainsIgnoreCase("E-AC-3"))
             {
-                 if (splitAdditionalFeatures.ContainsIgnoreCase("JOC"))
+                if (splitAdditionalFeatures.ContainsIgnoreCase("JOC"))
                 {
                     return "EAC3 Atmos";
                 }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -100,6 +100,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioFormat.ContainsIgnoreCase("E-AC-3"))
             {
+                 if (splitAdditionalFeatures.ContainsIgnoreCase("JOC"))
+                {
+                    return "EAC3 Atmos";
+                }
+
                 return "EAC3";
             }
 


### PR DESCRIPTION
Added a second if statement under "if (audioFormat.ContainsIgnoreCase("E-AC-3"))" to look for "JOC" in splitAdditionalFeatures to be able to identify EAC3 tracks that contain atmos. I used the audioFormat "MLP FBA" with "TrueHD Atmos" as a reference.


#### Description


#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #
