### PR TITLE
Treat any CF over FormatCutoff as being Cutoff met

### DIFF
--- a/src/NzbDrone.Core.Test/CustomFormats/CustomFormatsFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/CustomFormatsFixture.cs
@@ -1,17 +1,18 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Test.Framework;
 
-namespace NzbDrone.Core.Test.CustomFormat
+namespace NzbDrone.Core.Test.CustomFormats
 {
     [TestFixture]
     public class CustomFormatsFixture : CoreTest
     {
-        private static List<CustomFormats.CustomFormat> _customFormats { get; set; }
+        private static List<CustomFormat> _customFormats { get; set; }
 
-        public static void GivenCustomFormats(params CustomFormats.CustomFormat[] formats)
+        public static void GivenCustomFormats(params CustomFormat[] formats)
         {
             _customFormats = formats.ToList();
         }
@@ -28,7 +29,7 @@ namespace NzbDrone.Core.Test.CustomFormat
                 new ProfileFormatItem
                 {
                     Allowed = true,
-                    Format = CustomFormats.CustomFormat.None
+                    Format = CustomFormat.None
                 }
             };
         }

--- a/src/NzbDrone.Core.Test/CustomFormats/QualityTagFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/QualityTagFixture.cs
@@ -5,7 +5,7 @@ using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Test.Framework;
 
