### PR TITLE
Fixed: In some cases MinVotes is int from v0.2, causes migration failure

### DIFF
--- a/src/NzbDrone.Core/Datastore/Converters/StringConverter.cs
+++ b/src/NzbDrone.Core/Datastore/Converters/StringConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+public class StringConverter : JsonConverter<string>
+{
+    public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            var stringValue = reader.GetInt32();
+            return stringValue.ToString();
+        }
+        else if (reader.TokenType == JsonTokenType.String)
+        {
+            return reader.GetString();
+        }
+
+        throw new System.Text.Json.JsonException();
+    }
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value);
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/166_fix_tmdb_list_config.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/166_fix_tmdb_list_config.cs
@@ -25,6 +25,8 @@ namespace NzbDrone.Core.Datastore.Migration
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                 WriteIndented = true
             };
+
+            _serializerSettings.Converters.Add(new StringConverter());
         }
 
         protected override void MainDbUpgrade()


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add int to string converter to migration 166. There are cases where minVotes is stored in the v0.2 db as a int. This causes migration to blow up from v0.2 to v3. Workaround this by converting int values to string when string is typed. 

MinVotes was a int until this change <https://github.com/Radarr/Radarr/commit/4d745d360013e6be0cc588664f6ba746a0a404d2> in 2017

Any list created before that would hold an Int value instead of the string value it is today. 
