### PR TITLE
Fixed: Remove Static/Dynamic Settings, Allow Folder Move from Editor

### DIFF
--- a/frontend/src/Movie/MoveMovie/MoveMovieModal.js
+++ b/frontend/src/Movie/MoveMovie/MoveMovieModal.js
@@ -49,6 +49,13 @@ function MoveMovieModal(props) {
               `Would you like to move the movie folders to '${destinationRootFolder}'?` :
               `Would you like to move the movie files from '${originalPath}' to '${destinationPath}'?`
           }
+          {
+            destinationRootFolder ?
+              <div>
+                This will also rename the movie folder per the movie folder format in settings.
+              </div> :
+              null
+          }
         </ModalBody>
 
         <ModalFooter>

--- a/src/NzbDrone.Api/Config/MediaManagementConfigResource.cs
+++ b/src/NzbDrone.Api/Config/MediaManagementConfigResource.cs
@@ -39,7 +39,6 @@ namespace NzbDrone.Api.Config
                 CreateEmptySeriesFolders = model.CreateEmptyMovieFolders,
                 FileDate = model.FileDate,
                 AutoRenameFolders = model.AutoRenameFolders,
-                PathsDefaultStatic = model.PathsDefaultStatic,
 
                 SetPermissionsLinux = model.SetPermissionsLinux,
                 FileChmod = model.FileChmod,

--- a/src/NzbDrone.Api/Movies/MovieEditorModule.cs
+++ b/src/NzbDrone.Api/Movies/MovieEditorModule.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Api.Movies
 
             var movie = resources.Select(movieResource => movieResource.ToModel(_movieService.GetMovie(movieResource.Id))).ToList();
 
-            return ResponseWithCode(_movieService.UpdateMovie(movie)
+            return ResponseWithCode(_movieService.UpdateMovie(movie, true)
                                     .ToResource(),
                                     HttpStatusCode.Accepted);
         }

--- a/src/NzbDrone.Api/Movies/MovieResource.cs
+++ b/src/NzbDrone.Api/Movies/MovieResource.cs
@@ -43,7 +43,6 @@ namespace NzbDrone.Api.Movies
         //View & Edit
         public string Path { get; set; }
         public int ProfileId { get; set; }
-        public MoviePathState PathState { get; set; }
 
         //Editing Only
         public bool Monitored { get; set; }
@@ -144,7 +143,6 @@ namespace NzbDrone.Api.Movies
 
                 Path = model.Path,
                 ProfileId = model.ProfileId,
-                PathState = model.PathState,
 
                 Monitored = model.Monitored,
                 MinimumAvailability = model.MinimumAvailability,
@@ -209,7 +207,6 @@ namespace NzbDrone.Api.Movies
 
                 Path = resource.Path,
                 ProfileId = resource.ProfileId,
-                PathState = resource.PathState,
 
                 Monitored = resource.Monitored,
                 MinimumAvailability = resource.MinimumAvailability,

