### PR TITLE
Add crossorigin use-credentials attribute to manifest tag

### DIFF
--- a/src/UI/index.html
+++ b/src/UI/index.html
@@ -33,7 +33,7 @@
     <link rel="icon" type="image/png" href="/Content/Images/favicon/favicon-194x194.png" sizes="194x194">
     <link rel="icon" type="image/png" href="/Content/Images/favicon/android-chrome-192x192.png" sizes="192x192">
     <link rel="icon" type="image/png" href="/Content/Images/favicon/favicon-16x16.png" sizes="16x16">
-    <link rel="manifest" href="/Content/Images/favicon/manifest.json">
+    <link rel="manifest" href="/Content/Images/favicon/manifest.json" crossorigin="use-credentials">
     <link rel="mask-icon" href="/Content/Images/favicon/safari-pinned-tab.svg" color="#ffc230">
     <link rel="shortcut icon" href="/Content/Images/favicon/favicon.ico">
     <meta name="apple-mobile-web-app-title" content="Radarr">

--- a/src/UI/login.html
+++ b/src/UI/login.html
@@ -19,7 +19,7 @@
     <link rel="icon" type="image/png" href="/Content/Images/favicon/favicon-194x194.png" sizes="194x194">
     <link rel="icon" type="image/png" href="/Content/Images/favicon/android-chrome-192x192.png" sizes="192x192">
     <link rel="icon" type="image/png" href="/Content/Images/favicon/favicon-16x16.png" sizes="16x16">
-    <link rel="manifest" href="/Content/Images/favicon/manifest.json">
+    <link rel="manifest" href="/Content/Images/favicon/manifest.json" crossorigin="use-credentials">
     <link rel="mask-icon" href="/Content/Images/favicon/safari-pinned-tab.svg" color="#ffc230">
     <link rel="shortcut icon" href="/Content/Images/favicon/favicon.ico">
     <meta name="apple-mobile-web-app-title" content="Radarr">


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When serving Radarr behind an authentication proxy (ex. https://github.com/pusher/oauth2_proxy) the manifest request will fail because cookies are not sent with the manifest request.

See https://developer.mozilla.org/en-US/docs/Web/Manifest:
> Note: If the manifest requires credentials to fetch - the `crossorigin` attribute must be set to `"use-credentials"`, even if the manifest file is in the same origin as the current page.

This PR adds the necessary attribute so that cookies will be sent with manifest requests.

#### Todos
None

#### Issues Fixed or Closed by this PR
None
