### PR TITLE
Add support for movie file names containing AKA

### DIFF
--- a/src/NzbDrone.Api/Indexers/ReleaseResource.cs
+++ b/src/NzbDrone.Api/Indexers/ReleaseResource.cs
@@ -31,7 +31,7 @@ namespace NzbDrone.Api.Indexers
         public int SeasonNumber { get; set; }
         public List<Language> Languages { get; set; }
         public int Year { get; set; }
-        public string MovieTitle { get; set; }
+        public List<string> MovieTitles { get; set; }
         public int[] EpisodeNumbers { get; set; }
         public int[] AbsoluteEpisodeNumbers { get; set; }
         public bool Approved { get; set; }
@@ -109,7 +109,7 @@ namespace NzbDrone.Api.Indexers
                 Title = releaseInfo.Title,
                 Languages = parsedMovieInfo.Languages,
                 Year = parsedMovieInfo.Year,
-                MovieTitle = parsedMovieInfo.MovieTitle,
+                MovieTitles = parsedMovieInfo.MovieTitles,
                 Approved = model.Approved,
                 TemporarilyRejected = model.TemporarilyRejected,
                 Rejected = model.Rejected,

--- a/src/NzbDrone.Api/Movies/MovieBulkImportModule.cs
+++ b/src/NzbDrone.Api/Movies/MovieBulkImportModule.cs
@@ -115,7 +115,7 @@ namespace NzbDrone.Api.Movies
 
                     m = new Core.Movies.Movie
                     {
-                        Title = parsedTitle.MovieTitle,
+                        Title = parsedTitle.PrimaryMovieTitle,
                         Year = parsedTitle.Year,
                         ImdbId = parsedTitle.ImdbId,
                         Path = f.Path,

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/PrioritizeDownloadDecisionFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/PrioritizeDownloadDecisionFixture.cs
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             var remoteMovie = new RemoteMovie();
             remoteMovie.ParsedMovieInfo = new ParsedMovieInfo();
-            remoteMovie.ParsedMovieInfo.MovieTitle = "A Movie";
+            remoteMovie.ParsedMovieInfo.MovieTitles = new List<string>() { "A Movie" };
             remoteMovie.ParsedMovieInfo.Year = 1998;
             remoteMovie.ParsedMovieInfo.Quality = quality;
 

--- a/src/NzbDrone.Core.Test/Download/DownloadApprovedReportsTests/DownloadApprovedFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadApprovedReportsTests/DownloadApprovedFixture.cs
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
                 {
                     Quality = quality,
                     Year = 1998,
-                    MovieTitle = "A Movie",
+                    MovieTitles = new List<string>() { "A Movie" },
                 },
                 Movie = movie,
 

--- a/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/RemovePendingFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/RemovePendingFixture.cs
@@ -52,7 +52,7 @@ namespace NzbDrone.Core.Test.Download.Pending.PendingReleaseServiceTests
             _pending.Add(new PendingRelease
             {
                 Id = id,
-                ParsedMovieInfo = new ParsedMovieInfo { MovieTitle = title, Year = year },
+                ParsedMovieInfo = new ParsedMovieInfo { MovieTitles = new List<string>() { title }, Year = year },
                 MovieId = _movie.Id
             });
         }

--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -47,13 +47,13 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
 
                 ParsedMovieInfo = new ParsedMovieInfo()
                 {
-                    MovieTitle = "A Movie",
+                    MovieTitles = new List<string>() { "A Movie" },
                     Year = 1998
                 }
             };
 
             Mocker.GetMock<IParsingService>()
-                  .Setup(s => s.Map(It.Is<ParsedMovieInfo>(i => i.MovieTitle == "A Movie"), It.IsAny<string>(), null))
+                  .Setup(s => s.Map(It.Is<ParsedMovieInfo>(i => i.PrimaryMovieTitle == "A Movie"), It.IsAny<string>(), null))
                   .Returns(new MappingResult { RemoteMovie = remoteEpisode });
 
             ParseMovieTitle();