--- a/src/NzbDrone.Core.Test/Datastore/WhereBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/WhereBuilderFixture.cs
@@ -153,30 +153,30 @@ namespace NzbDrone.Core.Test.Datastore
         [Test]
         public void enum_as_int()
         {
-            _subject = Where(x => x.PathState == MoviePathState.Static);
+            _subject = Where(x => x.Status == MovieStatusType.Released);
 
             var name = _subject.Parameters.ParameterNames.First();
-            _subject.ToString().Should().Be($"(\"Movies\".\"PathState\" = @{name})");
+            _subject.ToString().Should().Be($"(\"Movies\".\"Status\" = @{name})");
         }
 
         [Test]
         public void enum_in_list()
         {
-            var allowed = new List<MoviePathState> { MoviePathState.Dynamic, MoviePathState.Static };
-            _subject = Where(x => allowed.Contains(x.PathState));
+            var allowed = new List<MovieStatusType> { MovieStatusType.InCinemas, MovieStatusType.Released };
+            _subject = Where(x => allowed.Contains(x.Status));
 
             var name = _subject.Parameters.ParameterNames.First();
-            _subject.ToString().Should().Be($"(\"Movies\".\"PathState\" IN @{name})");
+            _subject.ToString().Should().Be($"(\"Movies\".\"Status\" IN @{name})");
         }
 
         [Test]
         public void enum_in_array()
         {
-            var allowed = new MoviePathState[] { MoviePathState.Dynamic, MoviePathState.Static };
-            _subject = Where(x => allowed.Contains(x.PathState));
+            var allowed = new MovieStatusType[] { MovieStatusType.InCinemas, MovieStatusType.Released };
+            _subject = Where(x => allowed.Contains(x.Status));
 
             var name = _subject.Parameters.ParameterNames.First();
-            _subject.ToString().Should().Be($"(\"Movies\".\"PathState\" IN @{name})");
+            _subject.ToString().Should().Be($"(\"Movies\".\"Status\" IN @{name})");
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MovieTests/MovieFolderPathBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieFolderPathBuilderFixture.cs
@@ -1,0 +1,94 @@
+﻿using System.IO;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.RootFolders;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.MovieTests
+{
+    [TestFixture]
+    public class MovieFolderPathBuilderFixture : CoreTest<MoviePathBuilder>
+    {
+        private Movie _movie;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movie = Builder<Movie>.CreateNew()
+                                     .With(s => s.Title = "Movie Title")
+                                     .With(s => s.Path = @"C:\Test\Movies\Movie.Title".AsOsAgnostic())
+                                     .With(s => s.RootFolderPath = null)
+                                     .Build();
+        }
+
+        public void GivenMovieFolderName(string name)
+        {
+            Mocker.GetMock<IBuildFileNames>()
+                  .Setup(s => s.GetMovieFolder(_movie, null))
+                  .Returns(name);
+        }
+
+        public void GivenExistingRootFolder(string rootFolder)
+        {
+            Mocker.GetMock<IRootFolderService>()
+                  .Setup(s => s.GetBestRootFolderPath(It.IsAny<string>()))
+                  .Returns(rootFolder);
+        }
+
+        [Test]
+        public void should_create_new_movie_path()
+        {
+            var rootFolder = @"C:\Test\Movies2".AsOsAgnostic();
+
+            GivenMovieFolderName(_movie.Title);
+            _movie.RootFolderPath = rootFolder;
+
+            Subject.BuildPath(_movie, false).Should().Be(Path.Combine(rootFolder, _movie.Title));
+        }
+
+        [Test]
+        public void should_reuse_existing_relative_folder_name()
+        {
+            var folderName = Path.GetFileName(_movie.Path);
+            var rootFolder = @"C:\Test\Movies2".AsOsAgnostic();
+
+            GivenExistingRootFolder(Path.GetDirectoryName(_movie.Path));
+            GivenMovieFolderName(_movie.Title);
+            _movie.RootFolderPath = rootFolder;
+
+            Subject.BuildPath(_movie, true).Should().Be(Path.Combine(rootFolder, folderName));
+        }
+
+        [Test]
+        public void should_reuse_existing_relative_folder_structure()
+        {
+            var existingRootFolder = @"C:\Test\Movies".AsOsAgnostic();
+            var existingRelativePath = @"M\Movie.Title";
+            var rootFolder = @"C:\Test\Movies2".AsOsAgnostic();
+
+            GivenExistingRootFolder(existingRootFolder);
+            GivenMovieFolderName(_movie.Title);
+            _movie.RootFolderPath = rootFolder;
+            _movie.Path = Path.Combine(existingRootFolder, existingRelativePath);
+
+            Subject.BuildPath(_movie, true).Should().Be(Path.Combine(rootFolder, existingRelativePath));
+        }
+
+        [Test]
+        public void should_use_built_path_for_new_movie()
+        {
+            var rootFolder = @"C:\Test\Movies2".AsOsAgnostic();
+
+            GivenMovieFolderName(_movie.Title);
+            _movie.RootFolderPath = rootFolder;
+            _movie.Path = null;
+
+            Subject.BuildPath(_movie, true).Should().Be(Path.Combine(rootFolder, _movie.Title));
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NetImport/NetImportSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/NetImport/NetImportSearchServiceFixture.cs
@@ -116,7 +116,7 @@ namespace NzbDrone.Core.Test.NetImport
                   .Verify(v => v.GetAllMovies(), Times.Never());
 
             Mocker.GetMock<IMovieService>()
-                  .Verify(v => v.UpdateMovie(new List<Movie>()), Times.Once());
+                  .Verify(v => v.UpdateMovie(new List<Movie>(), true), Times.Once());
         }
 
         [Test]
@@ -139,7 +139,7 @@ namespace NzbDrone.Core.Test.NetImport
                   .Verify(v => v.DeleteMovie(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never());
 
             Mocker.GetMock<IMovieService>()
-                  .Verify(v => v.UpdateMovie(new List<Movie>()), Times.Once());
+                  .Verify(v => v.UpdateMovie(new List<Movie>(), true), Times.Once());
         }
 
         [Test]
@@ -162,7 +162,7 @@ namespace NzbDrone.Core.Test.NetImport
                   .Verify(v => v.DeleteMovie(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never());
 
             Mocker.GetMock<IMovieService>()
-                  .Verify(v => v.UpdateMovie(It.Is<List<Movie>>(s => s.Count == 3 && s.All(m => !m.Monitored))), Times.Once());
+                  .Verify(v => v.UpdateMovie(It.Is<List<Movie>>(s => s.Count == 3 && s.All(m => !m.Monitored)), true), Times.Once());
         }
 
         [Test]
@@ -181,7 +181,7 @@ namespace NzbDrone.Core.Test.NetImport
             Subject.Execute(_command);
 
             Mocker.GetMock<IMovieService>()
-                  .Verify(v => v.UpdateMovie(It.Is<List<Movie>>(s => s.Count == 2 && s.All(m => !m.Monitored))), Times.Once());
+                  .Verify(v => v.UpdateMovie(It.Is<List<Movie>>(s => s.Count == 2 && s.All(m => !m.Monitored)), true), Times.Once());
         }
 
         [Test]
@@ -201,7 +201,7 @@ namespace NzbDrone.Core.Test.NetImport
             Subject.Execute(_command);
 
             Mocker.GetMock<IMovieService>()
-                  .Verify(v => v.UpdateMovie(It.Is<List<Movie>>(s => s.Count == 2 && s.All(m => !m.Monitored))), Times.Once());
+                  .Verify(v => v.UpdateMovie(It.Is<List<Movie>>(s => s.Count == 2 && s.All(m => !m.Monitored)), true), Times.Once());
         }
 
         [Test]
