### PR TITLE
Fixed: Speed up azure build/test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -357,14 +357,12 @@ stages:
       - bash: find ${TESTSFOLDER} -name "Radarr.Test.Dummy" -exec chmod a+x {} \;
         displayName: Make Test Dummy Executable
         condition: and(succeeded(), ne(variables['osName'], 'Windows'))
-      - task: Bash@3
+      - bash: |
+          chmod a+x ${TESTSFOLDER}/test.sh
+          ${TESTSFOLDER}/test.sh ${OSNAME} Unit Test
         displayName: Run Tests
         env:
           TEST_DIR: $(Build.SourcesDirectory)/_tests
-        inputs:
-          targetType: 'filePath'
-          filePath: '$(testsFolder)/test.sh'
-          arguments: '$(osName) Unit Test'
       - task: PublishTestResults@2
         displayName: Publish Test Results
         inputs:
@@ -413,12 +411,10 @@ stages:
           buildType: 'current'
           artifactName: LinuxTests
           targetPath: $(testsFolder)
-      - task: Bash@3
+      - bash: |
+          chmod a+x ${TESTSFOLDER}/test.sh
+          ${TESTSFOLDER}/test.sh Linux Unit Test
         displayName: Run Tests
-        inputs:
-          targetType: 'filePath'
-          filePath: '$(testsFolder)/test.sh'
-          arguments: 'Linux Unit Test'
       - task: PublishTestResults@2
         displayName: Publish Test Results
         inputs:
@@ -506,12 +502,10 @@ stages:
           mkdir -p ./bin/
           cp -r -v ${BUILD_ARTIFACTSTAGINGDIRECTORY}/bin/Radarr/. ./bin/
         displayName: Move Package Contents
-      - task: Bash@3
+      - bash: |
+          chmod a+x ${TESTSFOLDER}/test.sh
+          ${TESTSFOLDER}/test.sh ${OSNAME} Integration Test
         displayName: Run Integration Tests
-        inputs:
-          targetType: 'filePath'
-          filePath: '$(testsFolder)/test.sh'
-          arguments: $(osName) Integration Test
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: 'NUnit'
@@ -579,12 +573,10 @@ stages:
           mkdir -p ./bin/
           cp -r -v ${BUILD_ARTIFACTSTAGINGDIRECTORY}/bin/Radarr/. ./bin/
         displayName: Move Package Contents
-      - task: Bash@3
+      - bash: |
+          chmod a+x ${TESTSFOLDER}/test.sh
+          ${TESTSFOLDER}/test.sh Linux Integration Test
         displayName: Run Integration Tests
-        inputs:
-          targetType: 'filePath'
-          filePath: '$(testsFolder)/test.sh'
-          arguments: Linux Integration Test
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: 'NUnit'
@@ -662,12 +654,10 @@ stages:
           mv geckodriver _tests
         displayName: Install Gecko Driver
         condition: and(succeeded(), ne(variables['osName'], 'Windows'))
-      - task: Bash@3
-        displayName: Run Automation Tests
-        inputs:
-          targetType: 'filePath'
-          filePath: '$(testsFolder)/test.sh'
-          arguments: $(osName) Automation Test
+      - bash: |
+          chmod a+x ${TESTSFOLDER}/test.sh
+          ${TESTSFOLDER}/test.sh ${OSNAME} Automation Test
+        displayName: Run Integration Tests
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: 'NUnit'

--- a/src/NzbDrone.Core.Test/Framework/DbTest.cs
+++ b/src/NzbDrone.Core.Test/Framework/DbTest.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.SQLite;
+using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Datastore.Migration.Framework;
 
@@ -65,8 +67,7 @@ namespace NzbDrone.Core.Test.Framework
 
         protected virtual ITestDatabase WithTestDb(MigrationContext migrationContext)
         {
-            var factory = Mocker.Resolve<DbFactory>();
-            var database = factory.Create(migrationContext);
+            var database = CreateDatabase(migrationContext);
             Mocker.SetConstant(database);
 
             switch (MigrationType)
@@ -96,6 +97,48 @@ namespace NzbDrone.Core.Test.Framework
             var testDb = new TestDatabase(database);
 
             return testDb;
+        }
+
+        private IDatabase CreateDatabase(MigrationContext migrationContext)
+        {
+            var factory = Mocker.Resolve<DbFactory>();
+
+            // If a special migration test or log migration then create new
+            if (migrationContext.BeforeMigration != null)
+            {
+                return factory.Create(migrationContext);
+            }
+
+            // Otherwise try to use a cached migrated db
+            var cachedDb = GetCachedDatabase(migrationContext.MigrationType);
+            var testDb = GetTestDb(migrationContext.MigrationType);
+            if (File.Exists(cachedDb))
+            {
+                TestLogger.Info($"Using cached initial database {cachedDb}");
+                File.Copy(cachedDb, testDb);
+                return factory.Create(migrationContext);
+            }
+            else
+            {
+                var db = factory.Create(migrationContext);
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                SQLiteConnection.ClearAllPools();
+
+                TestLogger.Info("Caching database");
+                File.Copy(testDb, cachedDb);
+                return db;
+            }
+        }
+
+        private string GetCachedDatabase(MigrationType type)
+        {
+            return Path.Combine(TestContext.CurrentContext.TestDirectory, $"cached_{type}.db");
+        }
+
+        private string GetTestDb(MigrationType type)
+        {
+            return type == MigrationType.Main ? TestFolderInfo.GetDatabase() : TestFolderInfo.GetLogDatabase();
         }
 
         protected virtual void SetupLogging()