-namespace NzbDrone.Core.Test.CustomFormat
+namespace NzbDrone.Core.Test.CustomFormats
 {
     [TestFixture]
     public class QualityTagFixture : CoreTest

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/CustomFormatAllowedByProfileSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/CustomFormatAllowedByProfileSpecificationFixture.cs
@@ -2,12 +2,13 @@ using System.Collections.Generic;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Qualities;
-using NzbDrone.Core.Test.CustomFormat;
+using NzbDrone.Core.Test.CustomFormats;
 using NzbDrone.Core.Test.Framework;
 
 namespace NzbDrone.Core.Test.DecisionEngineTests
@@ -18,16 +19,16 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
     {
         private RemoteMovie _remoteMovie;
 
-        private CustomFormats.CustomFormat _format1;
-        private CustomFormats.CustomFormat _format2;
+        private CustomFormat _format1;
+        private CustomFormat _format2;
 
         [SetUp]
         public void Setup()
         {
-            _format1 = new CustomFormats.CustomFormat("Awesome Format");
+            _format1 = new CustomFormat("Awesome Format");
             _format1.Id = 1;
 
-            _format2 = new CustomFormats.CustomFormat("Cool Format");
+            _format2 = new CustomFormat("Cool Format");
             _format2.Id = 2;
 
             var fakeSeries = Builder<Movie>.CreateNew()
@@ -40,13 +41,13 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                 ParsedMovieInfo = new ParsedMovieInfo { Quality = new QualityModel(Quality.DVD, new Revision(version: 2)) },
             };
 
-            CustomFormatsFixture.GivenCustomFormats(CustomFormats.CustomFormat.None, _format1, _format2);
+            CustomFormatsFixture.GivenCustomFormats(CustomFormat.None, _format1, _format2);
         }
 
         [Test]
         public void should_allow_if_format_is_defined_in_profile()
         {
-            _remoteMovie.ParsedMovieInfo.Quality.CustomFormats = new List<CustomFormats.CustomFormat> { _format1 };
+            _remoteMovie.ParsedMovieInfo.Quality.CustomFormats = new List<CustomFormat> { _format1 };
             _remoteMovie.Movie.Profile.FormatItems = CustomFormatsFixture.GetSampleFormatItems(_format1.Name);
 
             Subject.IsSatisfiedBy(_remoteMovie, null).Accepted.Should().BeTrue();
@@ -55,7 +56,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         [Test]
         public void should_deny_if_format_is_defined_in_profile()
         {
-            _remoteMovie.ParsedMovieInfo.Quality.CustomFormats = new List<CustomFormats.CustomFormat> { _format2 };
+            _remoteMovie.ParsedMovieInfo.Quality.CustomFormats = new List<CustomFormat> { _format2 };
             _remoteMovie.Movie.Profile.FormatItems = CustomFormatsFixture.GetSampleFormatItems(_format1.Name);
 
             Subject.IsSatisfiedBy(_remoteMovie, null).Accepted.Should().BeFalse();
@@ -64,7 +65,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         [Test]
         public void should_deny_if_one_format_is_defined_in_profile()
         {
-            _remoteMovie.ParsedMovieInfo.Quality.CustomFormats = new List<CustomFormats.CustomFormat> { _format2, _format1 };
+            _remoteMovie.ParsedMovieInfo.Quality.CustomFormats = new List<CustomFormat> { _format2, _format1 };
             _remoteMovie.Movie.Profile.FormatItems = CustomFormatsFixture.GetSampleFormatItems(_format1.Name);
 
             Subject.IsSatisfiedBy(_remoteMovie, null).Accepted.Should().BeFalse();
@@ -73,7 +74,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         [Test]
         public void should_allow_if_all_format_is_defined_in_profile()
         {
-            _remoteMovie.ParsedMovieInfo.Quality.CustomFormats = new List<CustomFormats.CustomFormat> { _format2, _format1 };
+            _remoteMovie.ParsedMovieInfo.Quality.CustomFormats = new List<CustomFormat> { _format2, _format1 };
             _remoteMovie.Movie.Profile.FormatItems = CustomFormatsFixture.GetSampleFormatItems(_format1.Name, _format2.Name);
 
             Subject.IsSatisfiedBy(_remoteMovie, null).Accepted.Should().BeTrue();
@@ -82,7 +83,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         [Test]
         public void should_deny_if_no_format_was_parsed_and_none_not_in_profile()
         {
-            _remoteMovie.ParsedMovieInfo.Quality.CustomFormats = new List<CustomFormats.CustomFormat> { };
+            _remoteMovie.ParsedMovieInfo.Quality.CustomFormats = new List<CustomFormat> { };
             _remoteMovie.Movie.Profile.FormatItems = CustomFormatsFixture.GetSampleFormatItems(_format1.Name, _format2.Name);
 
             Subject.IsSatisfiedBy(_remoteMovie, null).Accepted.Should().BeFalse();
@@ -91,8 +92,8 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         [Test]
         public void should_allow_if_no_format_was_parsed_and_none_in_profile()
         {
-            _remoteMovie.ParsedMovieInfo.Quality.CustomFormats = new List<CustomFormats.CustomFormat> { };
-            _remoteMovie.Movie.Profile.FormatItems = CustomFormatsFixture.GetSampleFormatItems(CustomFormats.CustomFormat.None.Name, _format1.Name, _format2.Name);
+            _remoteMovie.ParsedMovieInfo.Quality.CustomFormats = new List<CustomFormat> { };
+            _remoteMovie.Movie.Profile.FormatItems = CustomFormatsFixture.GetSampleFormatItems(CustomFormat.None.Name, _format1.Name, _format2.Name);
 
             Subject.IsSatisfiedBy(_remoteMovie, null).Accepted.Should().BeTrue();
         }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/CutoffSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/CutoffSpecificationFixture.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Qualities;
-using NzbDrone.Core.Test.CustomFormat;
+using NzbDrone.Core.Test.CustomFormats;
 using NzbDrone.Core.Test.Framework;
 
 namespace NzbDrone.Core.Test.DecisionEngineTests
@@ -12,7 +13,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
     [TestFixture]
     public class CutoffSpecificationFixture : CoreTest<UpgradableSpecification>
     {
-        private CustomFormats.CustomFormat _customFormat;
+        private CustomFormat _customFormat;
 
         [SetUp]
         public void Setup()
@@ -21,9 +22,9 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
         private void GivenCustomFormatHigher()
         {
-            _customFormat = new CustomFormats.CustomFormat("My Format", "L_ENGLISH") { Id = 1 };
+            _customFormat = new CustomFormat("My Format", "L_ENGLISH") { Id = 1 };
 
-            CustomFormatsFixture.GivenCustomFormats(_customFormat, CustomFormats.CustomFormat.None);
+            CustomFormatsFixture.GivenCustomFormats(_customFormat, CustomFormat.None);
         }
 
         [Test]
@@ -68,15 +69,15 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             GivenCustomFormatHigher();
             var old = new QualityModel(Quality.HDTV720p);
-            old.CustomFormats = new List<CustomFormats.CustomFormat> { CustomFormats.CustomFormat.None };
+            old.CustomFormats = new List<CustomFormat> { CustomFormat.None };
             var newQ = new QualityModel(Quality.Bluray1080p);
-            newQ.CustomFormats = new List<CustomFormats.CustomFormat> { _customFormat };
+            newQ.CustomFormats = new List<CustomFormat> { _customFormat };
             Subject.CutoffNotMet(
                 new Profile
                 {
                     Cutoff = Quality.HDTV720p.Id,
                     Items = Qualities.QualityFixture.GetDefaultQualities(),
-                    FormatCutoff = CustomFormats.CustomFormat.None.Id,
+                    FormatCutoff = CustomFormat.None.Id,
                     FormatItems = CustomFormatsFixture.GetSampleFormatItems("None", "My Format")
                 },
                 old,

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/PrioritizeDownloadDecisionFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/PrioritizeDownloadDecisionFixture.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Movies;
@@ -13,7 +14,7 @@ using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Profiles.Delay;
 using NzbDrone.Core.Qualities;
-using NzbDrone.Core.Test.CustomFormat;
+using NzbDrone.Core.Test.CustomFormats;
 using NzbDrone.Core.Test.Framework;
 
 namespace NzbDrone.Core.Test.DecisionEngineTests
@@ -23,18 +24,18 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
     //TODO: Update for custom qualities!
     public class PrioritizeDownloadDecisionFixture : CoreTest<DownloadDecisionPriorizationService>
     {
-        private CustomFormats.CustomFormat _customFormat1;
-        private CustomFormats.CustomFormat _customFormat2;
+        private CustomFormat _customFormat1;
+        private CustomFormat _customFormat2;
 
         [SetUp]
         public void Setup()
         {
             GivenPreferredDownloadProtocol(DownloadProtocol.Usenet);
 
-            _customFormat1 = new CustomFormats.CustomFormat("My Format 1", "L_ENGLISH") { Id = 1 };
-            _customFormat2 = new CustomFormats.CustomFormat("My Format 2", "L_FRENCH") { Id = 2 };
+            _customFormat1 = new CustomFormat("My Format 1", "L_ENGLISH") { Id = 1 };
+            _customFormat2 = new CustomFormat("My Format 2", "L_FRENCH") { Id = 2 };
 
-            CustomFormatsFixture.GivenCustomFormats(CustomFormats.CustomFormat.None, _customFormat1, _customFormat2);
+            CustomFormatsFixture.GivenCustomFormats(CustomFormat.None, _customFormat1, _customFormat2);
         }
 
         private RemoteMovie GivenRemoteMovie(QualityModel quality, int age = 0, long size = 0, DownloadProtocol downloadProtocol = DownloadProtocol.Usenet)
@@ -323,7 +324,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         public void should_prefer_better_custom_format()
         {
             var quality1 = new QualityModel(Quality.Bluray720p);
-            quality1.CustomFormats.Add(CustomFormats.CustomFormat.None);
+            quality1.CustomFormats.Add(CustomFormat.None);
             var remoteMovie1 = GivenRemoteMovie(quality1);
 
             var quality2 = new QualityModel(Quality.Bluray720p);
@@ -365,7 +366,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             var remoteMovie1 = GivenRemoteMovie(quality1);
 
             var quality2 = new QualityModel(Quality.Bluray720p);
-            quality2.CustomFormats.AddRange(new List<CustomFormats.CustomFormat> { _customFormat1, _customFormat2 });
+            quality2.CustomFormats.AddRange(new List<CustomFormat> { _customFormat1, _customFormat2 });
             var remoteMovie2 = GivenRemoteMovie(quality2);
 
             var decisions = new List<DownloadDecision>();

--- a/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateQualityFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateQualityFixture.cs
@@ -31,10 +31,10 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieImport.Aggregation.Aggregators
                                .Returns(AugmentQualityResult.ResolutionOnly((int)Resolution.R1080p, Confidence.MediaInfo));
 
             _fileExtensionAugmenter.Setup(s => s.AugmentQuality(It.IsAny<LocalMovie>()))
-                                   .Returns(new AugmentQualityResult(Source.TV, Confidence.Fallback, (int)Resolution.R720p, Confidence.Fallback, Modifier.NONE, Confidence.Fallback, new Revision(), new List<CustomFormats.CustomFormat>()));
+                                   .Returns(new AugmentQualityResult(Source.TV, Confidence.Fallback, (int)Resolution.R720p, Confidence.Fallback, Modifier.NONE, Confidence.Fallback, new Revision(), new List<CustomFormat>()));
 
             _nameAugmenter.Setup(s => s.AugmentQuality(It.IsAny<LocalMovie>()))
-                          .Returns(new AugmentQualityResult(Source.TV, Confidence.Default, (int)Resolution.R480p, Confidence.Default, Modifier.NONE, Confidence.Default, new Revision(), new List<CustomFormats.CustomFormat>()));
+                          .Returns(new AugmentQualityResult(Source.TV, Confidence.Default, (int)Resolution.R480p, Confidence.Default, Modifier.NONE, Confidence.Default, new Revision(), new List<CustomFormat>()));
         }
 
         private void GivenAugmenters(params Mock<IAugmentQuality>[] mocks)

--- a/src/NzbDrone.Core.Test/MediaFiles/UpdateMovieFileQualityServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/UpdateMovieFileQualityServiceFixture.cs
@@ -3,6 +3,7 @@ using FizzWare.NBuilder;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.History;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Commands;
@@ -33,9 +34,9 @@ namespace NzbDrone.Core.Test.MediaFiles
             _movieFile.Quality = _oldQuality;
 
             _newQuality = _oldQuality.JsonClone();
-            var format = new CustomFormats.CustomFormat("Awesome Format");
+            var format = new CustomFormat("Awesome Format");
             format.Id = 1;
-            _newQuality.CustomFormats = new List<CustomFormats.CustomFormat> { format };
+            _newQuality.CustomFormats = new List<CustomFormat> { format };
 
             _newInfo = new ParsedMovieInfo
             {

--- a/src/NzbDrone.Core.Test/MovieTests/MovieRepositoryTests/MovieRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieRepositoryTests/MovieRepositoryFixture.cs
@@ -2,9 +2,11 @@ using System.Linq;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.CustomFormats;
 using NzbDrone.Core.Test.Framework;
 
 namespace NzbDrone.Core.Test.MovieTests.MovieRepositoryTests
@@ -28,8 +30,8 @@ namespace NzbDrone.Core.Test.MovieTests.MovieRepositoryTests
             var profile = new Profile
                 {
                     Items = Qualities.QualityFixture.GetDefaultQualities(Quality.Bluray1080p, Quality.DVD, Quality.HDTV720p),
-                    FormatItems = CustomFormat.CustomFormatsFixture.GetDefaultFormatItems(),
-                    FormatCutoff = CustomFormats.CustomFormat.None.Id,
+                    FormatItems = CustomFormatsFixture.GetDefaultFormatItems(),
+                    FormatCutoff = CustomFormat.None.Id,
                     Cutoff = Quality.Bluray1080p.Id,
                     Name = "TestProfile"
                 };

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/AugmentersTests/AugmentWithParsedMovieInfo.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/AugmentersTests/AugmentWithParsedMovieInfo.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.Parser.Augmenters;
 using NzbDrone.Core.Parser.Model;
@@ -68,22 +69,22 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests.AugmentersTests
                 Quality = new QualityModel(Quality.Bluray1080p)
             };
 
-            var format1 = new CustomFormats.CustomFormat("Awesome Format");
+            var format1 = new CustomFormat("Awesome Format");
             format1.Id = 1;
 
-            var format2 = new CustomFormats.CustomFormat("Cool Format");
+            var format2 = new CustomFormat("Cool Format");
             format2.Id = 2;
 
-            folderInfo.Quality.CustomFormats = new List<CustomFormats.CustomFormat> { format1 };
+            folderInfo.Quality.CustomFormats = new List<CustomFormat> { format1 };
 
-            MovieInfo.Quality.CustomFormats = new List<CustomFormats.CustomFormat> { format2 };
+            MovieInfo.Quality.CustomFormats = new List<CustomFormat> { format2 };
 
             var result = Subject.AugmentMovieInfo(MovieInfo, folderInfo);
 
             result.Quality.CustomFormats.Count.Should().Be(2);
             result.Quality.CustomFormats.Should().BeEquivalentTo(format2, format1);
 
-            folderInfo.Quality.CustomFormats = new List<CustomFormats.CustomFormat> { format1, format2 };
+            folderInfo.Quality.CustomFormats = new List<CustomFormat> { format1, format2 };
 
             result = Subject.AugmentMovieInfo(MovieInfo, folderInfo);
 

--- a/src/NzbDrone.Core.Test/Profiles/ProfileRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/Profiles/ProfileRepositoryFixture.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.CustomFormats;
 using NzbDrone.Core.Test.Framework;
 
 namespace NzbDrone.Core.Test.Profiles
@@ -20,8 +22,8 @@ namespace NzbDrone.Core.Test.Profiles
             var profile = new Profile
             {
                 Items = Qualities.QualityFixture.GetDefaultQualities(Quality.Bluray1080p, Quality.DVD, Quality.HDTV720p),
-                FormatCutoff = CustomFormats.CustomFormat.None.Id,
-                FormatItems = CustomFormat.CustomFormatsFixture.GetDefaultFormatItems(),
+                FormatCutoff = CustomFormat.None.Id,
+                FormatItems = CustomFormatsFixture.GetDefaultFormatItems(),
                 Cutoff = Quality.Bluray1080p.Id,
                 Name = "TestProfile"
             };

--- a/src/NzbDrone.Core.Test/Profiles/ProfileServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Profiles/ProfileServiceFixture.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Test.Profiles
         {
             Mocker.GetMock<ICustomFormatService>()
                 .Setup(s => s.All())
-                .Returns(new List<CustomFormats.CustomFormat>());
+                .Returns(new List<CustomFormat>());
 
             Subject.Handle(new ApplicationStartedEvent());
 

--- a/src/NzbDrone.Core.Test/Qualities/QualityModelComparerFixture.cs
+++ b/src/NzbDrone.Core.Test/Qualities/QualityModelComparerFixture.cs
@@ -16,6 +16,8 @@ namespace NzbDrone.Core.Test.Qualities
 
         private CustomFormat _customFormat1;
         private CustomFormat _customFormat2;
+        private CustomFormat _customFormat3;
+        private CustomFormat _customFormat4;
 
         [SetUp]
         public void Setup()
@@ -80,10 +82,12 @@ namespace NzbDrone.Core.Test.Qualities
         {
             _customFormat1 = new CustomFormat("My Format 1", "L_ENGLISH") { Id = 1 };
             _customFormat2 = new CustomFormat("My Format 2", "L_FRENCH") { Id = 2 };
+            _customFormat3 = new CustomFormat("My Format 3", "L_SPANISH") { Id = 3 };
+            _customFormat4 = new CustomFormat("My Format 4", "L_ITALIAN") { Id = 4 };
 
-            CustomFormatsFixture.GivenCustomFormats(CustomFormat.None, _customFormat1, _customFormat2);
+            CustomFormatsFixture.GivenCustomFormats(CustomFormat.None, _customFormat1, _customFormat2, _customFormat3, _customFormat4);
 
-            Subject = new QualityModelComparer(new Profile { Items = QualityFixture.GetDefaultQualities(), FormatItems = CustomFormatsFixture.GetSampleFormatItems() });
+            Subject = new QualityModelComparer(new Profile { Items = QualityFixture.GetDefaultQualities(), FormatItems = CustomFormatsFixture.GetSampleFormatItems(), FormatCutoff = _customFormat2.Id });
         }
 
         [Test]
@@ -188,6 +192,58 @@ namespace NzbDrone.Core.Test.Qualities
             var compare = Subject.Compare(first, second, true);
 
             compare.Should().BeLessThan(0);
+        }
+
+        [Test]
+        public void should_be_greater_when_one_format_over_cutoff()
+        {
+            GivenDefaultProfileWithFormats();
+
+            var first = new List<CustomFormat> { _customFormat3 };
+            var second = _customFormat2.Id;
+
+            var compare = Subject.Compare(first, second);
+
+            compare.Should().BeGreaterThan(0);
+        }
+
+        [Test]
+        public void should_be_greater_when_multiple_formats_over_cutoff()
+        {
+            GivenDefaultProfileWithFormats();
+
+            var first = new List<CustomFormat> { _customFormat3, _customFormat4 };
+            var second = _customFormat2.Id;
+
+            var compare = Subject.Compare(first, second);
+
+            compare.Should().BeGreaterThan(0);
+        }
+
+        [Test]
+        public void should_be_greater_when_one_better_one_worse_than_cutoff()
+        {
+            GivenDefaultProfileWithFormats();
+
+            var first = new List<CustomFormat> { _customFormat1, _customFormat3 };
+            var second = _customFormat2.Id;
+
+            var compare = Subject.Compare(first, second);
+
+            compare.Should().BeGreaterThan(0);
+        }
+
+        [Test]
+        public void should_be_zero_when_one_worse_one_equal_to_cutoff()
+        {
+            GivenDefaultProfileWithFormats();
+
+            var first = new List<CustomFormat> { _customFormat1, _customFormat2 };
+            var second = _customFormat2.Id;
+
+            var compare = Subject.Compare(first, second);
+
+            compare.Should().Be(0);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/Qualities/QualityModelComparerFixture.cs
+++ b/src/NzbDrone.Core.Test/Qualities/QualityModelComparerFixture.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Qualities;
-using NzbDrone.Core.Test.CustomFormat;
+using NzbDrone.Core.Test.CustomFormats;
 using NzbDrone.Core.Test.Framework;
 
 namespace NzbDrone.Core.Test.Qualities
@@ -13,8 +14,8 @@ namespace NzbDrone.Core.Test.Qualities
     {
         public QualityModelComparer Subject { get; set; }
 
-        private CustomFormats.CustomFormat _customFormat1;
-        private CustomFormats.CustomFormat _customFormat2;
+        private CustomFormat _customFormat1;
+        private CustomFormat _customFormat2;
 
         [SetUp]
         public void Setup()
@@ -77,10 +78,10 @@ namespace NzbDrone.Core.Test.Qualities
 
         private void GivenDefaultProfileWithFormats()
         {
-            _customFormat1 = new CustomFormats.CustomFormat("My Format 1", "L_ENGLISH") { Id = 1 };
-            _customFormat2 = new CustomFormats.CustomFormat("My Format 2", "L_FRENCH") { Id = 2 };
+            _customFormat1 = new CustomFormat("My Format 1", "L_ENGLISH") { Id = 1 };
+            _customFormat2 = new CustomFormat("My Format 2", "L_FRENCH") { Id = 2 };
 
-            CustomFormatsFixture.GivenCustomFormats(CustomFormats.CustomFormat.None, _customFormat1, _customFormat2);
+            CustomFormatsFixture.GivenCustomFormats(CustomFormat.None, _customFormat1, _customFormat2);
 
             Subject = new QualityModelComparer(new Profile { Items = QualityFixture.GetDefaultQualities(), FormatItems = CustomFormatsFixture.GetSampleFormatItems() });
         }
@@ -142,8 +143,8 @@ namespace NzbDrone.Core.Test.Qualities
         {
             GivenDefaultProfileWithFormats();
 
-            var first = new QualityModel(Quality.DVD) { CustomFormats = new List<CustomFormats.CustomFormat> { _customFormat1 } };
-            var second = new QualityModel(Quality.DVD) { CustomFormats = new List<CustomFormats.CustomFormat> { _customFormat2 } };
+            var first = new QualityModel(Quality.DVD) { CustomFormats = new List<CustomFormat> { _customFormat1 } };
+            var second = new QualityModel(Quality.DVD) { CustomFormats = new List<CustomFormat> { _customFormat2 } };
 
             var compare = Subject.Compare(first, second);
 
@@ -155,8 +156,8 @@ namespace NzbDrone.Core.Test.Qualities
         {
             GivenDefaultProfileWithFormats();
 
-            var first = new QualityModel(Quality.DVD) { CustomFormats = new List<CustomFormats.CustomFormat> { _customFormat2 } };
-            var second = new QualityModel(Quality.DVD) { CustomFormats = new List<CustomFormats.CustomFormat> { _customFormat1 } };
+            var first = new QualityModel(Quality.DVD) { CustomFormats = new List<CustomFormat> { _customFormat2 } };
+            var second = new QualityModel(Quality.DVD) { CustomFormats = new List<CustomFormat> { _customFormat1 } };
 
             var compare = Subject.Compare(first, second);
 

--- a/src/NzbDrone.Core/Qualities/QualityModelComparer.cs
+++ b/src/NzbDrone.Core/Qualities/QualityModelComparer.cs
@@ -79,20 +79,10 @@ namespace NzbDrone.Core.Qualities
 
         public int Compare(CustomFormat left, CustomFormat right)
         {
-            int leftIndex = _profile.FormatItems.FindIndex(v => Equals(v.Format, left));
-            int rightIndex = _profile.FormatItems.FindIndex(v => Equals(v.Format, right));
-
-            return leftIndex.CompareTo(rightIndex);
-        }
-
-        public int Compare(List<CustomFormat> left, CustomFormat right)
-        {
-            left = left.WithNone();
-
-            var leftIndicies = GetIndicies(left, _profile);
+            var leftIndex = _profile.FormatItems.FindIndex(v => Equals(v.Format, left));
             var rightIndex = _profile.FormatItems.FindIndex(v => Equals(v.Format, right));
 
-            return leftIndicies.Select(i => i.CompareTo(rightIndex)).Sum();
+            return leftIndex.CompareTo(rightIndex);
         }
 
         public int Compare(List<CustomFormat> left, int right)
@@ -102,7 +92,7 @@ namespace NzbDrone.Core.Qualities
             var leftIndicies = GetIndicies(left, _profile);
             var rightIndex = _profile.FormatItems.FindIndex(v => Equals(v.Format.Id, right));
 
-            return leftIndicies.Select(i => i.CompareTo(rightIndex)).Sum();
+            return leftIndicies.Select(i => i.CompareTo(rightIndex)).Max();
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- If formats are not used mutually exclusive, but instead more as preferred words its possible to upgrade if cutoff is already met. Cutoff status is currently calculated by summing the compare values from the different formats to the cutoff. So if one format is over cutoff, but two are below you can have a negative compare value despite being over cutoff, thus allowing a new download to grab.