@@ -227,7 +227,7 @@ namespace NzbDrone.Core.Test.NetImport
                   .Verify(v => v.DeleteMovie(It.IsAny<int>(), true, It.IsAny<bool>()), Times.Never());
 
             Mocker.GetMock<IMovieService>()
-                  .Verify(v => v.UpdateMovie(new List<Movie>()), Times.Once());
+                  .Verify(v => v.UpdateMovie(new List<Movie>(), true), Times.Once());
         }
 
         [Test]
@@ -253,7 +253,7 @@ namespace NzbDrone.Core.Test.NetImport
                   .Verify(v => v.DeleteMovie(It.IsAny<int>(), true, It.IsAny<bool>()), Times.Exactly(3));
 
             Mocker.GetMock<IMovieService>()
-                  .Verify(v => v.UpdateMovie(new List<Movie>()), Times.Once());
+                  .Verify(v => v.UpdateMovie(new List<Movie>(), true), Times.Once());
         }
 
         [Test]
@@ -267,7 +267,7 @@ namespace NzbDrone.Core.Test.NetImport
             Subject.Execute(_command);
 
             Mocker.GetMock<IMovieService>()
-                  .Verify(v => v.UpdateMovie(new List<Movie>()), Times.Never());
+                  .Verify(v => v.UpdateMovie(new List<Movie>(), true), Times.Never());
         }
 
         [Test]

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -299,13 +299,6 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("AutoRenameFolders", value); }
         }
 
