### PR TITLE
New: Reject Files at Import if they are Multi-Part for now

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Specifications/NotMultiDiscSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Specifications/NotMultiDiscSpecificationFixture.cs
@@ -1,0 +1,52 @@
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles.MovieImport.Specifications;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.MediaFiles.MovieImport.Specifications
+{
+    [TestFixture]
+    public class NotMultiDiscSpecificationFixture : CoreTest<NotMultiDiscSpecification>
+    {
+        private LocalMovie _localMovie;
+
+        [SetUp]
+        public void Setup()
+        {
+            _localMovie = new LocalMovie
+            {
+                Path = @"C:\Test\Downloaded\30.rock.s01e01.avi".AsOsAgnostic()
+            };
+        }
+
+        [TestCase(@"C:\Test\Downloaded\x.men.2018.avi")]
+        [TestCase(@"C:\Test\Downloaded\Bad Boys (2006).mkv")]
+        [TestCase(@"C:\Test\Downloaded\Bad Boys 2006.mkv")]
+        [TestCase(@"C:\Test\Downloaded\300 (2006).mkv")]
+        [TestCase(@"C:\Test\Downloaded\300 2006.mkv")]
+        [TestCase(@"C:\Test\Downloaded\Star Trek 1 - The motion picture.mkv")]
+        [TestCase(@"C:\Test\Downloaded\Red Riding in the Year of Our Lord 1983 (2009).mkv")]
+        public void should_be_accepted_for_legitimate_files(string path)
+        {
+            _localMovie.Path = path.AsOsAgnostic();
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
+        }
+
+        [TestCase(@"C:\Test\Downloaded\Bad Boys (2006) part1.mkv")]
+        [TestCase(@"C:\Test\Downloaded\300 2006 part1.mkv")]
+        [TestCase(@"C:\Test\Downloaded\Bad Boys (2006).part1.stv.unrated.multi.1080p.bluray.x264-rough.mkv")]
+        [TestCase(@"C:\Test\Downloaded\Bad Boys (2006) parta.mkv")]
+        [TestCase(@"C:\Test\Downloaded\blah blah - cd 1.mvk")]
+        [TestCase(@"C:\Test\Downloaded\Millennium.Part.1-Män.Som.Hatar.Kvinnor.2009.Extended.Cut.1080p.BluRay.DTS.x264-CtrlHD.mkv")]
+        public void should_be_rejected_for_multi_part_files(string path)
+        {
+            _localMovie.Path = path.AsOsAgnostic();
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeFalse();
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Specifications/NotMultiDiscSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Specifications/NotMultiDiscSpecification.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+using NLog;
+using NzbDrone.Core.DecisionEngine;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.MediaFiles.MovieImport.Specifications
+{
+    public class NotMultiDiscSpecification : IImportDecisionEngineSpecification
+    {
+        private readonly Logger _logger;
+
+        public NotMultiDiscSpecification(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        private static readonly Regex[] MovieMultiPartRegex = new Regex[]
+        {
+            new Regex(@"(.*?)([ _.-]*(?:cd|dvd|p(?:ar)?t|dis[ck])[ _.-]*[0-9]+)(.*?)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new Regex(@"(.*?)([ _.-]*(?:cd|dvd|p(?:ar)?t|dis[ck])[ _.-]*[a-d])(.*?)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+        };
+
+        public Decision IsSatisfiedBy(LocalMovie localMovie, DownloadClientItem downloadClientItem)
+        {
+            if (MovieMultiPartRegex.Any(v => v.IsMatch(localMovie.Path)))
+            {
+                _logger.Debug("Rejected Multi-Movie File: " + localMovie.Path);
+
+                return Decision.Reject("File is Multi-Disc, Radarr doesn't support");
+            }
+
+            return Decision.Accept();
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Instead of trying to import and only getting part, reject movie if they look like multi-part until we add support

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
Relates to #145
* #
