### PR TITLE
Fix IMDb ID handling for Torznab indexers

### DIFF
--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
@@ -39,11 +39,11 @@ namespace NzbDrone.Core.Indexers.Torznab
         protected override ReleaseInfo ProcessItem(XElement item, ReleaseInfo releaseInfo)
         {
             var torrentInfo = base.ProcessItem(item, releaseInfo) as TorrentInfo;
-            int? imdbId = GetImdbId(item);
+            var imdbId = GetImdbId(item);
 
             if (imdbId != null)
             {
-                torrentInfo.ImdbId = imdbId;
+                torrentInfo.ImdbId = int.Parse(imdbId);
             }
 
             torrentInfo.IndexerFlags = GetFlags(item);
@@ -105,10 +105,10 @@ namespace NzbDrone.Core.Indexers.Torznab
             return url;
         }
 
-        protected virtual int? GetImdbId(XElement item)
+        protected virtual string GetImdbId(XElement item)
         {
             var imdbId = TryGetTorznabAttribute(item, "imdbid");
-            return (!imdbId.IsNullOrWhiteSpace() ? int.Parse(imdbId) : null);
+            return (!imdbId.IsNullOrWhiteSpace() ? imdbId : null);
         }
 
         protected override string GetInfoHash(XElement item)

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Indexers.Torznab
 
             if (imdbId != null)
             {
-                torrentInfo.ImdbId = int.TryParse(imdbId);
+                int.TryParse(imdbId, torrentInfo.ImdbId);
             }
 
             torrentInfo.IndexerFlags = GetFlags(item);

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Indexers.Torznab
 
             if (imdbId != null)
             {
-                torrentInfo.ImdbId = int.Parse(imdbId);
+                torrentInfo.ImdbId = int.TryParse(imdbId);
             }
 
             torrentInfo.IndexerFlags = GetFlags(item);

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Indexers.Torznab
 
             if (imdbId != null)
             {
-                int.TryParse(imdbId, torrentInfo.ImdbId);
+                int.TryParse(imdbId, out torrentInfo.ImdbId);
             }
 
             torrentInfo.IndexerFlags = GetFlags(item);

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.Indexers.Torznab
 
         protected virtual string GetImdbId(XElement item)
         {
-            var imdbId = TryGetTorznabAttribute(item, "imdbid");
+            var imdbId = TryGetTorznabAttribute(item, "imdb");
             return (!imdbId.IsNullOrWhiteSpace() ? imdbId : null);
         }
 

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
@@ -39,12 +39,11 @@ namespace NzbDrone.Core.Indexers.Torznab
         protected override ReleaseInfo ProcessItem(XElement item, ReleaseInfo releaseInfo)
         {
             var torrentInfo = base.ProcessItem(item, releaseInfo) as TorrentInfo;
-            if (GetImdbId(item) != null)
+            int? imdbId = GetImdbId(item);
+
+            if (imdbId != null)
             {
-                if (torrentInfo != null)
-                {
-                    torrentInfo.ImdbId = int.Parse(GetImdbId(item).Substring(2));
-                }
+                torrentInfo.ImdbId = imdbId;
             }
 
             torrentInfo.IndexerFlags = GetFlags(item);
@@ -106,10 +105,10 @@ namespace NzbDrone.Core.Indexers.Torznab
             return url;
         }
 
-        protected virtual string GetImdbId(XElement item)
+        protected virtual int? GetImdbId(XElement item)
         {
-            var imdbIdString = TryGetTorznabAttribute(item, "imdbid");
-            return (!imdbIdString.IsNullOrWhiteSpace() ? imdbIdString.Substring(2) : null);
+            var imdbId = TryGetTorznabAttribute(item, "imdbid");
+            return (!imdbId.IsNullOrWhiteSpace() ? int.Parse(imdbId) : null);
         }
 
         protected override string GetInfoHash(XElement item)

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
@@ -40,10 +40,11 @@ namespace NzbDrone.Core.Indexers.Torznab
         {
             var torrentInfo = base.ProcessItem(item, releaseInfo) as TorrentInfo;
             var imdbId = GetImdbId(item);
+            int parsedImdbId;
 
-            if (imdbId != null)
+            if (imdbId != null && int.TryParse(imdbId, out parsedImdbId))
             {
-                int.TryParse(imdbId, out torrentInfo.ImdbId);
+                torrentInfo.ImdbId = parsedImdbId;
             }
 
             torrentInfo.IndexerFlags = GetFlags(item);


### PR DESCRIPTION
After looking through the [Jackett source code](https://github.com/Jackett/Jackett/blob/master/src/Jackett.Common/Models/ReleaseInfo.cs#L25) and raw XML responses from it, as well as reading through the [Torznab "specification" over at Sonarr](https://github.com/Sonarr/Sonarr/wiki/Implementing-a-Torznab-indexer#torznab-results), I'm rather certain that IMDb IDs are returned in their integer form. This means that the current IMDb handling in Radarr's Torznab indexer is quite broken since it assumes that IMDb IDs are in their string form (aka. prefixed with `tt`) and substrings them.

Taking a closer look at the indexer code, it actually seems to substring the IMDb IDs twice - so even if the IMDb IDs returned from the Torznab indexer were in their string form, it would still turn the IDs into garbage.

I'm not a C# developer, but I believe this change should fix the issue!

