### PR TITLE
remove initial dot in filename

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/CleanFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/CleanFixture.cs
@@ -10,7 +10,21 @@ namespace NzbDrone.Core.Test.OrganizerTests
     {
         [TestCase("Mission: Impossible - no [HDTV-720p]",
             "Mission Impossible - no [HDTV-720p]")]
-        public void CleanFileName(string name, string expectedName)
+        public void CleanInvalidCharacters(string name, string expectedName)
+        {
+            FileNameBuilder.CleanFileName(name).Should().Be(expectedName);
+        }
+
+        [TestCase(".45 (2006)",
+            "45 (2006)")]
+        public void CleanStartingDots(string name, string expectedName)
+        {
+            FileNameBuilder.CleanFileName(name).Should().Be(expectedName);
+        }
+
+        [TestCase(" The Movie Title ",
+            "The Movie Title")]
+        public void CleanSpaces(string name, string expectedName)
         {
             FileNameBuilder.CleanFileName(name).Should().Be(expectedName);
         }

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -214,7 +214,7 @@ namespace NzbDrone.Core.Organizer
                 result = result.Replace(badCharacters[i], replace ? goodCharacters[i] : string.Empty);
             }
 
-            return result.Trim();
+            return result.TrimStart(' ', '.').TrimEnd(' ');
         }
 
         public static string CleanFolderName(string name)


### PR DESCRIPTION
#### Database Migration
YES

#### Description
This is to remove initial dot in filenames. Hence, unix-like system won't see the files as hidden.

#### Issues Fixed or Closed by this PR

* Fixes #4350 
