### PR TITLE
Fixed Srt subtitles are not being renamed and copied

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,9 +154,9 @@ workflows:
             - unit_tests:
                 requires:
                     - build
-            #- integration_tests:
-            #    requires:
-            #        - build
+            - integration_tests:
+                requires:
+                    - build
             - publish_artifacts:
                 requires:
                     - build

--- a/src/NzbDrone.Api/Wanted/MovieCutoffModule.cs
+++ b/src/NzbDrone.Api/Wanted/MovieCutoffModule.cs
@@ -26,6 +26,11 @@ namespace NzbDrone.Api.Wanted
 
             pagingSpec.FilterExpression = _movieService.ConstructFilterExpression(pagingResource.FilterKey, pagingResource.FilterValue);
 
+            if (pagingResource.FilterKey == null)
+            {
+                pagingSpec.FilterExpression = m => m.Monitored == true;
+            }
+
             var resource = ApplyToPage(_movieCutoffService.MoviesWhereCutoffUnmet, pagingSpec, v => MapToResource(v, true));
 
             return resource;

--- a/src/NzbDrone.Api/Wanted/MovieCutoffModule.cs
+++ b/src/NzbDrone.Api/Wanted/MovieCutoffModule.cs
@@ -26,11 +26,6 @@ namespace NzbDrone.Api.Wanted
 
             pagingSpec.FilterExpression = _movieService.ConstructFilterExpression(pagingResource.FilterKey, pagingResource.FilterValue);
 
-            if (pagingResource.FilterKey == null)
-            {
-                pagingSpec.FilterExpression = m => m.Monitored == true;
-            }
-
             var resource = ApplyToPage(_movieCutoffService.MoviesWhereCutoffUnmet, pagingSpec, v => MapToResource(v, true));
 
             return resource;

