### PR TITLE
Finer control over what search queries are made in newznab indexer. (in or exclude AKAs)

### DIFF
--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             {
                 if (!Settings.SearchByAkas)
                 {
-                    var searchTitle = System.Web.HttpUtility.UrlPathEncode(Parser.Parser.ReplaceGermanUmlauts(searchCriteria.Movie.Title));
+                    var searchTitle = System.Web.HttpUtility.UrlPathEncode(Parser.Parser.ReplaceGermanUmlauts(searchCriteria.Movie.Title).ToLower());
 
                     var altTitles = searchCriteria.Movie.AlternativeTitles.Take(5).Select(t => t.Title).ToList();
 
@@ -137,7 +137,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                 }
             }
         }
-        
+
         public Func<IDictionary<string, string>> GetCookies { get; set; }
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             {
                 if (!Settings.SearchByAkas)
                 {
-                    var searchTitle = System.Web.HttpUtility.UrlPathEncode(Parser.Parser.ReplaceGermanUmlauts(searchCriteria.Movie.Title));
+                    var searchTitle = System.Web.HttpUtility.UrlPathEncode(Parser.Parser.ReplaceGermanUmlauts(searchCriteria.Movie.Title).ToLower());
 
                     var altTitles = searchCriteria.Movie.AlternativeTitles.Take(5).Select(t => t.Title).ToList();
 

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -63,26 +63,49 @@ namespace NzbDrone.Core.Indexers.Newznab
             }
             else
             {
-                var altTitles = searchCriteria.Movie.AlternativeTitles.Take(5).Select(t => t.Title).ToList();
-                altTitles.Add(searchCriteria.Movie.Title);
-
-                var realMaxPages = (int)MaxPages / (altTitles.Count());
-
-                //pageableRequests.Add(GetPagedRequests(MaxPages - (altTitles.Count() * realMaxPages), Settings.Categories, "search", $"&q={searchTitle}%20{searchCriteria.Movie.Year}"));
-
-                //Also use alt titles for searching.
-                foreach (String altTitle in altTitles)
+                if (!Settings.SearchByAkas)
                 {
-                    var searchAltTitle = System.Web.HttpUtility.UrlPathEncode(Parser.Parser.ReplaceGermanUmlauts(Parser.Parser.NormalizeTitle(altTitle)));
-                    var queryString = $"&q={searchAltTitle}";
+                    var searchTitle = System.Web.HttpUtility.UrlPathEncode(Parser.Parser.ReplaceGermanUmlauts(searchCriteria.Movie.Title));
+
+                    var altTitles = searchCriteria.Movie.AlternativeTitles.Take(5).Select(t => t.Title).ToList();
+
+                    var realMaxPages = (int) MaxPages / (altTitles.Count() + 1);
+
+                    var queryString = $"&q={searchTitle}";
                     if (!Settings.RemoveYear)
                     {
                         queryString += $"%20{searchCriteria.Movie.Year}";
                     }
-                    pageableRequests.Add(GetPagedRequests(realMaxPages, Settings.Categories, "search", queryString));
+
+                    pageableRequests.Add(GetPagedRequests(realMaxPages, Settings.Categories, "search",
+                        queryString));
+                }
+                else
+                {
+                    var altTitles = searchCriteria.Movie.AlternativeTitles.Take(5).Select(t => t.Title).ToList();
+                    altTitles.Add(searchCriteria.Movie.Title);
+
+                    var realMaxPages = (int) MaxPages / (altTitles.Count());
+
+                    //pageableRequests.Add(GetPagedRequests(MaxPages - (altTitles.Count() * realMaxPages), Settings.Categories, "search", $"&q={searchTitle}%20{searchCriteria.Movie.Year}"));
+
+                    //Also use alt titles for searching.
+                    foreach (String altTitle in altTitles)
+                    {
+                        var searchAltTitle =
+                            System.Web.HttpUtility.UrlPathEncode(
+                                Parser.Parser.ReplaceGermanUmlauts(Parser.Parser.NormalizeTitle(altTitle)));
+                        var queryString = $"&q={searchAltTitle}";
+                        if (!Settings.RemoveYear)
+                        {
+                            queryString += $"%20{searchCriteria.Movie.Year}";
+                        }
+
+                        pageableRequests.Add(GetPagedRequests(realMaxPages, Settings.Categories, "search",
+                            queryString));
+                    }
                 }
             }
-
             return pageableRequests;
         }
 

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             {
                 if (!Settings.SearchByAkas)
                 {
-                    var searchTitle = System.Web.HttpUtility.UrlPathEncode(Parser.Parser.ReplaceGermanUmlauts(searchCriteria.Movie.Title).ToLower());
+                    var searchTitle = System.Web.HttpUtility.UrlPathEncode(Parser.Parser.ReplaceGermanUmlauts(searchCriteria.Movie.Title));
 
                     var altTitles = searchCriteria.Movie.AlternativeTitles.Take(5).Select(t => t.Title).ToList();
 

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
@@ -91,7 +91,12 @@ namespace NzbDrone.Core.Indexers.Newznab
             HelpText = "By default, Radarr will try to search by IMDB ID if your indexer supports that. However, some indexers are not very good at tagging their releases correctly, so you can force Radarr to search that indexer by title instead.",
             Advanced = true, Type = FieldType.Checkbox)]
         public bool SearchByTitle { get; set; }
