### PR TITLE
Fixed: Allow saving profiles with large negative CF scores

### DIFF
--- a/src/Radarr.Api.V3/Profiles/Quality/QualityProfileModule.cs
+++ b/src/Radarr.Api.V3/Profiles/Quality/QualityProfileModule.cs
@@ -32,7 +32,8 @@ namespace Radarr.Api.V3.Profiles.Quality
             }).WithMessage("All Custom Formats and no extra ones need to be present inside your Profile! Try refreshing your browser.");
             SharedValidator.RuleFor(c => c).Custom((profile, context) =>
             {
-                if (profile.FormatItems.Sum(x => x.Score) < profile.MinFormatScore)
+                if (profile.FormatItems.Where(x => x.Score > 0).Sum(x => x.Score) < profile.MinFormatScore &&
+                    profile.FormatItems.Max(x => x.Score) < profile.MinFormatScore)
                 {
                     context.AddFailure("Minimum Custom Format Score can never be satisfied");
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Validator was preventing saving with a legitimate min cutoff score.

Either sum of positive scores must be greater than cutoff, or (only applicable when all scores are negative) the maximum score must be greater than the cutoff.

