### PR TITLE
Fixed: "Not Available" instead of "?" when no InCinemas date (Follow-up)

### DIFF
--- a/frontend/src/Movie/MovieFileStatus.js
+++ b/frontend/src/Movie/MovieFileStatus.js
@@ -10,7 +10,6 @@ import styles from './MovieFileStatus.css';
 
 function MovieFileStatus(props) {
   const {
-    inCinemas,
     isAvailable,
     monitored,
     grabbed,
@@ -20,7 +19,7 @@ function MovieFileStatus(props) {
 
   const hasMovieFile = !!movieFile;
   const isQueued = !!queueItem;
-  const hasReleased = isAvailable && inCinemas;
+  const hasReleased = isAvailable;
 
   if (isQueued) {
     const {
@@ -78,7 +77,7 @@ function MovieFileStatus(props) {
     return (
       <div className={styles.center}>
         <Label
-          title="Announced"
+          title="Not Monitored"
           kind={kinds.WARNING}
         >
           Not Monitored
@@ -103,7 +102,7 @@ function MovieFileStatus(props) {
   return (
     <div className={styles.center}>
       <Label
-        title="Announced"
+        title="Not Available"
         kind={kinds.INFO}
       >
         Not Available
@@ -113,7 +112,6 @@ function MovieFileStatus(props) {
 }
 
 MovieFileStatus.propTypes = {
-  inCinemas: PropTypes.string,
   isAvailable: PropTypes.bool,
   monitored: PropTypes.bool.isRequired,
   grabbed: PropTypes.bool,

--- a/frontend/src/Store/Actions/movieActions.js
+++ b/frontend/src/Store/Actions/movieActions.js
@@ -168,7 +168,7 @@ export const sortPredicates = {
 
     const hasMovieFile = !!item.movieFile;
 
-    if (item.isAvailable && item.inCinemas) {
+    if (item.isAvailable) {
       result++;
     }
 


### PR DESCRIPTION

this is a follow-up to commit:
https://github.com/Radarr/Radarr/commit/64e9e48217002604c36a778d485c23b32352f72e

#### Database Migration
NO

#### Description
I had actually already made this change in the branch: https://github.com/geogolem/Radarr/tree/MovieStatusFix
and PR: https://github.com/Radarr/Radarr/pull/4012

however, this change is really separate and since the issue came up recently with the commit, it seems prudent to separate this change out from the simple colour change in the branch MovieStatusFix.
