### PR TITLE
Include Dolby Vision In HDR detection

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -539,14 +539,23 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 mediaInfo.VideoColourPrimaries.IsNotNullOrWhiteSpace() &&
                 mediaInfo.VideoTransferCharacteristics.IsNotNullOrWhiteSpace())
             {
-                if (mediaInfo.VideoColourPrimaries.EqualsIgnoreCase(ValidHdrColourPrimaries) &&
-                    ValidHdrTransferFunctions.Any(mediaInfo.VideoTransferCharacteristics.Contains))
+                // Check if mediaInfo.VideoCodecID contains a Dolby Vision codec
+                if (new[] {"hev1", "dvhe", "dvav", "dva1", "dvh1"}.Contains(mediaInfo.VideoCodecID))
                 {
-                    videoDynamicRange = "HDR";
+                    videoDynamicRange = "DV";
                 }
+                else
+                {
+                if (mediaInfo.VideoColourPrimaries.EqualsIgnoreCase(ValidHdrColourPrimaries) &&
+                        ValidHdrTransferFunctions.Any(mediaInfo.VideoTransferCharacteristics.Contains))
+                    {
+                        videoDynamicRange = "HDR";
+                    }
+                }	
             }
-
             return videoDynamicRange;
         }
     }
+    
 }
+


### PR DESCRIPTION
#### Database Migration
 NO

#### Description
Include Dolby Vision In HDR detection. Not sure what to call the abbreviation possible suggestions are DOVI or DV. This will only look at that first mediainfo index. 

#### Todos
- [ ] Tests