--- a/src/NzbDrone.Api/Wanted/MovieMissingModule.cs
+++ b/src/NzbDrone.Api/Wanted/MovieMissingModule.cs
@@ -15,9 +15,9 @@ namespace NzbDrone.Api.Wanted
     {
         protected readonly IMovieService _movieService;
 
-        public MovieMissingModule(IMovieService movieService, 
-                                  IQualityUpgradableSpecification qualityUpgradableSpecification, 
-                                  IBroadcastSignalRMessage signalRBroadcaster) 
+        public MovieMissingModule(IMovieService movieService,
+                                  IQualityUpgradableSpecification qualityUpgradableSpecification,
+                                  IBroadcastSignalRMessage signalRBroadcaster)
             : base(movieService, qualityUpgradableSpecification, signalRBroadcaster, "wanted/missing")
         {
 
@@ -30,6 +30,10 @@ namespace NzbDrone.Api.Wanted
             var pagingSpec = pagingResource.MapToPagingSpec<MovieResource, Core.Movies.Movie>("title", SortDirection.Descending);
 
             pagingSpec.FilterExpression = _movieService.ConstructFilterExpression(pagingResource.FilterKey, pagingResource.FilterValue);
+            if (pagingResource.FilterKey != "monitored")
+            {
+                pagingSpec.FilterExpression = m => m.Monitored == true;
+            }
 
             var resource = ApplyToPage(_movieService.MoviesWithoutFiles, pagingSpec, v => MapToResource(v, true));
 

--- a/src/NzbDrone.Api/Wanted/MovieMissingModule.cs
+++ b/src/NzbDrone.Api/Wanted/MovieMissingModule.cs
@@ -30,10 +30,6 @@ namespace NzbDrone.Api.Wanted
             var pagingSpec = pagingResource.MapToPagingSpec<MovieResource, Core.Movies.Movie>("title", SortDirection.Descending);
 
             pagingSpec.FilterExpression = _movieService.ConstructFilterExpression(pagingResource.FilterKey, pagingResource.FilterValue);
-            if (pagingResource.FilterKey != "monitored")
-            {
-                pagingSpec.FilterExpression = m => m.Monitored == true;
-            }
 
             var resource = ApplyToPage(_movieService.MoviesWithoutFiles, pagingSpec, v => MapToResource(v, true));
 

--- a/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
@@ -68,11 +68,12 @@ namespace NzbDrone.Common.Test.Http
         [Test]
         public void should_execute_typed_get()
         {
-            var request = new HttpRequest(string.Format("http://{0}/get", _httpBinHost));
+            var request = new HttpRequest(string.Format("http://{0}/get?test=1", _httpBinHost));
 
             var response = Subject.Get<HttpBinResource>(request);
 
-            response.Resource.Url.Should().Be(request.Url.FullUri);
+            response.Resource.Url.EndsWith("/get?test=1");
+            response.Resource.Args.Should().Contain("test", "1");
         }
 
         [Test]
@@ -514,7 +515,7 @@ namespace NzbDrone.Common.Test.Http
         public void should_not_send_old_cookie()
         {
             GivenOldCookie();
-            
+
             var requestCookies = new HttpRequest($"http://{_httpBinHost}/cookies");
             requestCookies.IgnorePersistentCookies = true;
             requestCookies.StoreRequestCookie = false;
@@ -626,6 +627,7 @@ namespace NzbDrone.Common.Test.Http
 
     public class HttpBinResource
     {
+        public Dictionary<string, object> Args { get; set; }
         public Dictionary<string, object> Headers { get; set; }
         public string Origin { get; set; }
         public string Url { get; set; }

--- a/src/NzbDrone.Core.Test/MovieTests/AlternativeTitleServiceTests/AlternativeTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/AlternativeTitleServiceTests/AlternativeTitleFixture.cs
@@ -1,0 +1,32 @@
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Movies.AlternativeTitles;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.MovieTests.AlternativeTitleServiceTests
+{
+    [TestFixture]
+    public class AlternativeTitleFixture : CoreTest
+    {
+        private AlternativeTitle CreateFakeTitle(SourceType source, int votes)
+        {
+            return Builder<AlternativeTitle>.CreateNew().With(t => t.SourceType = source).With(t => t.Votes = votes)
+                .Build();
+        }
+
+        [TestCase(SourceType.TMDB, -1, true)]
+        [TestCase(SourceType.TMDB, 1000, true)]
+        [TestCase(SourceType.Mappings, 0, false)]
+        [TestCase(SourceType.Mappings, 4, true)]
+        [TestCase(SourceType.Mappings, -1, false)]
+        [TestCase(SourceType.Indexer, 0, true)]
+        [TestCase(SourceType.User, 0, true)]
+        public void should_be_trusted(SourceType source, int votes, bool trusted)
+        {
+            var fakeTitle = CreateFakeTitle(source, votes);
+
+            fakeTitle.IsTrusted().Should().Be(trusted);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MovieTests/AlternativeTitleServiceTests/AlternativeTitleServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/AlternativeTitleServiceTests/AlternativeTitleServiceFixture.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.AlternativeTitles;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.MovieTests.AlternativeTitleServiceTests
+{
+    [TestFixture]
+    public class AlternativeTitleServiceFixture : CoreTest<AlternativeTitleService>
+    {
+        private AlternativeTitle _title1;
+        private AlternativeTitle _title2;
+        private AlternativeTitle _title3;
+
+        private Movie _movie;
+
+        [SetUp]
+        public void Setup()
+        {
+            var titles = Builder<AlternativeTitle>.CreateListOfSize(3).All().With(t => t.MovieId = 0).Build();
+            _title1 = titles[0];
+            _title2 = titles[1];
+            _title3 = titles[2];
+            _movie = Builder<Movie>.CreateNew().With(m => m.CleanTitle = "myothertitle").With(m => m.Id = 1).Build();
+        }
+
+        private void GivenExistingTitles(params AlternativeTitle[] titles)
+        {
+            Mocker.GetMock<IAlternativeTitleRepository>().Setup(r => r.FindByMovieId(_movie.Id))
+                .Returns(titles.ToList());
+        }
+
+        [Test]
+        public void should_update_insert_remove_titles()
+        {
+            var titles = new List<AlternativeTitle> {_title2, _title3};
+            var updates = new List<AlternativeTitle> {_title2};
+            var deletes = new List<AlternativeTitle> {_title1};
+            var inserts = new List<AlternativeTitle> {_title3};
+            GivenExistingTitles(_title1, _title2);
+
+            Subject.UpdateTitles(titles, _movie);
+
+            Mocker.GetMock<IAlternativeTitleRepository>().Verify(r => r.InsertMany(inserts), Times.Once());
+            Mocker.GetMock<IAlternativeTitleRepository>().Verify(r => r.UpdateMany(updates), Times.Once());
+            Mocker.GetMock<IAlternativeTitleRepository>().Verify(r => r.DeleteMany(deletes), Times.Once());
+        }
+
+        [Test]
+        public void should_not_insert_duplicates()
+        {
+            GivenExistingTitles();
+            var titles = new List<AlternativeTitle> {_title1, _title1};
+            var inserts = new List<AlternativeTitle>{ _title1 };
+
+            Subject.UpdateTitles(titles, _movie);
+
+            Mocker.GetMock<IAlternativeTitleRepository>().Verify(r => r.InsertMany(inserts), Times.Once());
+        }
+
+        [Test]
+        public void should_not_insert_main_title()
+        {
+            GivenExistingTitles();
+            var titles = new List<AlternativeTitle>{_title1};
+            var movie = Builder<Movie>.CreateNew().With(m => m.CleanTitle = _title1.CleanTitle).Build();
+
+            Subject.UpdateTitles(titles, movie);
+
+            Mocker.GetMock<IAlternativeTitleRepository>().Verify(r => r.InsertMany(new List<AlternativeTitle>()), Times.Once());
+        }
+
+        [Test]
+        public void should_update_movie_id()
+        {
+            GivenExistingTitles();
+            var titles = new List<AlternativeTitle> {_title1, _title2};
+
+            Subject.UpdateTitles(titles, _movie);
+
+            _title1.MovieId.Should().Be(_movie.Id);
+            _title2.MovieId.Should().Be(_movie.Id);
+        }
+
+        [Test]
+        public void should_update_with_correct_id()
+        {
+            var existingTitle = Builder<AlternativeTitle>.CreateNew().With(t => t.Id = 2).Build();
+            GivenExistingTitles(existingTitle);
+            var updateTitle = existingTitle.JsonClone();
+            updateTitle.Id = 0;
+
+            Subject.UpdateTitles(new List<AlternativeTitle> {updateTitle}, _movie);
+
+            Mocker.GetMock<IAlternativeTitleRepository>().Verify(r => r.UpdateMany(It.Is<IList<AlternativeTitle>>(list => list.First().Id == existingTitle.Id)), Times.Once());
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -296,6 +296,8 @@
     <Compile Include="MetadataSource\SkyHook\SkyHookProxySearchFixture.cs" />
     <Compile Include="MetadataSource\SearchMovieComparerFixture.cs" />
     <Compile Include="MetadataSource\SkyHook\SkyHookProxyFixture.cs" />
+    <Compile Include="MovieTests\AlternativeTitleServiceTests\AlternativeTitleFixture.cs" />
+    <Compile Include="MovieTests\AlternativeTitleServiceTests\AlternativeTitleServiceFixture.cs" />
     <Compile Include="NetImport\CouchPotato\CouchPotatoParserFixture.cs" />
     <Compile Include="NetImport\RSSImportFixture.cs" />
     <Compile Include="NetImport\RSSImportParserFixture.cs" />

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -72,6 +72,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("2 Broke Girls - S01E01 - Pilot-eng-forced.sub", Language.English)]
         [TestCase("2_Eng.srt", Language.English)]
         [TestCase("3_English.srt", Language.English)]
+        [TestCase("Title.2000.1080p.BluRay.H264.AAC-RARBG.idx", Language.Unknown)]
+        [TestCase("Title.2000.1080p.BluRay.H264.AAC-RARBG.sub", Language.Unknown)]
         public void should_parse_subtitle_language(string fileName, Language language)
         {
             var result = LanguageParser.ParseSubtitleLanguage(fileName);

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -26,6 +26,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Castle.2009.S01E14.Mandarin.HDTV.XviD-LOL", Language.Mandarin)]
         [TestCase("Castle.2009.S01E14.Korean.HDTV.XviD-LOL", Language.Korean)]
         [TestCase("Castle.2009.S01E14.Russian.HDTV.XviD-LOL", Language.Russian)]
+        [TestCase("Castle.2009.S01E14.Ukrainian.HDTV.XviD-LOL", Language.Ukrainian)]
+        [TestCase("Castle.2009.S01E14.Ukr.HDTV.XviD-LOL", Language.Ukrainian)]
         [TestCase("Castle.2009.S01E14.Polish.HDTV.XviD-LOL", Language.Polish)]
         [TestCase("Castle.2009.S01E14.Vietnamese.HDTV.XviD-LOL", Language.Vietnamese)]
         [TestCase("Castle.2009.S01E14.Swedish.HDTV.XviD-LOL", Language.Swedish)]

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -70,6 +70,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("2 Broke Girls - S01E01 - Pilot.sub", Language.Unknown)]
         [TestCase("2 Broke Girls - S01E01 - Pilot.eng.forced.sub", Language.English)]
         [TestCase("2 Broke Girls - S01E01 - Pilot-eng-forced.sub", Language.English)]
+        [TestCase("2_Eng.srt", Language.English)]
+        [TestCase("3_English.srt", Language.English)]
         public void should_parse_subtitle_language(string fileName, Language language)
         {
             var result = LanguageParser.ParseSubtitleLanguage(fileName);

--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeProxy.cs
@@ -48,9 +48,25 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
         public string GetVersion(DelugeSettings settings)
         {
-            var response = ProcessRequest<string>(settings, "daemon.info");
+            try
+            {
+                var response = ProcessRequest<string>(settings, "daemon.info");
 
-            return response;
+                return response;
+            }
+            catch (DownloadClientException ex)
+            {
+                if (ex.Message.Contains("Unknown method"))
+                {
+                    // Deluge v2 beta replaced 'daemon.info' with 'daemon.get_version'.
+                    // It may return or become official, for now we just retry with the get_version api.
+                    var response = ProcessRequest<string>(settings, "daemon.get_version");
+
+                    return response;
+                }
+
+                throw;
+            }
         }
 
         public Dictionary<string, object> GetConfig(DelugeSettings settings)

--- a/src/NzbDrone.Core/Extras/ExtraService.cs
+++ b/src/NzbDrone.Core/Extras/ExtraService.cs
@@ -66,16 +66,11 @@ namespace NzbDrone.Core.Extras
             var sourcePath = localMovie.Path;
             var sourceFolder = _diskProvider.GetParentFolder(sourcePath);
             var sourceFileName = Path.GetFileNameWithoutExtension(sourcePath);
-            // jpogs: sort files descending so that higher detailed subs will be loaded first
-            //var files = _diskProvider.GetFiles(sourceFolder, SearchOption.AllDirectories);
             var files = _diskProvider.GetFiles(sourceFolder, SearchOption.AllDirectories).OrderByDescending(d => d).ToArray();
 
             var wantedExtensions = _configService.ExtraFileExtensions.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                                                                      .Select(e => e.Trim(' ', '.'))
                                                                      .ToList();
-
-            // jpogs: import files regardless of filename ie. subtitles 2_Eng.srt
-            //var matchingFilenames = files.Where(f => Path.GetFileNameWithoutExtension(f).StartsWith(sourceFileName, StringComparison.InvariantCultureIgnoreCase));
 
             foreach (var matchingFilename in files)
             {

--- a/src/NzbDrone.Core/Extras/ExtraService.cs
+++ b/src/NzbDrone.Core/Extras/ExtraService.cs
@@ -66,15 +66,18 @@ namespace NzbDrone.Core.Extras
             var sourcePath = localMovie.Path;
             var sourceFolder = _diskProvider.GetParentFolder(sourcePath);
             var sourceFileName = Path.GetFileNameWithoutExtension(sourcePath);
-            var files = _diskProvider.GetFiles(sourceFolder, SearchOption.TopDirectoryOnly);
+            // jpogs: sort files descending so that higher detailed subs will be loaded first
+            //var files = _diskProvider.GetFiles(sourceFolder, SearchOption.AllDirectories);
+            var files = _diskProvider.GetFiles(sourceFolder, SearchOption.AllDirectories).OrderByDescending(d => d).ToArray();
 
             var wantedExtensions = _configService.ExtraFileExtensions.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                                                                      .Select(e => e.Trim(' ', '.'))
                                                                      .ToList();
 
-            var matchingFilenames = files.Where(f => Path.GetFileNameWithoutExtension(f).StartsWith(sourceFileName, StringComparison.InvariantCultureIgnoreCase));
+            // jpogs: import files regardless of filename ie. subtitles 2_Eng.srt
+            //var matchingFilenames = files.Where(f => Path.GetFileNameWithoutExtension(f).StartsWith(sourceFileName, StringComparison.InvariantCultureIgnoreCase));
 
-            foreach (var matchingFilename in matchingFilenames)
+            foreach (var matchingFilename in files)
             {
                 var matchingExtension = wantedExtensions.FirstOrDefault(e => matchingFilename.EndsWith(e));
 

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -94,16 +94,10 @@ namespace NzbDrone.Core.Extras.Subtitles
                     .Where(m => m.Extension == extension);
 
                 var suffix = GetSuffix(language, existingSrtSubs.Count() + 1, extension.EqualsIgnoreCase(".srt"));                
-                var subtitleFile = new SubtitleFile();
-                
-                if ((extension.EqualsIgnoreCase(".srt") && language != Language.Unknown) ||
-                    !extension.EqualsIgnoreCase(".srt"))
-                {
-                    subtitleFile = ImportFile(movie, movieFile, path, readOnly, extension, suffix);
-                    subtitleFile.Language = language;
+                var subtitleFile = ImportFile(movie, movieFile, path, readOnly, extension, suffix);
+                subtitleFile.Language = language;
 
-                    _subtitleFileService.Upsert(subtitleFile);                                            
-                }
+                _subtitleFileService.Upsert(subtitleFile);                                            
 
                 return subtitleFile;
             }

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -101,7 +101,7 @@ namespace NzbDrone.Core.Extras.Subtitles
                 var suffix = GetSuffix(language, existingSrtSubs.Count() + 1, extension.ToLower() == ".srt");                
                 var subtitleFile = new SubtitleFile();
                 
-                if (extension.ToLower() == ".srt" && language != Language.Unknown ||
+                if ((extension.ToLower() == ".srt" && language != Language.Unknown) ||
                     extension.ToLower() != ".srt")
                 {
                     subtitleFile = ImportFile(movie, movieFile, path, readOnly, extension, suffix);

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -88,11 +88,6 @@ namespace NzbDrone.Core.Extras.Subtitles
             if (SubtitleFileExtensions.Extensions.Contains(Path.GetExtension(path)))
             {
                 var language = LanguageParser.ParseSubtitleLanguage(path);
-
-                // jpogs: accomodate multiple subtitle files
-                //var subtitleFile = ImportFile(movie, movieFile, path, readOnly, extension, suffix);
-                //subtitleFile.Language = language;
-
                 var subtitleFiles = _subtitleFileService.GetFilesByMovie(movie.Id);
                 var existingSrtSubs = subtitleFiles.Where(m => m.MovieFileId == movieFile.Id)
                     .Where(m => m.Language == language)

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -93,11 +93,11 @@ namespace NzbDrone.Core.Extras.Subtitles
                     .Where(m => m.Language == language)
                     .Where(m => m.Extension == extension);
 
-                var suffix = GetSuffix(language, existingSrtSubs.Count() + 1, extension.ToLower() == ".srt");                
+                var suffix = GetSuffix(language, existingSrtSubs.Count() + 1, extension.EqualsIgnoreCase(".srt"));                
                 var subtitleFile = new SubtitleFile();
                 
-                if ((extension.ToLower() == ".srt" && language != Language.Unknown) ||
-                    extension.ToLower() != ".srt")
+                if ((extension.EqualsIgnoreCase(".srt") && language != Language.Unknown) ||
+                    !extension.EqualsIgnoreCase(".srt"))
                 {
                     subtitleFile = ImportFile(movie, movieFile, path, readOnly, extension, suffix);
                     subtitleFile.Language = language;

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.IndexerSearch.Definitions;
@@ -60,7 +61,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
                 requestBuilder.AddQueryParam("ranked", "0");
             }
 
-            requestBuilder.AddQueryParam("category", "movies");
+            requestBuilder.AddQueryParam("category", string.Join(";", Settings.Categories.Distinct()));
             requestBuilder.AddQueryParam("limit", "100");
             requestBuilder.AddQueryParam("token", _tokenProvider.GetToken(Settings));
             requestBuilder.AddQueryParam("format", "json_extended");
@@ -98,7 +99,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
                 requestBuilder.AddQueryParam("ranked", "0");
             }
 
-            requestBuilder.AddQueryParam("category", "movies");
+            requestBuilder.AddQueryParam("category", string.Join(";", Settings.Categories.Distinct()));
             requestBuilder.AddQueryParam("limit", "100");
             requestBuilder.AddQueryParam("token", _tokenProvider.GetToken(Settings));
             requestBuilder.AddQueryParam("format", "json_extended");

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgSettings.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Parser;
@@ -12,6 +12,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
         public RarbgSettingsValidator()
         {
             RuleFor(c => c.BaseUrl).ValidRootUrl();
+            RuleFor(c => c.Categories).NotEmpty();
         }
     }
 
@@ -24,6 +25,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
             BaseUrl = "https://torrentapi.org";
             RankedOnly = false;
             MinimumSeeders = IndexerDefaults.MINIMUM_SEEDERS;
+            Categories = new[] { 14, 48, 17, 44, 45, 47, 50, 51, 52, 42, 46 };
         }
 
         [FieldDefinition(0, Label = "API URL", HelpText = "URL to Rarbg api, not the website.")]
@@ -43,6 +45,9 @@ namespace NzbDrone.Core.Indexers.Rarbg
 
         [FieldDefinition(5, Type = FieldType.Tag, SelectOptions = typeof(IndexerFlags), Label = "Required Flags", HelpText = "What indexer flags are required?", HelpLink = "https://github.com/Radarr/Radarr/wiki/Indexer-Flags#1-required-flags", Advanced = true)]
         public IEnumerable<int> RequiredFlags { get; set; }
+
+        [FieldDefinition(6, Type = FieldType.Textbox, Label = "Categories", HelpText = "Comma Separated list, you can retrieve the ID by checking the URL behind the category on the website (i.e. Movie/x264/1080 = 44)", HelpLink = "https://rarbgmirror.org/torrents.php?category=movies", Advanced = true)]
+        public IEnumerable<int> Categories { get; set; }
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitle.cs
+++ b/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitle.cs
@@ -17,30 +17,30 @@ namespace NzbDrone.Core.Movies.AlternativeTitles
         public int VoteCount { get; set; }
         public Language Language { get; set; }
         public LazyLoaded<Movie> Movie { get; set; }
-        
-        public AlternativeTitle() 
-        { 
-             
-        } 
- 
-        public AlternativeTitle(string title, SourceType sourceType = SourceType.TMDB, int sourceId = 0, Language language = Language.English) 
-        { 
-            Title = title; 
-            CleanTitle = title.CleanSeriesTitle(); 
-            SourceType = sourceType;
-            SourceId = sourceId;
-            Language = language; 
+
+        public AlternativeTitle()
+        {
+
         }
 
-        public bool IsTrusted(int minVotes = 3)
+        public AlternativeTitle(string title, SourceType sourceType = SourceType.TMDB, int sourceId = 0, Language language = Language.English)
+        {
+            Title = title;
+            CleanTitle = title.CleanSeriesTitle();
+            SourceType = sourceType;
+            SourceId = sourceId;
+            Language = language;
+        }
+
+        public bool IsTrusted(int minVotes = 4)
         {
             switch (SourceType)
             {
-                case SourceType.TMDB:
+                case SourceType.Mappings:
                     return Votes >= minVotes;
                 default:
                     return true;
-            }   
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitleRepository.cs
+++ b/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitleRepository.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
+using Marr.Data;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Messaging.Events;

--- a/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitleService.cs
+++ b/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitleService.cs
@@ -3,6 +3,7 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Messaging.Events;
 using System.Collections.Generic;
 using System.Linq;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Movies.Events;
 
 namespace NzbDrone.Core.Movies.AlternativeTitles
@@ -13,7 +14,7 @@ namespace NzbDrone.Core.Movies.AlternativeTitles
         AlternativeTitle AddAltTitle(AlternativeTitle title, Movie movie);
         List<AlternativeTitle> AddAltTitles(List<AlternativeTitle> titles, Movie movie);
         AlternativeTitle GetById(int id);
-        void DeleteNotEnoughVotes(List<AlternativeTitle> mappingsTitles);
+        List<AlternativeTitle> UpdateTitles(List<AlternativeTitle> titles, Movie movie);
     }
 
     public class AlternativeTitleService : IAlternativeTitleService, IHandleAsync<MovieDeletedEvent>
@@ -63,11 +64,28 @@ namespace NzbDrone.Core.Movies.AlternativeTitles
             _titleRepo.Delete(title);
         }
 
-        public void DeleteNotEnoughVotes(List<AlternativeTitle> mappingsTitles)
+        public List<AlternativeTitle> UpdateTitles(List<AlternativeTitle> titles, Movie movie)
         {
-            var toRemove = mappingsTitles.Where(t => t.SourceType == SourceType.Mappings && t.Votes < 4);
-            var realT = _titleRepo.FindBySourceIds(toRemove.Select(t => t.SourceId).ToList());
-            _titleRepo.DeleteMany(realT);
+            int movieId = movie.Id;
+            // First update the movie ids so we can correlate them later.
+            titles.ForEach(t => t.MovieId = movieId);
+            // Then make sure none of them are the same as the main title.
+            titles = titles.Where(t => t.CleanTitle != movie.CleanTitle).ToList();
+            // Then make sure they are all distinct titles
+            titles = titles.DistinctBy(t => t.CleanTitle).ToList();
+
+            // Now find titles to delete, update and insert.
+            var existingTitles = _titleRepo.FindByMovieId(movieId);
+
+            var insert = titles.Where(t => !existingTitles.Contains(t));
+            var update = existingTitles.Where(t => titles.Contains(t));
+            var delete = existingTitles.Where(t => !titles.Contains(t));
+
+            _titleRepo.DeleteMany(delete.ToList());
+            _titleRepo.UpdateMany(update.ToList());
+            _titleRepo.InsertMany(insert.ToList());
+
+            return titles;
         }
 
         public void HandleAsync(MovieDeletedEvent message)

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -108,26 +108,16 @@ namespace NzbDrone.Core.Movies
                 _logger.Warn(e, "Couldn't update movie path for " + movie.Path);
             }
 
-            movieInfo.AlternativeTitles = movieInfo.AlternativeTitles.Where(t => t.CleanTitle != movie.CleanTitle)
-                .DistinctBy(t => t.CleanTitle)
-                .ExceptBy(t => t.CleanTitle, movie.AlternativeTitles, t => t.CleanTitle, EqualityComparer<string>.Default).ToList();
-
             try
             {
-                movie.AlternativeTitles.AddRange(_titleService.AddAltTitles(movieInfo.AlternativeTitles, movie));
-                
                 var mappings = _apiClient.AlternativeTitlesAndYearForMovie(movieInfo.TmdbId);
                 var mappingsTitles = mappings.Item1;
 
-                _titleService.DeleteNotEnoughVotes(mappingsTitles);
+                mappingsTitles = mappingsTitles.Where(t => t.IsTrusted()).ToList();
 
-                mappingsTitles = mappingsTitles.ExceptBy(t => t.CleanTitle, movie.AlternativeTitles,
-                    t => t.CleanTitle, EqualityComparer<string>.Default).ToList();
-
-
-                mappingsTitles = mappingsTitles.Where(t => t.Votes > 3).ToList();
-
-                movie.AlternativeTitles.AddRange(_titleService.AddAltTitles(mappingsTitles, movie));
+                movieInfo.AlternativeTitles.AddRange(mappingsTitles);
+                
+                movie.AlternativeTitles = _titleService.UpdateTitles(movieInfo.AlternativeTitles, movie);
 
                 if (mappings.Item2 != null)
                 {

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -31,6 +31,7 @@ namespace NzbDrone.Core.Parser
                                                                new IsoLanguage("hu", "hun", Language.Hungarian),
                                                                new IsoLanguage("he", "heb", Language.Hebrew),
                                                                new IsoLanguage("cs", "ces", Language.Czech),
+                                                               new IsoLanguage("ua", "ukr", Language.Ukrainian),
                                                                new IsoLanguage("an", "any", Language.Any)
                                                            };
 

--- a/src/NzbDrone.Core/Parser/Language.cs
+++ b/src/NzbDrone.Core/Parser/Language.cs
@@ -30,6 +30,7 @@ namespace NzbDrone.Core.Parser
         Hungarian = 22,
         Hebrew = 23,
         Czech = 24,
+        Ukrainian = 25,
         Any = -1,
     }
 

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -16,7 +16,8 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VOSTFR|VO|VFF|VFQ|VF2|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<dutch>nl\W?subs?)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<czech>\b(?:CZ|SK)\b)|(?<ukrainian>\bukr\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        // jpogs: updated regex to match RARBG subtitle naming convention
+        private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?.*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static List<Language> ParseLanguages(string title)
         {
@@ -152,14 +153,15 @@ namespace NzbDrone.Core.Parser
 #endif
 
                 var simpleFilename = Path.GetFileNameWithoutExtension(fileName);
-                var languageMatch = SubtitleLanguageRegex.Match(simpleFilename);
+                var languageMatch = SubtitleLanguageRegex.Match(simpleFilename.ToLower());
 
                 if (languageMatch.Success)
                 {
                     var isoCode = languageMatch.Groups["iso_code"].Value;
                     var isoLanguage = IsoLanguages.Find(isoCode);
 
-                    return isoLanguage?.Language ?? Language.Unknown;
+                    Logger.Debug("Parsed language: {0}", isoLanguage?.Language ?? Language.Unknown);
+                    return isoLanguage?.Language ?? Language.Unknown;                    
                 }
 #if !LIBRARY
                 Logger.Debug("Unable to parse langauge from subtitle file: {0}", fileName);

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -13,7 +13,7 @@ namespace NzbDrone.Core.Parser
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(LanguageParser));
 
-        private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VOSTFR|VO|VFF|VFQ|VF2|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<dutch>nl\W?subs?)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<czech>\b(?:CZ|SK)\b)",
+        private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VOSTFR|VO|VFF|VFQ|VF2|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<dutch>nl\W?subs?)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<czech>\b(?:CZ|SK)\b)|(?<ukrainian>\bukr\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -86,6 +86,9 @@ namespace NzbDrone.Core.Parser
             if (lowerTitle.Contains("czech"))
                 languages.Add( Language.Czech);
 
+            if (lowerTitle.Contains("ukrainian"))
+                languages.Add(Language.Ukrainian);
+
             var match = LanguageRegex.Match(title);
 
             if (match.Groups["italian"].Captures.Cast<Capture>().Any())
@@ -118,6 +121,8 @@ namespace NzbDrone.Core.Parser
             if (match.Groups["czech"].Success)
                 languages.Add( Language.Czech);
 
+            if (match.Groups["ukrainian"].Success)
+                languages.Add( Language.Ukrainian);
 
             return languages.DistinctBy(l => (int)l).ToList();
         }

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -15,8 +15,6 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VOSTFR|VO|VFF|VFQ|VF2|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<dutch>nl\W?subs?)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<czech>\b(?:CZ|SK)\b)|(?<ukrainian>\bukr\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        // jpogs: updated regex to match RARBG subtitle naming convention
         private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex RarbgSubtitleLanguageRegex = new Regex("^[0-9]{1,2}_(?<iso_code>[A-Za-z]{2,3}).*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         public static List<Language> ParseLanguages(string title)
@@ -154,8 +152,7 @@ namespace NzbDrone.Core.Parser
 
                 var simpleFilename = Path.GetFileNameWithoutExtension(fileName);
                 var languageMatch = SubtitleLanguageRegex.Match(simpleFilename);
-
-                // jpogs: retry match for RARBG subs
+                
                 if (!languageMatch.Success)
                 {
                     languageMatch = RarbgSubtitleLanguageRegex.Match(simpleFilename);

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Parser
 
         // jpogs: updated regex to match RARBG subtitle naming convention
         private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex RarbgSubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[A-Za-z]{2,3}).*(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RarbgSubtitleLanguageRegex = new Regex("^[0-9]{1,2}_(?<iso_code>[A-Za-z]{2,3}).*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         public static List<Language> ParseLanguages(string title)
         {
             var lowerTitle = title.ToLower();

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -17,8 +17,8 @@ namespace NzbDrone.Core.Parser
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         // jpogs: updated regex to match RARBG subtitle naming convention
-        private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?.*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
+        private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RarbgSubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[A-Za-z]{2,3}).*(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         public static List<Language> ParseLanguages(string title)
         {
             var lowerTitle = title.ToLower();
@@ -153,12 +153,18 @@ namespace NzbDrone.Core.Parser
 #endif
 
                 var simpleFilename = Path.GetFileNameWithoutExtension(fileName);
-                var languageMatch = SubtitleLanguageRegex.Match(simpleFilename.ToLower());
+                var languageMatch = SubtitleLanguageRegex.Match(simpleFilename);
+
+                // jpogs: retry match for RARBG subs
+                if (!languageMatch.Success)
+                {
+                    languageMatch = RarbgSubtitleLanguageRegex.Match(simpleFilename);
+                }
 
                 if (languageMatch.Success)
                 {
                     var isoCode = languageMatch.Groups["iso_code"].Value;
-                    var isoLanguage = IsoLanguages.Find(isoCode);
+                    var isoLanguage = IsoLanguages.Find(isoCode.ToLower());
 
                     Logger.Debug("Parsed language: {0}", isoLanguage?.Language ?? Language.Unknown);
                     return isoLanguage?.Language ?? Language.Unknown;                    

--- a/src/NzbDrone.Integration.Test/ApiTests/CommandFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/CommandFixture.cs
@@ -5,7 +5,6 @@ using NzbDrone.Api.Commands;
 namespace NzbDrone.Integration.Test.ApiTests
 {
     [TestFixture]
-    [Ignore("Not ready to be used on this branch")]
     public class CommandFixture : IntegrationTest
     {
         [Test]

--- a/src/NzbDrone.Integration.Test/ApiTests/WantedTests/CutoffUnmetFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/WantedTests/CutoffUnmetFixture.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
             var movie = EnsureMovie(680, "Pulp Fiction", true);
             EnsureMovieFile(movie, Quality.SDTV);
 
-            var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc");
+            var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "true");
 
             result.Records.Should().NotBeEmpty();
         }
@@ -27,7 +27,19 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
             var movie = EnsureMovie(680, "Pulp Fiction", false);
             EnsureMovieFile(movie, Quality.SDTV);
 
-            var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc");
+            var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "true");
+
+            result.Records.Should().BeEmpty();
+        }
+
+        [Test, Order(1)]
+        public void cutoff_should_not_have_released_items()
+        {
+            EnsureProfileCutoff(1, Quality.HDTV720p);
+            var movie = EnsureMovie(680, "Pulp Fiction", true);
+            EnsureMovieFile(movie, Quality.SDTV);
+
+            var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc", "status", "inCinemas");
 
             result.Records.Should().BeEmpty();
         }
@@ -52,6 +64,18 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
             EnsureMovieFile(movie, Quality.SDTV);
 
             var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "false");
+
+            result.Records.Should().NotBeEmpty();
+        }
+        
+        [Test, Order(2)]
+        public void cutoff_should_have_released_items()
+        {
+            EnsureProfileCutoff(1, Quality.HDTV720p);
+            var movie = EnsureMovie(680, "Pulp Fiction", false);
+            EnsureMovieFile(movie, Quality.SDTV);
+
+            var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc", "status", "released");
 
             result.Records.Should().NotBeEmpty();
         }

--- a/src/NzbDrone.Integration.Test/ApiTests/WantedTests/CutoffUnmetFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/WantedTests/CutoffUnmetFixture.cs
@@ -3,41 +3,11 @@ using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.Qualities;
 
-namespace NzbDrone.Integration.Test.ApiTests
+namespace NzbDrone.Integration.Test.ApiTests.WantedTests
 {
     [TestFixture]
-    public class WantedFixture : IntegrationTest
+    public class CutoffUnmetFixture : IntegrationTest
     {
-        [Test, Order(0)]
-        public void missing_should_be_empty()
-        {
-            EnsureNoMovie(680, "Pulp Fiction");
-
-            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc");
-
-            result.Records.Should().BeEmpty();
-        }
-
-        [Test, Order(1)]
-        public void missing_should_have_monitored_items()
-        {
-            EnsureMovie(680, "Pulp Fiction", true);
-
-            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc");
-
-            result.Records.Should().NotBeEmpty();
-        }
-
-        [Test, Order(1)]
-        public void missing_should_have_movie()
-        {
-            EnsureMovie(680, "Pulp Fiction", true);
-
-            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc");
-
-            result.Records.First().Title.Should().Be("Pulp Fiction");
-        }
-
         [Test, Order(1)]
         public void cutoff_should_have_monitored_items()
         {
@@ -48,16 +18,6 @@ namespace NzbDrone.Integration.Test.ApiTests
             var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc");
 
             result.Records.Should().NotBeEmpty();
-        }
-
-        [Test, Order(1)]
-        public void missing_should_not_have_unmonitored_items()
-        {
-            EnsureMovie(680, "Pulp Fiction", false);
-
-            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc");
-
-            result.Records.Should().BeEmpty();
         }
 
         [Test, Order(1)]
@@ -82,16 +42,6 @@ namespace NzbDrone.Integration.Test.ApiTests
             var result = WantedCutoffUnmet.GetPaged(0, 15, "physicalRelease", "desc");
 
             result.Records.First().Title.Should().Be("Pulp Fiction");
-        }
-
-        [Test, Order(2)]
-        public void missing_should_have_unmonitored_items()
-        {
-            EnsureMovie(680, "Pulp Fiction", false);
-
-            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "false");
-
-            result.Records.Should().NotBeEmpty();
         }
 
         [Test, Order(2)]

--- a/src/NzbDrone.Integration.Test/ApiTests/WantedTests/MissingFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/WantedTests/MissingFixture.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Qualities;
+
+namespace NzbDrone.Integration.Test.ApiTests.WantedTests
+{
+    [TestFixture]
+    public class MissingFixture : IntegrationTest
+    {
+        [Test, Order(0)]
+        public void missing_should_be_empty()
+        {
+            EnsureNoMovie(680, "Pulp Fiction");
+
+            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc");
+
+            result.Records.Should().BeEmpty();
+        }
+
+        [Test, Order(1)]
+        public void missing_should_have_monitored_items()
+        {
+            EnsureMovie(680, "Pulp Fiction", true);
+
+            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc");
+
+            result.Records.Should().NotBeEmpty();
+        }
+
+        [Test, Order(1)]
+        public void missing_should_have_movie()
+        {
+            EnsureMovie(680, "Pulp Fiction", true);
+
+            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc");
+
+            result.Records.First().Title.Should().Be("Pulp Fiction");
+        }
+
+        [Test, Order(1)]
+        public void missing_should_not_have_unmonitored_items()
+        {
+            EnsureMovie(680, "Pulp Fiction", false);
+
+            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc");
+
+            result.Records.Should().BeEmpty();
+        }
+
+        [Test, Order(2)]
+        public void missing_should_have_unmonitored_items()
+        {
+            EnsureMovie(680, "Pulp Fiction", false);
+
+            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "false");
+
+            result.Records.Should().NotBeEmpty();
+        }
+    }
+}

--- a/src/NzbDrone.Integration.Test/ApiTests/WantedTests/MissingFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/WantedTests/MissingFixture.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
         {
             EnsureMovie(680, "Pulp Fiction", true);
 
-            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc");
+            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "true");
 
             result.Records.Should().NotBeEmpty();
         }
@@ -43,7 +43,17 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
         {
             EnsureMovie(680, "Pulp Fiction", false);
 
-            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc");
+            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "true");
+
+            result.Records.Should().BeEmpty();
+        }
+        
+        [Test, Order(1)]
+        public void missing_should_not_have_released_items()
+        {
+            EnsureMovie(680, "Pulp Fiction", false);
+
+            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc", "status", "inCinemas");
 
             result.Records.Should().BeEmpty();
         }
@@ -54,6 +64,16 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
             EnsureMovie(680, "Pulp Fiction", false);
 
             var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc", "monitored", "false");
+
+            result.Records.Should().NotBeEmpty();
+        }
+        
+        [Test, Order(2)]
+        public void missing_should_have_released_items()
+        {
+            EnsureMovie(680, "Pulp Fiction", false);
+
+            var result = WantedMissing.GetPaged(0, 15, "physicalRelease", "desc", "status", "released");
 
             result.Records.Should().NotBeEmpty();
         }

--- a/src/NzbDrone.Integration.Test/IntegrationTestBase.cs
+++ b/src/NzbDrone.Integration.Test/IntegrationTestBase.cs
@@ -235,6 +235,8 @@ namespace NzbDrone.Integration.Test
                 }
             }
 
