### PR TITLE
Fixed Srt subtitles are not being renamed and copied

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -72,6 +72,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("2 Broke Girls - S01E01 - Pilot-eng-forced.sub", Language.English)]
         [TestCase("2_Eng.srt", Language.English)]
         [TestCase("3_English.srt", Language.English)]
+        [TestCase("Title.2000.1080p.BluRay.H264.AAC-RARBG.idx", Language.Unknown)]
+        [TestCase("Title.2000.1080p.BluRay.H264.AAC-RARBG.sub", Language.Unknown)]
         public void should_parse_subtitle_language(string fileName, Language language)
         {
             var result = LanguageParser.ParseSubtitleLanguage(fileName);

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -70,6 +70,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("2 Broke Girls - S01E01 - Pilot.sub", Language.Unknown)]
         [TestCase("2 Broke Girls - S01E01 - Pilot.eng.forced.sub", Language.English)]
         [TestCase("2 Broke Girls - S01E01 - Pilot-eng-forced.sub", Language.English)]
+        [TestCase("2_Eng.srt", Language.English)]
+        [TestCase("3_English.srt", Language.English)]
         public void should_parse_subtitle_language(string fileName, Language language)
         {
             var result = LanguageParser.ParseSubtitleLanguage(fileName);

--- a/src/NzbDrone.Core/Extras/ExtraService.cs
+++ b/src/NzbDrone.Core/Extras/ExtraService.cs
@@ -66,16 +66,11 @@ namespace NzbDrone.Core.Extras
             var sourcePath = localMovie.Path;
             var sourceFolder = _diskProvider.GetParentFolder(sourcePath);
             var sourceFileName = Path.GetFileNameWithoutExtension(sourcePath);
-            // jpogs: sort files descending so that higher detailed subs will be loaded first
-            //var files = _diskProvider.GetFiles(sourceFolder, SearchOption.AllDirectories);
             var files = _diskProvider.GetFiles(sourceFolder, SearchOption.AllDirectories).OrderByDescending(d => d).ToArray();
 
             var wantedExtensions = _configService.ExtraFileExtensions.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                                                                      .Select(e => e.Trim(' ', '.'))
                                                                      .ToList();
-
-            // jpogs: import files regardless of filename ie. subtitles 2_Eng.srt
-            //var matchingFilenames = files.Where(f => Path.GetFileNameWithoutExtension(f).StartsWith(sourceFileName, StringComparison.InvariantCultureIgnoreCase));
 
             foreach (var matchingFilename in files)
             {

--- a/src/NzbDrone.Core/Extras/ExtraService.cs
+++ b/src/NzbDrone.Core/Extras/ExtraService.cs
@@ -66,15 +66,18 @@ namespace NzbDrone.Core.Extras
             var sourcePath = localMovie.Path;
             var sourceFolder = _diskProvider.GetParentFolder(sourcePath);
             var sourceFileName = Path.GetFileNameWithoutExtension(sourcePath);
-            var files = _diskProvider.GetFiles(sourceFolder, SearchOption.TopDirectoryOnly);
+            // jpogs: sort files descending so that higher detailed subs will be loaded first
+            //var files = _diskProvider.GetFiles(sourceFolder, SearchOption.AllDirectories);
+            var files = _diskProvider.GetFiles(sourceFolder, SearchOption.AllDirectories).OrderByDescending(d => d).ToArray();
 
             var wantedExtensions = _configService.ExtraFileExtensions.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                                                                      .Select(e => e.Trim(' ', '.'))
                                                                      .ToList();
 
-            var matchingFilenames = files.Where(f => Path.GetFileNameWithoutExtension(f).StartsWith(sourceFileName, StringComparison.InvariantCultureIgnoreCase));
+            // jpogs: import files regardless of filename ie. subtitles 2_Eng.srt
+            //var matchingFilenames = files.Where(f => Path.GetFileNameWithoutExtension(f).StartsWith(sourceFileName, StringComparison.InvariantCultureIgnoreCase));
 
-            foreach (var matchingFilename in matchingFilenames)
+            foreach (var matchingFilename in files)
             {
                 var matchingExtension = wantedExtensions.FirstOrDefault(e => matchingFilename.EndsWith(e));
 

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -94,16 +94,10 @@ namespace NzbDrone.Core.Extras.Subtitles
                     .Where(m => m.Extension == extension);
 
                 var suffix = GetSuffix(language, existingSrtSubs.Count() + 1, extension.EqualsIgnoreCase(".srt"));                
-                var subtitleFile = new SubtitleFile();
-                
-                if ((extension.EqualsIgnoreCase(".srt") && language != Language.Unknown) ||
-                    !extension.EqualsIgnoreCase(".srt"))
-                {
-                    subtitleFile = ImportFile(movie, movieFile, path, readOnly, extension, suffix);
-                    subtitleFile.Language = language;
+                var subtitleFile = ImportFile(movie, movieFile, path, readOnly, extension, suffix);
+                subtitleFile.Language = language;
 
-                    _subtitleFileService.Upsert(subtitleFile);                                            
-                }
+                _subtitleFileService.Upsert(subtitleFile);                                            
 
                 return subtitleFile;
             }

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -101,7 +101,7 @@ namespace NzbDrone.Core.Extras.Subtitles
                 var suffix = GetSuffix(language, existingSrtSubs.Count() + 1, extension.ToLower() == ".srt");                
                 var subtitleFile = new SubtitleFile();
                 
-                if (extension.ToLower() == ".srt" && language != Language.Unknown ||
+                if ((extension.ToLower() == ".srt" && language != Language.Unknown) ||
                     extension.ToLower() != ".srt")
                 {
                     subtitleFile = ImportFile(movie, movieFile, path, readOnly, extension, suffix);

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -88,11 +88,6 @@ namespace NzbDrone.Core.Extras.Subtitles
             if (SubtitleFileExtensions.Extensions.Contains(Path.GetExtension(path)))
             {
                 var language = LanguageParser.ParseSubtitleLanguage(path);
-
-                // jpogs: accomodate multiple subtitle files
-                //var subtitleFile = ImportFile(movie, movieFile, path, readOnly, extension, suffix);
-                //subtitleFile.Language = language;
-
                 var subtitleFiles = _subtitleFileService.GetFilesByMovie(movie.Id);
                 var existingSrtSubs = subtitleFiles.Where(m => m.MovieFileId == movieFile.Id)
                     .Where(m => m.Language == language)

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -93,11 +93,11 @@ namespace NzbDrone.Core.Extras.Subtitles
                     .Where(m => m.Language == language)
                     .Where(m => m.Extension == extension);
 
-                var suffix = GetSuffix(language, existingSrtSubs.Count() + 1, extension.ToLower() == ".srt");                
+                var suffix = GetSuffix(language, existingSrtSubs.Count() + 1, extension.EqualsIgnoreCase(".srt"));                
                 var subtitleFile = new SubtitleFile();
                 
-                if ((extension.ToLower() == ".srt" && language != Language.Unknown) ||
-                    extension.ToLower() != ".srt")
+                if ((extension.EqualsIgnoreCase(".srt") && language != Language.Unknown) ||
+                    !extension.EqualsIgnoreCase(".srt"))
                 {
                     subtitleFile = ImportFile(movie, movieFile, path, readOnly, extension, suffix);
                     subtitleFile.Language = language;

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -16,7 +16,8 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VOSTFR|VO|VFF|VFQ|VF2|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<dutch>nl\W?subs?)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<czech>\b(?:CZ|SK)\b)|(?<ukrainian>\bukr\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        // jpogs: updated regex to match RARBG subtitle naming convention
+        private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?.*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static List<Language> ParseLanguages(string title)
         {
@@ -152,14 +153,15 @@ namespace NzbDrone.Core.Parser
 #endif
 
                 var simpleFilename = Path.GetFileNameWithoutExtension(fileName);
-                var languageMatch = SubtitleLanguageRegex.Match(simpleFilename);
+                var languageMatch = SubtitleLanguageRegex.Match(simpleFilename.ToLower());
 
                 if (languageMatch.Success)
                 {
                     var isoCode = languageMatch.Groups["iso_code"].Value;
                     var isoLanguage = IsoLanguages.Find(isoCode);
 
-                    return isoLanguage?.Language ?? Language.Unknown;
+                    Logger.Debug("Parsed language: {0}", isoLanguage?.Language ?? Language.Unknown);
+                    return isoLanguage?.Language ?? Language.Unknown;                    
                 }
 #if !LIBRARY
                 Logger.Debug("Unable to parse langauge from subtitle file: {0}", fileName);

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -15,8 +15,6 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VOSTFR|VO|VFF|VFQ|VF2|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<dutch>nl\W?subs?)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<czech>\b(?:CZ|SK)\b)|(?<ukrainian>\bukr\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        // jpogs: updated regex to match RARBG subtitle naming convention
         private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex RarbgSubtitleLanguageRegex = new Regex("^[0-9]{1,2}_(?<iso_code>[A-Za-z]{2,3}).*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         public static List<Language> ParseLanguages(string title)
@@ -154,8 +152,7 @@ namespace NzbDrone.Core.Parser
 
                 var simpleFilename = Path.GetFileNameWithoutExtension(fileName);
                 var languageMatch = SubtitleLanguageRegex.Match(simpleFilename);
-
-                // jpogs: retry match for RARBG subs
+                
                 if (!languageMatch.Success)
                 {
                     languageMatch = RarbgSubtitleLanguageRegex.Match(simpleFilename);

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Parser
 
         // jpogs: updated regex to match RARBG subtitle naming convention
         private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex RarbgSubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[A-Za-z]{2,3}).*(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RarbgSubtitleLanguageRegex = new Regex("^[0-9]{1,2}_(?<iso_code>[A-Za-z]{2,3}).*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         public static List<Language> ParseLanguages(string title)
         {
             var lowerTitle = title.ToLower();

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -17,8 +17,8 @@ namespace NzbDrone.Core.Parser
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         // jpogs: updated regex to match RARBG subtitle naming convention
-        private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?.*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
+        private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RarbgSubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[A-Za-z]{2,3}).*(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         public static List<Language> ParseLanguages(string title)
         {
             var lowerTitle = title.ToLower();
@@ -153,12 +153,18 @@ namespace NzbDrone.Core.Parser
 #endif
 
                 var simpleFilename = Path.GetFileNameWithoutExtension(fileName);
-                var languageMatch = SubtitleLanguageRegex.Match(simpleFilename.ToLower());
+                var languageMatch = SubtitleLanguageRegex.Match(simpleFilename);
+
+                // jpogs: retry match for RARBG subs
+                if (!languageMatch.Success)
+                {
+                    languageMatch = RarbgSubtitleLanguageRegex.Match(simpleFilename);
+                }
 
                 if (languageMatch.Success)
                 {
                     var isoCode = languageMatch.Groups["iso_code"].Value;
-                    var isoLanguage = IsoLanguages.Find(isoCode);
+                    var isoLanguage = IsoLanguages.Find(isoCode.ToLower());
 
                     Logger.Debug("Parsed language: {0}", isoLanguage?.Language ?? Language.Unknown);
                     return isoLanguage?.Language ?? Language.Unknown;                    


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- This fixes issue on movie.2019.srt subtitles not being imported after fix for #1958 
- Note that this will still rename subtitle to movie.2019.x.srt (where x is the number of subtitle) to account for multiple srt subtitle files

#### Todos
- None

#### Issues Fixed or Closed by this PR

* #3935
