### PR TITLE
Fixed: green/success colour for downloads meeting cutoff

### DIFF
--- a/frontend/src/Movie/MovieQuality.js
+++ b/frontend/src/Movie/MovieQuality.js
@@ -38,7 +38,7 @@ function MovieQuality(props) {
     isCutoffNotMet
   } = props;
 
-  let kind = kinds.DEFAULT;
+  let kind = kinds.SUCCESS;
   if (!isMonitored) {
     kind = kinds.DISABLED;
   } else if (isCutoffNotMet) {


### PR DESCRIPTION
met should have green or SUCCESS colour

#### Database Migration
NO

#### Description
minor fix regarding colour (to match legend)

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

Since the cutoff met/unmet changes to the MovieStatus it no longer has green/success colour for monitored/downloaded items with cutoff met.. This returns the green color

* #
