### PR TITLE
Fix #1352 - 'nordic' matches all of the nordic languages

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -124,6 +124,19 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Languages.Should().BeEquivalentTo(Language.Swedish);
         }
 
+        [TestCase("Sune.Best.Man.2019.NORDiC.1080p.BluRay.x264-RAPiDCOWS")]
+        public void should_parse_language_region(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle, true);
+            result.Languages.Should().BeEquivalentTo(new List<NzbDrone.Core.Languages.Language>
+            {
+                Language.Norwegian,
+                Language.Swedish,
+                Language.Danish,
+                Language.Finnish
+            });
+        }
+
         [TestCase("Pulp.Fiction.1994.Norwegian.1080p.XviD-LOL")]
         public void should_parse_language_norwegian(string postTitle)
         {

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -100,6 +100,9 @@ namespace NzbDrone.Core.Parser
             if (lowerTitle.Contains("nordic"))
             {
                 languages.Add(Language.Norwegian);
+                languages.Add(Language.Swedish);
+                languages.Add(Language.Danish);
+                languages.Add(Language.Finnish);
             }
 
             if (lowerTitle.Contains("finnish"))


### PR DESCRIPTION
#### Database Migration
NO

#### Description
It seems like the definition of "nordic" is wrong - it should be identified as all the Nordic languages.

#### Todos
- There didn't seem to be any tests for this.. Found a  "// TODO Add tests for this in the title-parser.."

#### Issues Fixed or Closed by this PR

* #1352
* #3466
