### PR TITLE
remove initial dot in filename

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/CleanFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/CleanFixture.cs
@@ -10,6 +10,8 @@ namespace NzbDrone.Core.Test.OrganizerTests
     {
         [TestCase("Mission: Impossible - no [HDTV-720p]",
             "Mission Impossible - no [HDTV-720p]")]
+        [TestCase(".45 (2006)", "45 (2006)")]
+        [TestCase(" The Movie Title ", "The Movie Title")]
         public void CleanFileName(string name, string expectedName)
         {
             FileNameBuilder.CleanFileName(name).Should().Be(expectedName);

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -231,7 +231,7 @@ namespace NzbDrone.Core.Organizer
                 result = result.Replace(badCharacters[i], replace ? goodCharacters[i] : string.Empty);
             }
 
-            return result.Trim();
+            return result.TrimStart(' ', '.').TrimEnd(' ');
         }
 
         public static string CleanFolderName(string name)


### PR DESCRIPTION
Database Migration
NO

Description
This is to remove initial dot in filenames. Hence, unix-like system won't see the files as hidden.

Issues Fixed or Closed by this PR
Fixes #4350