### PR TITLE
Fix file scan ignoring DVD image files (iso, img, m2ts)

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MovieImport/DetectSampleFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MovieImport/DetectSampleFixture.cs
@@ -62,6 +62,36 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieImport
         }
 
         [Test]
+        public void should_return_false_for_iso()
+        {
+            _localMovie.Path = @"C:\Test\some movie (2000).iso";
+
+            ShouldBeNotSample();
+
+            Mocker.GetMock<IVideoFileInfoReader>().Verify(c => c.GetRunTime(It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
+        public void should_return_false_for_img()
+        {
+            _localMovie.Path = @"C:\Test\some movie (2000).img";
+
+            ShouldBeNotSample();
+
+            Mocker.GetMock<IVideoFileInfoReader>().Verify(c => c.GetRunTime(It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
+        public void should_return_false_for_m2ts()
+        {
+            _localMovie.Path = @"C:\Test\some movie (2000).m2ts";
+
+            ShouldBeNotSample();
+
+            Mocker.GetMock<IVideoFileInfoReader>().Verify(c => c.GetRunTime(It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
         public void should_use_runtime()
         {
             GivenRuntime(120);

--- a/src/NzbDrone.Core/MediaFiles/MediaFileExtensions.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileExtensions.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.MediaFiles
 
         static MediaFileExtensions()
         {
-            _fileExtensions = new Dictionary<string, Quality>
+            _fileExtensions = new Dictionary<string, Quality>(StringComparer.OrdinalIgnoreCase)
             {
                 //Unknown
                 { ".webm", Quality.Unknown },
@@ -75,9 +75,9 @@ namespace NzbDrone.Core.MediaFiles
 
         public static Quality GetQualityForExtension(string extension)
         {
-            if (_fileExtensions.ContainsKey(extension))
+            if (_fileExtensions.TryGetValue(extension, out var quality))
             {
-                return _fileExtensions[extension];
+                return quality;
             }
 
             return Quality.Unknown;

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/DetectSample.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/DetectSample.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
+using System.Linq;
 using NLog;
 using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Qualities;
 
 namespace NzbDrone.Core.MediaFiles.MovieImport
 {
@@ -32,16 +34,25 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
 
             var extension = Path.GetExtension(path);
 
-            if (extension != null && extension.Equals(".flv", StringComparison.InvariantCultureIgnoreCase))
+            if (extension != null)
             {
-                _logger.Debug("Skipping sample check for .flv file");
-                return DetectSampleResult.NotSample;
-            }
+                if (extension.Equals(".flv", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    _logger.Debug("Skipping sample check for .flv file");
+                    return DetectSampleResult.NotSample;
+                }
 
-            if (extension != null && extension.Equals(".strm", StringComparison.InvariantCultureIgnoreCase))
-            {
-                _logger.Debug("Skipping sample check for .strm file");
-                return DetectSampleResult.NotSample;
+                if (extension.Equals(".strm", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    _logger.Debug("Skipping sample check for .strm file");
+                    return DetectSampleResult.NotSample;
+                }
+
+                if (new Quality[] { Quality.DVD, Quality.Bluray720p }.Contains(MediaFileExtensions.GetQualityForExtension(extension)))
+                {
+                    _logger.Debug($"Skipping sample check for DVD image file '{path}'");
+                    return DetectSampleResult.NotSample;
+                }
             }
 
             // TODO: Use MediaInfo from the import process, no need to re-process the file again here

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/DetectSample.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/DetectSample.cs
@@ -48,9 +48,9 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
                     return DetectSampleResult.NotSample;
                 }
 
-                if (new Quality[] { Quality.DVD, Quality.Bluray720p }.Contains(MediaFileExtensions.GetQualityForExtension(extension)))
+                if (new string[] { ".iso", ".img", ".m2ts" }.Contains(extension, StringComparer.OrdinalIgnoreCase))
                 {
-                    _logger.Debug($"Skipping sample check for DVD image file '{path}'");
+                    _logger.Debug($"Skipping sample check for DVD/BR image file '{path}'");
                     return DetectSampleResult.NotSample;
                 }
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix file scan ignoring DVD image files (iso, img, vob, m2ts)
Always allow DVD and BR file types without analysis, instead of detecting as 0 runtime.
Bonus bug fix: Add support for video files with non-lowercase extensions.

#### Todos



#### Issues Fixed or Closed by this PR

* #809
