### PR TITLE
New: Quality Preferred Setting

### DIFF
--- a/frontend/src/Settings/Quality/Definition/QualityDefinition.css
+++ b/frontend/src/Settings/Quality/Definition/QualityDefinition.css
@@ -31,7 +31,7 @@
   background-color: $sliderAccentColor;
   box-shadow: 0 0 0 #000;
 
-  &:nth-child(odd) {
+  &:nth-child(3n+1) {
     background-color: #ddd;
   }
 }
@@ -56,7 +56,7 @@
 .megabytesPerMinute {
   display: flex;
   justify-content: space-between;
-  flex: 0 0 250px;
+  flex: 0 0 400px;
 }
 
 .sizeInput {

--- a/frontend/src/Settings/Quality/Definition/QualityDefinition.js
+++ b/frontend/src/Settings/Quality/Definition/QualityDefinition.js
@@ -48,21 +48,24 @@ class QualityDefinition extends Component {
 
     this.state = {
       sliderMinSize: getSliderValue(props.minSize, slider.min),
-      sliderMaxSize: getSliderValue(props.maxSize, slider.max)
+      sliderMaxSize: getSliderValue(props.maxSize, slider.max),
+      sliderPreferredSize: getSliderValue(props.preferredSize, (slider.max - 3))
     };
   }
 
   //
   // Listeners
 
-  onSliderChange = ([sliderMinSize, sliderMaxSize]) => {
+  onSliderChange = ([sliderMinSize, sliderPreferredSize, sliderMaxSize]) => {
     this.setState({
       sliderMinSize,
-      sliderMaxSize
+      sliderMaxSize,
+      sliderPreferredSize
     });
 
     this.props.onSizeChange({
       minSize: roundNumber(Math.pow(sliderMinSize, 1.1)),
+      preferredSize: sliderPreferredSize === (slider.max - 3) ? null : roundNumber(Math.pow(sliderPreferredSize, 1.1)),
       maxSize: sliderMaxSize === slider.max ? null : roundNumber(Math.pow(sliderMaxSize, 1.1))
     });
   }
@@ -70,12 +73,14 @@ class QualityDefinition extends Component {
   onAfterSliderChange = () => {
     const {
       minSize,
-      maxSize
+      maxSize,
+      preferredSize
     } = this.props;
 
     this.setState({
       sliderMiSize: getSliderValue(minSize, slider.min),
-      sliderMaxSize: getSliderValue(maxSize, slider.max)
+      sliderMaxSize: getSliderValue(maxSize, slider.max),
+      sliderPreferredSize: getSliderValue(preferredSize, (slider.max - 3)) // fix
     });
   }
 
@@ -88,7 +93,22 @@ class QualityDefinition extends Component {
 
     this.props.onSizeChange({
       minSize,
-      maxSize: this.props.maxSize
+      maxSize: this.props.maxSize,
+      preferredSize: this.props.preferredSize
+    });
+  }
+
+  onPreferredSizeChange = ({ value }) => {
+    const preferredSize = value === (MAX - 3) ? null : getValue(value);
+
+    this.setState({
+      sliderPreferredSize: getSliderValue(preferredSize, slider.preferred)
+    });
+
+    this.props.onSizeChange({
+      minSize: this.props.minSize,
+      maxSize: this.props.maxSize,
+      preferredSize
     });
   }
 
@@ -101,7 +121,8 @@ class QualityDefinition extends Component {
 
     this.props.onSizeChange({
       minSize: this.props.minSize,
-      maxSize
+      maxSize,
+      preferredSize: this.props.preferredSize
     });
   }
 
@@ -115,17 +136,22 @@ class QualityDefinition extends Component {
       title,
       minSize,
       maxSize,
+      preferredSize,
       advancedSettings,
       onTitleChange
     } = this.props;
 
     const {
       sliderMinSize,
-      sliderMaxSize
+      sliderMaxSize,
+      sliderPreferredSize
     } = this.state;
 
     const minBytes = minSize * 1024 * 1024;
     const minSixty = `${formatBytes(minBytes * 60)}/h`;
+
+    const preferredBytes = preferredSize * 1024 * 1024;
+    const preferredSixty = preferredBytes ? `${formatBytes(preferredBytes * 60)}/h` : 'Unlimited';
 
     const maxBytes = maxSize && maxSize * 1024 * 1024;
     const maxSixty = maxBytes ? `${formatBytes(maxBytes * 60)}/h` : 'Unlimited';
@@ -149,9 +175,10 @@ class QualityDefinition extends Component {
             min={slider.min}
             max={slider.max}
             step={slider.step}
-            minDistance={10}
-            value={[sliderMinSize, sliderMaxSize]}
+            minDistance={3}
+            value={[sliderMinSize, sliderPreferredSize, sliderMaxSize]}
             withTracks={true}
+            allowCross={false}
             snapDragDisabled={true}
             className={styles.slider}
             trackClassName={styles.bar}
@@ -171,6 +198,22 @@ class QualityDefinition extends Component {
                   <QualityDefinitionLimits
                     bytes={minBytes}
                     message="No minimum for any runtime"
+                  />
+                }
+                position={tooltipPositions.BOTTOM}
+              />
+            </div>
+
+            <div>
+              <Popover
+                anchor={
+                  <Label kind={kinds.SUCCESS}>{preferredSixty}</Label>
+                }
+                title="Preferred Size"
+                body={
+                  <QualityDefinitionLimits
+                    bytes={preferredBytes}
+                    message="No limit for any runtime"
                   />
                 }
                 position={tooltipPositions.BOTTOM}
@@ -206,10 +249,25 @@ class QualityDefinition extends Component {
                   name={`${id}.min`}
                   value={minSize || MIN}
                   min={MIN}
-                  max={maxSize ? maxSize - 10 : MAX - 10}
+                  max={preferredSize ? preferredSize - 5 : MAX - 5}
                   step={0.1}
                   isFloat={true}
                   onChange={this.onMinSizeChange}
+                />
+              </div>
+
+              <div>
+                Preferred
+
+                <NumberInput
+                  className={styles.sizeInput}
+                  name={`${id}.min`}
+                  value={preferredSize || MAX - 5}
+                  min={MIN}
+                  max={maxSize ? maxSize - 5 : MAX - 5}
+                  step={0.1}
+                  isFloat={true}
+                  onChange={this.onPreferredSizeChange}
                 />
               </div>
 
@@ -220,7 +278,7 @@ class QualityDefinition extends Component {
                   className={styles.sizeInput}
                   name={`${id}.min`}
                   value={maxSize || MAX}
-                  min={minSize + 10}
+                  min={minSize + 5}
                   max={MAX}
                   step={0.1}
                   isFloat={true}
@@ -240,6 +298,7 @@ QualityDefinition.propTypes = {
   title: PropTypes.string.isRequired,
   minSize: PropTypes.number,
   maxSize: PropTypes.number,
+  preferredSize: PropTypes.number,
   advancedSettings: PropTypes.bool.isRequired,
   onTitleChange: PropTypes.func.isRequired,
   onSizeChange: PropTypes.func.isRequired

--- a/frontend/src/Settings/Quality/Definition/QualityDefinitionConnector.js
+++ b/frontend/src/Settings/Quality/Definition/QualityDefinitionConnector.js
@@ -23,11 +23,12 @@ class QualityDefinitionConnector extends Component {
     this.props.setQualityDefinitionValue({ id: this.props.id, name: 'title', value });
   }
 
-  onSizeChange = ({ minSize, maxSize }) => {
+  onSizeChange = ({ minSize, maxSize, preferredSize }) => {
     const {
       id,
       minSize: currentMinSize,
-      maxSize: currentMaxSize
+      maxSize: currentMaxSize,
+      preferredSize: currentPreferredSize
     } = this.props;
 
     if (minSize !== currentMinSize) {
@@ -36,6 +37,10 @@ class QualityDefinitionConnector extends Component {
 
     if (maxSize !== currentMaxSize) {
       this.props.setQualityDefinitionValue({ id, name: 'maxSize', value: maxSize });
+    }
+
+    if (preferredSize !== currentPreferredSize) {
+      this.props.setQualityDefinitionValue({ id, name: 'preferredSize', value: preferredSize });
     }
   }
 
@@ -57,6 +62,7 @@ QualityDefinitionConnector.propTypes = {
   id: PropTypes.number.isRequired,
   minSize: PropTypes.number,
   maxSize: PropTypes.number,
+  preferredSize: PropTypes.number,
   setQualityDefinitionValue: PropTypes.func.isRequired,
   clearPendingChanges: PropTypes.func.isRequired
 };

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "react-popper": "1.3.7",
     "react-redux": "7.1.3",
     "react-router-dom": "5.1.2",
-    "react-slider": "1.0.1",
+    "react-slider": "1.0.3",
     "react-tabs": "3.0.0",
     "react-text-truncate": "0.15.0",
     "react-virtualized": "9.21.1",

--- a/src/NzbDrone.Core/Datastore/Migration/171_quality_definition_preferred_size.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/171_quality_definition_preferred_size.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Data;
+using Dapper;
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(171)]
+    public class quality_definition_preferred_size : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("QualityDefinitions").AddColumn("PreferredSize").AsDouble().Nullable();
+
+            Execute.WithConnection(UpdateQualityDefinitions);
+        }
+
+        private void UpdateQualityDefinitions(IDbConnection conn, IDbTransaction tran)
+        {
+            var existing = conn.Query<QualityDefinition170>("SELECT Id, MaxSize FROM QualityDefinitions");
+
+            var updated = new List<QualityDefinition171>();
+
+            foreach (var row in existing)
+            {
+                var maxSize = row.MaxSize;
+                var preferredSize = maxSize;
+
+                if (maxSize.HasValue && maxSize.Value > 5)
+                {
+                    preferredSize = maxSize.Value - 5;
+                }
+
+                updated.Add(new QualityDefinition171
+                {
+                    Id = row.Id,
+                    PreferredSize = preferredSize
+                });
+            }
+
+            var updateSql = "UPDATE QualityDefinitions SET PreferredSize = @PreferredSize WHERE Id = @Id";
+            conn.Execute(updateSql, updated, transaction: tran);
+        }
+
+        private class QualityDefinition170 : ModelBase
+        {
+            public int? MaxSize { get; set; }
+        }
+
+        private class QualityDefinition171 : ModelBase
+        {
+            public int? PreferredSize { get; set; }
+        }
+    }
+}

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionPriorizationService.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionPriorizationService.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Profiles.Delay;
+using NzbDrone.Core.Qualities;
 
 namespace NzbDrone.Core.DecisionEngine
 {
@@ -15,11 +16,13 @@ namespace NzbDrone.Core.DecisionEngine
     {
         private readonly IConfigService _configService;
         private readonly IDelayProfileService _delayProfileService;
+        private readonly IQualityDefinitionService _qualityDefinitionService;
 
-        public DownloadDecisionPriorizationService(IConfigService configService, IDelayProfileService delayProfileService)
+        public DownloadDecisionPriorizationService(IConfigService configService, IDelayProfileService delayProfileService, IQualityDefinitionService qualityDefinitionService)
         {
             _configService = configService;
             _delayProfileService = delayProfileService;
+            _qualityDefinitionService = qualityDefinitionService;
         }
 
         public List<DownloadDecision> PrioritizeDecisionsForMovies(List<DownloadDecision> decisions)
@@ -27,7 +30,7 @@ namespace NzbDrone.Core.DecisionEngine
             return decisions.Where(c => c.RemoteMovie.MappingResult == MappingResultType.Success || c.RemoteMovie.MappingResult == MappingResultType.SuccessLenientMapping)
                             .GroupBy(c => c.RemoteMovie.Movie.Id, (movieId, downloadDecisions) =>
                             {
-                                return downloadDecisions.OrderByDescending(decision => decision, new DownloadDecisionComparer(_configService, _delayProfileService));
+                                return downloadDecisions.OrderByDescending(decision => decision, new DownloadDecisionComparer(_configService, _delayProfileService, _qualityDefinitionService));
                             })
                             .SelectMany(c => c)
                             .Union(decisions.Where(c => c.RemoteMovie.MappingResult != MappingResultType.Success || c.RemoteMovie.MappingResult != MappingResultType.SuccessLenientMapping))

--- a/src/NzbDrone.Core/Qualities/Quality.cs
+++ b/src/NzbDrone.Core/Qualities/Quality.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Core.Datastore;
@@ -167,41 +167,41 @@ namespace NzbDrone.Core.Qualities
 #if !LIBRARY
             DefaultQualityDefinitions = new HashSet<QualityDefinition>
             {
-                new QualityDefinition(Quality.Unknown)     { Weight = 1,  MinSize = 0, MaxSize = 100 },
-                new QualityDefinition(Quality.WORKPRINT)   { Weight = 2,  MinSize = 0, MaxSize = 100 },
-                new QualityDefinition(Quality.CAM)         { Weight = 3,  MinSize = 0, MaxSize = 100 },
-                new QualityDefinition(Quality.TELESYNC)    { Weight = 4,  MinSize = 0, MaxSize = 100 },
-                new QualityDefinition(Quality.TELECINE)    { Weight = 5,  MinSize = 0, MaxSize = 100 },
-                new QualityDefinition(Quality.REGIONAL)    { Weight = 6,  MinSize = 0, MaxSize = 100 },
-                new QualityDefinition(Quality.DVDSCR)      { Weight = 7,  MinSize = 0, MaxSize = 100 },
-                new QualityDefinition(Quality.SDTV)        { Weight = 8,  MinSize = 0, MaxSize = 100 },
-                new QualityDefinition(Quality.DVD)         { Weight = 9,  MinSize = 0, MaxSize = 100 },
-                new QualityDefinition(Quality.DVDR)        { Weight = 10,  MinSize = 0, MaxSize = 100 },
+                new QualityDefinition(Quality.Unknown)     { Weight = 1,  MinSize = 0, MaxSize = 100, PreferredSize = 95 },
+                new QualityDefinition(Quality.WORKPRINT)   { Weight = 2,  MinSize = 0, MaxSize = 100, PreferredSize = 95 },
+                new QualityDefinition(Quality.CAM)         { Weight = 3,  MinSize = 0, MaxSize = 100, PreferredSize = 95 },
+                new QualityDefinition(Quality.TELESYNC)    { Weight = 4,  MinSize = 0, MaxSize = 100, PreferredSize = 95 },
+                new QualityDefinition(Quality.TELECINE)    { Weight = 5,  MinSize = 0, MaxSize = 100, PreferredSize = 95 },
+                new QualityDefinition(Quality.REGIONAL)    { Weight = 6,  MinSize = 0, MaxSize = 100, PreferredSize = 95 },
+                new QualityDefinition(Quality.DVDSCR)      { Weight = 7,  MinSize = 0, MaxSize = 100, PreferredSize = 95 },
+                new QualityDefinition(Quality.SDTV)        { Weight = 8,  MinSize = 0, MaxSize = 100, PreferredSize = 95 },
+                new QualityDefinition(Quality.DVD)         { Weight = 9,  MinSize = 0, MaxSize = 100, PreferredSize = 95 },
+                new QualityDefinition(Quality.DVDR)        { Weight = 10,  MinSize = 0, MaxSize = 100, PreferredSize = 95 },
 
-                new QualityDefinition(Quality.WEBDL480p)   { Weight = 11, MinSize = 0, MaxSize = 100, GroupName = "WEB 480p" },
-                new QualityDefinition(Quality.WEBRip480p)   { Weight = 11, MinSize = 0, MaxSize = 100, GroupName = "WEB 480p" },
-                new QualityDefinition(Quality.Bluray480p)  { Weight = 12, MinSize = 0, MaxSize = 100 },
-                new QualityDefinition(Quality.Bluray576p)  { Weight = 13, MinSize = 0, MaxSize = 100 },
+                new QualityDefinition(Quality.WEBDL480p)   { Weight = 11, MinSize = 0, MaxSize = 100, PreferredSize = 95, GroupName = "WEB 480p" },
+                new QualityDefinition(Quality.WEBRip480p)   { Weight = 11, MinSize = 0, MaxSize = 100, PreferredSize = 95, GroupName = "WEB 480p" },
+                new QualityDefinition(Quality.Bluray480p)  { Weight = 12, MinSize = 0, MaxSize = 100, PreferredSize = 95 },
+                new QualityDefinition(Quality.Bluray576p)  { Weight = 13, MinSize = 0, MaxSize = 100, PreferredSize = 95 },
 
-                new QualityDefinition(Quality.HDTV720p)    { Weight = 14, MinSize = 0, MaxSize = 100 },
-                new QualityDefinition(Quality.WEBDL720p)   { Weight = 15, MinSize = 0, MaxSize = 100, GroupName = "WEB 720p" },
-                new QualityDefinition(Quality.WEBRip720p)   { Weight = 15, MinSize = 0, MaxSize = 100, GroupName = "WEB 720p" },
-                new QualityDefinition(Quality.Bluray720p)  { Weight = 16, MinSize = 0, MaxSize = 100 },
+                new QualityDefinition(Quality.HDTV720p)    { Weight = 14, MinSize = 0, MaxSize = 100, PreferredSize = 95 },
+                new QualityDefinition(Quality.WEBDL720p)   { Weight = 15, MinSize = 0, MaxSize = 100, PreferredSize = 95, GroupName = "WEB 720p" },
+                new QualityDefinition(Quality.WEBRip720p)   { Weight = 15, MinSize = 0, MaxSize = 100, PreferredSize = 95, GroupName = "WEB 720p" },
+                new QualityDefinition(Quality.Bluray720p)  { Weight = 16, MinSize = 0, MaxSize = 100, PreferredSize = 95 },
 
-                new QualityDefinition(Quality.HDTV1080p)   { Weight = 17, MinSize = 0, MaxSize = 100 },
-                new QualityDefinition(Quality.WEBDL1080p)  { Weight = 18, MinSize = 0, MaxSize = 100, GroupName = "WEB 1080p" },
-                new QualityDefinition(Quality.WEBRip1080p)   { Weight = 18, MinSize = 0, MaxSize = 100, GroupName = "WEB 1080p" },
-                new QualityDefinition(Quality.Bluray1080p) { Weight = 19, MinSize = 0, MaxSize = null },
-                new QualityDefinition(Quality.Remux1080p)  { Weight = 20, MinSize = 0, MaxSize = null },
+                new QualityDefinition(Quality.HDTV1080p)   { Weight = 17, MinSize = 0, MaxSize = 100, PreferredSize = 95 },
+                new QualityDefinition(Quality.WEBDL1080p)  { Weight = 18, MinSize = 0, MaxSize = 100, PreferredSize = 95, GroupName = "WEB 1080p" },
+                new QualityDefinition(Quality.WEBRip1080p)   { Weight = 18, MinSize = 0, MaxSize = 100, PreferredSize = 95, GroupName = "WEB 1080p" },
+                new QualityDefinition(Quality.Bluray1080p) { Weight = 19, MinSize = 0, MaxSize = null, PreferredSize = null },
+                new QualityDefinition(Quality.Remux1080p)  { Weight = 20, MinSize = 0, MaxSize = null, PreferredSize = null },
 
-                new QualityDefinition(Quality.HDTV2160p)   { Weight = 21, MinSize = 0, MaxSize = null },
-                new QualityDefinition(Quality.WEBDL2160p)  { Weight = 22, MinSize = 0, MaxSize = null, GroupName = "WEB 2160p" },
-                new QualityDefinition(Quality.WEBRip2160p)  { Weight = 22, MinSize = 0, MaxSize = null, GroupName = "WEB 2160p" },
-                new QualityDefinition(Quality.Bluray2160p) { Weight = 23, MinSize = 0, MaxSize = null },
-                new QualityDefinition(Quality.Remux2160p)  { Weight = 24, MinSize = 0, MaxSize = null },
+                new QualityDefinition(Quality.HDTV2160p)   { Weight = 21, MinSize = 0, MaxSize = null, PreferredSize = null },
+                new QualityDefinition(Quality.WEBDL2160p)  { Weight = 22, MinSize = 0, MaxSize = null, PreferredSize = null, GroupName = "WEB 2160p" },
+                new QualityDefinition(Quality.WEBRip2160p)  { Weight = 22, MinSize = 0, MaxSize = null, PreferredSize = null, GroupName = "WEB 2160p" },
+                new QualityDefinition(Quality.Bluray2160p) { Weight = 23, MinSize = 0, MaxSize = null, PreferredSize = null },
+                new QualityDefinition(Quality.Remux2160p)  { Weight = 24, MinSize = 0, MaxSize = null, PreferredSize = null },
 
-                new QualityDefinition(Quality.BRDISK)      { Weight = 25, MinSize = 0, MaxSize = null },
-                new QualityDefinition(Quality.RAWHD)       { Weight = 26, MinSize = 0, MaxSize = null }
+                new QualityDefinition(Quality.BRDISK)      { Weight = 25, MinSize = 0, MaxSize = null, PreferredSize = null },
+                new QualityDefinition(Quality.RAWHD)       { Weight = 26, MinSize = 0, MaxSize = null, PreferredSize = null }
             };
 #endif
         }

--- a/src/NzbDrone.Core/Qualities/QualityDefinition.cs
+++ b/src/NzbDrone.Core/Qualities/QualityDefinition.cs
@@ -12,6 +12,7 @@ namespace NzbDrone.Core.Qualities
 
         public double? MinSize { get; set; }
         public double? MaxSize { get; set; }
+        public double? PreferredSize { get; set; }
 
         public QualityDefinition()
         {

--- a/src/Radarr.Api.V3/Qualities/QualityDefinitionResource.cs
+++ b/src/Radarr.Api.V3/Qualities/QualityDefinitionResource.cs
@@ -15,6 +15,7 @@ namespace Radarr.Api.V3.Qualities
 
         public double? MinSize { get; set; }
         public double? MaxSize { get; set; }
+        public double? PreferredSize { get; set; }
     }
 
     public static class QualityDefinitionResourceMapper
@@ -38,6 +39,7 @@ namespace Radarr.Api.V3.Qualities
 
                 MinSize = model.MinSize,
                 MaxSize = model.MaxSize,
+                PreferredSize = model.PreferredSize
             };
         }
 
@@ -60,6 +62,7 @@ namespace Radarr.Api.V3.Qualities
 
                 MinSize = resource.MinSize,
                 MaxSize = resource.MaxSize,
+                PreferredSize = resource.PreferredSize
             };
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7250,10 +7250,10 @@ react-side-effect@^1.0.2:
   dependencies:
     shallowequal "^1.0.1"
 
-react-slider@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-slider/-/react-slider-1.0.1.tgz#4cb212d31c35d804805e31f02ce37771e95d5d45"
-  integrity sha512-SI2anLzeKlFxnntoM93VXrf3ll9uL/TYjIJB6PsQVp4mDVt2VfWyGtMoUvK/ir/PnjuirNtF1pU3cG9XCezfBA==
+react-slider@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-slider/-/react-slider-1.0.3.tgz#89bd9cf0bb87f07ce27d8724efa584d9c6e6dca8"
+  integrity sha512-6HSkzHeyPthoCuQseZ16KQePdj0VloHllXXXmtO1733wGhFa2v1kKjIuGpfHAgWshqB3F7Xn2s5FxTu3xvFXbg==
 
 react-tabs@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
#### Database Migration
YES (171 PreferredSize Column to Quality Definitions)

#### Description
Adds third slider to quality definitions, prioritize downloads based on closest to preferred size. This allows user to spec if they want smallest, largest, or someone in between for a given quality

![image](https://user-images.githubusercontent.com/376117/75211797-17b71d00-5753-11ea-9221-bc3d06497865.png)


#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
Fixes #4118 
Fixes #3659 ? I thought it already worked like this...