-        public bool PathsDefaultStatic
-        {
-            get { return GetValueBoolean("PathsDefaultStatic", true); }
-
-            set { SetValue("PathsDefaultStatic", value); }
-        }
-
         public RescanAfterRefreshType RescanAfterRefresh
         {
             get { return GetValueEnum("RescanAfterRefresh", RescanAfterRefreshType.Always); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -40,7 +40,6 @@ namespace NzbDrone.Core.Configuration
         string ExtraFileExtensions { get; set; }
         RescanAfterRefreshType RescanAfterRefresh { get; set; }
         bool AutoRenameFolders { get; set; }
-        bool PathsDefaultStatic { get; set; }
 
         //Permissions (Media Management)
         bool SetPermissionsLinux { get; set; }

--- a/src/NzbDrone.Core/Datastore/Migration/167_remove_movie_pathstate.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/167_remove_movie_pathstate.cs
@@ -1,0 +1,21 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(167)]
+    public class remove_movie_pathstate : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Delete.Column("PathState").FromTable("Movies");
+
+            Execute.Sql("DELETE FROM Config WHERE [KEY] IN ('pathsdefaultstatic')");
+
+            Alter.Table("MovieFiles").AddColumn("OriginalFilePath").AsString().Nullable();
+
+            //This is Ignored in mapping, should not be in DB
+            Delete.Column("Path").FromTable("MovieFiles");
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MovieFile.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieFile.cs
@@ -17,6 +17,7 @@ namespace NzbDrone.Core.MediaFiles
         public string Path { get; set; }
         public long Size { get; set; }
         public DateTime DateAdded { get; set; }
+        public string OriginalFilePath { get; set; }
         public string SceneName { get; set; }
         public string ReleaseGroup { get; set; }
         public IndexerFlags IndexerFlags { get; set; }

--- a/src/NzbDrone.Core/Movies/Commands/MoveMovieCommand.cs
+++ b/src/NzbDrone.Core/Movies/Commands/MoveMovieCommand.cs
@@ -9,6 +9,7 @@ namespace NzbDrone.Core.Movies.Commands
         public string DestinationPath { get; set; }
         public string DestinationRootFolder { get; set; }
 
+        public override bool SendUpdatesToClient => true;
         public override bool RequiresDiskAccess => true;
     }
 }

--- a/src/NzbDrone.Core/Movies/Movie.cs
+++ b/src/NzbDrone.Core/Movies/Movie.cs
@@ -42,7 +42,6 @@ namespace NzbDrone.Core.Movies
 
         public string Certification { get; set; }
         public string RootFolderPath { get; set; }
-        public MoviePathState PathState { get; set; }
         public DateTime Added { get; set; }
         public DateTime? InCinemas { get; set; }
         public DateTime? PhysicalRelease { get; set; }
@@ -154,7 +153,6 @@ namespace NzbDrone.Core.Movies
 
             Path = otherMovie.Path;
             ProfileId = otherMovie.ProfileId;
-            PathState = otherMovie.PathState;
 
             Monitored = otherMovie.Monitored;
             MinimumAvailability = otherMovie.MinimumAvailability;
@@ -163,12 +161,5 @@ namespace NzbDrone.Core.Movies
             Tags = otherMovie.Tags;
             AddOptions = otherMovie.AddOptions;
         }
-    }
-
-    public enum MoviePathState
-    {
-        Dynamic,
-        StaticOnce,
-        Static,
     }
 }

--- a/src/NzbDrone.Core/Movies/MoviePathBuilder.cs
+++ b/src/NzbDrone.Core/Movies/MoviePathBuilder.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.RootFolders;
+
+namespace NzbDrone.Core.Movies
+{
+    public interface IBuildMoviePaths
+    {
+        string BuildPath(Movie movie, bool useExistingRelativeFolder);
+    }
+
+    public class MoviePathBuilder : IBuildMoviePaths
+    {
+        private readonly IBuildFileNames _fileNameBuilder;
+        private readonly IRootFolderService _rootFolderService;
+
+        public MoviePathBuilder(IBuildFileNames fileNameBuilder, IRootFolderService rootFolderService)
+        {
+            _fileNameBuilder = fileNameBuilder;
+            _rootFolderService = rootFolderService;
+        }
+
+        public string BuildPath(Movie movie, bool useExistingRelativeFolder)
+        {
+            if (movie.RootFolderPath.IsNullOrWhiteSpace())
+            {
+                throw new ArgumentException("Root folder was not provided", nameof(movie));
+            }
+
+            if (useExistingRelativeFolder && movie.Path.IsNotNullOrWhiteSpace())
+            {
+                var relativePath = GetExistingRelativePath(movie);
+                return Path.Combine(movie.RootFolderPath, relativePath);
+            }
+
+            return Path.Combine(movie.RootFolderPath, _fileNameBuilder.GetMovieFolder(movie));
+        }
+
+        private string GetExistingRelativePath(Movie movie)
+        {
+            var rootFolderPath = _rootFolderService.GetBestRootFolderPath(movie.Path);
+
+            return rootFolderPath.GetRelativePath(movie.Path);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -138,7 +138,7 @@ namespace NzbDrone.Core.Movies
                 _logger.Info(ex, "Unable to communicate with Mappings Server.");
             }
 
-            _movieService.UpdateMovie(new List<Movie> { movie });
+            _movieService.UpdateMovie(new List<Movie> { movie }, true);
             _creditService.UpdateCredits(tuple.Item2, movie);
 
             try

--- a/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
+++ b/src/NzbDrone.Core/NetImport/NetImportSearchService.cs
@@ -194,7 +194,7 @@ namespace NzbDrone.Core.NetImport
                 }
             }
 
