### PR TITLE
Fixed: SqliteSchemaDumper with separate Primary Key clause

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/SqliteSchemaDumperTests/SqliteSchemaDumperFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/SqliteSchemaDumperTests/SqliteSchemaDumperFixture.cs
@@ -25,6 +25,12 @@ namespace NzbDrone.Core.Test.Datastore.SqliteSchemaDumperTests
         [TestCase(@"CREATE TABLE ""Test """"Table"" (""My""""Id"" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT)", "Test \"Table", "My\"Id")]
         [TestCase(@"CREATE TABLE [Test Table] ([My Id] INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT)", "Test Table", "My Id")]
         [TestCase(@" CREATE  TABLE  `Test ``Table`  ( `My``  Id`  INTEGER  NOT  NULL  PRIMARY  KEY  AUTOINCREMENT ) ", "Test `Table", "My`  Id")]
+        [TestCase(@"CREATE TABLE IF NOT EXISTS ""Test Table"" (
+        ""MyId""    INTEGER NOT NULL,
+        PRIMARY KEY(""MyId"" AUTOINCREMENT)
+);",
+                  "Test Table",
+                  "MyId")]
         public void should_parse_table_language_flavors(string sql, string tableName, string columnName)
         {
             var result = Subject.ReadTableSchema(sql);

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/SqliteSyntaxReader.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/SqliteSyntaxReader.cs
@@ -154,12 +154,12 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
             {
                 var start = Index;
                 var end = start + 1;
-                while (end < Buffer.Length && (char.IsLetter(Buffer[end]) || char.IsNumber(Buffer[end]) || Buffer[end] == '_' || Buffer[end] == '('))
+                while (end < Buffer.Length && (char.IsLetter(Buffer[end]) || char.IsNumber(Buffer[end]) || Buffer[end] == '_'))
                 {
                     end++;
                 }
 
-                if (end >= Buffer.Length || Buffer[end] == ',' || Buffer[end] == ')' || char.IsWhiteSpace(Buffer[end]))
+                if (end >= Buffer.Length || Buffer[end] == ',' || Buffer[end] == ')' || Buffer[end] == '(' || char.IsWhiteSpace(Buffer[end]))
                 {
                     Index = end;
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix sqlite schema dumper for tables like
```
CREATE TABLE IF NOT EXISTS "NamingConfig" (
        "Id"    INTEGER NOT NULL,
        "MultiEpisodeStyle"     INTEGER NOT NULL,
        "RenameEpisodes"        INTEGER,
        "ReplaceIllegalCharacters"      INTEGER NOT NULL,
        "StandardMovieFormat"   TEXT,
        "MovieFolderFormat"     TEXT,
        "ColonReplacementFormat"        INTEGER NOT NULL DEFAULT 0,
        PRIMARY KEY("Id" AUTOINCREMENT)
);
```

The old code wasn't correctly delimiting the end of a string token.

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* #
