### PR TITLE
Fixed: Correctly add parameters to migrations 36 and 154

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/036_update_with_quality_converters.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/036_update_with_quality_converters.cs
@@ -50,6 +50,7 @@ namespace NzbDrone.Core.Datastore.Migration
                             updateCmd.CommandText = "UPDATE QualityProfiles SET Items = ? WHERE Id = ?";
                             var param = updateCmd.CreateParameter();
                             qualityProfileItemConverter.SetValue(param, items);
+                            updateCmd.Parameters.Add(param);
                             updateCmd.AddParameter(id);
 
                             updateCmd.ExecuteNonQuery();
@@ -100,6 +101,7 @@ namespace NzbDrone.Core.Datastore.Migration
                             updateCmd.CommandText = "UPDATE " + tableName + " SET Quality = ? WHERE Quality = ?";
                             var param = updateCmd.CreateParameter();
                             qualityModelConverter.SetValue(param, qualityNew);
+                            updateCmd.Parameters.Add(param);
                             updateCmd.AddParameter(qualityJson);
 
                             updateCmd.ExecuteNonQuery();

--- a/src/NzbDrone.Core/Datastore/Migration/154_add_language_to_file_history_blacklist.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/154_add_language_to_file_history_blacklist.cs
@@ -89,6 +89,7 @@ namespace NzbDrone.Core.Datastore.Migration
                     updateMovieFilesCmd.CommandText = $"UPDATE MovieFiles SET Languages = ? WHERE MovieId IN ({movieIds})";
                     var param = updateMovieFilesCmd.CreateParameter();
                     languageConverter.SetValue(param, language);
+                    updateMovieFilesCmd.Parameters.Add(param);
 
                     updateMovieFilesCmd.ExecuteNonQuery();
                 }
@@ -99,6 +100,7 @@ namespace NzbDrone.Core.Datastore.Migration
                     updateHistoryCmd.CommandText = $"UPDATE History SET Languages = ? WHERE MovieId IN ({movieIds})";
                     var param = updateHistoryCmd.CreateParameter();
                     languageConverter.SetValue(param, language);
+                    updateHistoryCmd.Parameters.Add(param);
 
                     updateHistoryCmd.ExecuteNonQuery();
                 }
@@ -109,6 +111,7 @@ namespace NzbDrone.Core.Datastore.Migration
                     updateBlacklistCmd.CommandText = $"UPDATE Blacklist SET Languages = ? WHERE MovieId IN ({movieIds})";
                     var param = updateBlacklistCmd.CreateParameter();
                     languageConverter.SetValue(param, language);
+                    updateBlacklistCmd.Parameters.Add(param);
 
                     updateBlacklistCmd.ExecuteNonQuery();
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Actually add the parameters to the command.  They were created but not added, so if any movies were actually in the database the migrations would fail.

EnorMOZ confirmed fix works on discord.

#### Issues Fixed or Closed by this PR

* Fixes sentry RADARR3-5W
