### PR TITLE
Bugfix/html encoded magnet urls

### DIFF
--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -238,8 +238,8 @@ namespace NzbDrone.Core.Download
 
         private string ExperimentalUrlDecode(string potentiallyMalformedUrl)
         {
-            // Hack: Decode HTML encoded urls
-            return WebUtility.HtmlDecode(potentiallyMalformedUrl);
+            // Hack: Decode HTML encoded urls, replace ampersand to prevent splitting error
+            return WebUtility.HtmlDecode(potentiallyMalformedUrl).Replace("&", "And");
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Some magnet urls contain HTML encoded sequences that break MonoTorrent's magnet link parsing. Such broke urls contain sequences of character that are encoded by using an HTML character reference (eg: `&#039;` `&lt;`, which breaks the parsing because of the ampersand). Such a sequence can also contain the HTML character `&amp;`, which when decoded yields `&` and also breaks the parsing. Consequently, that character is changed to `And`.

Should we just replace the ampersand with an empty string?
Moroever, I don't think this is quite common, but the character _equals_ (`=`), would also in theory break the parsing, should we add support for it?
Also, I haven't explored Radarr's repo enough to judge where to put this fix (where to put the method). After knowing this information, it would be possible to start testing it.
#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #3256 
* #4202
