### PR TITLE
New: Add Year to Custom Script

### DIFF
--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -37,6 +37,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Radarr_EventType", "Grab");
             environmentVariables.Add("Radarr_Movie_Id", movie.Id.ToString());
             environmentVariables.Add("Radarr_Movie_Title", movie.Title);
+            environmentVariables.Add("Radarr_Movie_Year", movie.Year.ToString());
             environmentVariables.Add("Radarr_Movie_ImdbId", movie.ImdbId ?? string.Empty);
             environmentVariables.Add("Radarr_Movie_TmdbId", movie.TmdbId.ToString());
             environmentVariables.Add("Radarr_Movie_In_Cinemas_Date", movie.InCinemas.ToString() ?? string.Empty);
@@ -65,6 +66,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Radarr_IsUpgrade", message.OldMovieFiles.Any().ToString());
             environmentVariables.Add("Radarr_Movie_Id", movie.Id.ToString());
             environmentVariables.Add("Radarr_Movie_Title", movie.Title);
+            environmentVariables.Add("Radarr_Movie_Year", movie.Year.ToString());
             environmentVariables.Add("Radarr_Movie_Path", movie.Path);
             environmentVariables.Add("Radarr_Movie_ImdbId", movie.ImdbId ?? string.Empty);
             environmentVariables.Add("Radarr_Movie_TmdbId", movie.TmdbId.ToString());
@@ -96,6 +98,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Radarr_EventType", "Rename");
             environmentVariables.Add("Radarr_Movie_Id", movie.Id.ToString());
             environmentVariables.Add("Radarr_Movie_Title", movie.Title);
+            environmentVariables.Add("Radarr_Movie_Year", movie.Year.ToString());
             environmentVariables.Add("Radarr_Movie_Path", movie.Path);
             environmentVariables.Add("Radarr_Movie_ImdbId", movie.ImdbId ?? string.Empty);
             environmentVariables.Add("Radarr_Movie_TmdbId", movie.TmdbId.ToString());


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Added `Radarr_Movie_Year` to the environment variables passed to custom post-processing 'On Grab' scripts.

Did not give it a default empty string value because I believe that every movie entry in the DB has a `Year`, like it has a `TmdbId`.


#### Todos

#### Issues Fixed or Closed by this PR

N/A
