### PR TITLE
Fix typo in LogentriesCore.csproj

### DIFF
--- a/src/LogentriesCore/LogentriesCore.csproj
+++ b/src/LogentriesCore/LogentriesCore.csproj
@@ -52,7 +52,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />


### PR DESCRIPTION
Linux could not find ConfigurationManager due to case-sensitivity,
failing to build

#### Database Migration
NO

#### Description
Linux could not find ConfigurationManager due to case-sensitivity, failing to build

#### Todos

#### Issues Fixed or Closed by this PR

* #
