### PR TITLE
Aphrodite language improvements

### DIFF
--- a/frontend/src/Helpers/Props/icons.js
+++ b/frontend/src/Helpers/Props/icons.js
@@ -45,6 +45,7 @@ import {
   faCloud as fasCloud,
   faCog as fasCog,
   faCogs as fasCogs,
+  faCompactDisc as fasCompactDisc,
   faCopy as fasCopy,
   faDesktop as fasDesktop,
   faDownload as fasDownload,
@@ -133,6 +134,7 @@ export const COLLAPSE = fasChevronCircleUp;
 export const COMPUTER = fasDesktop;
 export const DANGER = fasExclamationCircle;
 export const DELETE = fasTrashAlt;
+export const DISC = fasCompactDisc;
 export const DOWNLOAD = fasDownload;
 export const DOWNLOADED = fasDownload;
 export const DOWNLOADING = fasCloudDownloadAlt;

--- a/frontend/src/Movie/Details/MovieAlternateTitles.js
+++ b/frontend/src/Movie/Details/MovieAlternateTitles.js
@@ -6,7 +6,7 @@ function MovieAlternateTitles({ alternateTitles }) {
   return (
     <ul>
       {
-        alternateTitles.map((alternateTitle) => {
+        alternateTitles.filter((x, i, a) => a.indexOf(x) === i).map((alternateTitle) => {
           return (
             <li
               key={alternateTitle}

--- a/frontend/src/Movie/Details/MovieDetails.js
+++ b/frontend/src/Movie/Details/MovieDetails.js
@@ -243,7 +243,7 @@ class MovieDetails extends Component {
       collection,
       overview,
       youTubeTrailerId,
-      inCinemas,
+      isAvailable,
       images,
       tags,
       isSaving,
@@ -483,7 +483,7 @@ class MovieDetails extends Component {
                       <MovieStatusLabel
                         hasMovieFiles={hasMovieFiles}
                         monitored={monitored}
-                        inCinemas={inCinemas}
+                        isAvailable={isAvailable}
                       />
                     </span>
                   </InfoLabel>
@@ -722,6 +722,7 @@ MovieDetails.propTypes = {
   studio: PropTypes.string,
   collection: PropTypes.object,
   youTubeTrailerId: PropTypes.string,
+  isAvailable: PropTypes.bool.isRequired,
   inCinemas: PropTypes.string,
   overview: PropTypes.string.isRequired,
   images: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/frontend/src/Movie/Details/MovieDetails.js
+++ b/frontend/src/Movie/Details/MovieDetails.js
@@ -40,6 +40,7 @@ import MovieDetailsLinks from './MovieDetailsLinks';
 import InteractiveSearchTable from 'InteractiveSearch/InteractiveSearchTable';
 import InteractiveSearchFilterMenuConnector from 'InteractiveSearch/InteractiveSearchFilterMenuConnector';
 import MovieTagsConnector from './MovieTagsConnector';
+import MovieReleaseDatesConnector from './MovieReleaseDatesConnector';
 import styles from './MovieDetails.css';
 
 const defaultFontSize = parseInt(fonts.defaultFontSize);
@@ -232,6 +233,9 @@ class MovieDetails extends Component {
       imdbId,
       title,
       year,
+      inCinemas,
+      physicalRelease,
+      digitalRelease,
       runtime,
       certification,
       ratings,
@@ -398,7 +402,20 @@ class MovieDetails extends Component {
                     {
                       year > 0 &&
                         <span className={styles.year}>
-                          {year}
+                          <Popover
+                            anchor={
+                              year
+                            }
+                            title="Release Dates"
+                            body={
+                              <MovieReleaseDatesConnector
+                                inCinemas={inCinemas}
+                                physicalRelease={physicalRelease}
+                                digitalRelease={digitalRelease}
+                              />
+                            }
+                            position={tooltipPositions.BOTTOM}
+                          />
                         </span>
                     }
 
@@ -724,6 +741,8 @@ MovieDetails.propTypes = {
   youTubeTrailerId: PropTypes.string,
   isAvailable: PropTypes.bool.isRequired,
   inCinemas: PropTypes.string,
+  physicalRelease: PropTypes.string,
+  digitalRelease: PropTypes.string,
   overview: PropTypes.string.isRequired,
   images: PropTypes.arrayOf(PropTypes.object).isRequired,
   alternateTitles: PropTypes.arrayOf(PropTypes.string).isRequired,

--- a/frontend/src/Movie/Details/MovieReleaseDates.css
+++ b/frontend/src/Movie/Details/MovieReleaseDates.css
@@ -1,0 +1,3 @@
+.dateIcon {
+  padding-right: 15px;
+}

--- a/frontend/src/Movie/Details/MovieReleaseDates.js
+++ b/frontend/src/Movie/Details/MovieReleaseDates.js
@@ -1,0 +1,68 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { icons } from 'Helpers/Props';
+import Icon from 'Components/Icon';
+import getRelativeDate from 'Utilities/Date/getRelativeDate';
+import styles from './MovieReleaseDates.css';
+
+function MovieReleaseDates(props) {
+  const {
+    showRelativeDates,
+    shortDateFormat,
+    timeFormat,
+    inCinemas,
+    physicalRelease,
+    digitalRelease
+  } = props;
+
+  return (
+    <div>
+      {
+        !!inCinemas &&
+          <div >
+            <span className={styles.dateIcon}>
+              <Icon
+                name={icons.IN_CINEMAS}
+              />
+            </span>
+            {getRelativeDate(inCinemas, shortDateFormat, showRelativeDates, { timeFormat, timeForToday: false })}
+          </div>
+      }
+      {
+        !!physicalRelease &&
+          <div >
+            <span className={styles.dateIcon}>
+              <Icon
+                name={icons.DISC}
+              />
+            </span>
+            {getRelativeDate(physicalRelease, shortDateFormat, showRelativeDates, { timeFormat, timeForToday: false })}
+          </div>
+      }
+
+      {
+        !!digitalRelease &&
+          <div >
+            <span className={styles.dateIcon}>
+              <Icon
+                name={icons.MOVIE_FILE}
+              />
+            </span>
+            {getRelativeDate(digitalRelease, shortDateFormat, showRelativeDates, { timeFormat, timeForToday: false })}
+          </div>
+      }
+    </div>
+  );
+}
+
+MovieReleaseDates.propTypes = {
+  showRelativeDates: PropTypes.bool.isRequired,
+  shortDateFormat: PropTypes.string.isRequired,
+  longDateFormat: PropTypes.string.isRequired,
+  timeFormat: PropTypes.string.isRequired,
+  inCinemas: PropTypes.string,
+  physicalRelease: PropTypes.string,
+  digitalRelease: PropTypes.string
+};
+
+export default MovieReleaseDates;

--- a/frontend/src/Movie/Details/MovieReleaseDatesConnector.js
+++ b/frontend/src/Movie/Details/MovieReleaseDatesConnector.js
@@ -1,0 +1,21 @@
+import _ from 'lodash';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
+import MovieReleaseDates from './MovieReleaseDates';
+
+function createMapStateToProps() {
+  return createSelector(
+    createUISettingsSelector(),
+    (uiSettings) => {
+      return _.pick(uiSettings, [
+        'showRelativeDates',
+        'shortDateFormat',
+        'longDateFormat',
+        'timeFormat'
+      ]);
+    }
+  );
+}
+
+export default connect(createMapStateToProps, null)(MovieReleaseDates);

--- a/frontend/src/Movie/Details/MovieStatusLabel.js
+++ b/frontend/src/Movie/Details/MovieStatusLabel.js
@@ -1,10 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
 import styles from './MovieStatusLabel.css';
 
-function getMovieStatus(hasFile, isMonitored, inCinemas) {
-  const currentTime = moment();
+function getMovieStatus(hasFile, isMonitored, isAvailable) {
 
   if (hasFile) {
     return 'Downloaded';
@@ -14,7 +12,7 @@ function getMovieStatus(hasFile, isMonitored, inCinemas) {
     return 'Unmonitored';
   }
 
-  if (inCinemas.isBefore(currentTime) && !hasFile) {
+  if (isAvailable && !hasFile) {
     return 'Missing';
   }
 
@@ -25,10 +23,10 @@ function MovieStatusLabel(props) {
   const {
     hasMovieFiles,
     monitored,
-    inCinemas
+    isAvailable
   } = props;
 
-  const status = getMovieStatus(hasMovieFiles, monitored, moment(inCinemas));
+  const status = getMovieStatus(hasMovieFiles, monitored, isAvailable);
 
   return (
     <span
@@ -42,7 +40,7 @@ function MovieStatusLabel(props) {
 MovieStatusLabel.propTypes = {
   hasMovieFiles: PropTypes.bool.isRequired,
   monitored: PropTypes.bool.isRequired,
-  inCinemas: PropTypes.string
+  isAvailable: PropTypes.bool.isRequired
 };
 
 MovieStatusLabel.defaultProps = {

--- a/frontend/src/Movie/Details/Titles/MovieTitlesRow.js
+++ b/frontend/src/Movie/Details/Titles/MovieTitlesRow.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import titleCase from 'Utilities/String/titleCase';
 import TableRow from 'Components/Table/TableRow';
 import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import MovieLanguage from 'Movie/MovieLanguage';
@@ -12,7 +13,8 @@ class MovieTitlesRow extends Component {
   render() {
     const {
       title,
-      language
+      language,
+      sourceType
     } = this.props;
 
     // TODO - Fix languages to all take arrays
@@ -31,6 +33,10 @@ class MovieTitlesRow extends Component {
           />
         </TableRowCell>
 
+        <TableRowCell>
+          {titleCase(sourceType)}
+        </TableRowCell>
+
       </TableRow>
     );
   }
@@ -39,7 +45,8 @@ class MovieTitlesRow extends Component {
 MovieTitlesRow.propTypes = {
   id: PropTypes.number.isRequired,
   title: PropTypes.string.isRequired,
-  language: PropTypes.object.isRequired
+  language: PropTypes.object.isRequired,
+  sourceType: PropTypes.object.isRequired
 };
 
 export default MovieTitlesRow;

--- a/frontend/src/Movie/Details/Titles/MovieTitlesTableContent.js
+++ b/frontend/src/Movie/Details/Titles/MovieTitlesTableContent.js
@@ -16,6 +16,11 @@ const columns = [
     name: 'language',
     label: 'Language',
     isVisible: true
+  },
+  {
+    name: 'sourceType',
+    label: 'Type',
+    isVisible: true
   }
 ];
 

--- a/frontend/src/Movie/Index/Menus/MovieIndexSortMenu.js
+++ b/frontend/src/Movie/Index/Menus/MovieIndexSortMenu.js
@@ -65,6 +65,15 @@ function MovieIndexSortMenu(props) {
         </SortMenuItem>
 
         <SortMenuItem
+          name="year"
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          onPress={onSortSelect}
+        >
+          Year
+        </SortMenuItem>
+
+        <SortMenuItem
           name="inCinemas"
           sortKey={sortKey}
           sortDirection={sortDirection}
@@ -80,6 +89,15 @@ function MovieIndexSortMenu(props) {
           onPress={onSortSelect}
         >
           Physical Release
+        </SortMenuItem>
+
+        <SortMenuItem
+          name="digitalRelease"
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          onPress={onSortSelect}
+        >
+          Digital Release
         </SortMenuItem>
 
         <SortMenuItem

--- a/frontend/src/Movie/Index/Table/MovieIndexHeader.css
+++ b/frontend/src/Movie/Index/Table/MovieIndexHeader.css
@@ -32,6 +32,7 @@
 .added,
 .inCinemas,
 .physicalRelease,
+.digitalRelease,
 .runtime,
 .genres {
   composes: headerCell from '~Components/Table/VirtualTableHeaderCell.css';

--- a/frontend/src/Movie/Index/Table/MovieIndexRow.css
+++ b/frontend/src/Movie/Index/Table/MovieIndexRow.css
@@ -39,6 +39,7 @@
 .added,
 .inCinemas,
 .physicalRelease,
+.digitalRelease,
 .runtime,
 .genres {
   composes: cell;

--- a/frontend/src/Movie/Index/Table/MovieIndexRow.js
+++ b/frontend/src/Movie/Index/Table/MovieIndexRow.js
@@ -72,6 +72,7 @@ class MovieIndexRow extends Component {
       year,
       inCinemas,
       physicalRelease,
+      digitalRelease,
       runtime,
       minimumAvailability,
       path,
@@ -220,6 +221,17 @@ class MovieIndexRow extends Component {
                   key={name}
                   className={styles[name]}
                   date={physicalRelease}
+                  component={VirtualTableRowCell}
+                />
+              );
+            }
+
+            if (name === 'digitalRelease') {
+              return (
+                <RelativeDateCellConnector
+                  key={name}
+                  className={styles[name]}
+                  date={digitalRelease}
                   component={VirtualTableRowCell}
                 />
               );
@@ -401,6 +413,7 @@ MovieIndexRow.propTypes = {
   year: PropTypes.number,
   inCinemas: PropTypes.string,
   physicalRelease: PropTypes.string,
+  digitalRelease: PropTypes.string,
   runtime: PropTypes.number,
   minimumAvailability: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,

--- a/frontend/src/MovieFile/Language/SelectLanguageModalContentConnector.js
+++ b/frontend/src/MovieFile/Language/SelectLanguageModalContentConnector.js
@@ -18,11 +18,14 @@ function createMapStateToProps() {
         items
       } = languages;
 
+      const filterItems = ['Any', 'Unknown'];
+      const filteredLanguages = items.filter((lang) => !filterItems.includes(lang.name));
+
       return {
         isFetching,
         isPopulated,
         error,
-        items
+        items: filteredLanguages
       };
     }
   );

--- a/frontend/src/Settings/UI/UISettings.js
+++ b/frontend/src/Settings/UI/UISettings.js
@@ -55,6 +55,7 @@ class UISettings extends Component {
       hasSettings,
       onInputChange,
       onSavePress,
+      languages,
       ...otherProps
     } = this.props;
 
@@ -174,6 +175,22 @@ class UISettings extends Component {
                     />
                   </FormGroup>
                 </FieldSet>
+
+                <FieldSet
+                  legend="Language"
+                >
+                  <FormGroup>
+                    <FormLabel>Movie Info Language</FormLabel>
+                    <FormInputGroup
+                      type={inputTypes.SELECT}
+                      name="movieInfoLanguage"
+                      values={languages}
+                      helpText="Language that Radarr will use to display Movie Title in UI"
+                      onChange={onInputChange}
+                      {...settings.movieInfoLanguage}
+                    />
+                  </FormGroup>
+                </FieldSet>
               </Form>
           }
         </PageContentBody>
@@ -189,6 +206,7 @@ UISettings.propTypes = {
   settings: PropTypes.object.isRequired,
   hasSettings: PropTypes.bool.isRequired,
   onSavePress: PropTypes.func.isRequired,
+  languages: PropTypes.arrayOf(PropTypes.object).isRequired,
   onInputChange: PropTypes.func.isRequired
 };
 

--- a/frontend/src/Settings/UI/UISettingsConnector.js
+++ b/frontend/src/Settings/UI/UISettingsConnector.js
@@ -9,13 +9,38 @@ import UISettings from './UISettings';
 
 const SECTION = 'ui';
 
+function createLanguagesSelector() {
+  return createSelector(
+    (state) => state.settings.languages,
+    (languages) => {
+      const items = languages.items;
+      const filterItems = ['Any', 'Unknown'];
+
+      if (!items) {
+        return [];
+      }
+
+      const newItems = items.filter((lang) => !filterItems.includes(lang.name)).map((item) => {
+        return {
+          key: item.id,
+          value: item.name
+        };
+      });
+
+      return newItems;
+    }
+  );
+}
+
 function createMapStateToProps() {
   return createSelector(
     (state) => state.settings.advancedSettings,
     createSettingsSectionSelector(SECTION),
-    (advancedSettings, sectionSettings) => {
+    createLanguagesSelector(),
+    (advancedSettings, sectionSettings, languages) => {
       return {
         advancedSettings,
+        languages,
         ...sectionSettings
       };
     }

--- a/frontend/src/Store/Actions/movieActions.js
+++ b/frontend/src/Store/Actions/movieActions.js
@@ -126,6 +126,10 @@ export const filterPredicates = {
     return dateFilterPredicate(item.physicalRelease, filterValue, type);
   },
 
+  digitalRelease: function(item, filterValue, type) {
+    return dateFilterPredicate(item.digitalRelease, filterValue, type);
+  },
+
   ratings: function(item, filterValue, type) {
     const predicate = filterTypePredicates[type];
 

--- a/frontend/src/Store/Actions/movieIndexActions.js
+++ b/frontend/src/Store/Actions/movieIndexActions.js
@@ -120,6 +120,12 @@ export const defaultState = {
       isVisible: false
     },
     {
+      name: 'digitalRelease',
+      label: 'Digital Release',
+      isSortable: true,
+      isVisible: false
+    },
+    {
       name: 'runtime',
       label: 'Runtime',
       isSortable: true,
@@ -290,6 +296,12 @@ export const defaultState = {
     {
       name: 'physicalRelease',
       label: 'Physical Release',
+      type: filterBuilderTypes.DATE,
+      valueType: filterBuilderValueTypes.DATE
+    },
+    {
+      name: 'digitalRelease',
+      label: 'Digital Release',
       type: filterBuilderTypes.DATE,
       valueType: filterBuilderValueTypes.DATE
     },

--- a/src/NzbDrone.Api/Calendar/CalendarFeedModule.cs
+++ b/src/NzbDrone.Api/Calendar/CalendarFeedModule.cs
@@ -133,9 +133,7 @@ namespace NzbDrone.Api.Calendar
             occurrence.Description = movie.Overview;
             occurrence.Categories = new List<string>() { movie.Studio };
 
-            var physicalText = movie.PhysicalReleaseNote.IsNotNullOrWhiteSpace()
-                ? $"(Physical Release, {movie.PhysicalReleaseNote})"
-                : "(Physical Release)";
+            var physicalText = "(Physical Release)";
             occurrence.Summary = $"{movie.Title} " + (cinemasRelease ? "(Theatrical Release)" : physicalText);
         }
     }

--- a/src/NzbDrone.Api/Config/IndexerConfigResource.cs
+++ b/src/NzbDrone.Api/Config/IndexerConfigResource.cs
@@ -1,5 +1,4 @@
 using NzbDrone.Core.Configuration;
-using NzbDrone.Core.Parser;
 using Radarr.Http.REST;
 
 namespace NzbDrone.Api.Config

--- a/src/NzbDrone.Api/Config/NamingConfigResource.cs
+++ b/src/NzbDrone.Api/Config/NamingConfigResource.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Api.Config
             {
                 Id = model.Id,
 
-                RenameEpisodes = model.RenameEpisodes,
+                RenameEpisodes = model.RenameMovies,
                 ReplaceIllegalCharacters = model.ReplaceIllegalCharacters,
                 ColonReplacementFormat = model.ColonReplacementFormat,
                 MultiEpisodeStyle = model.MultiEpisodeStyle,
@@ -59,7 +59,7 @@ namespace NzbDrone.Api.Config
             {
                 Id = resource.Id,
 
-                RenameEpisodes = resource.RenameEpisodes,
+                RenameMovies = resource.RenameEpisodes,
                 ReplaceIllegalCharacters = resource.ReplaceIllegalCharacters,
                 ColonReplacementFormat = resource.ColonReplacementFormat,
                 StandardMovieFormat = resource.StandardMovieFormat,

--- a/src/NzbDrone.Api/Movies/MovieResource.cs
+++ b/src/NzbDrone.Api/Movies/MovieResource.cs
@@ -122,7 +122,6 @@ namespace NzbDrone.Api.Movies
                 SortTitle = model.SortTitle,
                 InCinemas = model.InCinemas,
                 PhysicalRelease = model.PhysicalRelease,
-                PhysicalReleaseNote = model.PhysicalReleaseNote,
                 HasFile = model.HasFile,
                 Downloaded = downloaded,
 
@@ -139,7 +138,6 @@ namespace NzbDrone.Api.Movies
 
                 Year = model.Year,
                 SecondaryYear = model.SecondaryYear,
-                SecondaryYearSourceId = model.SecondaryYearSourceId,
 
                 Path = model.Path,
                 ProfileId = model.ProfileId,
@@ -189,7 +187,6 @@ namespace NzbDrone.Api.Movies
                 SortTitle = resource.SortTitle,
                 InCinemas = resource.InCinemas,
                 PhysicalRelease = resource.PhysicalRelease,
-                PhysicalReleaseNote = resource.PhysicalReleaseNote,
 
                 //TotalEpisodeCount
                 //EpisodeCount
@@ -203,7 +200,6 @@ namespace NzbDrone.Api.Movies
 
                 Year = resource.Year,
                 SecondaryYear = resource.SecondaryYear,
-                SecondaryYearSourceId = resource.SecondaryYearSourceId,
 
                 Path = resource.Path,
                 ProfileId = resource.ProfileId,

--- a/src/NzbDrone.Core.Test/Datastore/Migration/174_email_multiple_addressesFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/174_email_multiple_addressesFixture.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using NzbDrone.Common.Serializer;
 using NzbDrone.Core.Datastore.Migration;

--- a/src/NzbDrone.Core.Test/Download/DownloadHistoryTests/DownloadHistoryRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadHistoryTests/DownloadHistoryRepositoryFixture.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using FizzWare.NBuilder;

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/MonoNotNetCoreCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/MonoNotNetCoreCheckFixture.cs
@@ -3,7 +3,6 @@ using NUnit.Framework;
 using NzbDrone.Common.Processes;
 using NzbDrone.Core.HealthCheck.Checks;
 using NzbDrone.Core.Test.Framework;
-using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.HealthCheck.Checks
 {

--- a/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedExtraFilesFixture.cs
+++ b/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedExtraFilesFixture.cs
@@ -31,7 +31,7 @@ namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
         public void should_not_delete_extra_files_that_have_a_coresponding_movie()
         {
             var movie = Builder<Movie>.CreateNew()
-                                        .BuildNew();
+                                      .BuildNew();
 
             Db.Insert(movie);
 
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
         public void should_delete_extra_files_that_dont_have_a_coresponding_movie_file()
         {
             var movie = Builder<Movie>.CreateNew()
-                                        .BuildNew();
+                                      .BuildNew();
 
             Db.Insert(movie);
 
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
         public void should_not_delete_extra_files_that_have_a_coresponding_movie_file()
         {
             var movie = Builder<Movie>.CreateNew()
-                                        .BuildNew();
+                                      .BuildNew();
 
             var movieFile = Builder<MovieFile>.CreateNew()
                                                   .With(h => h.Quality = new QualityModel())

--- a/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedHistoryItemsFixture.cs
+++ b/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedHistoryItemsFixture.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
         public void Setup()
         {
             _movie = Builder<Movie>.CreateNew()
-                                     .BuildNew();
+                                   .BuildNew();
         }
 
         private void GivenSeries()

--- a/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedMetadataFilesFixture.cs
+++ b/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedMetadataFilesFixture.cs
@@ -32,7 +32,7 @@ namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
         public void should_not_delete_metadata_files_that_have_a_coresponding_movie()
         {
             var movie = Builder<Movie>.CreateNew()
-                                        .BuildNew();
+                                      .BuildNew();
 
             Db.Insert(movie);
 
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
         public void should_delete_metadata_files_that_dont_have_a_coresponding_movie_file()
         {
             var movie = Builder<Movie>.CreateNew()
-                                        .BuildNew();
+                                      .BuildNew();
 
             Db.Insert(movie);
 
@@ -68,7 +68,7 @@ namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
         public void should_not_delete_metadata_files_that_have_a_coresponding_movie_file()
         {
             var movie = Builder<Movie>.CreateNew()
-                                        .BuildNew();
+                                      .BuildNew();
 
             var movieFile = Builder<MovieFile>.CreateNew()
                                                   .With(h => h.Quality = new QualityModel())
@@ -92,7 +92,7 @@ namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
         public void should_delete_movie_metadata_files_that_have_moviefileid_of_zero()
         {
             var movie = Builder<Movie>.CreateNew()
-                                        .BuildNew();
+                                      .BuildNew();
 
             Db.Insert(movie);
 
@@ -111,7 +111,7 @@ namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
         public void should_delete_movie_image_files_that_have_moviefileid_of_zero()
         {
             var movie = Builder<Movie>.CreateNew()
-                                        .BuildNew();
+                                      .BuildNew();
 
             Db.Insert(movie);
 

--- a/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedMovieTranslationsFixture.cs
+++ b/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedMovieTranslationsFixture.cs
@@ -1,0 +1,47 @@
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Housekeeping.Housekeepers;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Translations;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
+{
+    [TestFixture]
+    public class CleanupOrphanedMovieTranslationsFixture : DbTest<CleanupOrphanedMovieTranslations, MovieTranslation>
+    {
+        [Test]
+        public void should_delete_orphaned_movie_translation_items()
+        {
+            var translation = Builder<MovieTranslation>.CreateNew()
+                                              .With(h => h.MovieId = default)
+                                              .With(h => h.Language = Language.English)
+                                              .BuildNew();
+
+            Db.Insert(translation);
+            Subject.Clean();
+            AllStoredModels.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_not_delete_unorphaned_movie_translation_items()
+        {
+            var movie = Builder<Movie>.CreateNew().BuildNew();
+
+            Db.Insert(movie);
+
+            var translation = Builder<MovieTranslation>.CreateNew()
+                                              .With(h => h.MovieId = default)
+                                              .With(h => h.Language = Language.English)
+                                              .With(b => b.MovieId = movie.Id)
+                                              .BuildNew();
+
+            Db.Insert(translation);
+
+            Subject.Clean();
+            AllStoredModels.Should().HaveCount(1);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedPendingReleasesFixture.cs
+++ b/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedPendingReleasesFixture.cs
@@ -1,4 +1,4 @@
-﻿using FizzWare.NBuilder;
+using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.Download.Pending;
@@ -28,12 +28,12 @@ namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
         [Test]
         public void should_not_delete_unorphaned_pending_items()
         {
-            var series = Builder<Movie>.CreateNew().BuildNew();
+            var movie = Builder<Movie>.CreateNew().BuildNew();
 
-            Db.Insert(series);
+            Db.Insert(movie);
 
             var pendingRelease = Builder<PendingRelease>.CreateNew()
-                .With(h => h.MovieId = series.Id)
+                .With(h => h.MovieId = movie.Id)
                 .With(h => h.ParsedMovieInfo = new ParsedMovieInfo())
                 .With(h => h.Release = new ReleaseInfo())
                 .BuildNew();

--- a/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedSubtitleFilesFixture.cs
+++ b/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedSubtitleFilesFixture.cs
@@ -32,7 +32,7 @@ namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
         public void should_not_delete_subtitle_files_that_have_a_coresponding_movie()
         {
             var movie = Builder<Movie>.CreateNew()
-                                        .BuildNew();
+                                      .BuildNew();
 
             Db.Insert(movie);
 
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
         public void should_delete_subtitle_files_that_dont_have_a_coresponding_movie_file()
         {
             var movie = Builder<Movie>.CreateNew()
-                                        .BuildNew();
+                                      .BuildNew();
 
             Db.Insert(movie);
 
@@ -70,7 +70,7 @@ namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
         public void should_not_delete_subtitle_files_that_have_a_coresponding_movie_file()
         {
             var movie = Builder<Movie>.CreateNew()
-                                        .BuildNew();
+                                      .BuildNew();
 
             var movieFile = Builder<MovieFile>.CreateNew()
                                                   .With(h => h.Quality = new QualityModel())

--- a/src/NzbDrone.Core.Test/IndexerTests/FileListTests/FileListRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/FileListTests/FileListRequestGeneratorFixture.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
@@ -24,7 +25,8 @@ namespace NzbDrone.Core.Test.IndexerTests.FileListTests
 
             _movieSearchCriteria = new MovieSearchCriteria
             {
-                Movie = new Movies.Movie { ImdbId = "tt0076759", Title = "Star Wars", Year = 1977 }
+                Movie = new Movies.Movie { ImdbId = "tt0076759", Title = "Star Wars", Year = 1977 },
+                SceneTitles = new List<string> { "Star Wars" }
             };
         }
 
@@ -70,7 +72,7 @@ namespace NzbDrone.Core.Test.IndexerTests.FileListTests
             var page = results.GetAllTiers().First().First();
 
             page.Url.Query.Should().Contain("type=name");
-            page.Url.Query.Should().Contain("query=Star Wars 1977");
+            page.Url.Query.Should().Contain("query=Star+Wars+1977");
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateLanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateLanguageFixture.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using FizzWare.NBuilder;
 using FluentAssertions;
-using FluentAssertions.Common;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.Languages;

--- a/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateLanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateLanguageFixture.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieImport.Aggregation.Aggregators
         [Test]
         public void should_return_default_if_no_info_is_known()
         {
-            Subject.Aggregate(_localMovie, false).Languages.Should().Contain(Language.English);
+            Subject.Aggregate(_localMovie, false).Languages.Should().Contain(Language.Unknown);
         }
 
         [Test]
@@ -70,8 +70,8 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieImport.Aggregation.Aggregators
         [Test]
         public void should_return_file_language_when_file_language_is_higher_than_others()
         {
-            _localMovie.DownloadClientMovieInfo = GetParsedMovieInfo(new List<Language> { Language.English });
-            _localMovie.FolderMovieInfo = GetParsedMovieInfo(new List<Language> { Language.English });
+            _localMovie.DownloadClientMovieInfo = GetParsedMovieInfo(new List<Language> { Language.Unknown });
+            _localMovie.FolderMovieInfo = GetParsedMovieInfo(new List<Language> { Language.Unknown });
             _localMovie.FileMovieInfo = GetParsedMovieInfo(new List<Language> { Language.French });
 
             Subject.Aggregate(_localMovie, false).Languages.Should().Equal(_localMovie.FileMovieInfo.Languages);
@@ -80,9 +80,9 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieImport.Aggregation.Aggregators
         [Test]
         public void should_return_multi_language()
         {
-            _localMovie.DownloadClientMovieInfo = GetParsedMovieInfo(new List<Language> { Language.English });
+            _localMovie.DownloadClientMovieInfo = GetParsedMovieInfo(new List<Language> { Language.Unknown });
             _localMovie.FolderMovieInfo = GetParsedMovieInfo(new List<Language> { Language.English, Language.German });
-            _localMovie.FileMovieInfo = GetParsedMovieInfo(new List<Language> { Language.English });
+            _localMovie.FileMovieInfo = GetParsedMovieInfo(new List<Language> { Language.Unknown });
 
             Subject.Aggregate(_localMovie, false).Languages.Should().Equal(_localMovie.FolderMovieInfo.Languages);
         }

--- a/src/NzbDrone.Core.Test/MovieTests/AddMovieFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/AddMovieFixture.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Credits;
+using NzbDrone.Core.Movies.Translations;
 using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Test.Common;

--- a/src/NzbDrone.Core.Test/MovieTests/AddMovieFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/AddMovieFixture.cs
@@ -11,7 +11,6 @@ using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Credits;
-using NzbDrone.Core.Movies.Translations;
 using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Test.Common;

--- a/src/NzbDrone.Core.Test/MovieTests/AlternativeTitleServiceTests/AlternativeTitleServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/AlternativeTitleServiceTests/AlternativeTitleServiceFixture.cs
@@ -27,7 +27,10 @@ namespace NzbDrone.Core.Test.MovieTests.AlternativeTitleServiceTests
             _title1 = titles[0];
             _title2 = titles[1];
             _title3 = titles[2];
-            _movie = Builder<Movie>.CreateNew().With(m => m.CleanTitle = "myothertitle").With(m => m.Id = 1).Build();
+            _movie = Builder<Movie>.CreateNew()
+                .With(m => m.CleanTitle = "myothertitle")
+                .With(m => m.Id = 1)
+                .Build();
         }
 
         private void GivenExistingTitles(params AlternativeTitle[] titles)

--- a/src/NzbDrone.Core.Test/MovieTests/CreditTests/CreditRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/CreditTests/CreditRepositoryFixture.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using FizzWare.NBuilder;
 using FluentAssertions;

--- a/src/NzbDrone.Core.Test/MovieTests/MovieRepositoryTests/MovieRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieRepositoryTests/MovieRepositoryFixture.cs
@@ -4,6 +4,7 @@ using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Qualities;

--- a/src/NzbDrone.Core.Test/MovieTests/MovieRepositoryTests/MovieRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieRepositoryTests/MovieRepositoryFixture.cs
@@ -4,7 +4,6 @@ using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.CustomFormats;
-using NzbDrone.Core.Languages;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Qualities;

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleFixture.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _episodeFile = new MovieFile { Quality = new QualityModel(), ReleaseGroup = "SonarrTest" };
 
             _namingConfig = NamingConfig.Default;
-            _namingConfig.RenameEpisodes = true;
+            _namingConfig.RenameMovies = true;
 
             Mocker.GetMock<INamingConfigService>()
                   .Setup(c => c.GetConfig()).Returns(_namingConfig);

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -6,9 +6,11 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Translations;
 using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Test.Framework;
@@ -21,18 +23,34 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
     {
         private Movie _movie;
         private MovieFile _movieFile;
+        private List<MovieTranslation> _movieTranslations;
         private NamingConfig _namingConfig;
 
         [SetUp]
         public void Setup()
         {
+            _movieTranslations = new List<MovieTranslation>
+            {
+                new MovieTranslation
+                {
+                    Language = Language.German,
+                    Title = "German South Park"
+                },
+
+                new MovieTranslation
+                {
+                    Language = Language.French,
+                    Title = "French South Park"
+                }
+            };
+
             _movie = Builder<Movie>
                     .CreateNew()
                     .With(s => s.Title = "South Park")
                     .Build();
 
             _namingConfig = NamingConfig.Default;
-            _namingConfig.RenameEpisodes = true;
+            _namingConfig.RenameMovies = true;
 
             Mocker.GetMock<INamingConfigService>()
                   .Setup(c => c.GetConfig()).Returns(_namingConfig);
@@ -46,6 +64,10 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             Mocker.GetMock<ICustomFormatService>()
                 .Setup(v => v.All())
                 .Returns(new List<CustomFormat>());
+
+            Mocker.GetMock<IMovieTranslationService>()
+                .Setup(v => v.GetAllTranslationsForMovie(It.IsAny<int>()))
+                .Returns(_movieTranslations);
         }
 
         private void GivenProper()
@@ -122,6 +144,51 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         }
 
         [Test]
+        public void should_replace_translated_movie_title()
+        {
+            _namingConfig.StandardMovieFormat = "{Movie Title:FR}";
+
+            Subject.BuildFileName(_movie, _movieFile)
+                   .Should().Be("French South Park");
+        }
+
+        [Test]
+        public void should_replace_translated_movie_title_with_base_title_if_invalid_code()
+        {
+            _namingConfig.StandardMovieFormat = "{Movie Title:JP}";
+
+            Subject.BuildFileName(_movie, _movieFile)
+                   .Should().Be("South Park");
+        }
+
+        [Test]
+        public void should_replace_translated_movie_title_with_base_title_if_no_translation_exists()
+        {
+            _namingConfig.StandardMovieFormat = "{Movie Title:JA}";
+
+            Subject.BuildFileName(_movie, _movieFile)
+                   .Should().Be("South Park");
+        }
+
+        [Test]
+        public void should_replace_translated_movie_title_with_fallback_if_no_translation_exists()
+        {
+            _namingConfig.StandardMovieFormat = "{Movie Title:JP|FR}";
+
+            Subject.BuildFileName(_movie, _movieFile)
+                   .Should().Be("French South Park");
+        }
+
+        [Test]
+        public void should_replace_translated_movie_title_with_original_if_no_translation_or_fallback_exists()
+        {
+            _namingConfig.StandardMovieFormat = "{Movie Title:JP|CN}";
+
+            Subject.BuildFileName(_movie, _movieFile)
+                   .Should().Be("South Park");
+        }
+
+        [Test]
         public void should_cleanup_Movie_Title()
         {
             _namingConfig.StandardMovieFormat = "{Movie.CleanTitle}";
@@ -172,7 +239,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [Test]
         public void use_file_name_when_sceneName_is_null()
         {
-            _namingConfig.RenameEpisodes = false;
+            _namingConfig.RenameMovies = false;
             _movieFile.RelativePath = "30 Rock - S01E01 - Test";
 
             Subject.BuildFileName(_movie, _movieFile)
@@ -182,7 +249,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [Test]
         public void use_path_when_sceneName_and_relative_path_are_null()
         {
-            _namingConfig.RenameEpisodes = false;
+            _namingConfig.RenameMovies = false;
             _movieFile.RelativePath = null;
             _movieFile.Path = @"C:\Test\Unsorted\Movie - S01E01 - Test";
 
@@ -193,7 +260,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [Test]
         public void use_file_name_when_sceneName_is_not_null()
         {
-            _namingConfig.RenameEpisodes = false;
+            _namingConfig.RenameMovies = false;
             _movieFile.SceneName = "30.Rock.S01E01.xvid-LOL";
             _movieFile.RelativePath = "30 Rock - S01E01 - Test";
 
@@ -317,7 +384,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [Test]
         public void should_use_existing_filename_when_scene_name_is_not_available()
         {
-            _namingConfig.RenameEpisodes = true;
+            _namingConfig.RenameMovies = true;
             _namingConfig.StandardMovieFormat = "{Original Title}";
 
             _movieFile.SceneName = null;

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/MovieTitleFirstCharacterFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/MovieTitleFirstCharacterFixture.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
                     .Build();
 
             _namingConfig = NamingConfig.Default;
-            _namingConfig.RenameEpisodes = true;
+            _namingConfig.RenameMovies = true;
 
             Mocker.GetMock<INamingConfigService>()
                   .Setup(c => c.GetConfig()).Returns(_namingConfig);

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TitleTheFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TitleTheFixture.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _movieFile = new MovieFile { Quality = new QualityModel(Quality.HDTV720p), ReleaseGroup = "RadarrTest" };
 
             _namingConfig = NamingConfig.Default;
-            _namingConfig.RenameEpisodes = true;
+            _namingConfig.RenameMovies = true;
 
             Mocker.GetMock<INamingConfigService>()
                   .Setup(c => c.GetConfig()).Returns(_namingConfig);

--- a/src/NzbDrone.Core.Test/ParserTests/IsoLanguagesFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/IsoLanguagesFixture.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.Languages;

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.Languages;

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -11,13 +11,20 @@ namespace NzbDrone.Core.Test.ParserTests
     public class LanguageParserFixture : CoreTest
     {
         [TestCase("Pulp.Fiction.1994.English.1080p.XviD-LOL")]
-        [TestCase("The Danish Girl 2015")]
-        [TestCase("Fantastic.Beasts.The.Crimes.Of.Grindelwald.2018.2160p.WEBRip.x265.10bit.HDR.DD5.1-GASMASK")]
         public void should_parse_language_english(string postTitle)
         {
             var result = Parser.Parser.ParseMovieTitle(postTitle, true);
 
             result.Languages.Should().BeEquivalentTo(Language.English);
+        }
+
+        [TestCase("The Danish Girl 2015")]
+        [TestCase("Fantastic.Beasts.The.Crimes.Of.Grindelwald.2018.2160p.WEBRip.x265.10bit.HDR.DD5.1-GASMASK")]
+        public void should_parse_language_unknown(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle, true);
+
+            result.Languages.Should().BeEquivalentTo(Language.Unknown);
         }
 
         [TestCase("Pulp.Fiction.1994.French.1080p.XviD-LOL")]
@@ -26,6 +33,15 @@ namespace NzbDrone.Core.Test.ParserTests
             var result = Parser.Parser.ParseMovieTitle(postTitle, true);
 
             result.Languages.Should().BeEquivalentTo(Language.French);
+        }
+
+        [TestCase("E.T. the Extra-Terrestrial.1982.Ger.Eng.AC3.DL.BDRip.x264-iNCEPTiON")]
+        public void should_parse_language_english_german(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle, true);
+
+            result.Languages.Should().Contain(Language.German);
+            result.Languages.Should().Contain(Language.English);
         }
 
         [TestCase("Pulp.Fiction.1994.Spanish.1080p.XviD-LOL")]

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -171,7 +171,7 @@ namespace NzbDrone.Core.Test.ParserTests
         {
             var parsed = Parser.Parser.ParseMovieTitle(postTitle, true);
             parsed.Languages.Count().Should().Be(1);
-            parsed.Languages.First().Should().Be(Language.English);
+            parsed.Languages.First().Should().Be(Language.Unknown);
         }
 
         [TestCase("The.Purge.3.Election.Year.2016.German.DTS.DL.720p.BluRay.x264-MULTiPLEX")]

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.AlternativeTitles;
 using NzbDrone.Core.Parser;
@@ -34,47 +35,55 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
                                    .With(m => m.CleanTitle = "fackjugoethe2")
                                    .With(m => m.Year = 2015)
                                    .With(m => m.AlternativeTitles = new List<AlternativeTitle> { new AlternativeTitle("Fack Ju Göthe 2: Same same") })
+                                   .With(m => m.OriginalLanguage = Language.English)
                                    .Build();
 
             _parsedMovieInfo = new ParsedMovieInfo
             {
                 MovieTitle = _movie.Title,
+                Languages = new List<Language> { Language.English },
                 Year = _movie.Year,
             };
 
             _wrongYearInfo = new ParsedMovieInfo
             {
                 MovieTitle = _movie.Title,
+                Languages = new List<Language> { Language.English },
                 Year = 1900,
             };
 
             _wrongTitleInfo = new ParsedMovieInfo
             {
                 MovieTitle = "Other Title",
+                Languages = new List<Language> { Language.English },
                 Year = 2015
             };
 
             _alternativeTitleInfo = new ParsedMovieInfo
             {
                 MovieTitle = _movie.AlternativeTitles.First().Title,
+                Languages = new List<Language> { Language.English },
                 Year = _movie.Year,
             };
 
             _romanTitleInfo = new ParsedMovieInfo
             {
                 MovieTitle = "Fack Ju Göthe II",
+                Languages = new List<Language> { Language.English },
                 Year = _movie.Year,
             };
 
             _umlautInfo = new ParsedMovieInfo
             {
                 MovieTitle = "Fack Ju Goethe 2",
+                Languages = new List<Language> { Language.English },
                 Year = _movie.Year
             };
 
             _umlautAltInfo = new ParsedMovieInfo
             {
                 MovieTitle = "Fack Ju Goethe 2: Same same",
+                Languages = new List<Language> { Language.English },
                 Year = _movie.Year
             };
 

--- a/src/NzbDrone.Core.Test/Profiles/ProfileServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Profiles/ProfileServiceFixture.cs
@@ -1,13 +1,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using FizzWare.NBuilder;
+using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.Lifecycle;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.NetImport;
 using NzbDrone.Core.Profiles;
+using NzbDrone.Core.Test.CustomFormats;
 using NzbDrone.Core.Test.Framework;
 
 namespace NzbDrone.Core.Test.Profiles
@@ -106,6 +109,46 @@ namespace NzbDrone.Core.Test.Profiles
             Subject.Delete(1);
 
             Mocker.GetMock<IProfileRepository>().Verify(c => c.Delete(1), Times.Once());
+        }
+
+        [Test]
+        public void get_acceptable_languages_should_return_profile_language()
+        {
+            var profile = Builder<Profile>.CreateNew().With(c => c.Language = Language.German).Build();
+
+            Mocker.GetMock<IProfileRepository>()
+                  .Setup(s => s.Get(It.IsAny<int>()))
+                  .Returns(profile);
+
+            var languages = Subject.GetAcceptableLanguages(profile.Id);
+
+            languages.Count.Should().Be(1);
+            languages.Should().Contain(Language.German);
+        }
+
+        [Test]
+        public void get_acceptable_languages_should_return_custom_format_positive_languages()
+        {
+            var profile = Builder<Profile>.CreateNew()
+                .With(c => c.Language = Language.German)
+                .Build();
+
+            var customFormat1 = new CustomFormat("My Format 1", new LanguageSpecification { Value = (int)Language.English }) { Id = 1 };
+            var customFormat2 = new CustomFormat("My Format 2", new LanguageSpecification { Value = (int)Language.French }) { Id = 2 };
+
+            CustomFormatsFixture.GivenCustomFormats(customFormat1, customFormat2);
+
+            profile.FormatItems = CustomFormatsFixture.GetSampleFormatItems(customFormat2.Name);
+
+            Mocker.GetMock<IProfileRepository>()
+                  .Setup(s => s.Get(It.IsAny<int>()))
+                  .Returns(profile);
+
+            var languages = Subject.GetAcceptableLanguages(profile.Id);
+
+            languages.Count.Should().Be(2);
+            languages.Should().Contain(Language.German);
+            languages.Should().Contain(Language.French);
         }
     }
 }

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -6,6 +6,7 @@ using NLog;
 using NzbDrone.Common.EnsureThat;
 using NzbDrone.Common.Http.Proxy;
 using NzbDrone.Core.Configuration.Events;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.MetadataSource.SkyHook.Resource;
@@ -369,6 +370,13 @@ namespace NzbDrone.Core.Configuration
             get { return GetValueBoolean("EnableColorImpairedMode", false); }
 
             set { SetValue("EnableColorImpairedMode", value); }
+        }
+
+        public int MovieInfoLanguage
+        {
+            get { return GetValueInt("MovieInfoLanguage", (int)Language.English); }
+
+            set { SetValue("MovieInfoLanguage", value); }
         }
 
         public bool CleanupMetadataImages

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -10,7 +10,6 @@ using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.MetadataSource.SkyHook.Resource;
-using NzbDrone.Core.Parser;
 using NzbDrone.Core.Security;
 
 namespace NzbDrone.Core.Configuration

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -75,6 +75,7 @@ namespace NzbDrone.Core.Configuration
         string TimeFormat { get; set; }
         bool ShowRelativeDates { get; set; }
         bool EnableColorImpairedMode { get; set; }
+        int MovieInfoLanguage { get; set; }
 
         //Internal
         bool CleanupMetadataImages { get; set; }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using NzbDrone.Common.Http.Proxy;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MetadataSource.SkyHook.Resource;
-using NzbDrone.Core.Parser;
 using NzbDrone.Core.Security;
 
 namespace NzbDrone.Core.Configuration

--- a/src/NzbDrone.Core/Datastore/Migration/175_remove_chown_and_folderchmod_config.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/175_remove_chown_and_folderchmod_config.cs
@@ -1,4 +1,3 @@
-using System.Data;
 using FluentMigrator;
 using NzbDrone.Core.Datastore.Migration.Framework;
 

--- a/src/NzbDrone.Core/Datastore/Migration/177_language_improvements.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/177_language_improvements.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text.Json;
+using Dapper;
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+using NzbDrone.Core.Languages;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(177)]
+    public class language_improvements : NzbDroneMigrationBase
+    {
+        private readonly JsonSerializerOptions _serializerSettings;
+
+        public language_improvements()
+        {
+            _serializerSettings = new JsonSerializerOptions
+            {
+                AllowTrailingCommas = true,
+                IgnoreNullValues = false,
+                PropertyNameCaseInsensitive = true,
+                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            };
+        }
+
+        protected override void MainDbUpgrade()
+        {
+            // Use original language to set default language fallback for releases
+            // Set all to English (1) on migration to ensure default behavior persists until refresh
+            Alter.Table("Movies").AddColumn("OriginalLanguage").AsInt32().WithDefaultValue((int)Language.English);
+            Alter.Table("Movies").AddColumn("OriginalTitle").AsString().Nullable();
+
+            Alter.Table("Movies").AddColumn("DigitalRelease").AsDateTime().Nullable();
+
+            // Column not used
+            Delete.Column("PhysicalReleaseNote").FromTable("Movies");
+            Delete.Column("SecondaryYearSourceId").FromTable("Movies");
+
+            Alter.Table("NamingConfig").AddColumn("RenameMovies").AsBoolean().WithDefaultValue(0);
+            Execute.Sql("UPDATE NamingConfig SET RenameMovies=RenameEpisodes");
+            Delete.Column("RenameEpisodes").FromTable("NamingConfig");
+
+            //Manual SQL, Fluent Migrator doesn't support multi-column unique contraint on table creation, SQLite doesn't support adding it after creation
+            Execute.Sql("CREATE TABLE MovieTranslations(" +
+                "Id INTEGER PRIMARY KEY, " +
+                "MovieId INTEGER NOT NULL, " +
+                "Title TEXT, " +
+                "CleanTitle TEXT, " +
+                "Overview TEXT, " +
+                "Language INTEGER NOT NULL, " +
+                "Unique(\"MovieId\", \"Language\"));");
+
+            // Prevent failure if two movies have same alt titles
+            Execute.Sql("DROP INDEX IF EXISTS \"IX_AlternativeTitles_CleanTitle\"");
+
+            Execute.WithConnection(FixLanguagesMoveFile);
+            Execute.WithConnection(FixLanguagesHistory);
+        }
+
+        private void FixLanguagesMoveFile(IDbConnection conn, IDbTransaction tran)
+        {
+            var rows = conn.Query<LanguageEntity177>($"SELECT Id, Languages FROM MovieFiles");
+
+            var corrected = new List<LanguageEntity177>();
+
+            foreach (var row in rows)
+            {
+                var languages = JsonSerializer.Deserialize<List<int>>(row.Languages, _serializerSettings);
+
+                var newLanguages = languages.Distinct().ToList();
+
+                corrected.Add(new LanguageEntity177
+                {
+                    Id = row.Id,
+                    Languages = JsonSerializer.Serialize(newLanguages, _serializerSettings)
+                });
+            }
+
+            var updateSql = "UPDATE MovieFiles SET Languages = @Languages WHERE Id = @Id";
+            conn.Execute(updateSql, corrected, transaction: tran);
+        }
+
+        private void FixLanguagesHistory(IDbConnection conn, IDbTransaction tran)
+        {
+            var rows = conn.Query<LanguageEntity177>($"SELECT Id, Languages FROM History");
+
+            var corrected = new List<LanguageEntity177>();
+
+            foreach (var row in rows)
+            {
+                var languages = JsonSerializer.Deserialize<List<int>>(row.Languages, _serializerSettings);
+
+                var newLanguages = languages.Distinct().ToList();
+
+                corrected.Add(new LanguageEntity177
+                {
+                    Id = row.Id,
+                    Languages = JsonSerializer.Serialize(newLanguages, _serializerSettings)
+                });
+            }
+
+            var updateSql = "UPDATE History SET Languages = @Languages WHERE Id = @Id";
+            conn.Execute(updateSql, corrected, transaction: tran);
+        }
+
+        private class LanguageEntity177 : ModelBase
+        {
+            public string Languages { get; set; }
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -26,6 +26,7 @@ using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.AlternativeTitles;
 using NzbDrone.Core.Movies.Credits;
+using NzbDrone.Core.Movies.Translations;
 using NzbDrone.Core.NetImport;
 using NzbDrone.Core.NetImport.ImportExclusions;
 using NzbDrone.Core.Notifications;
@@ -104,6 +105,8 @@ namespace NzbDrone.Core.Datastore
                   .Ignore(s => s.RootFolderPath);
 
             Mapper.Entity<AlternativeTitle>("AlternativeTitles").RegisterModel();
+
+            Mapper.Entity<MovieTranslation>("MovieTranslations").RegisterModel();
 
             Mapper.Entity<Credit>("Credits").RegisterModel();
 

--- a/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupOrphanedMovieTranslations.cs
+++ b/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupOrphanedMovieTranslations.cs
@@ -1,0 +1,28 @@
+using Dapper;
+using NzbDrone.Core.Datastore;
+
+namespace NzbDrone.Core.Housekeeping.Housekeepers
+{
+    public class CleanupOrphanedMovieTranslations : IHousekeepingTask
+    {
+        private readonly IMainDatabase _database;
+
+        public CleanupOrphanedMovieTranslations(IMainDatabase database)
+        {
+            _database = database;
+        }
+
+        public void Clean()
+        {
+            using (var mapper = _database.OpenConnection())
+            {
+                mapper.Execute(@"DELETE FROM MovieTranslations
+                                     WHERE Id IN (
+                                     SELECT MovieTranslations.Id FROM MovieTranslations
+                                     LEFT OUTER JOIN Movies
+                                     ON MovieTranslations.MovieId = Movies.Id
+                                     WHERE Movies.Id IS NULL)");
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/IndexerSearch/NzbSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/NzbSearchService.cs
@@ -9,7 +9,9 @@ using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Translations;
 using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Profiles;
 
 namespace NzbDrone.Core.IndexerSearch
 {
@@ -24,16 +26,22 @@ namespace NzbDrone.Core.IndexerSearch
         private readonly IIndexerFactory _indexerFactory;
         private readonly IMakeDownloadDecision _makeDownloadDecision;
         private readonly IMovieService _movieService;
+        private readonly IMovieTranslationService _movieTranslationService;
+        private readonly IProfileService _profileService;
         private readonly Logger _logger;
 
         public NzbSearchService(IIndexerFactory indexerFactory,
                                 IMakeDownloadDecision makeDownloadDecision,
                                 IMovieService movieService,
+                                IMovieTranslationService movieTranslationService,
+                                IProfileService profileService,
                                 Logger logger)
         {
             _indexerFactory = indexerFactory;
             _makeDownloadDecision = makeDownloadDecision;
             _movieService = movieService;
+            _movieTranslationService = movieTranslationService;
+            _profileService = profileService;
             _logger = logger;
         }
 
@@ -60,6 +68,24 @@ namespace NzbDrone.Core.IndexerSearch
                 UserInvokedSearch = userInvokedSearch,
                 InteractiveSearch = interactiveSearch
             };
+
+            var wantedLanguages = _profileService.GetAcceptableLanguages(movie.ProfileId);
+            var translations = _movieTranslationService.GetAllTranslationsForMovie(movie.Id);
+
+            var queryTranlations = new List<string>
+            {
+                movie.Title,
+                movie.OriginalTitle
+            };
+
+            //Add Translation of wanted languages to search query
+            foreach (var translation in translations.Where(a => wantedLanguages.Contains(a.Language)))
+            {
+                queryTranlations.Add(translation.Title);
+            }
+
+            spec.SceneTitles = queryTranlations.Distinct().ToList();
+
             return spec;
         }
 

--- a/src/NzbDrone.Core/Indexers/FileList/FileListRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/FileList/FileListRequestGenerator.cs
@@ -30,8 +30,11 @@ namespace NzbDrone.Core.Indexers.FileList
             }
             else
             {
-                var titleYearSearchQuery = string.Format("{0} {1}", searchCriteria.Movie.Title, searchCriteria.Movie.Year);
-                pageableRequests.Add(GetRequest("search-torrents", string.Format("&type=name&query={0}", titleYearSearchQuery.Trim())));
+                foreach (var queryTitle in searchCriteria.QueryTitles)
+                {
+                    var titleYearSearchQuery = string.Format("{0}+{1}", queryTitle, searchCriteria.Movie.Year);
+                    pageableRequests.Add(GetRequest("search-torrents", string.Format("&type=name&query={0}", titleYearSearchQuery.Trim())));
+                }
             }
 
             return pageableRequests;

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabCapabilities.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabCapabilities.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace NzbDrone.Core.Indexers.Newznab
 {
@@ -7,7 +7,6 @@ namespace NzbDrone.Core.Indexers.Newznab
         public int DefaultPageSize { get; set; }
         public int MaxPageSize { get; set; }
         public string[] SupportedSearchParameters { get; set; }
-        public string[] SupportedTvSearchParameters { get; set; }
         public string[] SupportedMovieSearchParameters { get; set; }
         public bool SupportsAggregateIdSearch { get; set; }
         public List<NewznabCategory> Categories { get; set; }
@@ -18,7 +17,6 @@ namespace NzbDrone.Core.Indexers.Newznab
             MaxPageSize = 100;
             SupportedSearchParameters = new[] { "q" };
             SupportedMovieSearchParameters = new[] { "q", "imdbid", "imdbtitle", "imdbyear" };
-            SupportedTvSearchParameters = new[] { "q", "rid", "season", "ep" }; // This should remain 'rid' for older newznab installs.
             SupportsAggregateIdSearch = false;
             Categories = new List<NewznabCategory>();
         }

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabCapabilitiesProvider.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabCapabilitiesProvider.cs
@@ -118,17 +118,6 @@ namespace NzbDrone.Core.Indexers.Newznab
                     capabilities.SupportedSearchParameters = xmlBasicSearch.Attribute("supportedParams").Value.Split(',');
                 }
 
-                var xmlTvSearch = xmlSearching.Element("tv-search");
-                if (xmlTvSearch == null || xmlTvSearch.Attribute("available").Value != "yes")
-                {
-                    capabilities.SupportedTvSearchParameters = null;
-                }
-                else if (xmlTvSearch.Attribute("supportedParams") != null)
-                {
-                    capabilities.SupportedTvSearchParameters = xmlTvSearch.Attribute("supportedParams").Value.Split(',');
-                    capabilities.SupportsAggregateIdSearch = true;
-                }
-
                 var xmlMovieSearch = xmlSearching.Element("movie-search");
                 if (xmlMovieSearch == null || xmlMovieSearch.Attribute("available").Value != "yes")
                 {

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRssParser.cs
@@ -77,21 +77,6 @@ namespace NzbDrone.Core.Indexers.Newznab
             releaseInfo = base.ProcessItem(item, releaseInfo);
             releaseInfo.ImdbId = GetImdbId(item);
 
-            //// This shouldn't be needed with changes to the DownloadDecisionMaker
-            //var imdbMovieTitle = GetImdbTitle(item);
-            //var imdbYear = GetImdbYear(item);
-
-            //// Fun, lets try to add year to the releaseTitle for our foriegn friends :)
-            //// if (!releaseInfo.Title.ContainsIgnoreCase(imdbMovieTitle + "." + imdbYear))
-            //var isMatch = Regex.IsMatch(releaseInfo.Title, $@"^{imdbMovieTitle}.*{imdbYear}", RegexOptions.IgnoreCase);
-            //if (!isMatch)
-            //{
-            //    if (imdbYear != 1900 && imdbMovieTitle != string.Empty)
-            //    {
-            //        // releaseInfo.Title = releaseInfo.Title.Replace(imdbMovieTitle, imdbMovieTitle + "." + imdbYear);
-            //        releaseInfo.Title = Regex.Replace(releaseInfo.Title, imdbMovieTitle, imdbMovieTitle + "." + imdbYear, RegexOptions.IgnoreCase);
-            //    }
-            //}
             return releaseInfo;
         }
 

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
@@ -88,13 +88,6 @@ namespace NzbDrone.Core.Indexers.Newznab
             Type = FieldType.Checkbox)]
         public bool RemoveYear { get; set; }
 
-        [FieldDefinition(7,
-            Label = "Search by Title",
-            HelpText = "By default, Radarr will try to search by IMDB ID if your indexer supports that. However, some indexers are not very good at tagging their releases correctly, so you can force Radarr to search that indexer by title instead.",
-            Advanced = true,
-            Type = FieldType.Checkbox)]
-        public bool SearchByTitle { get; set; }
-
         // Field 8 is used by TorznabSettings MinimumSeeders
         // If you need to add another field here, update TorznabSettings as well and this comment
         public virtual NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
@@ -58,7 +58,16 @@ namespace NzbDrone.Core.Indexers.Nyaa
 
         public IndexerPageableRequestChain GetSearchRequests(MovieSearchCriteria searchCriteria)
         {
-            return new IndexerPageableRequestChain();
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            foreach (var queryTitle in searchCriteria.QueryTitles)
+            {
+                pageableRequests.Add(GetPagedRequests(MaxPages,
+                    string.Format("&term={0}",
+                    PrepareQuery(string.Format("{0} {1}", queryTitle, searchCriteria.Movie.Year)))));
+            }
+
+            return pageableRequests;
         }
 
         public Func<IDictionary<string, string>> GetCookies { get; set; }

--- a/src/NzbDrone.Core/Indexers/Omgwtfnzbs/OmgwtfnzbsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Omgwtfnzbs/OmgwtfnzbsRequestGenerator.cs
@@ -26,6 +26,19 @@ namespace NzbDrone.Core.Indexers.Omgwtfnzbs
             return pageableRequests;
         }
 
+        public IndexerPageableRequestChain GetSearchRequests(MovieSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            foreach (var queryTitle in searchCriteria.QueryTitles)
+            {
+                pageableRequests.Add(GetPagedRequests(string.Format("{0}",
+                    queryTitle)));
+            }
+
+            return pageableRequests;
+        }
+
         private IEnumerable<IndexerRequest> GetPagedRequests(string query)
         {
             var url = new StringBuilder();
@@ -38,16 +51,6 @@ namespace NzbDrone.Core.Indexers.Omgwtfnzbs
             }
 
             yield return new IndexerRequest(url.ToString(), HttpAccept.Rss);
-        }
-
-        public IndexerPageableRequestChain GetSearchRequests(MovieSearchCriteria searchCriteria)
-        {
-            var pageableRequests = new IndexerPageableRequestChain();
-
-            pageableRequests.Add(GetPagedRequests(string.Format("{0}",
-                    searchCriteria.Movie.Title)));
-
-            return pageableRequests;
         }
 
         public Func<IDictionary<string, string>> GetCookies { get; set; }

--- a/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornRequestGenerator.cs
@@ -35,7 +35,10 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
             }
             else if (searchCriteria.Movie.Year > 0)
             {
-                pageableRequests.Add(GetRequest(string.Format("{0}&year={1}", searchCriteria.Movie.Title, searchCriteria.Movie.Year)));
+                foreach (var queryTitle in searchCriteria.QueryTitles)
+                {
+                    pageableRequests.Add(GetRequest(string.Format("{0}&year={1}", queryTitle, searchCriteria.Movie.Year)));
+                }
             }
 
             return pageableRequests;

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateLanguage.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateLanguage.cs
@@ -25,37 +25,33 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators
 
             languages.AddRange(localMovie.DownloadClientMovieInfo?.Languages ?? new List<Language>());
 
-            if (!languages.Any(l => l != Language.English))
+            if (!languages.Any(l => l != Language.Unknown))
             {
                 languages = localMovie.FolderMovieInfo?.Languages ?? new List<Language>();
             }
 
-            if (!languages.Any(l => l != Language.English))
+            if (!languages.Any(l => l != Language.Unknown))
             {
                 languages = localMovie.FileMovieInfo?.Languages ?? new List<Language>();
             }
 
             if (!languages.Any())
             {
-                languages.Add(Language.English);
+                languages.Add(Language.Unknown);
+            }
+
+            languages = languages.Distinct().ToList();
+
+            if (languages.Count == 1 && languages.Contains(Language.Unknown))
+            {
+                languages = new List<Language> { localMovie.Movie.OriginalLanguage };
             }
 
             _logger.Debug("Using languages: {0}", languages.Select(l => l.Name).ToList().Join(","));
 
-            localMovie.Languages = languages.Distinct().ToList();
+            localMovie.Languages = languages;
 
             return localMovie;
-        }
-
-        private List<Language> GetLanguage(ParsedMovieInfo parsedMovieInfo)
-        {
-            if (parsedMovieInfo == null)
-            {
-                // English is the default language when otherwise unknown
-                return new List<Language> { Language.English };
-            }
-
-            return parsedMovieInfo.Languages;
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageFromDownloadClientItem.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageFromDownloadClientItem.cs
@@ -1,0 +1,19 @@
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenters.Language
+{
+    public class AugmentLanguageFromDownloadClientItem : IAugmentLanguage
+    {
+        public AugmentLanguageResult AugmentLanguage(LocalMovie localMovie)
+        {
+            var languages = localMovie.DownloadClientMovieInfo?.Languages;
+
+            if (languages == null)
+            {
+                return null;
+            }
+
+            return new AugmentLanguageResult(languages, Confidence.DownloadClientItem);
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageFromFileName.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageFromFileName.cs
@@ -1,0 +1,19 @@
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenters.Language
+{
+    public class AugmentLanguageFromFileName : IAugmentLanguage
+    {
+        public AugmentLanguageResult AugmentLanguage(LocalMovie localMovie)
+        {
+            var languages = localMovie.FileMovieInfo?.Languages;
+
+            if (languages == null)
+            {
+                return null;
+            }
+
+            return new AugmentLanguageResult(languages, Confidence.Filename);
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageFromFolder.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageFromFolder.cs
@@ -1,0 +1,19 @@
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenters.Language
+{
+    public class AugmentLanguageFromFolder : IAugmentLanguage
+    {
+        public AugmentLanguageResult AugmentLanguage(LocalMovie localMovie)
+        {
+            var languages = localMovie.FolderMovieInfo?.Languages;
+
+            if (languages == null)
+            {
+                return null;
+            }
+
+            return new AugmentLanguageResult(languages, Confidence.Foldername);
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageFromMediaInfo.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageFromMediaInfo.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Linq;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenters.Language
+{
+    public class AugmentLanguageFromMediaInfo : IAugmentLanguage
+    {
+        public AugmentLanguageResult AugmentLanguage(LocalMovie localMovie)
+        {
+            if (localMovie.MediaInfo == null)
+            {
+                return null;
+            }
+
+            var audioLanguages = localMovie.MediaInfo.AudioLanguages.Split('/').Distinct().ToList();
+
+            var languages = new List<Languages.Language>();
+
+            foreach (var audioLanguage in audioLanguages)
+            {
+                var language = IsoLanguages.FindByName(audioLanguage)?.Language;
+                languages.AddIfNotNull(language);
+            }
+
+            if (languages.Count == 0)
+            {
+                return null;
+            }
+
+            return new AugmentLanguageResult(languages, Confidence.MediaInfo);
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageResult.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageResult.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenters.Language
+{
+    public class AugmentLanguageResult
+    {
+        public List<Languages.Language> Languages { get; set; }
+        public Confidence Confidence { get; set; }
+
+        public AugmentLanguageResult(List<Languages.Language> languages,
+                                    Confidence confidence)
+        {
+            Languages = languages;
+            Confidence = confidence;
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Language/Confidence.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Language/Confidence.cs
@@ -1,0 +1,11 @@
+namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenters.Language
+{
+    public enum Confidence
+    {
+        Default,
+        Filename,
+        Foldername,
+        DownloadClientItem,
+        MediaInfo
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Language/IAugmentLanguage.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Language/IAugmentLanguage.cs
@@ -1,0 +1,9 @@
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenters.Language
+{
+    public interface IAugmentLanguage
+    {
+        AugmentLanguageResult AugmentLanguage(LocalMovie localMovie);
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/DetectSample.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/DetectSample.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using NLog;
 using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Movies;
-using NzbDrone.Core.Qualities;
 
 namespace NzbDrone.Core.MediaFiles.MovieImport
 {

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/NzbDrone.Core/MetadataSource/IProvideMovieInfo.cs
+++ b/src/NzbDrone.Core/MetadataSource/IProvideMovieInfo.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Credits;
+using NzbDrone.Core.Movies.Translations;
 
 namespace NzbDrone.Core.MetadataSource
 {

--- a/src/NzbDrone.Core/MetadataSource/IProvideMovieInfo.cs
+++ b/src/NzbDrone.Core/MetadataSource/IProvideMovieInfo.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Credits;
-using NzbDrone.Core.Movies.Translations;
 
 namespace NzbDrone.Core.MetadataSource
 {

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/MovieResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/MovieResource.cs
@@ -9,6 +9,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public string ImdbId { get; set; }
         public string Overview { get; set; }
         public string Title { get; set; }
+        public string OriginalTitle { get; set; }
         public string TitleSlug { get; set; }
         public List<RatingResource> Ratings { get; set; }
         public int? Runtime { get; set; }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/TranslationResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/TranslationResource.cs
@@ -3,6 +3,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
     public class TranslationResource
     {
         public string Title { get; set; }
+        public string Overview { get; set; }
         public string Language { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -15,6 +15,7 @@ using NzbDrone.Core.Movies.AlternativeTitles;
 using NzbDrone.Core.Movies.Commands;
 using NzbDrone.Core.Movies.Credits;
 using NzbDrone.Core.Movies.Events;
+using NzbDrone.Core.Movies.Translations;
 
 namespace NzbDrone.Core.Movies
 {
@@ -22,6 +23,7 @@ namespace NzbDrone.Core.Movies
     {
         private readonly IProvideMovieInfo _movieInfo;
         private readonly IMovieService _movieService;
+        private readonly IMovieTranslationService _movieTranslationService;
         private readonly IAlternativeTitleService _titleService;
         private readonly ICreditService _creditService;
         private readonly IEventAggregator _eventAggregator;
@@ -33,6 +35,7 @@ namespace NzbDrone.Core.Movies
 
         public RefreshMovieService(IProvideMovieInfo movieInfo,
                                     IMovieService movieService,
+                                    IMovieTranslationService movieTranslationService,
                                     IAlternativeTitleService titleService,
                                     ICreditService creditService,
                                     IEventAggregator eventAggregator,
@@ -43,6 +46,7 @@ namespace NzbDrone.Core.Movies
         {
             _movieInfo = movieInfo;
             _movieService = movieService;
+            _movieTranslationService = movieTranslationService;
             _titleService = titleService;
             _creditService = creditService;
             _eventAggregator = eventAggregator;
@@ -104,8 +108,11 @@ namespace NzbDrone.Core.Movies
             movie.Year = movieInfo.Year;
             movie.SecondaryYear = movieInfo.SecondaryYear;
             movie.PhysicalRelease = movieInfo.PhysicalRelease;
+            movie.DigitalRelease = movieInfo.DigitalRelease;
             movie.YouTubeTrailerId = movieInfo.YouTubeTrailerId;
             movie.Studio = movieInfo.Studio;
+            movie.OriginalTitle = movieInfo.OriginalTitle;
+            movie.OriginalLanguage = movieInfo.OriginalLanguage;
             movie.HasPreDBEntry = movieInfo.HasPreDBEntry;
             movie.Recommendations = movieInfo.Recommendations;
 
@@ -120,6 +127,7 @@ namespace NzbDrone.Core.Movies
             }
 
             movie.AlternativeTitles = _titleService.UpdateTitles(movieInfo.AlternativeTitles, movie);
+            _movieTranslationService.UpdateTranslations(movieInfo.Translations, movie);
 
             _movieService.UpdateMovie(new List<Movie> { movie }, true);
             _creditService.UpdateCredits(credits, movie);

--- a/src/NzbDrone.Core/Movies/Translations/MovieTranslation.cs
+++ b/src/NzbDrone.Core/Movies/Translations/MovieTranslation.cs
@@ -1,0 +1,14 @@
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Languages;
+
+namespace NzbDrone.Core.Movies.Translations
+{
+    public class MovieTranslation : ModelBase
+    {
+        public int MovieId { get; set; }
+        public string Title { get; set; }
+        public string CleanTitle { get; set; }
+        public string Overview { get; set; }
+        public Language Language { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Movies/Translations/MovieTranslationRepository.cs
+++ b/src/NzbDrone.Core/Movies/Translations/MovieTranslationRepository.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.Messaging.Events;
+
+namespace NzbDrone.Core.Movies.Translations
+{
+    public interface IMovieTranslationRepository : IBasicRepository<MovieTranslation>
+    {
+        List<MovieTranslation> FindByMovieId(int movieId);
+        List<MovieTranslation> FindByLanguage(Language language);
+        void DeleteForMovies(List<int> movieIds);
+    }
+
+    public class MovieTranslationRepository : BasicRepository<MovieTranslation>, IMovieTranslationRepository
+    {
+        public MovieTranslationRepository(IMainDatabase database, IEventAggregator eventAggregator)
+            : base(database, eventAggregator)
+        {
+        }
+
+        public List<MovieTranslation> FindByMovieId(int movieId)
+        {
+            return Query(x => x.MovieId == movieId);
+        }
+
+        public List<MovieTranslation> FindByLanguage(Language language)
+        {
+            return Query(x => x.Language == language);
+        }
+
+        public void DeleteForMovies(List<int> movieIds)
+        {
+            Delete(x => movieIds.Contains(x.MovieId));
+        }
+    }
+}

--- a/src/NzbDrone.Core/Movies/Translations/MovieTranslationService.cs
+++ b/src/NzbDrone.Core/Movies/Translations/MovieTranslationService.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Linq;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Movies.Events;
+
+namespace NzbDrone.Core.Movies.Translations
+{
+    public interface IMovieTranslationService
+    {
+        List<MovieTranslation> GetAllTranslationsForMovie(int movieId);
+        List<MovieTranslation> GetAllTranslationsForLanguage(Language language);
+        List<MovieTranslation> UpdateTranslations(List<MovieTranslation> titles, Movie movie);
+    }
+
+    public class MovieTranslationService : IMovieTranslationService, IHandleAsync<MoviesDeletedEvent>
+    {
+        private readonly IMovieTranslationRepository _translationRepo;
+        private readonly Logger _logger;
+
+        public MovieTranslationService(IMovieTranslationRepository translationRepo,
+                             Logger logger)
+        {
+            _translationRepo = translationRepo;
+            _logger = logger;
+        }
+
+        public List<MovieTranslation> GetAllTranslationsForMovie(int movieId)
+        {
+            return _translationRepo.FindByMovieId(movieId).ToList();
+        }
+
+        public List<MovieTranslation> GetAllTranslationsForLanguage(Language language)
+        {
+            return _translationRepo.FindByLanguage(language).ToList();
+        }
+
+        public void RemoveTitle(MovieTranslation title)
+        {
+            _translationRepo.Delete(title);
+        }
+
+        public List<MovieTranslation> UpdateTranslations(List<MovieTranslation> translations, Movie movie)
+        {
+            int movieId = movie.Id;
+
+            // First update the movie ids so we can correlate them later
+            translations.ForEach(t => t.MovieId = movieId);
+
+            // Then throw out any we don't have languages for
+            translations = translations.Where(t => t.Language != null).ToList();
+
+            // Then make sure they are all distinct languages
+            translations = translations.DistinctBy(t => t.Language).ToList();
+
+            // Now find translations to delete, update and insert
+            var existingTranslations = _translationRepo.FindByMovieId(movieId);
+
+            translations.ForEach(c => c.Id = existingTranslations.FirstOrDefault(t => t.Language == c.Language)?.Id ?? 0);
+
+            var insert = translations.Where(t => t.Id == 0).ToList();
+            var update = translations.Where(t => t.Id > 0).ToList();
+            var delete = existingTranslations.Where(t => !translations.Any(c => c.Language == t.Language)).ToList();
+
+            _translationRepo.DeleteMany(delete.ToList());
+            _translationRepo.UpdateMany(update.ToList());
+            _translationRepo.InsertMany(insert.ToList());
+
+            return translations;
+        }
+
+        public void HandleAsync(MoviesDeletedEvent message)
+        {
+            _translationRepo.DeleteForMovies(message.Movies.Select(m => m.Id).ToList());
+        }
+    }
+}

--- a/src/NzbDrone.Core/NetImport/TMDb/Collection/TMDbCollectionParser.cs
+++ b/src/NzbDrone.Core/NetImport/TMDb/Collection/TMDbCollectionParser.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies;
 
 namespace NzbDrone.Core.NetImport.TMDb.Collection

--- a/src/NzbDrone.Core/NetImport/TMDb/List/TMDbListParser.cs
+++ b/src/NzbDrone.Core/NetImport/TMDb/List/TMDbListParser.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies;
 
 namespace NzbDrone.Core.NetImport.TMDb.List

--- a/src/NzbDrone.Core/NetImport/TMDb/Person/TMDbPersonParser.cs
+++ b/src/NzbDrone.Core/NetImport/TMDb/Person/TMDbPersonParser.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies;
 
 namespace NzbDrone.Core.NetImport.TMDb.Person

--- a/src/NzbDrone.Core/NetImport/TMDb/TMDbParser.cs
+++ b/src/NzbDrone.Core/NetImport/TMDb/TMDbParser.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Net;
 using Newtonsoft.Json;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.MediaCover;
-using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.NetImport.Exceptions;
 

--- a/src/NzbDrone.Core/NetImport/Trakt/TraktAPI.cs
+++ b/src/NzbDrone.Core/NetImport/Trakt/TraktAPI.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace NzbDrone.Core.NetImport.Trakt
 {
     public class TraktMovieIdsResource

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -11,6 +11,9 @@ using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.AlternativeTitles;
+using NzbDrone.Core.Movies.Translations;
+using NzbDrone.Core.Parser;
 using NzbDrone.Core.Qualities;
 
 namespace NzbDrone.Core.Organizer
@@ -30,10 +33,11 @@ namespace NzbDrone.Core.Organizer
         private readonly INamingConfigService _namingConfigService;
         private readonly IQualityDefinitionService _qualityDefinitionService;
         private readonly IUpdateMediaInfo _mediaInfoUpdater;
+        private readonly IMovieTranslationService _movieTranslationService;
         private readonly ICustomFormatService _formatService;
         private readonly Logger _logger;
 
-        private static readonly Regex TitleRegex = new Regex(@"\{(?<prefix>[- ._\[(]*)(?<token>(?:[a-z0-9]+)(?:(?<separator>[- ._]+)(?:[a-z0-9]+))?)(?::(?<customFormat>[a-z0-9]+))?(?<suffix>[- ._)\]]*)\}",
+        private static readonly Regex TitleRegex = new Regex(@"\{(?<prefix>[- ._\[(]*)(?<token>(?:[a-z0-9]+)(?:(?<separator>[- ._]+)(?:[a-z0-9]+))?)(?::(?<customFormat>[a-z0-9|]+))?(?<suffix>[- ._)\]]*)\}",
                                                              RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex TagsRegex = new Regex(@"(?<tags>\{tags(?:\:0+)?})",
@@ -50,7 +54,7 @@ namespace NzbDrone.Core.Organizer
         public static readonly Regex SeriesTitleRegex = new Regex(@"(?<token>\{(?:Series)(?<separator>[- ._])(Clean)?Title\})",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        public static readonly Regex MovieTitleRegex = new Regex(@"(?<token>\{((?:(Movie|Original))(?<separator>[- ._])(Clean)?(Title|Filename)(The)?)\})",
+        public static readonly Regex MovieTitleRegex = new Regex(@"(?<token>\{((?:(Movie|Original))(?<separator>[- ._])(Clean)?(Title|Filename)(The)?)(?::(?<customFormat>[a-z0-9]+))?\})",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex FileNameCleanupRegex = new Regex(@"([- ._])(\1)+", RegexOptions.Compiled);
@@ -69,12 +73,14 @@ namespace NzbDrone.Core.Organizer
         public FileNameBuilder(INamingConfigService namingConfigService,
                                IQualityDefinitionService qualityDefinitionService,
                                IUpdateMediaInfo mediaInfoUpdater,
+                               IMovieTranslationService movieTranslationService,
                                ICustomFormatService formatService,
                                Logger logger)
         {
             _namingConfigService = namingConfigService;
             _qualityDefinitionService = qualityDefinitionService;
             _mediaInfoUpdater = mediaInfoUpdater;
+            _movieTranslationService = movieTranslationService;
             _formatService = formatService;
             _logger = logger;
         }
@@ -86,7 +92,7 @@ namespace NzbDrone.Core.Organizer
                 namingConfig = _namingConfigService.GetConfig();
             }
 
-            if (!namingConfig.RenameEpisodes)
+            if (!namingConfig.RenameMovies)
             {
                 return GetOriginalTitle(movieFile);
             }
@@ -226,11 +232,38 @@ namespace NzbDrone.Core.Organizer
 
         private void AddMovieTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Movie movie)
         {
-            tokenHandlers["{Movie Title}"] = m => movie.Title;
-            tokenHandlers["{Movie CleanTitle}"] = m => CleanTitle(movie.Title);
+            tokenHandlers["{Movie Title}"] = m => GetLanguageTitle(movie, m.CustomFormat);
+            tokenHandlers["{Movie CleanTitle}"] = m => CleanTitle(GetLanguageTitle(movie, m.CustomFormat));
             tokenHandlers["{Movie Title The}"] = m => TitleThe(movie.Title);
             tokenHandlers["{Movie Certification}"] = mbox => movie.Certification;
             tokenHandlers["{Movie TitleFirstCharacter}"] = m => TitleThe(movie.Title).Substring(0, 1).FirstCharToUpper();
+        }
+
+        private string GetLanguageTitle(Movie movie, string isoCodes)
+        {
+            if (isoCodes.IsNotNullOrWhiteSpace())
+            {
+                foreach (var isoCode in isoCodes.Split('|'))
+                {
+                    var language = IsoLanguages.Find(isoCode.ToLower())?.Language;
+
+                    if (language == null)
+                    {
+                        continue;
+                    }
+
+                    var titles = movie.Translations.Where(t => t.Language == language).ToList();
+
+                    if (!movie.Translations.Any())
+                    {
+                        titles = _movieTranslationService.GetAllTranslationsForMovie(movie.Id).Where(t => t.Language == language).ToList();
+                    }
+
+                    return titles.FirstOrDefault()?.Title ?? movie.Title;
+                }
+            }
+
+            return movie.Title;
         }
 
         private void AddTagsTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, MovieFile movieFile)

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -11,7 +11,6 @@ using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Movies;
-using NzbDrone.Core.Movies.AlternativeTitles;
 using NzbDrone.Core.Movies.Translations;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Qualities;

--- a/src/NzbDrone.Core/Organizer/NamingConfig.cs
+++ b/src/NzbDrone.Core/Organizer/NamingConfig.cs
@@ -6,15 +6,15 @@ namespace NzbDrone.Core.Organizer
     {
         public static NamingConfig Default => new NamingConfig
         {
-            RenameEpisodes = false,
+            RenameMovies = false,
             ReplaceIllegalCharacters = true,
             ColonReplacementFormat = 0,
             MultiEpisodeStyle = 0,
-            MovieFolderFormat = "{Movie Title} ({Release Year})",
-            StandardMovieFormat = "{Movie Title} ({Release Year}) {Quality Full}",
+            MovieFolderFormat = "{Movie Title:EN} ({Release Year})",
+            StandardMovieFormat = "{Movie Title:EN} ({Release Year}) {Quality Full}",
         };
 
-        public bool RenameEpisodes { get; set; }
+        public bool RenameMovies { get; set; }
         public bool ReplaceIllegalCharacters { get; set; }
         public ColonReplacementFormat ColonReplacementFormat { get; set; }
         public int MultiEpisodeStyle { get; set; }

--- a/src/NzbDrone.Core/Parser/IsoLanguage.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguage.cs
@@ -7,13 +7,15 @@ namespace NzbDrone.Core.Parser
         public string TwoLetterCode { get; set; }
         public string ThreeLetterCode { get; set; }
         public string CountryCode { get; set; }
+        public string EnglishName { get; set; }
         public Language Language { get; set; }
 
-        public IsoLanguage(string twoLetterCode, string countryCode, string threeLetterCode, Language language)
+        public IsoLanguage(string twoLetterCode, string countryCode, string threeLetterCode, string englishName, Language language)
         {
             TwoLetterCode = twoLetterCode;
             ThreeLetterCode = threeLetterCode;
             CountryCode = countryCode;
+            EnglishName = englishName;
             Language = language;
         }
     }

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -8,30 +8,30 @@ namespace NzbDrone.Core.Parser
     {
         private static readonly HashSet<IsoLanguage> All = new HashSet<IsoLanguage>
                                                            {
-                                                               new IsoLanguage("en", "", "eng", Language.English),
-                                                               new IsoLanguage("fr", "", "fra", Language.French),
-                                                               new IsoLanguage("es", "", "spa", Language.Spanish),
-                                                               new IsoLanguage("de", "", "deu", Language.German),
-                                                               new IsoLanguage("it", "", "ita", Language.Italian),
-                                                               new IsoLanguage("da", "", "dan", Language.Danish),
-                                                               new IsoLanguage("nl", "", "nld", Language.Dutch),
-                                                               new IsoLanguage("ja", "", "jpn", Language.Japanese),
-                                                               new IsoLanguage("is", "", "isl", Language.Icelandic),
-                                                               new IsoLanguage("zh", "", "zho", Language.Chinese),
-                                                               new IsoLanguage("ru", "", "rus", Language.Russian),
-                                                               new IsoLanguage("pl", "", "pol", Language.Polish),
-                                                               new IsoLanguage("vi", "", "vie", Language.Vietnamese),
-                                                               new IsoLanguage("sv", "", "swe", Language.Swedish),
-                                                               new IsoLanguage("no", "", "nor", Language.Norwegian),
-                                                               new IsoLanguage("nb", "", "nob", Language.Norwegian),
-                                                               new IsoLanguage("fi", "", "fin", Language.Finnish),
-                                                               new IsoLanguage("tr", "", "tur", Language.Turkish),
-                                                               new IsoLanguage("pt", "", "por", Language.Portuguese),
-                                                               new IsoLanguage("el", "", "ell", Language.Greek),
-                                                               new IsoLanguage("ko", "", "kor", Language.Korean),
-                                                               new IsoLanguage("hu", "", "hun", Language.Hungarian),
-                                                               new IsoLanguage("he", "", "heb", Language.Hebrew),
-                                                               new IsoLanguage("cs", "", "ces", Language.Czech)
+                                                               new IsoLanguage("en", "", "eng", "English", Language.English),
+                                                               new IsoLanguage("fr", "", "fra", "French", Language.French),
+                                                               new IsoLanguage("es", "", "spa", "Spanish", Language.Spanish),
+                                                               new IsoLanguage("de", "", "deu", "German", Language.German),
+                                                               new IsoLanguage("it", "", "ita", "Italian", Language.Italian),
+                                                               new IsoLanguage("da", "", "dan", "Danish", Language.Danish),
+                                                               new IsoLanguage("nl", "", "nld", "Dutch", Language.Dutch),
+                                                               new IsoLanguage("ja", "", "jpn", "Japanese", Language.Japanese),
+                                                               new IsoLanguage("is", "", "isl", "Icelandic", Language.Icelandic),
+                                                               new IsoLanguage("zh", "", "zho", "Chinese", Language.Chinese),
+                                                               new IsoLanguage("ru", "", "rus", "Russian", Language.Russian),
+                                                               new IsoLanguage("pl", "", "pol", "Polish", Language.Polish),
+                                                               new IsoLanguage("vi", "", "vie", "Vietnamese", Language.Vietnamese),
+                                                               new IsoLanguage("sv", "", "swe", "Swedish", Language.Swedish),
+                                                               new IsoLanguage("no", "", "nor", "Norwegian", Language.Norwegian),
+                                                               new IsoLanguage("nb", "", "nob", "Norwegian Bokmal", Language.Norwegian),
+                                                               new IsoLanguage("fi", "", "fin", "Finnish", Language.Finnish),
+                                                               new IsoLanguage("tr", "", "tur", "Turkish", Language.Turkish),
+                                                               new IsoLanguage("pt", "", "por", "Portuguese", Language.Portuguese),
+                                                               new IsoLanguage("el", "", "ell", "Greek", Language.Greek),
+                                                               new IsoLanguage("ko", "", "kor", "Korean", Language.Korean),
+                                                               new IsoLanguage("hu", "", "hun", "Hungarian", Language.Hungarian),
+                                                               new IsoLanguage("he", "", "heb", "Hebrew", Language.Hebrew),
+                                                               new IsoLanguage("cs", "", "ces", "Czech", Language.Czech)
                                                            };
 
         public static IsoLanguage Find(string isoCode)
@@ -60,6 +60,11 @@ namespace NzbDrone.Core.Parser
             }
 
             return null;
+        }
+
+        public static IsoLanguage FindByName(string name)
+        {
+            return All.FirstOrDefault(l => l.EnglishName == name.Trim());
         }
 
         public static IsoLanguage Get(Language language)

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Parser
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(LanguageParser));
 
-        private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VOSTFR|VO|VFF|VFQ|VFI|VF2|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<dutch>nl\W?subs?)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)",
+        private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>\b(?:german|videomann|ger)\b)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VOSTFR|VO|VFF|VFQ|VFI|VF2|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<english>\beng\b)|(?<dutch>nl\W?subs?)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?<lithuanian>\bLT\b)|(?<czech>\bCZ\b)",
@@ -140,51 +140,59 @@ namespace NzbDrone.Core.Parser
                 languages.Add(Language.Czech);
             }
 
-            var match = LanguageRegex.Match(title);
+            var matches = LanguageRegex.Matches(title);
 
-            if (match.Groups["italian"].Captures.Cast<Capture>().Any())
+            foreach (Match match in matches)
             {
-                languages.Add(Language.Italian);
-            }
+                if (match.Groups["italian"].Captures.Cast<Capture>().Any())
+                {
+                    languages.Add(Language.Italian);
+                }
 
-            if (match.Groups["german"].Captures.Cast<Capture>().Any())
-            {
-                languages.Add(Language.German);
-            }
+                if (match.Groups["german"].Captures.Cast<Capture>().Any())
+                {
+                    languages.Add(Language.German);
+                }
 
-            if (match.Groups["flemish"].Captures.Cast<Capture>().Any())
-            {
-                languages.Add(Language.Flemish);
-            }
+                if (match.Groups["flemish"].Captures.Cast<Capture>().Any())
+                {
+                    languages.Add(Language.Flemish);
+                }
 
-            if (match.Groups["greek"].Captures.Cast<Capture>().Any())
-            {
-                languages.Add(Language.Greek);
-            }
+                if (match.Groups["greek"].Captures.Cast<Capture>().Any())
+                {
+                    languages.Add(Language.Greek);
+                }
 
-            if (match.Groups["french"].Success)
-            {
-                languages.Add(Language.French);
-            }
+                if (match.Groups["french"].Success)
+                {
+                    languages.Add(Language.French);
+                }
 
-            if (match.Groups["russian"].Success)
-            {
-                languages.Add(Language.Russian);
-            }
+                if (match.Groups["russian"].Success)
+                {
+                    languages.Add(Language.Russian);
+                }
 
-            if (match.Groups["dutch"].Success)
-            {
-                languages.Add(Language.Dutch);
-            }
+                if (match.Groups["english"].Success)
+                {
+                    languages.Add(Language.English);
+                }
 
-            if (match.Groups["hungarian"].Success)
-            {
-                languages.Add(Language.Hungarian);
-            }
+                if (match.Groups["dutch"].Success)
+                {
+                    languages.Add(Language.Dutch);
+                }
 
-            if (match.Groups["hebrew"].Success)
-            {
-                languages.Add(Language.Hebrew);
+                if (match.Groups["hungarian"].Success)
+                {
+                    languages.Add(Language.Hungarian);
+                }
+
+                if (match.Groups["hebrew"].Success)
+                {
+                    languages.Add(Language.Hebrew);
+                }
             }
 
             if (title.ToLower().Contains("multi"))
@@ -198,7 +206,7 @@ namespace NzbDrone.Core.Parser
 
             if (!languages.Any())
             {
-                languages.Add(Language.English);
+                languages.Add(Language.Unknown);
             }
 
             return languages.DistinctBy(l => (int)l).ToList();

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -6,6 +6,7 @@ using NLog;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.AlternativeTitles;
 using NzbDrone.Core.Parser.Augmenters;
@@ -139,6 +140,12 @@ namespace NzbDrone.Core.Parser
             {
                 result = new MappingResult { MappingResultType = MappingResultType.Unknown };
                 result.Movie = null;
+            }
+
+            //Use movie language as fallback if we could't parse a language (more accurate than just using English)
+            if (parsedMovieInfo.Languages.Count <= 1 && parsedMovieInfo.Languages.First() == Language.Unknown && result.Movie != null)
+            {
+                parsedMovieInfo.Languages = new List<Language> { result.Movie.OriginalLanguage };
             }
 
             result.RemoteMovie.ParsedMovieInfo = parsedMovieInfo;

--- a/src/NzbDrone.Core/Profiles/ProfileService.cs
+++ b/src/NzbDrone.Core/Profiles/ProfileService.cs
@@ -21,6 +21,7 @@ namespace NzbDrone.Core.Profiles
         Profile Get(int id);
         bool Exists(int id);
         Profile GetDefaultProfile(string name, Quality cutoff = null, params Quality[] allowed);
+        List<Language> GetAcceptableLanguages(int profileId);
     }
 
     public class ProfileService : IProfileService,
@@ -263,6 +264,24 @@ namespace NzbDrone.Core.Profiles
             };
 
             return qualityProfile;
+        }
+
+        public List<Language> GetAcceptableLanguages(int profileId)
+        {
+            var profile = Get(profileId);
+
+            var wantedTitleLanguages = profile.FormatItems.Where(i => i.Score > 0).Select(item => item.Format)
+                .SelectMany(format => format.Specifications)
+                .Where(specification => specification is LanguageSpecification && !specification.Negate)
+                .Cast<LanguageSpecification>()
+                .Where(specification => specification.Value > 0)
+                .Select(specification => (Language)specification.Value)
+                .Distinct()
+                .ToList();
+
+            wantedTitleLanguages.Add(profile.Language);
+
+            return wantedTitleLanguages;
         }
 
         private Profile AddDefaultProfile(string name, Quality cutoff, params Quality[] allowed)

--- a/src/Radarr.Api.V3/Calendar/CalendarFeedModule.cs
+++ b/src/Radarr.Api.V3/Calendar/CalendarFeedModule.cs
@@ -123,9 +123,7 @@ namespace Radarr.Api.V3.Calendar
             occurrence.Description = movie.Overview;
             occurrence.Categories = new List<string>() { movie.Studio };
 
-            var physicalText = movie.PhysicalReleaseNote.IsNotNullOrWhiteSpace()
-                ? $"(Physical Release, {movie.PhysicalReleaseNote})"
-                : "(Physical Release)";
+            var physicalText = "(Physical Release)";
             occurrence.Summary = $"{movie.Title} " + (cinemasRelease ? "(Theatrical Release)" : physicalText);
         }
     }

--- a/src/Radarr.Api.V3/Config/IndexerConfigResource.cs
+++ b/src/Radarr.Api.V3/Config/IndexerConfigResource.cs
@@ -1,5 +1,4 @@
 using NzbDrone.Core.Configuration;
-using NzbDrone.Core.Parser;
 using Radarr.Http.REST;
 
 namespace Radarr.Api.V3.Config

--- a/src/Radarr.Api.V3/Config/NamingExampleResource.cs
+++ b/src/Radarr.Api.V3/Config/NamingExampleResource.cs
@@ -16,7 +16,7 @@ namespace Radarr.Api.V3.Config
             {
                 Id = model.Id,
 
-                RenameMovies = model.RenameEpisodes,
+                RenameMovies = model.RenameMovies,
                 ReplaceIllegalCharacters = model.ReplaceIllegalCharacters,
                 ColonReplacementFormat = model.ColonReplacementFormat,
                 StandardMovieFormat = model.StandardMovieFormat,
@@ -43,7 +43,7 @@ namespace Radarr.Api.V3.Config
             {
                 Id = resource.Id,
 
-                RenameEpisodes = resource.RenameMovies,
+                RenameMovies = resource.RenameMovies,
                 ReplaceIllegalCharacters = resource.ReplaceIllegalCharacters,
                 ColonReplacementFormat = resource.ColonReplacementFormat,
                 StandardMovieFormat = resource.StandardMovieFormat,

--- a/src/Radarr.Api.V3/Config/UiConfigResource.cs
+++ b/src/Radarr.Api.V3/Config/UiConfigResource.cs
@@ -16,6 +16,7 @@ namespace Radarr.Api.V3.Config
         public bool ShowRelativeDates { get; set; }
 
         public bool EnableColorImpairedMode { get; set; }
+        public int MovieInfoLanguage { get; set; }
     }
 
     public static class UiConfigResourceMapper
@@ -33,6 +34,7 @@ namespace Radarr.Api.V3.Config
                 ShowRelativeDates = model.ShowRelativeDates,
 
                 EnableColorImpairedMode = model.EnableColorImpairedMode,
+                MovieInfoLanguage = model.MovieInfoLanguage
             };
         }
     }

--- a/src/Radarr.Api.V3/ManualImport/ManualImportResource.cs
+++ b/src/Radarr.Api.V3/ManualImport/ManualImportResource.cs
@@ -39,8 +39,7 @@ namespace Radarr.Api.V3.ManualImport
                 Id = HashConverter.GetHashInt31(model.Path),
                 Path = model.Path,
                 RelativePath = model.RelativePath,
-
-                // FolderName = model.FolderName,
+                FolderName = model.FolderName,
                 Name = model.Name,
                 Size = model.Size,
                 Movie = model.Movie.ToResource(),

--- a/src/Radarr.Api.V3/Movies/MovieLookupModule.cs
+++ b/src/Radarr.Api.V3/Movies/MovieLookupModule.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using Nancy;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies;
@@ -15,13 +17,18 @@ namespace Radarr.Api.V3.Movies
         private readonly ISearchForNewMovie _searchProxy;
         private readonly IProvideMovieInfo _movieInfo;
         private readonly IBuildFileNames _fileNameBuilder;
+        private readonly IConfigService _configService;
 
-        public MovieLookupModule(ISearchForNewMovie searchProxy, IProvideMovieInfo movieInfo, IBuildFileNames fileNameBuilder)
+        public MovieLookupModule(ISearchForNewMovie searchProxy,
+                                 IProvideMovieInfo movieInfo,
+                                 IBuildFileNames fileNameBuilder,
+                                 IConfigService configService)
             : base("/movie/lookup")
         {
             _movieInfo = movieInfo;
             _searchProxy = searchProxy;
             _fileNameBuilder = fileNameBuilder;
+            _configService = configService;
             Get("/", x => Search());
             Get("/tmdb", x => SearchByTmdbId());
             Get("/imdb", x => SearchByImdbId());
@@ -33,7 +40,8 @@ namespace Radarr.Api.V3.Movies
             if (int.TryParse(Request.Query.tmdbId, out tmdbId))
             {
                 var result = _movieInfo.GetMovieInfo(tmdbId).Item1;
-                return result.ToResource();
+                var translation = result.Translations.FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
+                return result.ToResource(translation);
             }
 
             throw new BadRequestException("Tmdb Id was not valid");
@@ -43,20 +51,24 @@ namespace Radarr.Api.V3.Movies
         {
             string imdbId = Request.Query.imdbId;
             var result = _movieInfo.GetMovieByImdbId(imdbId);
-            return result.ToResource();
+
+            var translation = result.Translations.FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
+            return result.ToResource(translation);
         }
 
         private object Search()
         {
-            var imdbResults = _searchProxy.SearchForNewMovie((string)Request.Query.term);
-            return MapToResource(imdbResults);
+            var searchResults = _searchProxy.SearchForNewMovie((string)Request.Query.term);
+
+            return MapToResource(searchResults);
         }
 
         private IEnumerable<MovieResource> MapToResource(IEnumerable<Movie> movies)
         {
             foreach (var currentMovie in movies)
             {
-                var resource = currentMovie.ToResource();
+                var translation = currentMovie.Translations.FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
+                var resource = currentMovie.ToResource(translation);
                 var poster = currentMovie.Images.FirstOrDefault(c => c.CoverType == MediaCoverTypes.Poster);
                 if (poster != null)
                 {

--- a/src/Radarr.Api.V3/Movies/MovieModule.cs
+++ b/src/Radarr.Api.V3/Movies/MovieModule.cs
@@ -1,9 +1,12 @@
 using System.Collections.Generic;
+using System.Linq;
 using FluentValidation;
 using Nancy;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.DecisionEngine.Specifications;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Events;
@@ -12,6 +15,7 @@ using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Commands;
 using NzbDrone.Core.Movies.Events;
+using NzbDrone.Core.Movies.Translations;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.Validation.Paths;
 using NzbDrone.SignalR;
@@ -30,17 +34,21 @@ namespace Radarr.Api.V3.Movies
                                 IHandle<MediaCoversUpdatedEvent>
     {
         private readonly IMovieService _moviesService;
+        private readonly IMovieTranslationService _movieTranslationService;
         private readonly IAddMovieService _addMovieService;
         private readonly IMapCoversToLocal _coverMapper;
         private readonly IManageCommandQueue _commandQueueManager;
         private readonly IUpgradableSpecification _qualityUpgradableSpecification;
+        private readonly IConfigService _configService;
 
         public MovieModule(IBroadcastSignalRMessage signalRBroadcaster,
                             IMovieService moviesService,
+                            IMovieTranslationService movieTranslationService,
                             IAddMovieService addMovieService,
                             IMapCoversToLocal coverMapper,
                             IManageCommandQueue commandQueueManager,
                             IUpgradableSpecification qualityUpgradableSpecification,
+                            IConfigService configService,
                             RootFolderValidator rootFolderValidator,
                             MappedNetworkDriveValidator mappedNetworkDriveValidator,
                             MoviePathValidator moviesPathValidator,
@@ -52,8 +60,10 @@ namespace Radarr.Api.V3.Movies
             : base(signalRBroadcaster)
         {
             _moviesService = moviesService;
+            _movieTranslationService = movieTranslationService;
             _addMovieService = addMovieService;
             _qualityUpgradableSpecification = qualityUpgradableSpecification;
+            _configService = configService;
             _coverMapper = coverMapper;
             _commandQueueManager = commandQueueManager;
 
@@ -95,33 +105,44 @@ namespace Radarr.Api.V3.Movies
 
             if (tmdbId > 0)
             {
-                moviesResources.AddIfNotNull(_moviesService.FindByTmdbId(tmdbId).ToResource(_qualityUpgradableSpecification));
+                var movie = _moviesService.FindByTmdbId(tmdbId);
+                var translation = _movieTranslationService.GetAllTranslationsForMovie(movie.Id).Where(t => t.Language == (Language)_configService.MovieInfoLanguage).FirstOrDefault();
+
+                moviesResources.AddIfNotNull(movie.ToResource(_qualityUpgradableSpecification, translation));
             }
             else
             {
-                moviesResources.AddRange(_moviesService.GetAllMovies().ToResource(_qualityUpgradableSpecification));
+                var translations = _movieTranslationService.GetAllTranslationsForLanguage((Language)_configService.MovieInfoLanguage);
+                var movies = _moviesService.GetAllMovies();
+
+                foreach (var movie in movies)
+                {
+                    var translation = translations.FirstOrDefault(t => t.MovieId == movie.Id);
+                    moviesResources.Add(movie.ToResource(_qualityUpgradableSpecification, translation));
+                }
             }
 
             MapCoversToLocal(moviesResources.ToArray());
-            PopulateAlternateTitles(moviesResources);
 
             return moviesResources;
         }
 
         private MovieResource GetMovie(int id)
         {
-            var movies = _moviesService.GetMovie(id);
-            return MapToResource(movies);
+            var movie = _moviesService.GetMovie(id);
+            return MapToResource(movie);
         }
 
-        protected MovieResource MapToResource(Movie movies)
+        protected MovieResource MapToResource(Movie movie)
         {
-            if (movies == null)
+            if (movie == null)
             {
                 return null;
             }
 
-            var resource = movies.ToResource();
+            var translation = _movieTranslationService.GetAllTranslationsForMovie(movie.Id).FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
+
+            var resource = movie.ToResource(_qualityUpgradableSpecification, translation);
             MapCoversToLocal(resource);
 
             return resource;
@@ -155,9 +176,10 @@ namespace Radarr.Api.V3.Movies
 
             var model = moviesResource.ToModel(movie);
 
-            _moviesService.UpdateMovie(model);
+            var updatedMovie = _moviesService.UpdateMovie(model);
+            var translation = _movieTranslationService.GetAllTranslationsForMovie(updatedMovie.Id).FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
 
-            BroadcastResourceChange(ModelAction.Updated, moviesResource);
+            BroadcastResourceChange(ModelAction.Updated, updatedMovie.ToResource(_qualityUpgradableSpecification, translation));
         }
 
         private void DeleteMovie(int id)
@@ -176,28 +198,10 @@ namespace Radarr.Api.V3.Movies
             }
         }
 
-        private void PopulateAlternateTitles(List<MovieResource> resources)
-        {
-            foreach (var resource in resources)
-            {
-                PopulateAlternateTitles(resource);
-            }
-        }
-
-        private void PopulateAlternateTitles(MovieResource resource)
-        {
-            //var mappings = null;//_sceneMappingService.FindByTvdbId(resource.TvdbId);
-
-            //if (mappings == null) return;
-
-            //Not necessary anymore
-
-            //resource.AlternateTitles = mappings.Select(v => new AlternateTitleResource { Title = v.Title, SeasonNumber = v.SeasonNumber, SceneSeasonNumber = v.SceneSeasonNumber }).ToList();
-        }
-
         public void Handle(MovieImportedEvent message)
         {
-            BroadcastResourceChange(ModelAction.Updated, message.ImportedMovie.MovieId);
+            var translation = _movieTranslationService.GetAllTranslationsForMovie(message.ImportedMovie.MovieId).FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
+            BroadcastResourceChange(ModelAction.Updated, message.ImportedMovie.Movie.ToResource(_qualityUpgradableSpecification, translation));
         }
 
         public void Handle(MovieFileDeletedEvent message)
@@ -212,12 +216,14 @@ namespace Radarr.Api.V3.Movies
 
         public void Handle(MovieUpdatedEvent message)
         {
-            BroadcastResourceChange(ModelAction.Updated, message.Movie.Id);
+            var translation = _movieTranslationService.GetAllTranslationsForMovie(message.Movie.Id).FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
+            BroadcastResourceChange(ModelAction.Updated, message.Movie.ToResource(_qualityUpgradableSpecification, translation));
         }
 
         public void Handle(MovieEditedEvent message)
         {
-            BroadcastResourceChange(ModelAction.Updated, message.Movie.Id);
+            var translation = _movieTranslationService.GetAllTranslationsForMovie(message.Movie.Id).FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
+            BroadcastResourceChange(ModelAction.Updated, message.Movie.ToResource(_qualityUpgradableSpecification, translation));
         }
 
         public void Handle(MoviesDeletedEvent message)
@@ -230,7 +236,8 @@ namespace Radarr.Api.V3.Movies
 
         public void Handle(MovieRenamedEvent message)
         {
-            BroadcastResourceChange(ModelAction.Updated, message.Movie.Id);
+            var translation = _movieTranslationService.GetAllTranslationsForMovie(message.Movie.Id).FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
+            BroadcastResourceChange(ModelAction.Updated, message.Movie.ToResource(_qualityUpgradableSpecification, translation));
         }
 
         public void Handle(MediaCoversUpdatedEvent message)

--- a/src/Radarr.Api.V3/Movies/MovieResource.cs
+++ b/src/Radarr.Api.V3/Movies/MovieResource.cs
@@ -35,6 +35,7 @@ namespace Radarr.Api.V3.Movies
         public string Overview { get; set; }
         public DateTime? InCinemas { get; set; }
         public DateTime? PhysicalRelease { get; set; }
+        public DateTime? DigitalRelease { get; set; }
         public string PhysicalReleaseNote { get; set; }
         public List<MediaCover> Images { get; set; }
         public string Website { get; set; }
@@ -94,6 +95,7 @@ namespace Radarr.Api.V3.Movies
                 SortTitle = model.SortTitle,
                 InCinemas = model.InCinemas,
                 PhysicalRelease = model.PhysicalRelease,
+                DigitalRelease = model.DigitalRelease,
                 HasFile = model.HasFile,
 
                 SizeOnDisk = size,
@@ -156,6 +158,7 @@ namespace Radarr.Api.V3.Movies
                 SortTitle = translatedTitle.NormalizeTitle(),
                 InCinemas = model.InCinemas,
                 PhysicalRelease = model.PhysicalRelease,
+                DigitalRelease = model.DigitalRelease,
                 HasFile = model.HasFile,
 
                 SizeOnDisk = size,
@@ -217,6 +220,7 @@ namespace Radarr.Api.V3.Movies
                 SortTitle = translatedTitle.NormalizeTitle(),
                 InCinemas = model.InCinemas,
                 PhysicalRelease = model.PhysicalRelease,
+                DigitalRelease = model.DigitalRelease,
                 HasFile = model.HasFile,
 
                 SizeOnDisk = size,


### PR DESCRIPTION
#### Database Migration
YES (173)

#### Description
- Don't use the language from profiles for the metadata pull from TMDB, Store English movie title as the title for Radarr DB
- Store TMDB Translations as new Alt Title type
  - Allow use of localized naming tokens: 
    - {Movie Title} will always give English title
    - {Movie Title:HU} will always give the Hungarian Title
    - If translated title doesn't exist, fallback to english title
- Store Original Movie Language in DB and grab from TMDB
- Default to Original Movie Language for Releases that can't be language parsed instead of English


#### Todos
- [x] Grab translations on add so that folder name gets set correctly (#3895)
- [x] Add multi Lang back to indexers
- [x] Tests and Test Fixups
- [x] Fixes #3980 - Search for both original title, and profile language translated title using querytitles?
- [x] Fixes #4045
- [x] #3747
- [x] Fixes #3497 
- [x] #3482? (Should we store original language, TMDB provides spoken languages in response already) Also relates to #3082 and #568

#### Issues Fixed or Closed by this PR
Fixes #3154, Fixes #4046, Fixes #2676 - pretty much same issue
Fixes #3895

#### Save for Languages 2
- Add additional languages (Brazilian, etc...)