### PR TITLE
Fixed: Populate Info in Lookup Results if Existing Movie

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -523,7 +523,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
                 var movieResults = response.Resource.results;
 
-                return movieResults.SelectList(MapMovie);
+                return movieResults.SelectList(MapSearchResult);
             }
             catch (HttpException)
             {
@@ -534,6 +534,18 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 _logger.Warn(ex, ex.Message);
                 throw new SkyHookException("Search for '{0}' failed. Invalid response received from TMDb.", title);
             }
+        }
+
+        private Movie MapSearchResult(MovieResult result)
+        {
+            var movie = _movieService.FindByTmdbId(result.id);
+
+            if (movie == null)
+            {
+                movie = MapMovie(result);
+            }
+
+            return movie;
         }
 
         public Movie MapMovie(MovieResult result)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
If movie exists on movie/lookup api call, return that movie object instead of the search result from TMDB.

Fixes issue found by @v0idp, pulled from Sonarr V3