+            Commands.WaitAll();
+
             return result;
         }
 
@@ -254,9 +256,13 @@ namespace NzbDrone.Integration.Test
 
             if (result.MovieFile == null)
             {
-                var path = Path.Combine(MovieRootFolder, movie.Title, string.Format("{0} - {1}.mkv", movie.Title, quality.Name));
+                var path = Path.Combine(MovieRootFolder, movie.Title, string.Format("{0} ({1}) - {2}.strm", movie.Title, movie.Year, quality.Name));
 
                 Directory.CreateDirectory(Path.GetDirectoryName(path));
+
+                var sourcePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "ApiTests", "Files", "H264_sample.mp4");
+
+                //File.Copy(sourcePath, path);
                 File.WriteAllText(path, "Fake Movie");
 
                 Commands.PostAndWait(new CommandResource { Name = "refreshmovie", Body = new RefreshMovieCommand(movie.Id) });

--- a/src/NzbDrone.Integration.Test/NzbDrone.Integration.Test.csproj
+++ b/src/NzbDrone.Integration.Test/NzbDrone.Integration.Test.csproj
@@ -113,7 +113,8 @@
     <Compile Include="ApiTests\MovieFileFixture.cs" />
     <Compile Include="ApiTests\FileSystemFixture.cs" />
     <Compile Include="ApiTests\MovieLookupFixture.cs" />
-    <Compile Include="ApiTests\WantedFixture.cs" />
+    <Compile Include="ApiTests\WantedTests\CutoffUnmetFixture.cs" />
+    <Compile Include="ApiTests\WantedTests\MissingFixture.cs" />
     <Compile Include="Client\ClientBase.cs" />
     <Compile Include="Client\IndexerClient.cs" />
     <Compile Include="Client\DownloadClientClient.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
* This fixes issue on movie.2019.srt subtitles not being imported after fix for #1958
* Note that this will still rename subtitle to movie.2019.x.srt (where x is the number of subtitle) to account for multiple srt subtitle files

#### Todos
* None

#### Issues Fixed or Closed by this PR

* #3935
