### PR TITLE
Fixed #3935 Srt subtitles are not being renamed and copied

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-msBuild='/MSBuild/15.0/Bin'
+msBuild='/MSBuild/Current/Bin'
 outputFolder='./_output'
 outputFolderMono='./_output_mono'
 outputFolderOsx='./_output_osx'

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -70,6 +70,12 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("2 Broke Girls - S01E01 - Pilot.sub", Language.Unknown)]
         [TestCase("2 Broke Girls - S01E01 - Pilot.eng.forced.sub", Language.English)]
         [TestCase("2 Broke Girls - S01E01 - Pilot-eng-forced.sub", Language.English)]
+
+        [TestCase("2_Eng.srt", Language.English)]
+        [TestCase("3_English.srt", Language.English)]
+        [TestCase("Title.2010.1080p.srt", Language.Unknown)]
+        [TestCase("Title.2000.1080p.BluRay.H264.AAC-RARBG.idx", Language.Unknown)]
+        [TestCase("Title.2000.1080p.BluRay.H264.AAC-RARBG.sub", Language.Unknown)]
         public void should_parse_subtitle_language(string fileName, Language language)
         {
             var result = LanguageParser.ParseSubtitleLanguage(fileName);

--- a/src/NzbDrone.Core/Extras/ExtraService.cs
+++ b/src/NzbDrone.Core/Extras/ExtraService.cs
@@ -66,15 +66,13 @@ namespace NzbDrone.Core.Extras
             var sourcePath = localMovie.Path;
             var sourceFolder = _diskProvider.GetParentFolder(sourcePath);
             var sourceFileName = Path.GetFileNameWithoutExtension(sourcePath);
-            var files = _diskProvider.GetFiles(sourceFolder, SearchOption.TopDirectoryOnly);
+            var files = _diskProvider.GetFiles(sourceFolder, SearchOption.AllDirectories).OrderByDescending(d => d).ToArray();
 
             var wantedExtensions = _configService.ExtraFileExtensions.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                                                                      .Select(e => e.Trim(' ', '.'))
                                                                      .ToList();
 
-            var matchingFilenames = files.Where(f => Path.GetFileNameWithoutExtension(f).StartsWith(sourceFileName, StringComparison.InvariantCultureIgnoreCase));
-
-            foreach (var matchingFilename in matchingFilenames)
+            foreach (var matchingFilename in files)
             {
                 var matchingExtension = wantedExtensions.FirstOrDefault(e => matchingFilename.EndsWith(e));
 

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -88,11 +88,16 @@ namespace NzbDrone.Core.Extras.Subtitles
             if (SubtitleFileExtensions.Extensions.Contains(Path.GetExtension(path)))
             {
                 var language = LanguageParser.ParseSubtitleLanguage(path);
-                var suffix = GetSuffix(language, 1, false);
+                var subtitleFiles = _subtitleFileService.GetFilesByMovie(movie.Id);
+                var existingSrtSubs = subtitleFiles.Where(m => m.MovieFileId == movieFile.Id)
+                    .Where(m => m.Language == language)
+                    .Where(m => m.Extension == extension);
+
+                var suffix = GetSuffix(language, existingSrtSubs.Count() + 1, extension.EqualsIgnoreCase(".srt"));                
                 var subtitleFile = ImportFile(movie, movieFile, path, readOnly, extension, suffix);
                 subtitleFile.Language = language;
 
-                _subtitleFileService.Upsert(subtitleFile);
+                _subtitleFileService.Upsert(subtitleFile);                                            
 
                 return subtitleFile;
             }

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -16,6 +16,7 @@ using NzbDrone.Core.MetadataSource.RadarrAPI;
 using NzbDrone.Core.Movies.AlternativeTitles;
 using NzbDrone.Core.Movies.Commands;
 using NzbDrone.Core.Movies.Events;
+using NzbDrone.Core.IndexerSearch;
 
 namespace NzbDrone.Core.Movies
 {
@@ -177,6 +178,9 @@ namespace NzbDrone.Core.Movies
                         try
                         {
                             RefreshMovieInfo(movie);
+
+                            // Initiate indexer search if update library is manually triggered
+                            _commandQueueManager.Push(new MoviesSearchCommand { MovieIds = new List<int> { movie.Id } });
                         }
                         catch (Exception e)
                         {

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -290,7 +290,7 @@ namespace NzbDrone.Core.Organizer
             var colonReplacementFormat = colonReplacement.GetFormatString();
 
             string result = name;
-            string[] badCharacters = { "\\", "/", "<", ">", "?", "*", ":", "|", "\"" };
+            string[] badCharacters = { "/", "<", ">", "?", "*", ":", "|", "\"" };
             string[] goodCharacters = { "+", "+", "", "", "!", "-", colonReplacementFormat, "", "" };
 
             for (int i = 0; i < badCharacters.Length; i++)

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -15,9 +15,8 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VOSTFR|VO|VFF|VFQ|VF2|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<dutch>nl\W?subs?)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<czech>\b(?:CZ|SK)\b)|(?<ukrainian>\bukr\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
         private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
+        private static readonly Regex RarbgSubtitleLanguageRegex = new Regex("^[0-9]{1,2}_(?<iso_code>[A-Za-z]{2,3}).*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         public static List<Language> ParseLanguages(string title)
         {
             var lowerTitle = title.ToLower();
@@ -153,13 +152,19 @@ namespace NzbDrone.Core.Parser
 
                 var simpleFilename = Path.GetFileNameWithoutExtension(fileName);
                 var languageMatch = SubtitleLanguageRegex.Match(simpleFilename);
+                
+                if (!languageMatch.Success)
+                {
+                    languageMatch = RarbgSubtitleLanguageRegex.Match(simpleFilename);
+                }
 
                 if (languageMatch.Success)
                 {
                     var isoCode = languageMatch.Groups["iso_code"].Value;
-                    var isoLanguage = IsoLanguages.Find(isoCode);
+                    var isoLanguage = IsoLanguages.Find(isoCode.ToLower());
 
-                    return isoLanguage?.Language ?? Language.Unknown;
+                    Logger.Debug("Parsed language: {0}", isoLanguage?.Language ?? Language.Unknown);
+                    return isoLanguage?.Language ?? Language.Unknown;                    
                 }
 #if !LIBRARY
                 Logger.Debug("Unable to parse langauge from subtitle file: {0}", fileName);

--- a/test.bat
+++ b/test.bat
@@ -1,0 +1,4 @@
+mkdir _tests\reports
+mkdir _tests\reports\junit
+
+sh test.sh Windows Unit


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The fix for #1958 only worked with SRT subs with tagged language which is exclusively being done in RARBG torrents. This fix allows ANY subs to be imported regardless of the language as in the previous releases.

#### Todos
- None

#### Issues Fixed or Closed by this PR
* #3935
* #4207
