### PR TITLE
Lenient parsing and German regex updates

### DIFF
--- a/src/NzbDrone.Api/Config/IndexerConfigResource.cs
+++ b/src/NzbDrone.Api/Config/IndexerConfigResource.cs
@@ -14,7 +14,6 @@ namespace NzbDrone.Api.Config
         public int AvailabilityDelay { get; set; }
         public bool AllowHardcodedSubs { get; set; }
         public string WhitelistedHardcodedSubs { get; set; }
-        public ParsingLeniencyType ParsingLeniency { get; set; }
     }
 
     public static class IndexerConfigResourceMapper
@@ -31,7 +30,6 @@ namespace NzbDrone.Api.Config
                 AvailabilityDelay = model.AvailabilityDelay,
                 AllowHardcodedSubs = model.AllowHardcodedSubs,
                 WhitelistedHardcodedSubs = model.WhitelistedHardcodedSubs,
-                ParsingLeniency = model.ParsingLeniency,
             };
         }
     }

--- a/src/NzbDrone.Core.Test/Framework/CoreTest.cs
+++ b/src/NzbDrone.Core.Test/Framework/CoreTest.cs
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.Test.Framework
             Mocker.GetMock<IParsingService>().Setup(c => c.ParseMovieInfo(It.IsAny<string>(), It.IsAny<System.Collections.Generic.List<object>>()))
                 .Returns<string, System.Collections.Generic.List<object>>((title, helpers) =>
                 {
-                    var result = Parser.Parser.ParseMovieTitle(title, false);
+                    var result = Parser.Parser.ParseMovieTitle(title);
                     if (result != null)
                     {
                         result.Quality = QualityParser.ParseQuality(title);

--- a/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedMoviesFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedMoviesFixture.cs
@@ -301,13 +301,13 @@ namespace NzbDrone.Core.Test.MediaFiles
         }
 
         [Test]
-        public void should_use_folder_info_release_title_to_find_relative_path()
+        public void should_use_folder_info_original_title_to_find_relative_path()
         {
-            var name = "Series.Title.S01E01.720p.HDTV.x264-Sonarr";
-            var outputPath = Path.Combine(@"C:\Test\Unsorted\TV\".AsOsAgnostic(), name);
+            var name = "Transformers.2007.720p.BluRay.x264-Radarr";
+            var outputPath = Path.Combine(@"C:\Test\Unsorted\movies\".AsOsAgnostic(), name);
             var localEpisode = _approvedDecisions.First().LocalMovie;
 
-            localEpisode.FolderMovieInfo = new ParsedMovieInfo { SimpleReleaseTitle = name };
+            localEpisode.FolderMovieInfo = new ParsedMovieInfo { OriginalTitle = name };
             localEpisode.Path = Path.Combine(outputPath, "subfolder", name + ".mkv");
 
             Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, null);

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("www.Torrenting.org - Revenge.2008.720p.X264-DIMENSION", "Revenge")]
         public void should_parse_movie_title(string postTitle, string title)
         {
-            Parser.Parser.ParseMovieTitle(postTitle, true).MovieTitle.Should().Be(title);
+            Parser.Parser.ParseMovieTitle(postTitle).MovieTitle.Should().Be(title);
         }
 
         [TestCase("Avatar.Aufbruch.nach.Pandora.Extended.2009.German.DTS.720p.BluRay.x264-SoW", "Avatar Aufbruch nach Pandora", "Extended", 2009)]
@@ -80,43 +80,22 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Life.Partners.2014.German.DL.PAL.DVDR-ETM", "Life Partners", "", 2014)]
         [TestCase("Joe.Dreck.2.EXTENDED.EDITION.2015.German.DL.PAL.DVDR-ETM", "Joe Dreck 2", "EXTENDED EDITION", 2015)]
         [TestCase("Rango.EXTENDED.2011.HDRip.AC3.German.XviD-POE", "Rango", "EXTENDED", 2011)]
-        [TestCase("Suicide.Squad.2016.EXTENDED.German.DL.AC3.BDRip.x264-hqc", "Suicide Squad", "EXTENDED", 2016)] //edition after year
-        public void should_parse_german_movie(string postTitle, string title, string edition, int year)
-        {
-            ParsedMovieInfo movie = Parser.Parser.ParseMovieTitle(postTitle, false);
-            using (new AssertionScope())
-            {
-                movie.MovieTitle.Should().Be(title);
-                movie.Edition.Should().Be(edition);
-                movie.Year.Should().Be(year);
-            }
-        }
 
-        [TestCase("Avatar.Aufbruch.nach.Pandora.Extended.2009.German.DTS.720p.BluRay.x264-SoW", "Avatar Aufbruch nach Pandora", "Extended", 2009)]
-        [TestCase("Drop.Zone.1994.German.AC3D.DL.720p.BluRay.x264-KLASSiGERHD", "Drop Zone", "", 1994)]
-        [TestCase("Kick.Ass.2.2013.German.DTS.DL.720p.BluRay.x264-Pate", "Kick Ass 2", "", 2013)]
-        [TestCase("Paradise.Hills.2019.German.DL.AC3.Dubbed.1080p.BluRay.x264-muhHD", "Paradise Hills", "", 2019)]
-        [TestCase("96.Hours.Taken.3.EXTENDED.2014.German.DL.1080p.BluRay.x264-ENCOUNTERS", "96 Hours Taken 3", "EXTENDED", 2014)]
-        [TestCase("World.War.Z.EXTENDED.CUT.2013.German.DL.1080p.BluRay.x264-HQX", "World War Z", "EXTENDED CUT", 2013)]
-        [TestCase("Sin.City.2005.RECUT.EXTENDED.German.DL.1080p.BluRay.x264-DETAiLS", "Sin City", "RECUT EXTENDED", 2005)]
-        [TestCase("Die.Klasse.von.1999.1990.German.720p.HDTV.x264-NORETAiL", "Die Klasse von 1999", "", 1990)] //year in the title
-        [TestCase("2.Tage.in.L.A.1996.GERMAN.DL.720p.WEB.H264-SOV", "2 Tage in L.A.", "", 1996)]
-        [TestCase("8.2019.GERMAN.720p.BluRay.x264-UNiVERSUM", "8", "", 2019)]
-        [TestCase("Life.Partners.2014.German.DL.PAL.DVDR-ETM", "Life Partners", "", 2014)]
-        [TestCase("Joe.Dreck.2.EXTENDED.EDITION.2015.German.DL.PAL.DVDR-ETM", "Joe Dreck 2", "EXTENDED EDITION", 2015)]
-        [TestCase("Rango.EXTENDED.2011.HDRip.AC3.German.XviD-POE", "Rango", "EXTENDED", 2011)]
+        //Special cases (see comment to the right)
         [TestCase("Suicide.Squad.2016.EXTENDED.German.DL.AC3.BDRip.x264-hqc", "Suicide Squad", "EXTENDED", 2016)] //edition after year
-
+        [TestCase("Knight.and.Day.2010.Extended.Cut.German.DTS.DL.720p.BluRay.x264-HDS", "Knight and Day", "Extended Cut", 2010)] //edition after year
+        [TestCase("Der.Soldat.James.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998", "Der Soldat James", "", 1998)] //year at the end
         [TestCase("Der.Hobbit.Eine.Unerwartete.Reise.Extended.German.720p.BluRay.x264-EXQUiSiTE", "Der Hobbit Eine Unerwartete Reise", "Extended", 0)] //no year
+        [TestCase("Wolverine.Weg.des.Kriegers.EXTENDED.German.720p.BluRay.x264-EXQUiSiTE", "Wolverine Weg des Kriegers", "EXTENDED", 0)] //no year
         [TestCase("Die.Unfassbaren.Now.You.See.Me.EXTENDED.German.DTS.720p.BluRay.x264-RHD", "Die Unfassbaren Now You See Me", "EXTENDED", 0)] //no year
-        [TestCase("Der.Soldat.James.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998", "Der Soldat James", "", 1998)]
+        [TestCase("Die Unfassbaren Now You See Me EXTENDED German DTS 720p BluRay x264-RHD", "Die Unfassbaren Now You See Me", "EXTENDED", 0)] //no year & without dots
         [TestCase("Passengers.German.DL.AC3.Dubbed..BluRay.x264-PsO", "Passengers", "", 0)] //no year
         [TestCase("Das.A.Team.Der.Film.Extended.Cut.German.720p.BluRay.x264-ANCIENT", "Das A Team Der Film", "Extended Cut", 0)] //no year
         [TestCase("Cars.2.German.DL.720p.BluRay.x264-EmpireHD", "Cars 2", "", 0)] //no year
         [TestCase("Der.Film.deines.Lebens.German.2011.PAL.DVDR-ETM", "Der Film deines Lebens", "", 2011)] //year at wrong position
-        public void should_parse_german_movie_lenient(string postTitle, string title, string edition, int year)
+        public void should_parse_german_movie(string postTitle, string title, string edition, int year)
         {
-            ParsedMovieInfo movie = Parser.Parser.ParseMovieTitle(postTitle, true);
+            ParsedMovieInfo movie = Parser.Parser.ParseMovieTitle(postTitle);
             using (new AssertionScope())
             {
                 movie.MovieTitle.Should().Be(title);
@@ -128,7 +107,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("(1995) Ghost in the Shell", "Ghost in the Shell")]
         public void should_parse_movie_folder_name(string postTitle, string title)
         {
-            Parser.Parser.ParseMovieTitle(postTitle, true, true).MovieTitle.Should().Be(title);
+            Parser.Parser.ParseMovieTitle(postTitle, true).MovieTitle.Should().Be(title);
         }
 
         [TestCase("1941.1979.EXTENDED.720p.BluRay.X264-AMIABLE", 1979)]
@@ -137,7 +116,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Leaving Jeruselem by Railway (1897) [DVD].mp4", 1897)]
         public void should_parse_movie_year(string postTitle, int year)
         {
-            Parser.Parser.ParseMovieTitle(postTitle, false).Year.Should().Be(year);
+            Parser.Parser.ParseMovieTitle(postTitle).Year.Should().Be(year);
         }
 
         [TestCase("Prometheus 2012 Directors Cut", "Directors Cut")]
@@ -180,7 +159,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Loving.Pablo.2018.TS.FRENCH.MD.x264-DROGUERiE", "")]
         public void should_parse_edition(string postTitle, string edition)
         {
-            var parsed = Parser.Parser.ParseMovieTitle(postTitle, true);
+            var parsed = Parser.Parser.ParseMovieTitle(postTitle);
             parsed.Edition.Should().Be(edition);
         }
 

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -1,8 +1,10 @@
 using System.Linq;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using NUnit.Framework;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Test.Framework;
 
 namespace NzbDrone.Core.Test.ParserTests
@@ -56,10 +58,56 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Leaving Jeruselem by Railway (1897) [DVD].mp4", "Leaving Jeruselem by Railway")]
         [TestCase("Climax.2018.1080p.AMZN.WEB-DL.DD5.1.H.264-NTG", "Climax")]
         [TestCase("Movie.Title.Imax.2018.1080p.AMZN.WEB-DL.DD5.1.H.264-NTG", "Movie Title")]
+        [TestCase("World.War.Z.EXTENDED.2013.German.DL.1080p.BluRay.AVC-XANOR", "World War Z")]
+        [TestCase("World.War.Z.2.EXTENDED.2013.German.DL.1080p.BluRay.AVC-XANOR", "World War Z 2")]
+        [TestCase("G.I.Joe.Retaliation.2013.THEATRiCAL.COMPLETE.BLURAY-GLiMMER", "G.I. Joe Retaliation")]
         [TestCase("www.Torrenting.org - Revenge.2008.720p.X264-DIMENSION", "Revenge")]
         public void should_parse_movie_title(string postTitle, string title)
         {
             Parser.Parser.ParseMovieTitle(postTitle, true).MovieTitle.Should().Be(title);
+        }
+
+        [TestCase("Avatar.Aufbruch.nach.Pandora.Extended.2009.German.DTS.720p.BluRay.x264-SoW", "Avatar Aufbruch nach Pandora", "Extended", 2009)]
+        [TestCase("Drop.Zone.1994.German.AC3D.DL.720p.BluRay.x264-KLASSiGERHD", "Drop Zone", "", 1994)]
+        [TestCase("Kick.Ass.2.2013.German.DTS.DL.720p.BluRay.x264-Pate", "Kick Ass 2", "", 2013)]
+        [TestCase("Paradise.Hills.2019.German.DL.AC3.Dubbed.1080p.BluRay.x264-muhHD", "Paradise Hills", "", 2019)]
+        [TestCase("96.Hours.Taken.3.EXTENDED.2014.German.DL.1080p.BluRay.x264-ENCOUNTERS", "96 Hours Taken 3", "EXTENDED", 2014)]
+        [TestCase("World.War.Z.EXTENDED.CUT.2013.German.DL.1080p.BluRay.x264-HQX", "World War Z", "EXTENDED CUT", 2013)]
+        [TestCase("Sin.City.2005.RECUT.EXTENDED.German.DL.1080p.BluRay.x264-DETAiLS", "Sin City", "RECUT EXTENDED", 2005)]
+        [TestCase("Die.Klasse.von.1999.1990.German.720p.HDTV.x264-NORETAiL", "Die Klasse von 1999", "", 1990)] //year in the title
+        [TestCase("2.Tage.in.L.A.1996.GERMAN.DL.720p.WEB.H264-SOV", "2 Tage in L.A.", "", 1996)]
+        [TestCase("8.2019.GERMAN.720p.BluRay.x264-UNiVERSUM", "8", "", 2019)]
+        [TestCase("Life.Partners.2014.German.DL.PAL.DVDR-ETM", "Life Partners", "", 2014)]
+        [TestCase("Joe.Dreck.2.EXTENDED.EDITION.2015.German.DL.PAL.DVDR-ETM", "Joe Dreck 2", "EXTENDED EDITION", 2015)]
+        [TestCase("Rango.EXTENDED.2011.HDRip.AC3.German.XviD-POE", "Rango", "EXTENDED", 2011)]
+        [TestCase("Suicide.Squad.2016.EXTENDED.German.DL.AC3.BDRip.x264-hqc", "Suicide Squad", "EXTENDED", 2016)] //edition after year
+        public void should_parse_german_movie(string postTitle, string title, string edition, int year)
+        {
+            ParsedMovieInfo movie = Parser.Parser.ParseMovieTitle(postTitle, false);
+            using (new AssertionScope())
+            {
+                movie.MovieTitle.Should().Be(title);
+                movie.Edition.Should().Be(edition);
+                movie.Year.Should().Be(year);
+            }
+        }
+
+        [TestCase("Der.Hobbit.Eine.Unerwartete.Reise.Extended.German.720p.BluRay.x264-EXQUiSiTE", "Der Hobbit Eine Unerwartete Reise", "Extended", 0)] //no year
+        [TestCase("Die.Unfassbaren.Now.You.See.Me.EXTENDED.German.DTS.720p.BluRay.x264-RHD", "Die Unfassbaren Now You See Me", "EXTENDED", 0)] //no year
+        [TestCase("Der.Soldat.James.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998", "Der Soldat James", "", 1998)]
+        [TestCase("Passengers.German.DL.AC3.Dubbed..BluRay.x264-PsO", "Passengers", "", 0)] //no year
+        [TestCase("Das.A.Team.Der.Film.Extended.Cut.German.720p.BluRay.x264-ANCIENT", "Das A Team Der Film", "Extended Cut", 0)] //no year
+        [TestCase("Cars.2.German.DL.720p.BluRay.x264-EmpireHD", "Cars 2", "", 0)] //no year
+        [TestCase("Der.Film.deines.Lebens.German.2011.PAL.DVDR-ETM", "Der Film deines Lebens", "", 2011)] //year at wrong position
+        public void should_parse_german_movie_lenient(string postTitle, string title, string edition, int year)
+        {
+            ParsedMovieInfo movie = Parser.Parser.ParseMovieTitle(postTitle, true);
+            using (new AssertionScope())
+            {
+                movie.MovieTitle.Should().Be(title);
+                movie.Edition.Should().Be(edition);
+                movie.Year.Should().Be(year);
+            }
         }
 
         [TestCase("(1995) Ghost in the Shell", "Ghost in the Shell")]

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -92,6 +92,21 @@ namespace NzbDrone.Core.Test.ParserTests
             }
         }
 
+        [TestCase("Avatar.Aufbruch.nach.Pandora.Extended.2009.German.DTS.720p.BluRay.x264-SoW", "Avatar Aufbruch nach Pandora", "Extended", 2009)]
+        [TestCase("Drop.Zone.1994.German.AC3D.DL.720p.BluRay.x264-KLASSiGERHD", "Drop Zone", "", 1994)]
+        [TestCase("Kick.Ass.2.2013.German.DTS.DL.720p.BluRay.x264-Pate", "Kick Ass 2", "", 2013)]
+        [TestCase("Paradise.Hills.2019.German.DL.AC3.Dubbed.1080p.BluRay.x264-muhHD", "Paradise Hills", "", 2019)]
+        [TestCase("96.Hours.Taken.3.EXTENDED.2014.German.DL.1080p.BluRay.x264-ENCOUNTERS", "96 Hours Taken 3", "EXTENDED", 2014)]
+        [TestCase("World.War.Z.EXTENDED.CUT.2013.German.DL.1080p.BluRay.x264-HQX", "World War Z", "EXTENDED CUT", 2013)]
+        [TestCase("Sin.City.2005.RECUT.EXTENDED.German.DL.1080p.BluRay.x264-DETAiLS", "Sin City", "RECUT EXTENDED", 2005)]
+        [TestCase("Die.Klasse.von.1999.1990.German.720p.HDTV.x264-NORETAiL", "Die Klasse von 1999", "", 1990)] //year in the title
+        [TestCase("2.Tage.in.L.A.1996.GERMAN.DL.720p.WEB.H264-SOV", "2 Tage in L.A.", "", 1996)]
+        [TestCase("8.2019.GERMAN.720p.BluRay.x264-UNiVERSUM", "8", "", 2019)]
+        [TestCase("Life.Partners.2014.German.DL.PAL.DVDR-ETM", "Life Partners", "", 2014)]
+        [TestCase("Joe.Dreck.2.EXTENDED.EDITION.2015.German.DL.PAL.DVDR-ETM", "Joe Dreck 2", "EXTENDED EDITION", 2015)]
+        [TestCase("Rango.EXTENDED.2011.HDRip.AC3.German.XviD-POE", "Rango", "EXTENDED", 2011)]
+        [TestCase("Suicide.Squad.2016.EXTENDED.German.DL.AC3.BDRip.x264-hqc", "Suicide Squad", "EXTENDED", 2016)] //edition after year
+
         [TestCase("Der.Hobbit.Eine.Unerwartete.Reise.Extended.German.720p.BluRay.x264-EXQUiSiTE", "Der Hobbit Eine Unerwartete Reise", "Extended", 0)] //no year
         [TestCase("Die.Unfassbaren.Now.You.See.Me.EXTENDED.German.DTS.720p.BluRay.x264-RHD", "Die Unfassbaren Now You See Me", "EXTENDED", 0)] //no year
         [TestCase("Der.Soldat.James.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998", "Der Soldat James", "", 1998)]

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -159,6 +159,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Mission Impossible: Rogue Nation 2012 Bluray", "")]
         [TestCase("Loving.Pablo.2018.TS.FRENCH.MD.x264-DROGUERiE", "")]
         [TestCase("Uncut.Gems.2019.720p.BluRay.x264-YOL0W", "")]
+        [TestCase("Directors.Cut.German.2006.COMPLETE.PAL.DVDR-LoD", "")]
         public void should_parse_edition(string postTitle, string edition)
         {
             var parsed = Parser.Parser.ParseMovieTitle(postTitle);

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -174,6 +174,23 @@ namespace NzbDrone.Core.Test.ParserTests
             parsed.Languages.First().Should().Be(Language.English);
         }
 
+        [TestCase("The.Purge.3.Election.Year.2016.German.DTS.DL.720p.BluRay.x264-MULTiPLEX")]
+        public void should_not_parse_multi_language_in_releasegroup(string postTitle)
+        {
+            var parsed = Parser.Parser.ParseMovieTitle(postTitle, true);
+            parsed.Languages.Count().Should().Be(1);
+            parsed.Languages.First().Should().Be(Language.German);
+        }
+
+        [TestCase("The.Purge.3.Election.Year.2016.German.Multi.DTS.DL.720p.BluRay.x264-MULTiPLEX")]
+        public void should_parse_multi_language(string postTitle)
+        {
+            var parsed = Parser.Parser.ParseMovieTitle(postTitle, true);
+            parsed.Languages.Count().Should().Be(2);
+            parsed.Languages.Should().Contain(Language.German);
+            parsed.Languages.Should().Contain(Language.English, "Added by the multi tag in the release name");
+        }
+
         [TestCase("The Italian Job 2008 [tt1234567] 720p BluRay X264", "tt1234567")]
         [TestCase("The Italian Job 2008 [tt12345678] 720p BluRay X264", "tt12345678")]
         public void should_parse_imdb_in_title(string postTitle, string imdb)

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -33,7 +33,6 @@ namespace NzbDrone.Core.Test.ParserTests
             title.CleanSeriesTitle().Should().Be("carnivale");
         }
 
-        //Note: This assumes extended language parser is activated
         [TestCase("The.Man.from.U.N.C.L.E.2015.1080p.BluRay.x264-SPARKS", "The Man from U.N.C.L.E.")]
         [TestCase("1941.1979.EXTENDED.720p.BluRay.X264-AMIABLE", "1941")]
         [TestCase("MY MOVIE (2016) [R][Action, Horror][720p.WEB-DL.AVC.8Bit.6ch.AC3].mkv", "MY MOVIE")]
@@ -74,26 +73,27 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("96.Hours.Taken.3.EXTENDED.2014.German.DL.1080p.BluRay.x264-ENCOUNTERS", "96 Hours Taken 3", "EXTENDED", 2014)]
         [TestCase("World.War.Z.EXTENDED.CUT.2013.German.DL.1080p.BluRay.x264-HQX", "World War Z", "EXTENDED CUT", 2013)]
         [TestCase("Sin.City.2005.RECUT.EXTENDED.German.DL.1080p.BluRay.x264-DETAiLS", "Sin City", "RECUT EXTENDED", 2005)]
