### PR TITLE
Fixed: Error in epic fail handler if console input redirected

### DIFF
--- a/src/NzbDrone.Console/ConsoleApp.cs
+++ b/src/NzbDrone.Console/ConsoleApp.cs
@@ -87,7 +87,7 @@ namespace NzbDrone.Console
                     for (int i = 0; i < 3600; i++)
                     {
                         System.Threading.Thread.Sleep(1000);
-                        if (System.Console.KeyAvailable) break;
+                        if (!System.Console.IsInputRedirected && System.Console.KeyAvailable) break;
                     }
                 }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Just sit there if console redirected, don't look for a key since that throws an error an makes Sentry go wild.  Can still be killed with ctrl-c.

Fixes Sentry Radarr-3AK

