### PR TITLE
Fixed: Webpack worker loading with UrlBase

### DIFF
--- a/frontend/gulp/webpack.js
+++ b/frontend/gulp/webpack.js
@@ -121,8 +121,7 @@ const config = {
         use: {
           loader: 'worker-loader',
           options: {
-            name: '[name].js',
-            inline: true
+            name: '[name].js'
           }
         }
       },

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,4 @@
-/* eslint-disable-next-line no-undef */
-__webpack_public_path__ = `${window.Radarr.urlBase}/`;
-
+import './preload.js';
 import React from 'react';
 import { render } from 'react-dom';
 import { createBrowserHistory } from 'history';

--- a/frontend/src/preload.js
+++ b/frontend/src/preload.js
@@ -1,0 +1,2 @@
+/* eslint no-undef: 0 */
+__webpack_public_path__ = `${window.Radarr.urlBase}/`;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Correctly set `__webpack_public_path__` so workers are loaded from correct path.

Since ES6 hoists imports to the top of the files, as currently set up all imports happen before `__webpack_public_path__` gets set.

#### Todos
- [x] Tests
