### PR TITLE
Fixed: Use portable pdb on net core

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,8 +82,8 @@ stages:
           find ${OUTPUTFOLDER} -depth -empty -type d -exec rm -r "{}" \;
           find ${TESTSFOLDER} -type f ! -path "*/publish/*" -exec rm -rf {} \;
           find ${TESTSFOLDER} -depth -empty -type d -exec rm -r "{}" \;
-          ls -lR
         displayName: Clean up intermediate output
+        condition: and(succeeded(), ne(variables['osName'], 'Windows'))
       - publish: $(outputFolder)
         artifact: '$(osName)Backend'
         displayName: Publish Backend
@@ -355,6 +355,7 @@ stages:
         condition: and(succeeded(), eq(variables['osName'], 'Mac'))
       - bash: find ${TESTSFOLDER} -name "Radarr.Test.Dummy" -exec chmod a+x {} \;
         displayName: Make Test Dummy Executable
+        condition: and(succeeded(), ne(variables['osName'], 'Windows'))
       - task: Bash@3
         displayName: Run Tests
         env:
@@ -576,7 +577,6 @@ stages:
       - bash: |
           mkdir -p ./bin/
           cp -r -v ${BUILD_ARTIFACTSTAGINGDIRECTORY}/bin/Radarr/. ./bin/
-          ls -lR
         displayName: Move Package Contents
       - task: Bash@3
         displayName: Run Integration Tests
@@ -661,7 +661,6 @@ stages:
           mv geckodriver _tests
         displayName: Install Gecko Driver
         condition: and(succeeded(), ne(variables['osName'], 'Windows'))
-      - bash: ls -lR
       - task: Bash@3
         displayName: Run Automation Tests
         inputs:

--- a/build.sh
+++ b/build.sh
@@ -25,23 +25,6 @@ UpdateVersionNumber()
     fi
 }
 
-CleanFolder()
-{
-    local path=$1
-
-    find $path -name "*.transform" -exec rm "{}" \;
-
-    echo "Removing FluentValidation.Resources files"
-    find $path -name "FluentValidation.resources.dll" -exec rm "{}" \;
-    find $path -name "App.config" -exec rm "{}" \;
-
-    echo "Removing vshost files"
-    find $path -name "*.vshost.exe" -exec rm "{}" \;
-
-    echo "Removing Empty folders"
-    find $path -depth -empty -type d -exec rm -r "{}" \;
-}
-
 LintUI()
 {
     ProgressStart 'ESLint'
@@ -104,8 +87,6 @@ PackageFiles()
     cp -r $outputFolder/$framework/$runtime/publish/* $folder
     cp -r $outputFolder/Radarr.Update/$framework/$runtime/publish $folder/Radarr.Update
     cp -r $outputFolder/UI $folder
-
-    CleanFolder $folder
 
     echo "Adding LICENSE"
     cp LICENSE $folder
@@ -208,8 +189,6 @@ PackageTests()
     curl -Lo gecko.zip "https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-win64.zip"
     unzip -o gecko.zip
     cp geckodriver.exe $testPackageFolder/netcoreapp3.1/win-x64/publish
-
-    CleanFolder $testPackageFolder
 
     ProgressEnd 'Creating Test Package'
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -44,8 +44,6 @@
     <IntermediateOutputPath>$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)'))</IntermediateOutputPath>
     <OutputPath>$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)', '$(OutputPath)'))</OutputPath>
 
-    <!-- below net4.7.1 the new portable pdb format has no line numbers, pdb to mdb probably doesn't like it either -->
-    <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,4 +1,9 @@
 <Project>
+  <!-- below net4.7.1 the new portable pdb format has no line numbers, pdb to mdb probably doesn't like it either -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
   <Import Project="PublishAllRids.targets" />
   <Import Project="MonoFacades.targets" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and !$(RuntimeIdentifier.StartsWith('win'))" />
 </Project>

--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,8 @@ TYPE=$2
 COVERAGE=$3
 WHERE="Category!=ManualTest"
 TEST_PATTERN="*Test.dll"
-ASSEMBLIES=""
+FILES=( "Radarr.Api.Test.dll" "Radarr.Automation.Test.dll" "Radarr.Common.Test.dll" "Radarr.Core.Test.dll" "Radarr.Host.Test.dll" "Radarr.Integration.Test.dll" "Radarr.Libraries.Test.dll" "Radarr.Mono.Test.dll" "Radarr.Update.Test.dll" "Radarr.Windows.Test.dll" )
+ASSMEBLIES=""
 TEST_LOG_FILE="TestLog.txt"
 
 echo "test dir: $TEST_DIR"
@@ -55,8 +56,8 @@ else
   exit 2
 fi
 
-for i in `find $TEST_DIR -name "$TEST_PATTERN"`;
-  do ASSEMBLIES="$ASSEMBLIES $i"
+for i in "${FILES[@]}";
+  do ASSEMBLIES="$ASSEMBLIES $TEST_DIR/$i"
 done
 
 DOTNET_PARAMS="$ASSEMBLIES --TestCaseFilter:$WHERE $VSTEST_PARAMS"


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The windows build was generating old-style PDB for net core output which don't produce line numbers in stack traces on linux.  Only force `full` pdb for the `net462` build.
