### PR TITLE
Add custom format, Surround Sound (N).

### DIFF
--- a/src/Radarr.Api.V3/CustomFormats/CustomFormatModule.cs
+++ b/src/Radarr.Api.V3/CustomFormats/CustomFormatModule.cs
@@ -110,6 +110,12 @@ namespace Radarr.Api.V3.CustomFormats
 
             yield return new ReleaseTitleSpecification
             {
+                Name = "Surround Sound (N)",
+                Value = @"DTS-HDChina"
+            };
+
+            yield return new ReleaseTitleSpecification
+            {
                 Name = "Preferred Words",
                 Value = @"\b(SPARKS|Framestor)\b"
             };


### PR DESCRIPTION
This will remove false postives from the custom format Surround Sound when used with the custom format Surround Sound.

#### Database Migration
NO

#### Description

An extra custom format should be included to remove false positives from the already included custom format Surround Sound.

Demonstration of the false postive on [regex101](https://regex101.com/).

Regular Expression (custom format, Surround Sound):
````
DTS.?(HD|ES|X(?!\D))|TRUEHD|ATMOS|DD(\+|P).?([5-9])|EAC3.?([5-9])
````
Test String:
```
Hidden.2019.BluRay.720p.x264.DTS-HDChina
Hidden.2019.BluRay.720p.x264.DTS-MollyBe

```

Is it possible for custom format presets to define a value for negate/required?

### Todos
- [ ] Tests
- [ ] Define the value for Negate (Should be set to enabled)

#### Issues Fixed or Closed by this PR

* #