-            _movieService.UpdateMovie(moviesToUpdate);
+            _movieService.UpdateMovie(moviesToUpdate, true);
         }
     }
 }

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -18,7 +18,6 @@ namespace NzbDrone.Core.Organizer
     {
         string BuildFileName(Movie movie, MovieFile movieFile, NamingConfig namingConfig = null);
         string BuildFilePath(Movie movie, string fileName, string extension);
-        string BuildMoviePath(Movie movie, NamingConfig namingConfig = null);
         BasicNamingConfig GetBasicNamingConfig(NamingConfig nameSpec);
         string GetMovieFolder(Movie movie, NamingConfig namingConfig = null);
     }
@@ -110,57 +109,9 @@ namespace NzbDrone.Core.Organizer
         {
             Ensure.That(extension, () => extension).IsNotNullOrWhiteSpace();
 
-            var path = "";
-
-            if (movie.PathState > 0)
-            {
-                path = movie.Path;
-            }
-            else
-            {
-                path = BuildMoviePath(movie);
-            }
+            var path = movie.Path;
 
             return Path.Combine(path, fileName + extension);
-        }
-
-        public string BuildMoviePath(Movie movie, NamingConfig namingConfig = null)
-        {
-            if (namingConfig == null)
-            {
-                namingConfig = _namingConfigService.GetConfig();
-            }
-
-            var path = movie.Path;
-            var directory = new DirectoryInfo(path).Name;
-            var parentDirectoryPath = new DirectoryInfo(path).Parent.FullName;
-
-            var movieFile = movie.MovieFile;
-
-            var pattern = namingConfig.MovieFolderFormat;
-            var tokenHandlers = new Dictionary<string, Func<TokenMatch, string>>(FileNameBuilderTokenEqualityComparer.Instance);
-
-            AddMovieTokens(tokenHandlers, movie);
-            AddReleaseDateTokens(tokenHandlers, movie.Year);
-            AddIdTokens(tokenHandlers, movie);
-
-            if (movie.MovieFile != null)
-            {
-                AddQualityTokens(tokenHandlers, movie, movieFile);
-                AddMediaInfoTokens(tokenHandlers, movieFile);
-                AddMovieFileTokens(tokenHandlers, movieFile);
-                AddTagsTokens(tokenHandlers, movieFile);
-            }
-            else
-            {
-                AddMovieFileTokens(tokenHandlers, new MovieFile { SceneName = $"{movie.Title} {movie.Year}", RelativePath = $"{movie.Title} {movie.Year}" });
-            }
-
-            var directoryName = ReplaceTokens(pattern, tokenHandlers, namingConfig).Trim();
-            directoryName = FileNameCleanupRegex.Replace(directoryName, match => match.Captures[0].Value[0].ToString());
-            directoryName = TrimSeparatorsRegex.Replace(directoryName, string.Empty);
-
-            return Path.Combine(parentDirectoryPath, directoryName);
         }
 
         public BasicNamingConfig GetBasicNamingConfig(NamingConfig nameSpec)

--- a/src/Radarr.Api.V3/Config/MediaManagementConfigResource.cs
+++ b/src/Radarr.Api.V3/Config/MediaManagementConfigResource.cs
@@ -46,7 +46,6 @@ namespace Radarr.Api.V3.Config
                 FileDate = model.FileDate,
                 RescanAfterRefresh = model.RescanAfterRefresh,
                 AutoRenameFolders = model.AutoRenameFolders,
