### PR TITLE
Fixed: NET Core not deleting source when moving across drives

### DIFF
--- a/src/NzbDrone.Common.Test/DiskTests/DiskProviderFixtureBase.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DiskProviderFixtureBase.cs
@@ -82,23 +82,6 @@ namespace NzbDrone.Common.Test.DiskTests
         }
 
         [Test]
-        [Retry(5)]
-        public void MoveFile_should_not_overwrite_existing_file()
-        {
-            var source1 = GetTempFilePath();
-            var source2 = GetTempFilePath();
-            var destination = GetTempFilePath();
-
-            File.WriteAllText(source1, "SourceFile1");
-            File.WriteAllText(source2, "SourceFile2");
-
-            Subject.MoveFile(source1, destination);
-            Assert.Throws<IOException>(() => Subject.MoveFile(source2, destination, false));
-
-            File.ReadAllText(destination).Should().Be("SourceFile1");
-        }
-
-        [Test]
         public void MoveFile_should_not_move_overwrite_itself()
         {
             var source = GetTempFilePath();

--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -227,18 +227,13 @@ namespace NzbDrone.Common.Disk
                 throw new IOException(string.Format("Source and destination can't be the same {0}", source));
             }
 
-            var destExists = FileExists(destination);
-
-            if (destExists && overwrite)
+            if (FileExists(destination) && overwrite)
             {
                 DeleteFile(destination);
             }
 
             RemoveReadOnly(source);
-
-            // NET Core is too eager to copy/delete if overwrite is false
-            // Therefore we also set overwrite if we know destination doesn't exist
-            MoveFileInternal(source, destination, overwrite || !destExists);
+            MoveFileInternal(source, destination);
         }
 
         public void MoveFolder(string source, string destination, bool overwrite = false)
@@ -260,13 +255,9 @@ namespace NzbDrone.Common.Disk
             Directory.Move(source, destination);
         }
 
-        protected virtual void MoveFileInternal(string source, string destination, bool overwrite)
+        protected virtual void MoveFileInternal(string source, string destination)
         {
-#if NETCOREAPP
-            File.Move(source, destination, overwrite);
-#else
             File.Move(source, destination);
-#endif
         }
 
         public abstract bool TryCreateHardLink(string source, string destination);

--- a/src/NzbDrone.Mono/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Mono/Disk/DiskProvider.cs
@@ -179,7 +179,7 @@ namespace NzbDrone.Mono.Disk
             }
         }
 
-        protected override void MoveFileInternal(string source, string destination, bool overwrite)
+        protected override void MoveFileInternal(string source, string destination)
         {
             var sourceInfo = UnixFileSystemInfo.GetFileSystemEntry(source);
 
@@ -217,11 +217,11 @@ namespace NzbDrone.Mono.Disk
             else if ((PlatformInfo.Platform == PlatformType.Mono && PlatformInfo.GetVersion() >= new Version(6, 0)) ||
                      PlatformInfo.Platform == PlatformType.NetCore)
             {
-                TransferFilePatched(source, destination, overwrite, true);
+                TransferFilePatched(source, destination, false, true);
             }
             else
             {
-                base.MoveFileInternal(source, destination, overwrite);
+                base.MoveFileInternal(source, destination);
             }
         }
 
@@ -233,7 +233,9 @@ namespace NzbDrone.Mono.Disk
             // Catch the exception and attempt to handle these edgecases
 
             // Mono 6.x till 6.10 doesn't properly try use rename first.
-            if (move && PlatformInfo.Platform == PlatformType.Mono && PlatformInfo.GetVersion() < new Version(6, 10))
+            if (move &&
+                ((PlatformInfo.Platform == PlatformType.Mono && PlatformInfo.GetVersion() < new Version(6, 10)) ||
+                 (PlatformInfo.Platform == PlatformType.NetCore)))
             {
                 if (Syscall.lstat(source, out var sourcestat) == 0 &&
                     Syscall.lstat(destination, out var deststat) != 0 &&
@@ -248,11 +250,11 @@ namespace NzbDrone.Mono.Disk
             {
                 if (move)
                 {
-                    base.MoveFileInternal(source, destination, overwrite);
+                    base.MoveFileInternal(source, destination);
                 }
                 else
                 {
-                    base.CopyFileInternal(source, destination, overwrite);
+                    base.CopyFileInternal(source, destination);
                 }
             }
             catch (UnauthorizedAccessException)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This reverts commit 10fc0b071fae9807fa456144b0708d95574d17ff.  Use the
mono fix from 43a35c84477fd194eaa816f1b3e4ade6cb4af42a in NET Core also