--- a/src/NzbDrone.Core.Test/MediaFiles/MovieImport/ImportDecisionMakerFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MovieImport/ImportDecisionMakerFixture.cs
@@ -73,7 +73,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieImport
 
             _fileInfo = new ParsedMovieInfo
             {
-                MovieTitle = "The Office",
+                MovieTitles = new List<string>() { "The Office" },
                 Year = 2018,
                 Quality = _quality
             };

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -57,63 +57,91 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("www.Torrenting.org - Revenge.2008.720p.X264-DIMENSION", "Revenge")]
         public void should_parse_movie_title(string postTitle, string title)
         {
-            Parser.Parser.ParseMovieTitle(postTitle, true).MovieTitle.Should().Be(title);
+            Parser.Parser.ParseMovieTitle(postTitle, true).PrimaryMovieTitle.Should().Be(title);
         }
 
         [TestCase(
             "L'hypothèse.du.tableau.volé.AKA.The.Hypothesis.of.the.Stolen.Painting.1978.1080p.CINET.WEB-DL.AAC2.0.x264-Cinefeel.mkv",
-            "L'hypothèse du tableau volé AKA The Hypothesis of the Stolen Painting",
-            new string[] { "L'hypothèse du tableau volé", "The Hypothesis of the Stolen Painting" })]
+            new string[]
+            {
+                "L'hypothèse du tableau volé AKA The Hypothesis of the Stolen Painting",
+                "L'hypothèse du tableau volé",
+                "The Hypothesis of the Stolen Painting"
+            })]
         [TestCase(
             "Akahige.AKA.Red.Beard.1965.CD1.CRiTERiON.DVDRip.XviD-KG.avi",
-            "Akahige AKA Red Beard",
-            new string[] { "Akahige", "Red Beard" })]
+            new string[]
+            {
+                "Akahige AKA Red Beard",
+                "Akahige",
+                "Red Beard"
+            })]
         [TestCase(
             "Akasen.chitai.AKA.Street.of.Shame.1956.1080p.BluRay.x264.FLAC.1.0.mkv",
-            "Akasen chitai AKA Street of Shame",
-            new string[] { "Akasen chitai", "Street of Shame" })]
+            new string[]
+            {
+                "Akasen chitai AKA Street of Shame",
+                "Akasen chitai",
+                "Street of Shame"
+            })]
         [TestCase(
             "Time.Under.Fire.(aka.Beneath.the.Bermuda.Triangle).1997.DVDRip.x264.CG-Grzechsin.mkv",
-            "Time Under Fire (aka Beneath the Bermuda Triangle)",
-            new string[] { "Time Under Fire", "Beneath the Bermuda Triangle" })]
+            new string[]
+            {
+                "Time Under Fire (aka Beneath the Bermuda Triangle)",
+                "Time Under Fire",
+                "Beneath the Bermuda Triangle"
+            })]
         [TestCase(
             "Nochnoy.prodavet. AKA.Graveyard.Shift.2005.DVDRip.x264-HANDJOB.mkv",
-            "Nochnoy prodavet  AKA Graveyard Shift",
-            new string[] { "Nochnoy prodavet", "Graveyard Shift" })]
+            new string[]
+            {
+                "Nochnoy prodavet  AKA Graveyard Shift",
+                "Nochnoy prodavet",
+                "Graveyard Shift"
+            })]
         [TestCase(
             "AKA.2002.DVDRip.x264-HANDJOB.mkv",
-            "AKA",
-            new string[] { })]
+            new string[]
+            {
+                "AKA"
+            })]
         [TestCase(
             "Unbreakable.2000.BluRay.1080p.DTS.x264.dxva-EuReKA.mkv",
-            "Unbreakable",
-            new string[] { })]
+            new string[]
+            {
+                "Unbreakable"
+            })]
         [TestCase(
             "Aka Ana (2008).avi",
-            "Aka Ana",
-            new string[] { })]
+            new string[]
+            {
+                "Aka Ana"
+            })]
         [TestCase(
             "Return to Return to Nuke 'em High aka Volume 2 (2018) 1080p.mp4",
-            "Return to Return to Nuke 'em High aka Volume 2",
-            new string[] { "Return to Return to Nuke 'em High", "Volume 2" })]
-        public void should_parse_movie_alternative_titles(string postTitle, string standardTitle, string[] alternativeTitles)
+            new string[]
+            {
+                "Return to Return to Nuke 'em High aka Volume 2",
+                "Return to Return to Nuke 'em High",
+                "Volume 2"
+            })]
+        public void should_parse_movie_alternative_titles(string postTitle, string[] parsedTitles)
         {
             var movieInfo = Parser.Parser.ParseMovieTitle(postTitle, true);
 
-            movieInfo.MovieTitle.Should().Be(standardTitle);
+            movieInfo.MovieTitles.Count.Should().Be(parsedTitles.Length);
 
-            movieInfo.AlternativeMovieTitles.Count.Should().Be(alternativeTitles.Length);
-
-            for (var i = 0; i < movieInfo.AlternativeMovieTitles.Count; i += 1)
+            for (var i = 0; i < movieInfo.MovieTitles.Count; i += 1)
             {
-                movieInfo.AlternativeMovieTitles[i].Should().Be(alternativeTitles[i]);
+                movieInfo.MovieTitles[i].Should().Be(parsedTitles[i]);
             }
         }
 
         [TestCase("(1995) Ghost in the Shell", "Ghost in the Shell")]
         public void should_parse_movie_folder_name(string postTitle, string title)
         {
-            Parser.Parser.ParseMovieTitle(postTitle, true, true).MovieTitle.Should().Be(title);
+            Parser.Parser.ParseMovieTitle(postTitle, true, true).PrimaryMovieTitle.Should().Be(title);
         }
 
         [TestCase("1941.1979.EXTENDED.720p.BluRay.X264-AMIABLE", 1979)]

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -60,6 +60,56 @@ namespace NzbDrone.Core.Test.ParserTests
             Parser.Parser.ParseMovieTitle(postTitle, true).MovieTitle.Should().Be(title);
         }
 