-        // Field 8 is used by TorznabSettings MinimumSeeders
+        
+        [FieldDefinition(8, Label = "and by \"Also known as\"",
+            HelpText = "Search by Title has to be activated!\nWill also search for the \"Also known as\" titles.",
+            Advanced = true, Type = FieldType.Checkbox)]
+        public bool SearchByAkas { get; set; }
+        // Field 9 is used by TorznabSettings MinimumSeeders
         // If you need to add another field here, update TorznabSettings as well and this comment
 
         public virtual NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
@@ -58,10 +58,10 @@ namespace NzbDrone.Core.Indexers.Torznab
             MinimumSeeders = IndexerDefaults.MINIMUM_SEEDERS;
         }
 
-        [FieldDefinition(8, Type = FieldType.Textbox, Label = "Minimum Seeders", HelpText = "Minimum number of seeders required.", Advanced = true)]
+        [FieldDefinition(9, Type = FieldType.Textbox, Label = "Minimum Seeders", HelpText = "Minimum number of seeders required.", Advanced = true)]
         public int MinimumSeeders { get; set; }
 
-        [FieldDefinition(9, Type = FieldType.Tag, SelectOptions = typeof(IndexerFlags), Label = "Required Flags", HelpText = "What indexer flags are required?", HelpLink = "https://github.com/Radarr/Radarr/wiki/Indexer-Flags#1-required-flags", Advanced = true)]
+        [FieldDefinition(10, Type = FieldType.Tag, SelectOptions = typeof(IndexerFlags), Label = "Required Flags", HelpText = "What indexer flags are required?", HelpLink = "https://github.com/Radarr/Radarr/wiki/Indexer-Flags#1-required-flags", Advanced = true)]
         public IEnumerable<int> RequiredFlags { get; set; }
 
         public override NzbDroneValidationResult Validate()


### PR DESCRIPTION
#### Description
Added ability to select if radarr should only search with the Title or also with the AKAs. 
This may provide faster api response since only 1 request is made. 
Can decrease search results because of the same reason. 

But i mainly did this change because i have localized titles and i dont want it to search AKAs because they are always english and give me no results anyway.
So reducing api request and responsetime is great. 

#### Issues Fixed or Closed by this PR
https://github.com/Radarr/Radarr/issues/3980
* #

Screenshot: 
![image](https://user-images.githubusercontent.com/32980670/71316433-c26b4080-246f-11ea-93ed-f2ca5216f75d.png)
