### PR TITLE
Added Dolby Digital Plus with Atmos

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -173,7 +173,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             }
 
             if (audioFormat.EqualsIgnoreCase("E-AC-3"))
-            {                 
+            {
                 return "EAC3";
             }
 

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -168,7 +168,12 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             }
 
             if (audioFormat.EqualsIgnoreCase("E-AC-3"))
-            {
+            {                 
+                if (splitAdditionalFeatures.ContainsIgnoreCase("JOC"))
+                {
+                    return "EAC3 Atmos";
+                }
+                
                 return "EAC3";
             }
 

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -57,6 +57,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioFormat.EqualsIgnoreCase("E-AC-3"))
             {
+                if (splitAdditionalFeatures.ContainsIgnoreCase("JOC"))
+                {
+                    return "EAC3 Atmos";
+                }
+                
                 return "EAC3";
             }
 
@@ -169,11 +174,6 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioFormat.EqualsIgnoreCase("E-AC-3"))
             {                 
-                if (splitAdditionalFeatures.ContainsIgnoreCase("JOC"))
-                {
-                    return "EAC3 Atmos";
-                }
-                
                 return "EAC3";
             }
 

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -57,7 +57,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioFormat.EqualsIgnoreCase("E-AC-3"))
             {
-                if (splitAdditionalFeatures.ContainsIgnoreCase("JOC"))
+                if (audioAdditionalFeatures == "JOC")
                 {
                     return "EAC3 Atmos";
                 }


### PR DESCRIPTION
Sorry for the double pull request, I hadn't realized I was previously working on V3. 

Added Dolby Digital Plus with Atmos by checking the codec additional features for JOC, which stands for Joint Object Coding and is the technique used for adding Atmos metadata to Dolby Digital Plus audio streams. This is similar to the 16-ch additional feature used to distinguish Atmos in a TrueHD audio stream.
