### PR TITLE
Improved matching for Surround Sound formats

### DIFF
--- a/src/Radarr.Api.V3/CustomFormats/CustomFormatModule.cs
+++ b/src/Radarr.Api.V3/CustomFormats/CustomFormatModule.cs
@@ -106,7 +106,7 @@ namespace Radarr.Api.V3.CustomFormats
             yield return new ReleaseTitleSpecification
             {
                 Name = "Surround Sound",
-                Value = @"DTS.?(HD|ES|X(?!\D))|TRUEHD|ATMOS|DD(\+|P|).?([5-9])|(EA|A)C3.?([5-9])"
+                Value = @"TRUEHD|ATMOS|((DD(+|P|))|((EA|A)C3)|DTS|FLAC|OPUS|AAC).?([5-9]|HD|ES|X(?!\D))"
             };
 
             yield return new ReleaseTitleSpecification

--- a/src/Radarr.Api.V3/CustomFormats/CustomFormatModule.cs
+++ b/src/Radarr.Api.V3/CustomFormats/CustomFormatModule.cs
@@ -106,7 +106,7 @@ namespace Radarr.Api.V3.CustomFormats
             yield return new ReleaseTitleSpecification
             {
                 Name = "Surround Sound",
-                Value = @"TRUEHD|ATMOS|((DD(+|P|))|((EA|A)C3)|DTS|FLAC|OPUS|AAC).?([5-9]|HD|ES|X(?!\D))"
+                Value = @"TRUEHD|ATMOS|((DD(\+|P|))|((EA|A)C3)|DTS|FLAC|OPUS|AAC).?([5-9]|HD|ES|X(?!\D))"
             };
 
             yield return new ReleaseTitleSpecification

--- a/src/Radarr.Api.V3/CustomFormats/CustomFormatModule.cs
+++ b/src/Radarr.Api.V3/CustomFormats/CustomFormatModule.cs
@@ -106,7 +106,7 @@ namespace Radarr.Api.V3.CustomFormats
             yield return new ReleaseTitleSpecification
             {
                 Name = "Surround Sound",
-                Value = @"DTS.?(HD|ES|X(?!\D))|TRUEHD|ATMOS|DD(\+|P).?([5-9])|EAC3.?([5-9])"
+                Value = @"DTS.?(HD|ES|X(?!\D))|TRUEHD|ATMOS|DD(\+|P|).?([5-9])|(EA|A)C3.?([5-9])"
             };
 
             yield return new ReleaseTitleSpecification


### PR DESCRIPTION
Enables matching for DD/AC3 5.1 surround sound formats. 

Previously AC3 and DD would not match using the existing default configuration.

#### Database Migration
YES | NO

#### Description


#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #
