### PR TITLE
Fixed: Use TMDB ReleaseDate Year for Year (Match Cinema Date)

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -176,17 +176,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             {
                 movie.InCinemas = DateTime.Parse(resource.release_date);
 
-                // get the lowest year in all release date
-                var lowestYear = new List<int>();
-                foreach (ReleaseDates releaseDates in resource.release_dates.results)
-                {
-                    foreach (ReleaseDate releaseDate in releaseDates.release_dates)
-                    {
-                        lowestYear.Add(DateTime.Parse(releaseDate.release_date).Year);
-                    }
-                }
-
-                movie.Year = lowestYear.Min();
+                movie.Year = movie.InCinemas.Value.Year;
             }
 
             movie.TitleSlug += "-" + movie.TmdbId.ToString();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Uses the release date from TMDB to set year instead of looping thru all release dates for earliest. (This can grab limited premiers, etc..) and creates year differences at time between cinema date and year.

#### Issues Fixed or Closed by this PR
Fixes #4074 
Fixes #4161