### PR TITLE
Fixed: WhereBuilder exception when string variable null

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/WhereBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/WhereBuilderFixture.cs
@@ -67,6 +67,23 @@ namespace NzbDrone.Core.Test.Datastore
         }
 
         [Test]
+        public void where_string_is_null()
+        {
+            _subject = Where(x => x.ImdbId == null);
+
+            _subject.ToString().Should().Be($"(\"Movies\".\"ImdbId\" IS NULL)");
+        }
+
+        [Test]
+        public void where_string_is_null_value()
+        {
+            string imdb = null;
+            _subject = Where(x => x.ImdbId == imdb);
+
+            _subject.ToString().Should().Be($"(\"Movies\".\"ImdbId\" IS NULL)");
+        }
+
+        [Test]
         public void where_column_contains_string()
         {
             var test = "small";

--- a/src/NzbDrone.Core/Movies/MovieRepository.cs
+++ b/src/NzbDrone.Core/Movies/MovieRepository.cs
@@ -120,7 +120,7 @@ namespace NzbDrone.Core.Movies
         public Movie FindByImdbId(string imdbid)
         {
             var imdbIdWithPrefix = Parser.Parser.NormalizeImdbId(imdbid);
-            return Query(x => x.ImdbId == imdbIdWithPrefix).FirstOrDefault();
+            return imdbIdWithPrefix == null ? null : Query(x => x.ImdbId == imdbIdWithPrefix).FirstOrDefault();
         }
 
         public Movie FindByTmdbId(int tmdbid)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix NRE in where builder if you pass in a string variable that's null to the query.  Also prevent such a query from being attempted in the first place.

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes Sentry RADARR3-6V
* Fixes Sentry RADARR3-B4