-        [TestCase("Die.Klasse.von.1999.1990.German.720p.HDTV.x264-NORETAiL", "Die Klasse von 1999", "", 1990)] //year in the title
         [TestCase("2.Tage.in.L.A.1996.GERMAN.DL.720p.WEB.H264-SOV", "2 Tage in L.A.", "", 1996)]
         [TestCase("8.2019.GERMAN.720p.BluRay.x264-UNiVERSUM", "8", "", 2019)]
         [TestCase("Life.Partners.2014.German.DL.PAL.DVDR-ETM", "Life Partners", "", 2014)]
         [TestCase("Joe.Dreck.2.EXTENDED.EDITION.2015.German.DL.PAL.DVDR-ETM", "Joe Dreck 2", "EXTENDED EDITION", 2015)]
         [TestCase("Rango.EXTENDED.2011.HDRip.AC3.German.XviD-POE", "Rango", "EXTENDED", 2011)]
 
-        //Special cases (see comment to the right)
-        [TestCase("Suicide.Squad.2016.EXTENDED.German.DL.AC3.BDRip.x264-hqc", "Suicide Squad", "EXTENDED", 2016)] //edition after year
-        [TestCase("Knight.and.Day.2010.Extended.Cut.German.DTS.DL.720p.BluRay.x264-HDS", "Knight and Day", "Extended Cut", 2010)] //edition after year
-        [TestCase("Der.Soldat.James.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998", "Der Soldat James", "", 1998)] //year at the end
-        [TestCase("Der.Hobbit.Eine.Unerwartete.Reise.Extended.German.720p.BluRay.x264-EXQUiSiTE", "Der Hobbit Eine Unerwartete Reise", "Extended", 0)] //no year
-        [TestCase("Wolverine.Weg.des.Kriegers.EXTENDED.German.720p.BluRay.x264-EXQUiSiTE", "Wolverine Weg des Kriegers", "EXTENDED", 0)] //no year
-        [TestCase("Die.Unfassbaren.Now.You.See.Me.EXTENDED.German.DTS.720p.BluRay.x264-RHD", "Die Unfassbaren Now You See Me", "EXTENDED", 0)] //no year
-        [TestCase("Die Unfassbaren Now You See Me EXTENDED German DTS 720p BluRay x264-RHD", "Die Unfassbaren Now You See Me", "EXTENDED", 0)] //no year & without dots
-        [TestCase("Passengers.German.DL.AC3.Dubbed..BluRay.x264-PsO", "Passengers", "", 0)] //no year
-        [TestCase("Das.A.Team.Der.Film.Extended.Cut.German.720p.BluRay.x264-ANCIENT", "Das A Team Der Film", "Extended Cut", 0)] //no year
-        [TestCase("Cars.2.German.DL.720p.BluRay.x264-EmpireHD", "Cars 2", "", 0)] //no year
-        [TestCase("Die.fantastische.Reise.des.Dr.Dolittle.2020.German.DL.LD.1080p.WEBRip.x264-PRD", "Die fantastische Reise des Dr. Dolittle", "", 2020)] //year at wrong position
-        [TestCase("Der.Film.deines.Lebens.German.2011.PAL.DVDR-ETM", "Der Film deines Lebens", "", 2011)] //year at wrong position
+        //Special cases (see description)
+        [TestCase("Die.Klasse.von.1999.1990.German.720p.HDTV.x264-NORETAiL", "Die Klasse von 1999", "", 1990, Description = "year in the title")]
+        [TestCase("Suicide.Squad.2016.EXTENDED.German.DL.AC3.BDRip.x264-hqc", "Suicide Squad", "EXTENDED", 2016, Description = "edition after year")]
+        [TestCase("Knight.and.Day.2010.Extended.Cut.German.DTS.DL.720p.BluRay.x264-HDS", "Knight and Day", "Extended Cut", 2010, Description = "edition after year")]
+        [TestCase("Der.Soldat.James.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998", "Der Soldat James", "", 1998, Description = "year at the end")]
+        [TestCase("Der.Hobbit.Eine.Unerwartete.Reise.Extended.German.720p.BluRay.x264-EXQUiSiTE", "Der Hobbit Eine Unerwartete Reise", "Extended", 0, Description = "no year & edition")]
+        [TestCase("Wolverine.Weg.des.Kriegers.EXTENDED.German.720p.BluRay.x264-EXQUiSiTE", "Wolverine Weg des Kriegers", "EXTENDED", 0, Description = "no year & edition")]
+        [TestCase("Die.Unfassbaren.Now.You.See.Me.EXTENDED.German.DTS.720p.BluRay.x264-RHD", "Die Unfassbaren Now You See Me", "EXTENDED", 0, Description = "no year & edition")]
+        [TestCase("Die Unfassbaren Now You See Me EXTENDED German DTS 720p BluRay x264-RHD", "Die Unfassbaren Now You See Me", "EXTENDED", 0, Description = "no year & edition & without dots")]
+        [TestCase("Passengers.German.DL.AC3.Dubbed..BluRay.x264-PsO", "Passengers", "", 0, Description = "no year")]
+        [TestCase("Das.A.Team.Der.Film.Extended.Cut.German.720p.BluRay.x264-ANCIENT", "Das A Team Der Film", "Extended Cut", 0, Description = "no year")]
+        [TestCase("Cars.2.German.DL.720p.BluRay.x264-EmpireHD", "Cars 2", "", 0, Description = "no year")]
+        [TestCase("Die.fantastische.Reise.des.Dr.Dolittle.2020.German.DL.LD.1080p.WEBRip.x264-PRD", "Die fantastische Reise des Dr. Dolittle", "", 2020, Description = "dot after dr")]
+        [TestCase("Der.Film.deines.Lebens.German.2011.PAL.DVDR-ETM", "Der Film deines Lebens", "", 2011, Description = "year at wrong position")]
+        [TestCase("Kick.Ass.2.2013.German.DTS.DL.720p.BluRay.x264-Pate_", "Kick Ass 2", "", 2013, Description = "underscore at the end")]
         public void should_parse_german_movie(string postTitle, string title, string edition, int year)
         {
             ParsedMovieInfo movie = Parser.Parser.ParseMovieTitle(postTitle);

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -92,6 +92,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Passengers.German.DL.AC3.Dubbed..BluRay.x264-PsO", "Passengers", "", 0)] //no year
         [TestCase("Das.A.Team.Der.Film.Extended.Cut.German.720p.BluRay.x264-ANCIENT", "Das A Team Der Film", "Extended Cut", 0)] //no year
         [TestCase("Cars.2.German.DL.720p.BluRay.x264-EmpireHD", "Cars 2", "", 0)] //no year
+        [TestCase("Die.fantastische.Reise.des.Dr.Dolittle.2020.German.DL.LD.1080p.WEBRip.x264-PRD", "Die fantastische Reise des Dr. Dolittle", "", 2020)] //year at wrong position
         [TestCase("Der.Film.deines.Lebens.German.2011.PAL.DVDR-ETM", "Der Film deines Lebens", "", 2011)] //year at wrong position
         public void should_parse_german_movie(string postTitle, string title, string edition, int year)
         {
@@ -157,6 +158,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("My.Movie.GERMAN.Extended.Cut", "Extended Cut")]
         [TestCase("Mission Impossible: Rogue Nation 2012 Bluray", "")]
         [TestCase("Loving.Pablo.2018.TS.FRENCH.MD.x264-DROGUERiE", "")]
+        [TestCase("Uncut.Gems.2019.720p.BluRay.x264-YOL0W", "")]
         public void should_parse_edition(string postTitle, string edition)
         {
             var parsed = Parser.Parser.ParseMovieTitle(postTitle);

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetMovieFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetMovieFixture.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             Subject.GetMovie(title);
 
             Mocker.GetMock<IMovieService>()
-                  .Verify(s => s.FindByTitle(Parser.Parser.ParseMovieTitle(title, false, false).MovieTitle), Times.Once());
+                  .Verify(s => s.FindByTitle(Parser.Parser.ParseMovieTitle(title, false).MovieTitle), Times.Once());
         }
 
         /*[Test]

--- a/src/NzbDrone.Core.Test/ParserTests/SceneCheckerFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SceneCheckerFixture.cs
@@ -12,6 +12,7 @@ namespace NzbDrone.Core.Test.ParserTests
         //[TestCase("Archer.2009.720p.WEB-DL.DD5.1.H.264-iT00NZ")]
         //[TestCase("30.Rock.S04E17.720p.HDTV.X264-DIMENSION")]
         //[TestCase("30.Rock.S04.720p.HDTV.X264-DIMENSION")]
+        [TestCase("Kick.Ass.2.2013.German.DTS.DL.720p.BluRay.x264-Pate")]
         public void should_return_true_for_scene_names(string title)
         {
             SceneChecker.IsSceneTitle(title).Should().BeTrue();
@@ -21,13 +22,21 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("S08E05 - Virtual In-Stanity.With.Dots [WEBDL-720p]")]
         [TestCase("Something")]
         [TestCase("86de66b7ef385e2fa56a3e41b98481ea1658bfab")]
-        [TestCase("30.Rock.2017.720p.HDTV.X264", Description = "no group")]
-        [TestCase("2017.720p.HDTV.X264-DIMENSION", Description = "no series title")]
-        [TestCase("30.Rock.2017-DIMENSION", Description = "no quality")]
-        [TestCase("30.Rock.720p.HDTV.X264-DIMENSION", Description = "no episode")]
+        [TestCase("Kick.Ass.2.2013.German.DTS.DL.720p.BluRay.x264-", Description = "no group")]
+        [TestCase("Kick.Ass.2.2013.German.DTS.DL-Pate", Description = "no quality")]
+        [TestCase("2013.German.DTS.DL.BluRay.x264-Pate", Description = "no movietitle")]
         public void should_return_false_for_non_scene_names(string title)
         {
             SceneChecker.IsSceneTitle(title).Should().BeFalse();
+        }
+
+        [TestCase("Kick.Ass.2.2013.German.DTS.DL.720p.BluRay.x264-Pate_", "Kick.Ass.2.2013.German.DTS.DL.720p.BluRay.x264-Pate", Description = "underscore at the end")]
+        [TestCase("Kick.Ass.2.2013.German.DTS.DL.720p.BluRay.x264-Pate.mkv", "Kick.Ass.2.2013.German.DTS.DL.720p.BluRay.x264-Pate", Description = "file extension")]
+        [TestCase("Kick.Ass.2.2013.German.DTS.DL.720p.BluRay.x264-Pate.nzb", "Kick.Ass.2.2013.German.DTS.DL.720p.BluRay.x264-Pate", Description = "file extension")]
+        [TestCase("Kick.Ass.2.2013.German.DTS.DL.【720p】.BluRay.x264-Pate.nzb", "Kick.Ass.2.2013.German.DTS.DL.[720p].BluRay.x264-Pate", Description = "brackets")]
+        public void should_correctly_parse_scene_names(string title, string result)
+        {
+            SceneChecker.GetSceneTitle(title).Should().Be(result);
         }
     }
 }

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -190,12 +190,6 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("WhitelistedHardcodedSubs", value); }
         }
 
-        public ParsingLeniencyType ParsingLeniency
-        {
-            get { return GetValueEnum<ParsingLeniencyType>("ParsingLeniency", ParsingLeniencyType.Strict); }
-            set { SetValue("ParsingLeniency", value); }
-        }
-
         public bool RemoveCompletedDownloads
         {
             get { return GetValueBoolean("RemoveCompletedDownloads", false); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -61,7 +61,6 @@ namespace NzbDrone.Core.Configuration
 
         bool AllowHardcodedSubs { get; set; }
         string WhitelistedHardcodedSubs { get; set; }
-        ParsingLeniencyType ParsingLeniency { get; set; }
 
         int NetImportSyncInterval { get; set; }
         string ListSyncLevel { get; set; }

--- a/src/NzbDrone.Core/Datastore/Migration/117_update_movie_file.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/117_update_movie_file.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Datastore.Migration
                         var id = seriesReader.GetInt32(0);
                         var relativePath = seriesReader.GetString(1);
 
-                        var result = Parser.Parser.ParseMovieTitle(relativePath, false);
+                        var result = Parser.Parser.ParseMovieTitle(relativePath);
 
                         var edition = "";
 

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -89,12 +89,7 @@ namespace NzbDrone.Core.DecisionEngine
                             Quality = new QualityModel(),
                         };
 
-                        if (_configService.ParsingLeniency == ParsingLeniencyType.MappingLenient)
-                        {
-                            result = _parsingService.Map(parsedMovieInfo, report.ImdbId.ToString(), searchCriteria);
-                        }
-
-                        if (result == null || result.MappingResultType != MappingResultType.SuccessLenientMapping)
+                        if (result == null)
                         {
                             result = new MappingResult { MappingResultType = MappingResultType.NotParsable };
                             result.Movie = null; //To ensure we have a remote movie, else null exception on next line!
@@ -113,7 +108,7 @@ namespace NzbDrone.Core.DecisionEngine
                     remoteMovie.Release = report;
                     remoteMovie.MappingResult = result.MappingResultType;
 
-                    if (result.MappingResultType != MappingResultType.Success && result.MappingResultType != MappingResultType.SuccessLenientMapping)
+                    if (result.MappingResultType != MappingResultType.Success)
                     {
                         var rejection = result.ToRejection();
                         decision = new DownloadDecision(remoteMovie, rejection);

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionPriorizationService.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionPriorizationService.cs
@@ -27,13 +27,13 @@ namespace NzbDrone.Core.DecisionEngine
 
         public List<DownloadDecision> PrioritizeDecisionsForMovies(List<DownloadDecision> decisions)
         {
-            return decisions.Where(c => c.RemoteMovie.MappingResult == MappingResultType.Success || c.RemoteMovie.MappingResult == MappingResultType.SuccessLenientMapping)
+            return decisions.Where(c => c.RemoteMovie.MappingResult == MappingResultType.Success)
                             .GroupBy(c => c.RemoteMovie.Movie.Id, (movieId, downloadDecisions) =>
                             {
                                 return downloadDecisions.OrderByDescending(decision => decision, new DownloadDecisionComparer(_configService, _delayProfileService, _qualityDefinitionService));
                             })
                             .SelectMany(c => c)
-                            .Union(decisions.Where(c => c.RemoteMovie.MappingResult != MappingResultType.Success || c.RemoteMovie.MappingResult != MappingResultType.SuccessLenientMapping))
+                            .Union(decisions.Where(c => c.RemoteMovie.MappingResult != MappingResultType.Success))
                             .ToList();
         }
     }

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
@@ -70,7 +70,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
                 RelativePath = movie.Path.GetRelativePath(path)
             };
 
-            var parseResult = Parser.Parser.ParseMovieTitle(filename, false);
+            var parseResult = Parser.Parser.ParseMovieTitle(filename);
 
             if (parseResult != null)
             {

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Wdtv/WdtvMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Wdtv/WdtvMetadata.cs
@@ -72,7 +72,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
                 return metadata;
             }
 
-            var parseResult = Parser.Parser.ParseMovieTitle(filename, false);
+            var parseResult = Parser.Parser.ParseMovieTitle(filename);
 
             if (parseResult != null)
             {

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -93,7 +93,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                 return metadata;
             }
 
-            var parseResult = Parser.Parser.ParseMovieTitle(filename, false);
+            var parseResult = Parser.Parser.ParseMovieTitle(filename);
 
             if (parseResult != null &&
                 Path.GetExtension(filename).Equals(".nfo", StringComparison.OrdinalIgnoreCase) &&

--- a/src/NzbDrone.Core/MediaFiles/DownloadedMovieImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DownloadedMovieImportService.cs
@@ -123,7 +123,7 @@ namespace NzbDrone.Core.MediaFiles
                 foreach (var videoFile in videoFiles)
                 {
                     var movieParseResult =
-                        Parser.Parser.ParseMovieTitle(Path.GetFileName(videoFile), _config.ParsingLeniency > 0);
+                        Parser.Parser.ParseMovieTitle(Path.GetFileName(videoFile));
 
                     if (movieParseResult == null)
                     {

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
@@ -120,7 +120,6 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
                     {
                         movieFile.OriginalFilePath = GetOriginalFilePath(downloadClientItem, localMovie);
                         movieFile.SceneName = GetSceneName(downloadClientItem, localMovie);
-
                         var moveResult = _movieFileUpgrader.UpgradeMovieFile(movieFile, localMovie, copyOnly); //TODO: Check if this works
                         oldFiles = moveResult.OldFiles;
                     }
@@ -212,21 +211,18 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
         {
             if (downloadClientItem != null)
             {
-                var title = Parser.Parser.RemoveFileExtension(downloadClientItem.Title);
-
-                var parsedTitle = Parser.Parser.ParseMovieTitle(title);
-
-                if (parsedTitle != null)
+                var sceneNameTitle = SceneChecker.GetSceneTitle(downloadClientItem.Title);
+                if (sceneNameTitle != null)
                 {
-                    return title;
+                    return sceneNameTitle;
                 }
             }
 
             var fileName = Path.GetFileNameWithoutExtension(localMovie.Path.CleanFilePath());
-
-            if (SceneChecker.IsSceneTitle(fileName))
+            var sceneNameFile = SceneChecker.GetSceneTitle(fileName);
+            if (sceneNameFile != null)
             {
-                return fileName;
+                return sceneNameFile;
             }
 
             return null;

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
@@ -214,7 +214,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
             {
                 var title = Parser.Parser.RemoveFileExtension(downloadClientItem.Title);
 
-                var parsedTitle = Parser.Parser.ParseMovieTitle(title, false);
+                var parsedTitle = Parser.Parser.ParseMovieTitle(title);
 
                 if (parsedTitle != null)
                 {

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
@@ -189,7 +189,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
 
             if (folderMovieInfo != null)
             {
-                var folderPath = path.GetAncestorPath(folderMovieInfo.SimpleReleaseTitle);
+                var folderPath = path.GetAncestorPath(folderMovieInfo.OriginalTitle);
 
                 if (folderPath != null)
                 {

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportDecisionMaker.cs
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
 
             if (downloadClientItem != null)
             {
-                downloadClientItemInfo = Parser.Parser.ParseMovieTitle(downloadClientItem.Title, false);
+                downloadClientItemInfo = Parser.Parser.ParseMovieTitle(downloadClientItem.Title);
                 downloadClientItemInfo = _parsingService.EnhanceMovieInfo(downloadClientItemInfo);
             }
 
@@ -97,7 +97,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
         {
             ImportDecision decision = null;
 
-            var fileMovieInfo = Parser.Parser.ParseMoviePath(localMovie.Path, false);
+            var fileMovieInfo = Parser.Parser.ParseMoviePath(localMovie.Path);
 
             if (fileMovieInfo != null)
             {

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
@@ -129,7 +129,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
                 return processedFiles.Concat(processedFolders).Where(i => i != null).ToList();
             }
 
-            var folderInfo = Parser.Parser.ParseMovieTitle(directoryInfo.Name, false);
+            var folderInfo = Parser.Parser.ParseMovieTitle(directoryInfo.Name);
             var movieFiles = _diskScanService.GetVideoFiles(baseFolder).ToList();
             var decisions = _importDecisionMaker.GetImportDecisions(movieFiles, movie, downloadClientItem, folderInfo, SceneSource(movie, baseFolder), filterExistingFiles);
 
@@ -164,7 +164,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
 
             if (movie == null)
             {
-                var relativeParseInfo = Parser.Parser.ParseMoviePath(relativeFile, false);
+                var relativeParseInfo = Parser.Parser.ParseMoviePath(relativeFile);
 
                 if (relativeParseInfo != null)
                 {
@@ -241,7 +241,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
 
                 var file = message.Files[i];
                 var movie = _movieService.GetMovie(file.MovieId);
-                var fileMovieInfo = Parser.Parser.ParseMoviePath(file.Path, false) ?? new ParsedMovieInfo();
+                var fileMovieInfo = Parser.Parser.ParseMoviePath(file.Path) ?? new ParsedMovieInfo();
                 var existingFile = movie.Path.IsParentPath(file.Path);
                 TrackedDownload trackedDownload = null;
 
@@ -264,7 +264,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
 
                 if (file.FolderName.IsNotNullOrWhiteSpace())
                 {
-                    localMovie.FolderMovieInfo = Parser.Parser.ParseMovieTitle(file.FolderName, false);
+                    localMovie.FolderMovieInfo = Parser.Parser.ParseMovieTitle(file.FolderName);
                 }
 
                 localMovie = _aggregationService.Augment(localMovie, false);

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -290,7 +290,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
                 lowerTitle = lowerTitle.Replace(".", "");
 
-                var parserResult = Parser.Parser.ParseMovieTitle(title, true, true);
+                var parserResult = Parser.Parser.ParseMovieTitle(title, true);
 
                 var yearTerm = "";
 

--- a/src/NzbDrone.Core/NetImport/RSSImport/RSSImportParser.cs
+++ b/src/NzbDrone.Core/NetImport/RSSImport/RSSImportParser.cs
@@ -142,7 +142,7 @@ namespace NzbDrone.Core.NetImport.RSSImport
             }
 
             releaseInfo.Title = title;
-            var result = Parser.Parser.ParseMovieTitle(title, false); //Depreciated anyways
+            var result = Parser.Parser.ParseMovieTitle(title); //Depreciated anyways
 
             if (result != null)
             {

--- a/src/NzbDrone.Core/Organizer/FileNameValidationService.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameValidationService.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Organizer
         public ValidationFailure ValidateMovieFilename(SampleResult sampleResult)
         {
             var validationFailure = new ValidationFailure("MovieFormat", ERROR_MESSAGE);
-            var parsedMovieInfo = Parser.Parser.ParseMovieTitle(sampleResult.FileName, false); //We are not lenient when testing naming schemes
+            var parsedMovieInfo = Parser.Parser.ParseMovieTitle(sampleResult.FileName);
 
             if (parsedMovieInfo == null)
             {

--- a/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
@@ -8,6 +8,8 @@ namespace NzbDrone.Core.Parser.Model
     public class ParsedMovieInfo
     {
         public string MovieTitle { get; set; }
+        public string OriginalTitle { get; set; }
+        public string ReleaseTitle { get; set; }
         public string SimpleReleaseTitle { get; set; }
         public QualityModel Quality { get; set; }
         public List<Language> Languages { get; set; } = new List<Language>();

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -18,15 +18,17 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex ReportYearRegex = new Regex(@"^.*(?<year>(19|20)\d{2}).*$", RegexOptions.Compiled);
 
-        private static readonly Regex ReportEditionRegex = new Regex(@"\(?\b(?<edition>(((Recut.|Extended.|Ultimate.)?(Director.?s|Collector.?s|Theatrical|Ultimate|Final(?=(.(Cut|Edition|Version)))|Extended|Rogue|Special|Despecialized|\d{2,3}(th)?.Anniversary)(.(Cut|Edition|Version))?(.(Extended|Uncensored|Remastered|Unrated|Uncut|IMAX|Fan.?Edit))?|((Uncensored|Remastered|Unrated|Uncut|IMAX|Fan.?Edit|Edition|Restored|((2|3|4)in1))))))\b\)?", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex EditionRegex = new Regex(@"\(?\b(?<edition>(((Recut.|Extended.|Ultimate.)?(Director.?s|Collector.?s|Theatrical|Ultimate|Final(?=(.(Cut|Edition|Version)))|Extended|Rogue|Special|Despecialized|\d{2,3}(th)?.Anniversary)(.(Cut|Edition|Version))?(.(Extended|Uncensored|Remastered|Unrated|Uncut|IMAX|Fan.?Edit))?|((Uncensored|Remastered|Unrated|Uncut|IMAX|Fan.?Edit|Edition|Restored|((2|3|4)in1))))))\b\)?", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex ReportEditionRegex = new Regex(@"^.+?" + EditionRegex, RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex[] ReportMovieTitleRegex = new[]
         {
             //Some german or french tracker formats (missing year, ...) (Only applies to german and French/TrueFrench releases) - see ParserFixture for examples and tests
-            new Regex(@"^(?<title>(?![(\[]).+?)((\W|_))(" + ReportEditionRegex + @".{1,3})?(?:(?<!(19|20)\d{2}.*?)(German|French|TrueFrench))(.+?)(?=((19|20)\d{2}|$))(?<year>(19|20)\d{2}(?!p|i|\d+|\]|\W\d+))?(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<title>(?![(\[]).+?)((\W|_))(" + EditionRegex + @".{1,3})?(?:(?<!(19|20)\d{2}.*?)(German|French|TrueFrench))(.+?)(?=((19|20)\d{2}|$))(?<year>(19|20)\d{2}(?!p|i|\d+|\]|\W\d+))?(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
             //Special, Despecialized, etc. Edition Movies, e.g: Mission.Impossible.3.Special.Edition.2011
-            new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*" + ReportEditionRegex + @".{1,3}(?<year>(1(8|9)|20)\d{2}(?!p|i|\d+|\]|\W\d+)))+(\W+|_|$)(?!\\)",
+            new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*" + EditionRegex + @".{1,3}(?<year>(1(8|9)|20)\d{2}(?!p|i|\d+|\]|\W\d+)))+(\W+|_|$)(?!\\)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
             //Special, Despecialized, etc. Edition Movies, e.g: Mission.Impossible.3.2011.Special.Edition //TODO: Seems to slow down parsing heavily!
@@ -487,6 +489,11 @@ namespace NzbDrone.Core.Parser
                     previousAcronym = true;
                 }
                 else if (part.ToLower() == "a" && (previousAcronym || nextPart.Length == 1))
+                {
+                    movieName += part + ".";
+                    previousAcronym = true;
+                }
+                else if (part.ToLower() == "dr")
                 {
                     movieName += part + ".";
                     previousAcronym = true;

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -187,6 +187,9 @@ namespace NzbDrone.Core.Parser
 
                 var releaseTitle = RemoveFileExtension(title);
 
+                //Trim dashes from end
+                releaseTitle = releaseTitle.Trim('-', '_');
+
                 releaseTitle = releaseTitle.Replace("【", "[").Replace("】", "]");
 
                 var simpleTitle = SimpleTitleRegex.Replace(releaseTitle);

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -165,6 +165,7 @@ namespace NzbDrone.Core.Parser
 
         public static ParsedMovieInfo ParseMovieTitle(string title, bool isDir = false)
         {
+            var originalTitle = title;
             try
             {
                 if (!ValidateBeforeParsing(title))
@@ -227,7 +228,7 @@ namespace NzbDrone.Core.Parser
                             if (result != null)
                             {
                                 //TODO: Add tests for this!
-                                var simpleReleaseTitle = SimpleReleaseTitleRegex.Replace(title, string.Empty);
+                                var simpleReleaseTitle = SimpleReleaseTitleRegex.Replace(releaseTitle, string.Empty);
 
                                 var simpleTitleReplaceString = match[0].Groups["title"].Success ? match[0].Groups["title"].Value : result.MovieTitle;
 
@@ -247,7 +248,7 @@ namespace NzbDrone.Core.Parser
                                     result.Edition = ParseEdition(simpleReleaseTitle);
                                 }
 
-                                result.ReleaseGroup = ParseReleaseGroup(releaseTitle);
+                                result.ReleaseGroup = ParseReleaseGroup(simpleReleaseTitle);
 
                                 var subGroup = GetSubGroup(match);
                                 if (!subGroup.IsNullOrWhiteSpace())
@@ -263,6 +264,8 @@ namespace NzbDrone.Core.Parser
                                     Logger.Debug("Release Hash parsed: {0}", result.ReleaseHash);
                                 }
 
+                                result.OriginalTitle = originalTitle;
+                                result.ReleaseTitle = releaseTitle;
                                 result.SimpleReleaseTitle = simpleReleaseTitle;
 
                                 result.ImdbId = ParseImdbId(simpleReleaseTitle);

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -52,7 +52,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex[] ReportMovieTitleLenientRegexBefore = new[]
         {
             //Some german or french tracker formats
-            new Regex(@"^(?<title>(?![(\[]).+?)((\W|_))(" + ReportEditionRegex + @".{1,3})?(?:(?<!(19|20)\d{2}.)(German|French|TrueFrench))(.+?)(?=((19|20)\d{2}|$))(?<year>(19|20)\d{2}(?!p|i|\d+|\]|\W\d+))?(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<title>(?![(\[]).+?)((\W|_))(" + ReportEditionRegex + @".{1,3})?(?:(?<!(19|20)\d{2}.*?)(German|French|TrueFrench))(.+?)(?=((19|20)\d{2}|$))(?<year>(19|20)\d{2}(?!p|i|\d+|\]|\W\d+))?(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
 
         private static readonly Regex[] ReportMovieTitleLenientRegexAfter = new Regex[]

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -240,17 +240,6 @@ namespace NzbDrone.Core.Parser
                                     simpleReleaseTitle = simpleReleaseTitle.Replace(simpleTitleReplaceString, simpleTitleReplaceString.Contains(".") ? "A.Movie" : "A Movie");
                                 }
 
-                                result.Languages = LanguageParser.ParseLanguages(simpleReleaseTitle);
-                                Logger.Debug("Languages parsed: {0}", string.Join(", ", result.Languages));
-
-                                result.Quality = QualityParser.ParseQuality(title);
-                                Logger.Debug("Quality parsed: {0}", result.Quality);
-
-                                if (result.Edition.IsNullOrWhiteSpace())
-                                {
-                                    result.Edition = ParseEdition(simpleReleaseTitle);
-                                }
-
                                 result.ReleaseGroup = ParseReleaseGroup(simpleReleaseTitle);
 
                                 var subGroup = GetSubGroup(match);
@@ -260,6 +249,18 @@ namespace NzbDrone.Core.Parser
                                 }
 
                                 Logger.Debug("Release Group parsed: {0}", result.ReleaseGroup);
+
+                                result.Languages = LanguageParser.ParseLanguages(result.ReleaseGroup.IsNotNullOrWhiteSpace() ? simpleReleaseTitle.Replace(result.ReleaseGroup, "RlsGrp") : simpleReleaseTitle);
+                                Logger.Debug("Languages parsed: {0}", string.Join(", ", result.Languages));
+
+                                result.Quality = QualityParser.ParseQuality(title);
+                                Logger.Debug("Quality parsed: {0}", result.Quality);
+
+                                if (result.Edition.IsNullOrWhiteSpace())
+                                {
+                                    result.Edition = ParseEdition(simpleReleaseTitle);
+                                    Logger.Debug("Edition parsed: {0}", result.Edition);
+                                }
 
                                 result.ReleaseHash = GetReleaseHash(match);
                                 if (!result.ReleaseHash.IsNullOrWhiteSpace())

--- a/src/NzbDrone.Core/Parser/ParsingLeniency.cs
+++ b/src/NzbDrone.Core/Parser/ParsingLeniency.cs
@@ -1,9 +1,0 @@
-namespace NzbDrone.Core.Parser
-{
-    public enum ParsingLeniencyType
-    {
-        Strict = 0,
-        ParsingLenient = 1,
-        MappingLenient = 2,
-    }
-}

--- a/src/NzbDrone.Core/Parser/SceneChecker.cs
+++ b/src/NzbDrone.Core/Parser/SceneChecker.cs
@@ -16,7 +16,7 @@
                 return false;
             }
 
-            var parsedTitle = Parser.ParseMovieTitle(title, false); //We are not lenient when it comes to scene checking!
+            var parsedTitle = Parser.ParseMovieTitle(title);
 
             if (parsedTitle == null ||
                 parsedTitle.ReleaseGroup == null ||

--- a/src/NzbDrone.Core/Parser/SceneChecker.cs
+++ b/src/NzbDrone.Core/Parser/SceneChecker.cs
@@ -4,16 +4,21 @@
     {
         //This method should prefer false negatives over false positives.
         //It's better not to use a title that might be scene than to use one that isn't scene
-        public static bool IsSceneTitle(string title)
+        public static string GetSceneTitle(string title)
         {
+            if (title == null)
+            {
+                return null;
+            }
+
             if (!title.Contains("."))
             {
-                return false;
+                return null;
             }
 
             if (title.Contains(" "))
             {
-                return false;
+                return null;
             }
 
             var parsedTitle = Parser.ParseMovieTitle(title);
@@ -21,12 +26,18 @@
             if (parsedTitle == null ||
                 parsedTitle.ReleaseGroup == null ||
                 parsedTitle.Quality.Quality == Qualities.Quality.Unknown ||
-                string.IsNullOrWhiteSpace(parsedTitle.MovieTitle))
+                string.IsNullOrWhiteSpace(parsedTitle.MovieTitle) ||
+                string.IsNullOrWhiteSpace(parsedTitle.ReleaseTitle))
             {
-                return false;
+                return null;
             }
 
-            return true;
+            return parsedTitle.ReleaseTitle;
+        }
+
+        public static bool IsSceneTitle(string title)
+        {
+            return GetSceneTitle(title) != null;
         }
     }
 }

--- a/src/Radarr.Api.V3/Config/IndexerConfigResource.cs
+++ b/src/Radarr.Api.V3/Config/IndexerConfigResource.cs
@@ -14,7 +14,6 @@ namespace Radarr.Api.V3.Config
         public int AvailabilityDelay { get; set; }
         public bool AllowHardcodedSubs { get; set; }
         public string WhitelistedHardcodedSubs { get; set; }
-        public ParsingLeniencyType ParsingLeniency { get; set; }
     }
 
     public static class IndexerConfigResourceMapper
@@ -31,7 +30,6 @@ namespace Radarr.Api.V3.Config
                 AvailabilityDelay = model.AvailabilityDelay,
                 AllowHardcodedSubs = model.AllowHardcodedSubs,
                 WhitelistedHardcodedSubs = model.WhitelistedHardcodedSubs,
-                ParsingLeniency = model.ParsingLeniency,
             };
         }
     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The Regex for German and french tracker formats (ReportMovieTitleLenientRegexBefore) has been updated to support the same editions as the English versions, but the regex is only used if ParsingLeniency is set to Lenient. Should resolve a lot of cases for German releases where the movieTitle wasn't parsed correctly before. Also some fixes for movieTitles with dots in the name. Also fixed langauge and edition parsing if a language or edition name is present in the movie title.

#### Todos

- [x] Fixed german and french regex to support editions
- [x] Updated acronym method. Fixed wrong dots for "World War Z.", "World War Z. 2", but still supports "R.I.P.D.", "V.H.S. 2", "G.I. Joe" and "2 Tage in L.A.". It now adds a dot after "Dr" and doesn't add a dot after "-" or "_".
- [x] Added a lot of tests
- [x] Fixed correctly replacing SimpleReleaseTitle by A Movie. This resolves a lot of cases where a wrong language or edition has been parsed because it has parsed a part of the movie title (also applies to custom formats parsing)
- [x] #2129 and #4140 (tried in queue and using manual import, works all fine)


#### Issues Fixed or Closed by this PR

* Closes #2129, closes #4394 and closes #4140


##### My thoughts before I made the PR:
Discuss how we are going to continue with the lenient parsing option
After upgrade to v3, if you enabled lenient parsing before, it is still set to true, but you don't notice it because there is no UI.
I would consider the following options:

1. Make a migration and remove the config entry. If we do this, a lot of German releases aren't imported anymore.
Qstick said on discord:

> We would prefer to better the parser than to add a setting like that, thus it was left out purposely

 
The lenient parsing option currently only adds a regex for German and french releases and is therefore only applicable to those languages. It has no impact on English and other languages. If we remove lenient parsing, we have to decide how we improve the parser.... Only removing it would break a LOT of German releases. The problem mostly comes from releases which don't have years in it, how would we handle them without lenient parsing (Optional year is allowed by [German scene rules](https://scenerules.org/t.html?id=2013_DE_SDX264.nfo))?

2. Add the ui setting so first of all we see that lenient parsing is still on, else we don't even notice it. And in addition, German releases won't break with v3. I would put this discussion on the aphrodite roadmap for aphrodite and further talk how we can improve it, in the meantime it works until we fix all of the questions in option 1.