### PR TITLE
Fix queue dupe develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ src/**/[Oo]bj/
 *.user
 *.sln.docstates
 .vs/
+.vscode/
 
 # Build results
 *_i.c
@@ -44,6 +45,10 @@ _dotCover*
 
 # DevExpress CodeRush
 src/.cr/
+
+# Emacs
+*~
+\#*\#
 
 # NCrunch
 *.ncrunch*
@@ -80,7 +85,6 @@ TestResults
 [Tt]est[Rr]esult*
 *.Cache
 ClientBin
-[Ss]tyle[Cc]op.*
 ~$*
 *.dbmdl
 Generated_Code #added for RIA/Silverlight projects
@@ -102,40 +106,44 @@ _NCrunch_*
 _TeamCity*
 
 # Radarr
-Backups/
-logs/
-#MediaCover/
-UpdateLogs/
-xdg/
 config.xml
-logs.db*
-nzbdrone.db*
-nzbdrone.pid
+nzbdrone.log*txt
+UpdateLogs/
 *workspace.xml
 *.test-cache
 *.userprefs
 */test-results/*
 src/UI/.idea/*
+*log.txt
 node_modules/
 _output*
+_artifacts
 _rawPackage/
 _dotTrace*
 _tests/
 *.Result.xml
+coverage*.xml
+coverage*.json
 setup/Output/
 *.~is
-
-UI.Phantom/
 
 # VS outout folders
 bin
 obj
 output/*
 
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+**/Properties/launchSettings.json
+
 # Packages
 Radarr_*/
 Radarr_*.zip
 Radarr_*.gz
+gecko.zip
+geckodriver.exe
 
 # macOS metadata files
 ._*
@@ -163,6 +171,8 @@ packages.config.md5sum
 **/.idea/**/tasks.xml
 **/.idea/shelf/*
 **/.idea/dictionaries
+**/.idea/.idea.Radarr.Posix
+**/.idea/.idea.Radarr.Windows
 
 # Sensitive or high-churn files
 **/.idea/**/dataSources/

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/AugmentersTests/AugmentWithHistoryFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/AugmentersTests/AugmentWithHistoryFixture.cs
@@ -79,9 +79,9 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests.AugmentersTests
         [Test]
         public void should_add_size()
         {
-            var history = HistoryWithData("Size", 1500.ToString());
+            var history = HistoryWithData("Size", 9663676416.ToString());
             var movieInfo = Subject.AugmentMovieInfo(MovieInfo, history);
-            movieInfo.ExtraInfo["Size"].ShouldBeEquivalentTo(1500);
+            movieInfo.ExtraInfo["Size"].ShouldBeEquivalentTo(9663676416);
         }
 
         [Test]

--- a/src/NzbDrone.Core/Parser/Augmenters/AugmentWithHistory.cs
+++ b/src/NzbDrone.Core/Parser/Augmenters/AugmentWithHistory.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.Parser.Augmenters
                     releaseInfo.IndexerId = indexerId;
                 }
 
-                if (int.TryParse(history.Data.GetValueOrDefault("size"), out var size))
+                if (long.TryParse(history.Data.GetValueOrDefault("size"), out var size))
                 {
                     releaseInfo.Size = size;
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Backport a19bcf968 to 0.2: prevent multiple duplicates being grabbed due to size custom formats being incorrectly calculated from history

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes #4262 