-                PathsDefaultStatic = model.PathsDefaultStatic,
 
                 SetPermissionsLinux = model.SetPermissionsLinux,
                 FileChmod = model.FileChmod,

--- a/src/Radarr.Api.V3/MovieFiles/MovieFileResource.cs
+++ b/src/Radarr.Api.V3/MovieFiles/MovieFileResource.cs
@@ -23,6 +23,7 @@ namespace Radarr.Api.V3.MovieFiles
         public QualityModel Quality { get; set; }
         public List<CustomFormatResource> CustomFormats { get; set; }
         public MediaInfoResource MediaInfo { get; set; }
+        public string OriginalFilePath { get; set; }
         public bool QualityCutoffNotMet { get; set; }
         public List<Language> Languages { get; set; }
     }
@@ -51,8 +52,7 @@ namespace Radarr.Api.V3.MovieFiles
                 Quality = model.Quality,
                 Languages = model.Languages,
                 MediaInfo = model.MediaInfo.ToResource(model.SceneName),
-
-                //QualityCutoffNotMet
+                OriginalFilePath = model.OriginalFilePath
             };
         }
 
@@ -76,7 +76,8 @@ namespace Radarr.Api.V3.MovieFiles
                 IndexerFlags = model.IndexerFlags,
                 Quality = model.Quality,
                 Languages = model.Languages,
-                MediaInfo = model.MediaInfo.ToResource(model.SceneName)
+                MediaInfo = model.MediaInfo.ToResource(model.SceneName),
+                OriginalFilePath = model.OriginalFilePath
             };
         }
 
@@ -101,7 +102,8 @@ namespace Radarr.Api.V3.MovieFiles
                 Quality = model.Quality,
                 Languages = model.Languages,
                 MediaInfo = model.MediaInfo.ToResource(model.SceneName),
-                QualityCutoffNotMet = upgradableSpecification.QualityCutoffNotMet(movie.Profile, model.Quality)
+                QualityCutoffNotMet = upgradableSpecification.QualityCutoffNotMet(movie.Profile, model.Quality),
+                OriginalFilePath = model.OriginalFilePath
             };
         }
     }

--- a/src/Radarr.Api.V3/Movies/MovieEditorModule.cs
+++ b/src/Radarr.Api.V3/Movies/MovieEditorModule.cs
@@ -85,7 +85,7 @@ namespace Radarr.Api.V3.Movies
                 });
             }
 
-            return ResponseWithCode(_movieService.UpdateMovie(moviesToUpdate)
+            return ResponseWithCode(_movieService.UpdateMovie(moviesToUpdate, !resource.MoveFiles)
                                     .ToResource(),
                                     HttpStatusCode.Accepted);
         }

--- a/src/Radarr.Api.V3/Movies/MovieResource.cs
+++ b/src/Radarr.Api.V3/Movies/MovieResource.cs
@@ -45,7 +45,6 @@ namespace Radarr.Api.V3.Movies
         //View & Edit
         public string Path { get; set; }
         public int QualityProfileId { get; set; }
-        public MoviePathState PathState { get; set; }
 
         //Editing Only
         public bool Monitored { get; set; }
@@ -105,7 +104,6 @@ namespace Radarr.Api.V3.Movies
 
                 Path = model.Path,
                 QualityProfileId = model.ProfileId,
-                PathState = model.PathState,
 
                 Monitored = model.Monitored,
                 MinimumAvailability = model.MinimumAvailability,
@@ -166,7 +164,6 @@ namespace Radarr.Api.V3.Movies
 
                 Path = model.Path,
                 QualityProfileId = model.ProfileId,
-                PathState = model.PathState,
 
                 Monitored = model.Monitored,
                 MinimumAvailability = model.MinimumAvailability,
@@ -221,7 +218,6 @@ namespace Radarr.Api.V3.Movies
 
                 Path = resource.Path,
                 ProfileId = resource.QualityProfileId,
-                PathState = resource.PathState,
 
                 Monitored = resource.Monitored,
                 MinimumAvailability = resource.MinimumAvailability,


### PR DESCRIPTION
#### Database Migration
YES [167 - Remove Static/Dynamic Config Values and PathState]

#### Description
Remove Static/Dynamic config values per movie and in media management, Allow folder name change during movie move in editor or edit. 

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
Fixes #3969 
Fixes #1787