+        [TestCase(
+            "L'hypothèse.du.tableau.volé.AKA.The.Hypothesis.of.the.Stolen.Painting.1978.1080p.CINET.WEB-DL.AAC2.0.x264-Cinefeel.mkv",
+            "L'hypothèse du tableau volé AKA The Hypothesis of the Stolen Painting",
+            new string[] { "L'hypothèse du tableau volé", "The Hypothesis of the Stolen Painting" })]
+        [TestCase(
+            "Akahige.AKA.Red.Beard.1965.CD1.CRiTERiON.DVDRip.XviD-KG.avi",
+            "Akahige AKA Red Beard",
+            new string[] { "Akahige", "Red Beard" })]
+        [TestCase(
+            "Akasen.chitai.AKA.Street.of.Shame.1956.1080p.BluRay.x264.FLAC.1.0.mkv",
+            "Akasen chitai AKA Street of Shame",
+            new string[] { "Akasen chitai", "Street of Shame" })]
+        [TestCase(
+            "Time.Under.Fire.(aka.Beneath.the.Bermuda.Triangle).1997.DVDRip.x264.CG-Grzechsin.mkv",
+            "Time Under Fire (aka Beneath the Bermuda Triangle)",
+            new string[] { "Time Under Fire", "Beneath the Bermuda Triangle" })]
+        [TestCase(
+            "Nochnoy.prodavet. AKA.Graveyard.Shift.2005.DVDRip.x264-HANDJOB.mkv",
+            "Nochnoy prodavet  AKA Graveyard Shift",
+            new string[] { "Nochnoy prodavet", "Graveyard Shift" })]
+        [TestCase(
+            "AKA.2002.DVDRip.x264-HANDJOB.mkv",
+            "AKA",
+            new string[] { })]
+        [TestCase(
+            "Unbreakable.2000.BluRay.1080p.DTS.x264.dxva-EuReKA.mkv",
+            "Unbreakable",
+            new string[] { })]
+        [TestCase(
+            "Aka Ana (2008).avi",
+            "Aka Ana",
+            new string[] { })]
+        [TestCase(
+            "Return to Return to Nuke 'em High aka Volume 2 (2018) 1080p.mp4",
+            "Return to Return to Nuke 'em High aka Volume 2",
+            new string[] { "Return to Return to Nuke 'em High", "Volume 2" })]
+        public void should_parse_movie_alternative_titles(string postTitle, string standardTitle, string[] alternativeTitles)
+        {
+            var movieInfo = Parser.Parser.ParseMovieTitle(postTitle, true);
+
+            movieInfo.MovieTitle.Should().Be(standardTitle);
+
+            movieInfo.AlternativeMovieTitles.Count.Should().Be(alternativeTitles.Length);
+
+            for (var i = 0; i < movieInfo.AlternativeMovieTitles.Count; i += 1)
+            {
+                movieInfo.AlternativeMovieTitles[i].Should().Be(alternativeTitles[i]);
+            }
+        }
+
         [TestCase("(1995) Ghost in the Shell", "Ghost in the Shell")]
         public void should_parse_movie_folder_name(string postTitle, string title)
         {

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/AugmentersTests/AugmentMovieInfoFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/AugmentersTests/AugmentMovieInfoFixture.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+using System.Collections.Generic;
+using NUnit.Framework;
 using NzbDrone.Core.Parser.Augmenters;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;
@@ -17,7 +18,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests.AugmentersTests
         {
             MovieInfo = new ParsedMovieInfo
             {
-                MovieTitle = "A Movie",
+                MovieTitles = new List<string>() { "A Movie" },
                 Year = 1998,
                 SimpleReleaseTitle = "A Movie Title 1998 Bluray 1080p",
                 Quality = new QualityModel(Quality.Bluray1080p)

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetMovieFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetMovieFixture.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             Subject.GetMovie(title);
 
             Mocker.GetMock<IMovieService>()
-                  .Verify(s => s.FindByTitle(Parser.Parser.ParseMovieTitle(title, false, false).MovieTitle), Times.Once());
+                  .Verify(s => s.FindByTitle(Parser.Parser.ParseMovieTitle(title, false, false).PrimaryMovieTitle), Times.Once());
         }
 
         /*[Test]

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
@@ -38,43 +38,43 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
 
             _parsedMovieInfo = new ParsedMovieInfo
             {
-                MovieTitle = _movie.Title,
+                MovieTitles = new List<string>() { _movie.Title },
                 Year = _movie.Year,
             };
 
             _wrongYearInfo = new ParsedMovieInfo
             {
-                MovieTitle = _movie.Title,
+                MovieTitles = new List<string>() { _movie.Title },
                 Year = 1900,
             };
 
             _wrongTitleInfo = new ParsedMovieInfo
             {
-                MovieTitle = "Other Title",
+                MovieTitles = new List<string>() { "Other Title" },
                 Year = 2015
             };
 
             _alternativeTitleInfo = new ParsedMovieInfo
             {
-                MovieTitle = _movie.AlternativeTitles.First().Title,
+                MovieTitles = new List<string>() { _movie.AlternativeTitles.First().Title },
                 Year = _movie.Year,
             };
 
             _romanTitleInfo = new ParsedMovieInfo
             {
-                MovieTitle = "Fack Ju Göthe II",
+                MovieTitles = new List<string>() { "Fack Ju Göthe II" },
                 Year = _movie.Year,
             };
 
             _umlautInfo = new ParsedMovieInfo
             {
-                MovieTitle = "Fack Ju Goethe 2",
+                MovieTitles = new List<string>() { "Fack Ju Goethe 2" },
                 Year = _movie.Year
             };
 
             _umlautAltInfo = new ParsedMovieInfo
             {
-                MovieTitle = "Fack Ju Goethe 2: Same same",
+                MovieTitles = new List<string>() { "Fack Ju Goethe 2: Same same" },
                 Year = _movie.Year
             };
 

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -61,7 +61,7 @@ namespace NzbDrone.Core.CustomFormats
         {
             var info = new ParsedMovieInfo
             {
-                MovieTitle = movieFile.Movie.Title,
+                MovieTitles = new List<string>() { movieFile.Movie.Title },
                 SimpleReleaseTitle = movieFile.GetSceneOrFileName().SimplifyReleaseTitle(),
                 Quality = movieFile.Quality,
                 Languages = movieFile.Languages,
@@ -96,7 +96,7 @@ namespace NzbDrone.Core.CustomFormats
 
             var info = new ParsedMovieInfo
             {
-                MovieTitle = blacklist.Movie.Title,
+                MovieTitles = new List<string>() { blacklist.Movie.Title },
                 SimpleReleaseTitle = parsed?.SimpleReleaseTitle ?? blacklist.SourceTitle.SimplifyReleaseTitle(),
                 Quality = blacklist.Quality,
                 Languages = blacklist.Languages,
@@ -124,7 +124,7 @@ namespace NzbDrone.Core.CustomFormats
 
             var info = new ParsedMovieInfo
             {
-                MovieTitle = movie.Title,
+                MovieTitles = new List<string>() { movie.Title },
                 SimpleReleaseTitle = parsed?.SimpleReleaseTitle ?? history.SourceTitle.SimplifyReleaseTitle(),
                 Quality = history.Quality,
                 Languages = history.Languages,

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -77,12 +77,12 @@ namespace NzbDrone.Core.DecisionEngine
 
                     MappingResult result = null;
 
-                    if (parsedMovieInfo == null || parsedMovieInfo.MovieTitle.IsNullOrWhiteSpace())
+                    if (parsedMovieInfo == null || parsedMovieInfo.PrimaryMovieTitle.IsNullOrWhiteSpace())
                     {
                         _logger.Debug("{0} could not be parsed :(.", report.Title);
                         parsedMovieInfo = new ParsedMovieInfo
                         {
-                            MovieTitle = report.Title,
+                            MovieTitles = new List<string>() { report.Title },
                             SimpleReleaseTitle = report.Title.SimplifyReleaseTitle(),
                             Year = 1290,
                             Languages = new List<Language> { Language.Unknown },

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
@@ -227,7 +227,7 @@ namespace NzbDrone.Core.Download.Pending
             var targetItem = FindPendingRelease(queueId);
             var movieReleases = _repository.AllByMovieId(targetItem.MovieId);
 
-            var releasesToRemove = movieReleases.Where(c => c.ParsedMovieInfo.MovieTitle == targetItem.ParsedMovieInfo.MovieTitle);
+            var releasesToRemove = movieReleases.Where(c => c.ParsedMovieInfo.PrimaryMovieTitle == targetItem.ParsedMovieInfo.PrimaryMovieTitle);
 
             _repository.DeleteMany(releasesToRemove.Select(c => c.Id));
         }

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
@@ -143,7 +143,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
 
             if (movie == null)
             {
-                _parsingService.GetMovie(relativeFile.Split('\\', '/')[0]);
+                movie = _parsingService.GetMovie(relativeFile.Split('\\', '/')[0]);
             }
 
             if (movie == null)
@@ -164,12 +164,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
 
             if (movie == null)
             {
-                var relativeParseInfo = Parser.Parser.ParseMoviePath(relativeFile, false);
-
-                if (relativeParseInfo != null)
-                {
-                    movie = _movieService.FindByTitle(relativeParseInfo.MovieTitle);
-                }
+                movie = _parsingService.GetMovieFromPath(relativeFile);
             }
 
             if (movie == null)

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -305,10 +305,10 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
                 var yearTerm = "";
 
-                if (parserResult != null && parserResult.MovieTitle != title)
+                if (parserResult != null && parserResult.PrimaryMovieTitle != title)
                 {
                     //Parser found something interesting!
-                    lowerTitle = parserResult.MovieTitle.ToLower().Replace(".", " "); //TODO Update so not every period gets replaced (e.g. R.I.P.D.)
+                    lowerTitle = parserResult.PrimaryMovieTitle.ToLower().Replace(".", " "); //TODO Update so not every period gets replaced (e.g. R.I.P.D.)
                     if (parserResult.Year > 1800)
                     {
                         yearTerm = parserResult.Year.ToString();

--- a/src/NzbDrone.Core/NetImport/RSSImport/RSSImportParser.cs
+++ b/src/NzbDrone.Core/NetImport/RSSImport/RSSImportParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -146,7 +146,7 @@ namespace NzbDrone.Core.NetImport.RSSImport
 
             if (result != null)
             {
-                releaseInfo.Title = result.MovieTitle;
+                releaseInfo.Title = result.PrimaryMovieTitle;
                 releaseInfo.Year = result.Year;
                 releaseInfo.ImdbId = result.ImdbId;
             }

--- a/src/NzbDrone.Core/Parser/Augmenters/AugmentWithReleaseInfo.cs
+++ b/src/NzbDrone.Core/Parser/Augmenters/AugmentWithReleaseInfo.cs
@@ -36,10 +36,11 @@ namespace NzbDrone.Core.Parser.Augmenters
                 catch (Exception)
                 {
                     //_logger.Debug("Indexer with id {0} does not exist, skipping minimum seeder checks.", subject.Release.IndexerId);
-                }                // First, let's augment the language!
+                }
 
+                // First, let's augment the language!
                 var languageTitle = movieInfo.SimpleReleaseTitle;
-                if (movieInfo.MovieTitle.IsNotNullOrWhiteSpace())
+                if (movieInfo.PrimaryMovieTitle.IsNotNullOrWhiteSpace())
                 {
                     if (languageTitle.ToLower().Contains("multi") && indexerSettings?.MultiLanguages?.Any() == true)
                     {

--- a/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
@@ -1,14 +1,14 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using NzbDrone.Core.Languages;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Qualities;
 
 namespace NzbDrone.Core.Parser.Model
 {
     public class ParsedMovieInfo
     {
-        public string MovieTitle { get; set; }
-        public List<string> AlternativeMovieTitles { get; set; }
+        public List<string> MovieTitles { get; set; } = new List<string>();
         public string SimpleReleaseTitle { get; set; }
         public QualityModel Quality { get; set; }
         public List<Language> Languages { get; set; } = new List<Language>();
@@ -20,9 +20,22 @@ namespace NzbDrone.Core.Parser.Model
         [JsonIgnore]
         public Dictionary<string, object> ExtraInfo { get; set; } = new Dictionary<string, object>();
 
+        public string PrimaryMovieTitle
+        {
+            get
+            {
+                if (MovieTitles.Count > 0)
+                {
+                    return MovieTitles[0];
+                }
+
+                return null;
+            }
+        }
+
         public override string ToString()
         {
-            return string.Format("{0} - {1} {2}", MovieTitle, Year, Quality);
+            return string.Format("{0} - {1} {2}", PrimaryMovieTitle, Year, Quality);
         }
 
 #if LIBRARY

--- a/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.Parser.Model
     public class ParsedMovieInfo
     {
         public string MovieTitle { get; set; }
+        public List<string> AlternativeMovieTitles { get; set; }
         public string SimpleReleaseTitle { get; set; }
         public QualityModel Quality { get; set; }
         public List<Language> Languages { get; set; } = new List<Language>();

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -247,9 +247,9 @@ namespace NzbDrone.Core.Parser
                                 //TODO: Add tests for this!
                                 var simpleReleaseTitle = SimpleReleaseTitleRegex.Replace(title, string.Empty);
 
-                                if (result.MovieTitle.IsNotNullOrWhiteSpace())
+                                if (result.PrimaryMovieTitle.IsNotNullOrWhiteSpace())
                                 {
-                                    simpleReleaseTitle = simpleReleaseTitle.Replace(result.MovieTitle, result.MovieTitle.Contains(".") ? "A.Movie" : "A Movie");
+                                    simpleReleaseTitle = simpleReleaseTitle.Replace(result.PrimaryMovieTitle, result.PrimaryMovieTitle.Contains(".") ? "A.Movie" : "A Movie");
                                 }
 
                                 result.Languages = LanguageParser.EnhanceLanguages(simpleReleaseTitle, LanguageParser.ParseLanguages(releaseTitle));
@@ -531,18 +531,19 @@ namespace NzbDrone.Core.Parser
                 result.Edition = matchCollection[0].Groups["edition"].Value.Replace(".", " ");
             }
 
-            result.MovieTitle = movieName;
+            var movieTitles = new List<string>();
+            movieTitles.Add(movieName);
 
-            if (movieName.IsNotNullOrWhiteSpace())
-            {
-                //Delete parentheses of the form (aka ...).
-                var unbracketedName = BracketedAlternativeTitleRegex.Replace(movieName, "$1 AKA $2");
+            //Delete parentheses of the form (aka ...).
+            var unbracketedName = BracketedAlternativeTitleRegex.Replace(movieName, "$1 AKA $2");
 
-                //Split by AKA and filter out empty and duplicate names.
-                result.AlternativeMovieTitles = new List<string>(AlternativeTitleRegex
-                    .Split(unbracketedName)
-                    .Where(alternativeName => alternativeName.IsNotNullOrWhiteSpace() && alternativeName != movieName));
-            }
+            //Split by AKA and filter out empty and duplicate names.
+            movieTitles
+                .AddRange(AlternativeTitleRegex
+                        .Split(unbracketedName)
+                        .Where(alternativeName => alternativeName.IsNotNullOrWhiteSpace() && alternativeName != movieName));
+
+            result.MovieTitles = movieTitles;
 
             Logger.Debug("Movie Parsed. {0}", result);
 

--- a/src/NzbDrone.Core/Parser/SceneChecker.cs
+++ b/src/NzbDrone.Core/Parser/SceneChecker.cs
@@ -1,4 +1,4 @@
-﻿namespace NzbDrone.Core.Parser
+namespace NzbDrone.Core.Parser
 {
     public static class SceneChecker
     {
@@ -21,7 +21,7 @@
             if (parsedTitle == null ||
                 parsedTitle.ReleaseGroup == null ||
                 parsedTitle.Quality.Quality == Qualities.Quality.Unknown ||
-                string.IsNullOrWhiteSpace(parsedTitle.MovieTitle))
+                string.IsNullOrWhiteSpace(parsedTitle.PrimaryMovieTitle))
             {
                 return false;
             }

--- a/src/NzbDrone.Integration.Test/ApiTests/ReleaseFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/ReleaseFixture.cs
@@ -47,7 +47,7 @@ namespace NzbDrone.Integration.Test.ApiTests
             releaseResource.Age.Should().BeGreaterOrEqualTo(-1);
             releaseResource.Title.Should().NotBeNullOrWhiteSpace();
             releaseResource.DownloadUrl.Should().NotBeNullOrWhiteSpace();
-            releaseResource.MovieTitle.Should().NotBeNullOrWhiteSpace();
+            releaseResource.MovieTitles.Should().NotBeEmpty();
 
             //TODO: uncomment these after moving to restsharp for rss
             //releaseResource.NzbInfoUrl.Should().NotBeNullOrWhiteSpace();

--- a/src/Radarr.Api.V3/Indexers/ReleaseResource.cs
+++ b/src/Radarr.Api.V3/Indexers/ReleaseResource.cs
@@ -30,7 +30,7 @@ namespace Radarr.Api.V3.Indexers
         public string ReleaseHash { get; set; }
         public string Title { get; set; }
         public bool SceneSource { get; set; }
-        public string MovieTitle { get; set; }
+        public List<string> MovieTitles { get; set; }
         public List<Language> Languages { get; set; }
         public bool Approved { get; set; }
         public bool TemporarilyRejected { get; set; }
@@ -84,7 +84,7 @@ namespace Radarr.Api.V3.Indexers
                 ReleaseGroup = parsedMovieInfo.ReleaseGroup,
                 ReleaseHash = parsedMovieInfo.ReleaseHash,
                 Title = releaseInfo.Title,
-                MovieTitle = parsedMovieInfo.MovieTitle,
+                MovieTitles = parsedMovieInfo.MovieTitles,
                 Languages = parsedMovieInfo.Languages,
                 Approved = model.Approved,
                 TemporarilyRejected = model.TemporarilyRejected,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
First pass at addressing #3748. Have hooked everything up and it seems to be working well when testing on my server.

This PR adds an `AlternativeMovieTitles` to `ParsedMovieInfo` which contains alternative titles specified by the occurrence of `AKA`. An example of this is `Akahige.AKA.Red.Beard.1965.CD1.CRiTERiON.DVDRip.XviD-KG.avi`, which parses to alternative titles `Akahige` and `Red Beard`, and movie title `Akahige AKA Red Beard`.

I've added a bunch of test cases from files I've found on PTP, hopefully there's a good enough variety there.

My biggest question is whether it's the best idea to turn `MovieTitle` into a collection rather than adding an additional property? I'm worried that by having an additional property to check we'll end up adding complexity that could be avoiding by just making everything search the whole collection of names.

#### Todos
- [X] Parser support and relevant test fixtures
- [x] Hooking this up to the wider codebase
- [ ] Ensure the frontend works correctly and add further tests

#### Issues Fixed or Closed by this PR
* #3748
