### PR TITLE
Fixed: File move uses rename not copy/delete in more cases

### DIFF
--- a/src/NzbDrone.Common.Test/DiskTests/DiskProviderFixtureBase.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DiskProviderFixtureBase.cs
@@ -81,6 +81,23 @@ namespace NzbDrone.Common.Test.DiskTests
         }
 
         [Test]
+        [Retry(5)]
+        public void MoveFile_should_not_overwrite_existing_file()
+        {
+            var source1 = GetTempFilePath();
+            var source2 = GetTempFilePath();
+            var destination = GetTempFilePath();
+
+            File.WriteAllText(source1, "SourceFile1");
+            File.WriteAllText(source2, "SourceFile2");
+
+            Subject.MoveFile(source1, destination);
+            Assert.Throws<IOException>(() => Subject.MoveFile(source2, destination, false));
+
+            File.ReadAllText(destination).Should().Be("SourceFile1");
+        }
+
+        [Test]
         public void MoveFile_should_not_move_overwrite_itself()
         {
             var source = GetTempFilePath();

--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -218,13 +218,18 @@ namespace NzbDrone.Common.Disk
                 throw new IOException(string.Format("Source and destination can't be the same {0}", source));
             }
 
-            if (FileExists(destination) && overwrite)
+            var destExists = FileExists(destination);
+
+            if (destExists && overwrite)
             {
                 DeleteFile(destination);
             }
 
             RemoveReadOnly(source);
-            MoveFileInternal(source, destination);
+
+            // NET Core is too eager to copy/delete if overwrite is false
+            // Therefore we also set overwrite if we know destination doesn't exist
+            MoveFileInternal(source, destination, overwrite || !destExists);
         }
 
         public void MoveFolder(string source, string destination, bool overwrite = false)
@@ -246,9 +251,13 @@ namespace NzbDrone.Common.Disk
             Directory.Move(source, destination);
         }
 
-        protected virtual void MoveFileInternal(string source, string destination)
+        protected virtual void MoveFileInternal(string source, string destination, bool overwrite)
         {
+#if NETCOREAPP
+            File.Move(source, destination, overwrite);
+#else
             File.Move(source, destination);
+#endif
         }
 
         public abstract bool TryCreateHardLink(string source, string destination);

--- a/src/NzbDrone.Mono/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Mono/Disk/DiskProvider.cs
@@ -151,7 +151,7 @@ namespace NzbDrone.Mono.Disk
             }
         }
 
-        protected override void MoveFileInternal(string source, string destination)
+        protected override void MoveFileInternal(string source, string destination, bool overwrite)
         {
             var sourceInfo = UnixFileSystemInfo.GetFileSystemEntry(source);
 
@@ -188,7 +188,7 @@ namespace NzbDrone.Mono.Disk
             }
             else
             {
-                base.MoveFileInternal(source, destination);
+                base.MoveFileInternal(source, destination, overwrite);
             }
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
File.Move in .NET Core was falling back to copy/delete too eagerly.  To workaround, check if destination exists and if not call move with overwrite true, to prompt a move and not copy/delete.