### PR TITLE
Clarify Replace Illegal Characters setting

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/Naming.js
+++ b/frontend/src/Settings/MediaManagement/Naming/Naming.js
@@ -133,7 +133,7 @@ class Naming extends Component {
                 <FormInputGroup
                   type={inputTypes.CHECK}
                   name="replaceIllegalCharacters"
-                  helpText="Replace or Remove illegal characters"
+                  helpText="Replace illegal characters. If unchecked, Radarr will simply remove them instead"
                   onChange={onInputChange}
                   {...settings.replaceIllegalCharacters}
                 />

--- a/frontend/src/Settings/MediaManagement/Naming/Naming.js
+++ b/frontend/src/Settings/MediaManagement/Naming/Naming.js
@@ -133,7 +133,7 @@ class Naming extends Component {
                 <FormInputGroup
                   type={inputTypes.CHECK}
                   name="replaceIllegalCharacters"
-                  helpText="Replace illegal characters. If unchecked, Radarr will simply remove them instead"
+                  helpText="Replace illegal characters. If unchecked, Radarr will remove them instead"
                   onChange={onInputChange}
                   {...settings.replaceIllegalCharacters}
                 />


### PR DESCRIPTION
#### Database Migration
NO
#### Description
See https://github.com/Sonarr/Sonarr/pull/3703

Goal is to clarify the help text to indicate that the setting explicitly is for replacing illegal characters, and not enabling it will cause Radarr to remove them instead.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #
