### PR TITLE
New: HealthCheck to warn if running legacy mono version

### DIFF
--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/MonoNotNetCoreCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/MonoNotNetCoreCheckFixture.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using NzbDrone.Common.Processes;
+using NzbDrone.Core.HealthCheck.Checks;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.HealthCheck.Checks
+{
+    [TestFixture]
+    public class MonoNotNetCoreCheckFixture : CoreTest<MonoNotNetCoreCheck>
+    {
+        [Test]
+        [Platform(Exclude = "Mono")]
+        public void should_return_ok_if_net_core()
+        {
+            Subject.Check().ShouldBeOk();
+        }
+
+        [Test]
+        [Platform("Mono")]
+        public void should_log_warning_if_mono()
+        {
+            Subject.Check().ShouldBeWarning();
+        }
+
+        [Test]
+        [Platform("Mono")]
+        public void should_return_ok_if_bsd()
+        {
+            Mocker.GetMock<IProcessProvider>()
+                .Setup(x => x.StartAndCapture("uname", null, null))
+                .Returns(new ProcessOutput
+                    {
+                        Lines = new List<ProcessOutputLine>
+                        {
+                            new ProcessOutputLine(ProcessOutputLevel.Standard, "FreeBSD")
+                        }
+                    });
+            Subject.Check().ShouldBeOk();
+        }
+    }
+}

--- a/src/NzbDrone.Core/HealthCheck/Checks/MonoNotNetCoreCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/MonoNotNetCoreCheck.cs
@@ -1,0 +1,51 @@
+﻿using System.Linq;
+using System.Runtime.InteropServices;
+using NLog;
+using NzbDrone.Common.EnvironmentInfo;
+using NzbDrone.Common.Processes;
+
+namespace NzbDrone.Core.HealthCheck.Checks
+{
+    public class MonoNotNetCoreCheck : HealthCheckBase
+    {
+        private static string[] MonoUnames = new string[] { "FreeBSD", "OpenBSD", "MidnightBSD", "NetBSD" };
+        private readonly IOsInfo _osInfo;
+        private readonly IProcessProvider _processProvider;
+
+        public MonoNotNetCoreCheck(IOsInfo osInfo,
+                                   IProcessProvider processProvider,
+                                   Logger logger)
+        {
+            _osInfo = osInfo;
+            _processProvider = processProvider;
+        }
+
+        public override HealthCheck Check()
+        {
+            if (!PlatformInfo.IsMono)
+            {
+                return new HealthCheck(GetType());
+            }
+
+            // Don't warn on arm based synology - could be arm5 or something else rubbish
+            if (_osInfo.Name == "DSM" && RuntimeInformation.ProcessArchitecture == Architecture.Arm)
+            {
+                return new HealthCheck(GetType());
+            }
+
+            // Check for BSD
+            var output = _processProvider.StartAndCapture("uname");
+            if (output?.ExitCode == 0 && MonoUnames.Contains(output?.Lines.First().Content))
+            {
+                return new HealthCheck(GetType());
+            }
+
+            return new HealthCheck(GetType(),
+                                   HealthCheckResult.Warning,
+                                   "Please upgrade to the .NET Core version of Radarr",
+                                   "#update-to-net-core-version");
+        }
+
+        public override bool CheckOnSchedule => false;
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Nudge people to move to net core if they upgraded a native linux install to the mono aphrodite build.

Disabled on ARM Synology (where I think docker is not supported) and BSD.

#### Todos
- [x] Tests