--- a/src/NzbDrone.Core.Test/Framework/DbTestCleanup.cs
+++ b/src/NzbDrone.Core.Test/Framework/DbTestCleanup.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace NzbDrone.Core.Test
+{
+    [SetUpFixture]
+    public class RemoveCachedDatabase
+    {
+        [OneTimeSetUp]
+        [OneTimeTearDown]
+        public void ClearCachedDatabase()
+        {
+            var mainCache = Path.Combine(TestContext.CurrentContext.TestDirectory, $"cached_Main.db");
+            if (File.Exists(mainCache))
+            {
+                File.Delete(mainCache);
+            }
+
+            var logCache = Path.Combine(TestContext.CurrentContext.TestDirectory, $"cached_Log.db");
+            if (File.Exists(logCache))
+            {
+                File.Delete(logCache);
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/166_fix_tmdb_list_config.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/166_fix_tmdb_list_config.cs
@@ -5,7 +5,6 @@ using System.Text.Json;
 using Dapper;
 using FluentMigrator;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Common.Serializer;
 using NzbDrone.Core.Datastore.Migration.Framework;
 
 namespace NzbDrone.Core.Datastore.Migration
@@ -163,8 +162,6 @@ namespace NzbDrone.Core.Datastore.Migration
                     });
                 }
             }
-
-            Console.WriteLine(corrected.ToJson());
 
             var updateSql = "UPDATE NetImport SET Implementation = @Implementation, ConfigContract = @ConfigContract, Settings = @Settings WHERE Id = @Id";
             conn.Execute(updateSql, corrected, transaction: tran);

--- a/src/NzbDrone.Integration.Test/IntegrationTestCleanup.cs
+++ b/src/NzbDrone.Integration.Test/IntegrationTestCleanup.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace NzbDrone.Integration.Test
+{
+    [SetUpFixture]
+    public class IntegrationTestSetup
+    {
+        [OneTimeSetUp]
+        [OneTimeTearDown]
+        public void CleanUp()
+        {
+            var dir = Path.Combine(TestContext.CurrentContext.TestDirectory, "CachedAppData");
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Test.Common/NzbDroneRunner.cs
+++ b/src/NzbDrone.Test.Common/NzbDroneRunner.cs
@@ -27,13 +27,43 @@ namespace NzbDrone.Test.Common
             _restClient = new RestClient("http://localhost:7878/api/v3");
         }
 
+        private void CopyDirectory(string source, string target)
+        {
+            foreach (var dirPath in Directory.GetDirectories(source, "*", SearchOption.AllDirectories))
+            {
+                Directory.CreateDirectory(dirPath.Replace(source, target));
+            }
+
+            foreach (var newPath in Directory.GetFiles(source, "*.*", SearchOption.AllDirectories))
+            {
+                File.Copy(newPath, newPath.Replace(source, target), true);
+            }
+        }
+
         public void Start()
         {
             AppData = Path.Combine(TestContext.CurrentContext.TestDirectory, "_intg_" + TestBase.GetUID());
-            Directory.CreateDirectory(AppData);
 
-            GenerateConfigFile();
+            if (!Directory.Exists(Path.Combine(TestContext.CurrentContext.TestDirectory, "CachedAppData")))
+            {
+                Directory.CreateDirectory(AppData);
+                GenerateConfigFile();
+                StartInternal();
+                KillAll(false);
 
+                CopyDirectory(AppData, Path.Combine(TestContext.CurrentContext.TestDirectory, "CachedAppData"));
+            }
+            else
+            {
+                CopyDirectory(Path.Combine(TestContext.CurrentContext.TestDirectory, "CachedAppData"), AppData);
+                GenerateConfigFile();
+            }
+
+            StartInternal();
+        }
+
+        private void StartInternal()
+        {
             string consoleExe;
             if (OsInfo.IsWindows)
             {
@@ -85,7 +115,7 @@ namespace NzbDrone.Test.Common
             }
         }
 
-        public void KillAll()
+        public void KillAll(bool delete = true)
         {
             try
             {
@@ -102,7 +132,10 @@ namespace NzbDrone.Test.Common
                 // May happen if the process closes while being closed
             }
 
-            TestBase.DeleteTempFolder(AppData);
+            if (delete)
+            {
+                TestBase.DeleteTempFolder(AppData);
+            }
         }
 
         private void Start(string outputRadarrConsoleExe)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Cache database to avoid repeatedly re-initializing
- Pull over Lidarr `build.sh` fixes to only build one RID for Sonar

#### Todos
- [ ] Check analyzer execution time output and disable any stand-out rules

