### PR TITLE
Fixed: Check for EnableCompletedDownloadHandling Enabled, Not Defined

### DIFF
--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/ImportMechanismCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/ImportMechanismCheckFixture.cs
@@ -13,10 +13,6 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
             if (enabled.HasValue)
             {
                 Mocker.GetMock<IConfigService>()
-                      .Setup(s => s.IsDefined("EnableCompletedDownloadHandling"))
-                      .Returns(true);
-
-                Mocker.GetMock<IConfigService>()
                       .SetupGet(s => s.EnableCompletedDownloadHandling)
                       .Returns(enabled.Value);
             }
@@ -24,12 +20,6 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
 
         [Test]
         public void should_return_warning_when_completed_download_handling_not_configured()
-        {
-            Subject.Check().ShouldBeWarning();
-        }
-
-        [Test]
-        public void should_return_warning_when_both_completeddownloadhandling_and_dronefactory_are_not_configured()
         {
             GivenCompletedDownloadHandling(false);
 

--- a/src/NzbDrone.Core/HealthCheck/Checks/ImportMechanismCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/ImportMechanismCheck.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Configuration.Events;
 using NzbDrone.Core.Download;
-using NzbDrone.Core.Download.Clients.Nzbget;
-using NzbDrone.Core.Download.Clients.Sabnzbd;
 using NzbDrone.Core.ThingiProvider.Events;
 
 namespace NzbDrone.Core.HealthCheck.Checks
@@ -16,55 +11,14 @@ namespace NzbDrone.Core.HealthCheck.Checks
     public class ImportMechanismCheck : HealthCheckBase
     {
         private readonly IConfigService _configService;
-        private readonly IProvideDownloadClient _provideDownloadClient;
 
-        public ImportMechanismCheck(IConfigService configService, IProvideDownloadClient provideDownloadClient)
+        public ImportMechanismCheck(IConfigService configService)
         {
             _configService = configService;
-            _provideDownloadClient = provideDownloadClient;
         }
 
         public override HealthCheck Check()
         {
-            List<ImportMechanismCheckStatus> downloadClients;
-
-            try
-            {
-                downloadClients = _provideDownloadClient.GetDownloadClients().Select(v => new ImportMechanismCheckStatus
-                {
-                    DownloadClient = v,
-                    Status = v.GetStatus()
-                }).ToList();
-            }
-            catch (Exception)
-            {
-                // One or more download clients failed, assume the health is okay and verify later
-                return new HealthCheck(GetType());
-            }
-
-            var downloadClientIsLocalHost = downloadClients.All(v => v.Status.IsLocalhost);
-
-            if (!_configService.IsDefined("EnableCompletedDownloadHandling"))
-            {
-                // Migration helper logic
-                if (!downloadClientIsLocalHost)
-                {
-                    return new HealthCheck(GetType(), HealthCheckResult.Warning, "Enable Completed Download Handling if possible (Multi-Computer unsupported)", "Migrating-to-Completed-Download-Handling#Unsupported-download-client-on-different-computer");
-                }
-
-                if (downloadClients.All(v => v.DownloadClient is Sabnzbd))
-                {
-                    return new HealthCheck(GetType(), HealthCheckResult.Warning, "Enable Completed Download Handling if possible (Sabnzbd)", "Migrating-to-Completed-Download-Handling#sabnzbd-enable-completed-download-handling");
-                }
-
-                if (downloadClients.All(v => v.DownloadClient is Nzbget))
-                {
-                    return new HealthCheck(GetType(), HealthCheckResult.Warning, "Enable Completed Download Handling if possible (Nzbget)", "Migrating-to-Completed-Download-Handling#nzbget-enable-completed-download-handling");
-                }
-
-                return new HealthCheck(GetType(), HealthCheckResult.Warning, "Enable Completed Download Handling if possible", "Migrating-to-Completed-Download-Handling");
-            }
-
             if (!_configService.EnableCompletedDownloadHandling)
             {
                 return new HealthCheck(GetType(), HealthCheckResult.Warning, "Enable Completed Download Handling");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This check was put into place during the Sonarr implementation of completed download handling, if the config value is not defined the health issue throws despite the default value for enabled being true. This change modifies the health check to only look to see if the value is true, not that the config value is explicitly defined in the db. 

Currently new users get false warnings given we no longer write the `enabledCompletedHandling` config value explicitly in a migration. This is easily mitigated by toggling the option in settings. 

#### Todos
- [x] Tests
