### PR TITLE
Parsing improvements

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
@@ -166,10 +166,11 @@ namespace NzbDrone.Core.Test.MediaFiles.DiskScanServiceTests
                            Path.Combine(_movie.Path, "Deleted Scenes", "file2.mkv").AsOsAgnostic(),
                            Path.Combine(_movie.Path, "Featurettes", "file3.mkv").AsOsAgnostic(),
                            Path.Combine(_movie.Path, "Interviews", "file4.mkv").AsOsAgnostic(),
-                           Path.Combine(_movie.Path, "Samples", "file5.mkv").AsOsAgnostic(),
-                           Path.Combine(_movie.Path, "Scenes", "file6.mkv").AsOsAgnostic(),
-                           Path.Combine(_movie.Path, "Shorts", "file7.mkv").AsOsAgnostic(),
-                           Path.Combine(_movie.Path, "Trailers", "file8.mkv").AsOsAgnostic(),
+                           Path.Combine(_movie.Path, "Sample", "file5.mkv").AsOsAgnostic(),
+                           Path.Combine(_movie.Path, "Samples", "file6.mkv").AsOsAgnostic(),
+                           Path.Combine(_movie.Path, "Scenes", "file7.mkv").AsOsAgnostic(),
+                           Path.Combine(_movie.Path, "Shorts", "file8.mkv").AsOsAgnostic(),
+                           Path.Combine(_movie.Path, "Trailers", "file9.mkv").AsOsAgnostic(),
                            Path.Combine(_movie.Path, "The Count of Monte Cristo (2002) (1080p BluRay x265 10bit Tigole).mkv").AsOsAgnostic(),
                        });
 

--- a/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
@@ -383,6 +383,24 @@ namespace NzbDrone.Core.Test.MediaFiles.DiskScanServiceTests
         }
 
         [Test]
+        public void should_exclude_inline_extra_files()
+        {
+            GivenMovieFolder();
+
+            GivenFiles(new List<string>
+                       {
+                           Path.Combine(_movie.Path, "Avatar (2009).mkv").AsOsAgnostic(),
+                           Path.Combine(_movie.Path, "Deleted Scenes-deleted.mkv").AsOsAgnostic(),
+                           Path.Combine(_movie.Path, "The World of Pandora-other.mkv").AsOsAgnostic()
+                       });
+
+            Subject.Scan(_movie);
+
+            Mocker.GetMock<IMakeImportDecision>()
+                  .Verify(v => v.GetImportDecisions(It.Is<List<string>>(l => l.Count == 1), _movie), Times.Once());
+        }
+
+        [Test]
         public void should_exclude_osx_metadata_files()
         {
             GivenMovieFolder();

--- a/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxyFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxyFixture.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Test.MetadataSource.SkyHook
         {
             movie.Should().NotBeNull();
             movie.Title.Should().NotBeNullOrWhiteSpace();
-            movie.CleanTitle.Should().Be(Parser.Parser.CleanSeriesTitle(movie.Title));
+            movie.CleanTitle.Should().Be(Parser.Parser.CleanMovieTitle(movie.Title));
             movie.SortTitle.Should().Be(MovieTitleNormalizer.Normalize(movie.Title, movie.TmdbId));
             movie.Overview.Should().NotBeNullOrWhiteSpace();
             movie.InCinemas.Should().HaveValue();

--- a/src/NzbDrone.Core.Test/ParserTests/NormalizeTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/NormalizeTitleFixture.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Law_and_Order_SVU", "lawordersvu")]
         public void should_normalize_series_title(string parsedSeriesName, string seriesName)
         {
-            var result = parsedSeriesName.CleanSeriesTitle();
+            var result = parsedSeriesName.CleanMovieTitle();
             result.Should().Be(seriesName);
         }
 
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Im a cyborg, but thats ok", "imcyborgbutthatsok")]
         public void should_remove_special_characters_and_casing(string dirty, string clean)
         {
-            var result = dirty.CleanSeriesTitle();
+            var result = dirty.CleanMovieTitle();
             result.Should().Be(clean);
         }
 
@@ -52,7 +52,7 @@ namespace NzbDrone.Core.Test.ParserTests
             foreach (var s in dirtyFormat)
             {
                 var dirty = string.Format(s, word);
-                dirty.CleanSeriesTitle().Should().Be("wordword");
+                dirty.CleanMovieTitle().Should().Be("wordword");
             }
         }
 
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Test.ParserTests
             foreach (var s in dirtyFormat)
             {
                 var dirty = string.Format(s, "a");
-                dirty.CleanSeriesTitle().Should().Be("wordword");
+                dirty.CleanMovieTitle().Should().Be("wordword");
             }
         }
 
@@ -86,7 +86,7 @@ namespace NzbDrone.Core.Test.ParserTests
             foreach (var s in dirtyFormat)
             {
                 var dirty = string.Format(s, "a");
-                dirty.CleanSeriesTitle().Should().Be("wordankleword");
+                dirty.CleanMovieTitle().Should().Be("wordankleword");
             }
         }
 
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.Test.ParserTests
             foreach (var s in dirtyFormat)
             {
                 var dirty = string.Format(s, "a");
-                dirty.CleanSeriesTitle().Should().Be("wordnkleaword");
+                dirty.CleanMovieTitle().Should().Be("wordnkleaword");
             }
         }
 
@@ -128,7 +128,7 @@ namespace NzbDrone.Core.Test.ParserTests
             foreach (var s in dirtyFormat)
             {
                 var dirty = string.Format(s, word);
-                dirty.CleanSeriesTitle().Should().Be("word" + word.ToLower() + "word");
+                dirty.CleanMovieTitle().Should().Be("word" + word.ToLower() + "word");
             }
         }
 
@@ -137,7 +137,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("The.Daily.Show", "thedailyshow")]
         public void should_not_remove_from_the_beginning_of_the_title(string parsedSeriesName, string seriesName)
         {
-            var result = parsedSeriesName.CleanSeriesTitle();
+            var result = parsedSeriesName.CleanMovieTitle();
             result.Should().Be(seriesName);
         }
 
@@ -159,14 +159,14 @@ namespace NzbDrone.Core.Test.ParserTests
             foreach (var s in dirtyFormat)
             {
                 var dirty = string.Format(s, word);
-                dirty.CleanSeriesTitle().Should().Be(word + "wordword");
+                dirty.CleanMovieTitle().Should().Be(word + "wordword");
             }
         }
 
         [Test]
         public void should_not_clean_trailing_a()
         {
-            "Tokyo Ghoul A".CleanSeriesTitle().Should().Be("tokyoghoula");
+            "Tokyo Ghoul A".CleanMovieTitle().Should().Be("tokyoghoula");
         }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Test.ParserTests
         {
             const string title = "Carniv\u00E0le";
 
-            title.CleanSeriesTitle().Should().Be("carnivale");
+            title.CleanMovieTitle().Should().Be("carnivale");
         }
 
         [TestCase("The.Man.from.U.N.C.L.E.2015.1080p.BluRay.x264-SPARKS", "The Man from U.N.C.L.E.")]

--- a/src/NzbDrone.Core/Datastore/Migration/179_movie_translation_indexes.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/179_movie_translation_indexes.cs
@@ -1,0 +1,15 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(179)]
+    public class movie_translation_indexes : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Create.Index("IX_MovieTranslations_Language").OnTable("MovieTranslations").OnColumn("Language");
+            Create.Index("IX_MovieTranslations_MovieId").OnTable("MovieTranslations").OnColumn("MovieId");
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -64,6 +64,7 @@ namespace NzbDrone.Core.MediaFiles
 
         private static readonly Regex ExcludedExtrasSubFolderRegex = new Regex(@"(?:\\|\/|^)(?:extras|extrafanart|behind the scenes|deleted scenes|featurettes|interviews|scenes|sample[s]?|shorts|trailers)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex ExcludedSubFoldersRegex = new Regex(@"(?:\\|\/|^)(?:@eadir|\.@__thumb|plex versions|\.[^\\/]+)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ExcludedExtraFilesRegex = new Regex(@"(-(trailer|other|behindthescenes|deleted|featurette|interview|scene|short)\.[^.]+$)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex ExcludedFilesRegex = new Regex(@"^\._|^Thumbs\.db$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public void Scan(Movie movie)
@@ -179,7 +180,9 @@ namespace NzbDrone.Core.MediaFiles
 
             if (filterExtras)
             {
-                filteredFiles = filteredFiles.Where(file => !ExcludedExtrasSubFolderRegex.IsMatch(basePath.GetRelativePath(file))).ToList();
+                filteredFiles = filteredFiles.Where(file => !ExcludedExtrasSubFolderRegex.IsMatch(basePath.GetRelativePath(file)))
+                                             .Where(file => !ExcludedExtraFilesRegex.IsMatch(Path.GetFileName(file)))
+                                             .ToList();
             }
 
             return filteredFiles;

--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -62,7 +62,7 @@ namespace NzbDrone.Core.MediaFiles
             _logger = logger;
         }
 
-        private static readonly Regex ExcludedExtrasSubFolderRegex = new Regex(@"(?:\\|\/|^)(?:extras|extrafanart|behind the scenes|deleted scenes|featurettes|interviews|scenes|samples|shorts|trailers)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ExcludedExtrasSubFolderRegex = new Regex(@"(?:\\|\/|^)(?:extras|extrafanart|behind the scenes|deleted scenes|featurettes|interviews|scenes|sample[s]?|shorts|trailers)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex ExcludedSubFoldersRegex = new Regex(@"(?:\\|\/|^)(?:@eadir|\.@__thumb|plex versions|\.[^\\/]+)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex ExcludedFilesRegex = new Regex(@"^\._|^Thumbs\.db$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
@@ -167,7 +167,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
 
                 if (relativeParseInfo != null)
                 {
-                    movie = _movieService.FindByTitle(relativeParseInfo.MovieTitle);
+                    movie = _movieService.FindByTitle(relativeParseInfo.MovieTitle, relativeParseInfo.Year);
                 }
             }
 

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -166,7 +166,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             movie.Title = resource.Title;
             movie.OriginalTitle = resource.OriginalTitle;
             movie.TitleSlug = resource.TitleSlug;
-            movie.CleanTitle = resource.Title.CleanSeriesTitle();
+            movie.CleanTitle = resource.Title.CleanMovieTitle();
             movie.SortTitle = Parser.Parser.NormalizeTitle(resource.Title);
             movie.Overview = resource.Overview;
 
@@ -461,7 +461,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             {
                 Title = arg.Title,
                 SourceType = SourceType.TMDB,
-                CleanTitle = arg.Title.CleanSeriesTitle(),
+                CleanTitle = arg.Title.CleanMovieTitle(),
                 Language = IsoLanguages.Find(arg.Language.ToLower())?.Language ?? Language.English
             };
 
@@ -474,7 +474,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             {
                 Title = arg.Title,
                 Overview = arg.Overview,
-                CleanTitle = arg.Title.CleanSeriesTitle(),
+                CleanTitle = arg.Title.CleanMovieTitle(),
                 Language = IsoLanguages.Find(arg.Language.ToLower())?.Language
             };
 

--- a/src/NzbDrone.Core/Movies/AddMovieService.cs
+++ b/src/NzbDrone.Core/Movies/AddMovieService.cs
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.Movies
                 newMovie.Path = Path.Combine(newMovie.RootFolderPath, folderName);
             }
 
-            newMovie.CleanTitle = newMovie.Title.CleanSeriesTitle();
+            newMovie.CleanTitle = newMovie.Title.CleanMovieTitle();
             newMovie.SortTitle = MovieTitleNormalizer.Normalize(newMovie.Title, newMovie.TmdbId);
             newMovie.Added = DateTime.UtcNow;
 

--- a/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitle.cs
+++ b/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitle.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Movies.AlternativeTitles
         public AlternativeTitle(string title, SourceType sourceType = SourceType.TMDB, int sourceId = 0, Language language = null)
         {
             Title = title;
-            CleanTitle = title.CleanSeriesTitle();
+            CleanTitle = title.CleanMovieTitle();
             SourceType = sourceType;
             SourceId = sourceId;
             Language = language ?? Language.English;

--- a/src/NzbDrone.Core/Movies/MovieRepository.cs
+++ b/src/NzbDrone.Core/Movies/MovieRepository.cs
@@ -6,6 +6,7 @@ using NzbDrone.Core.Datastore;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Movies.AlternativeTitles;
+using NzbDrone.Core.Movies.Translations;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Qualities;
 
@@ -15,7 +16,6 @@ namespace NzbDrone.Core.Movies
     {
         bool MoviePathExists(string path);
         List<Movie> FindByTitles(List<string> titles);
-        List<Movie> FindByTitleInexact(string cleanTitle);
         Movie FindByImdbId(string imdbid);
         Movie FindByTmdbId(int tmdbid);
         List<Movie> FindByTmdbId(List<int> tmdbids);
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.Movies
             .LeftJoin<Movie, AlternativeTitle>((m, t) => m.Id == t.MovieId)
             .LeftJoin<Movie, MovieFile>((m, f) => m.Id == f.MovieId);
 
-        private Movie Map(Dictionary<int, Movie> dict, Movie movie, Profile profile, AlternativeTitle altTitle, MovieFile movieFile)
+        private Movie Map(Dictionary<int, Movie> dict, Movie movie, Profile profile, AlternativeTitle altTitle, MovieFile movieFile, MovieTranslation translation = null)
         {
             Movie movieEntry;
 
@@ -60,6 +60,11 @@ namespace NzbDrone.Core.Movies
             if (altTitle != null)
             {
                 movieEntry.AlternativeTitles.Add(altTitle);
+            }
+
+            if (translation != null)
+            {
+                movieEntry.Translations.Add(translation);
             }
 
             return movieEntry;
@@ -102,13 +107,19 @@ namespace NzbDrone.Core.Movies
         public List<Movie> FindByTitles(List<string> titles)
         {
             var distinct = titles.Distinct().ToList();
-            return Query(Builder().OrWhere<Movie>(x => distinct.Contains(x.CleanTitle))
-                         .OrWhere<AlternativeTitle>(x => distinct.Contains(x.CleanTitle)));
-        }
+            var movieDictionary = new Dictionary<int, Movie>();
 
-        public List<Movie> FindByTitleInexact(string cleanTitle)
-        {
-            return Query(x => cleanTitle.Contains(x.CleanTitle));
+            var builder = Builder()
+                .LeftJoin<Movie, MovieTranslation>((m, tr) => m.Id == tr.MovieId)
+                .OrWhere<Movie>(x => distinct.Contains(x.CleanTitle))
+                .OrWhere<AlternativeTitle>(x => distinct.Contains(x.CleanTitle))
+                .OrWhere<MovieTranslation>(x => distinct.Contains(x.CleanTitle));
+
+            _ = _database.QueryJoined<Movie, Profile, AlternativeTitle, MovieFile, MovieTranslation>(
+                builder,
+                (movie, profile, altTitle, file, trans) => Map(movieDictionary, movie, profile, altTitle, file, trans));
+
+            return movieDictionary.Values.ToList();
         }
 
         public Movie FindByImdbId(string imdbid)

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -103,12 +103,12 @@ namespace NzbDrone.Core.Movies
 
         public Movie FindByTitle(string title)
         {
-            return FindByTitle(title.CleanSeriesTitle(), null);
+            return FindByTitle(title.CleanMovieTitle(), null);
         }
 
         public Movie FindByTitle(string title, int year)
         {
-            return FindByTitle(title.CleanSeriesTitle(), year as int?);
+            return FindByTitle(title.CleanMovieTitle(), year as int?);
         }
 
         private Movie FindByTitle(string cleanTitle, int? year)
@@ -166,7 +166,7 @@ namespace NzbDrone.Core.Movies
         private List<Movie> FindByTitleInexactAll(string title)
         {
             // find any movie clean title within the provided release title
-            string cleanTitle = title.CleanSeriesTitle();
+            string cleanTitle = title.CleanMovieTitle();
             var list = _movieRepository.FindByTitleInexact(cleanTitle);
             if (!list.Any())
             {
@@ -180,7 +180,7 @@ namespace NzbDrone.Core.Movies
                 {
                     position = cleanTitle.IndexOf(movie.CleanTitle),
                     length = movie.CleanTitle.Length,
-                    movie = movie
+                    movie
                 })
                     .Where(s => (s.position >= 0))
                     .ToList()
@@ -359,7 +359,7 @@ namespace NzbDrone.Core.Movies
             {
                 if (movie.Year > 1850)
                 {
-                    result = FindByTitle(movie.Title.CleanSeriesTitle(), movie.Year);
+                    result = FindByTitle(movie.Title.CleanMovieTitle(), movie.Year);
                     if (result != null)
                     {
                         return true;
@@ -367,7 +367,7 @@ namespace NzbDrone.Core.Movies
                 }
                 else
                 {
-                    result = FindByTitle(movie.Title.CleanSeriesTitle());
+                    result = FindByTitle(movie.Title.CleanMovieTitle());
                     if (result != null)
                     {
                         return true;
@@ -389,7 +389,7 @@ namespace NzbDrone.Core.Movies
 
             var ret = withTmdbid.ExceptBy(m => m.TmdbId, allMovies, m => m.TmdbId, EqualityComparer<int>.Default)
                 .Union(withImdbid.ExceptBy(m => m.ImdbId, allMovies, m => m.ImdbId, EqualityComparer<string>.Default))
-                .Union(rest.ExceptBy(m => m.Title.CleanSeriesTitle(), allMovies, m => m.CleanTitle, EqualityComparer<string>.Default)).ToList();
+                .Union(rest.ExceptBy(m => m.Title.CleanMovieTitle(), allMovies, m => m.CleanTitle, EqualityComparer<string>.Default)).ToList();
 
             return ret;
         }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -374,7 +374,7 @@ namespace NzbDrone.Core.Parser
             return value;
         }
 
-        public static string CleanSeriesTitle(this string title)
+        public static string CleanMovieTitle(this string title)
         {
             long number = 0;
 

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -68,20 +68,13 @@ namespace NzbDrone.Core.Parser
         {
             if (helpers != null)
             {
-                minimalInfo = AugmentMovieInfo(minimalInfo, helpers);
-            }
+                var augmenters = _augmenters.Where(a => helpers.Any(t => a.HelperType.IsInstanceOfType(t)) || a.HelperType == null);
 
-            return minimalInfo;
-        }
-
-        private ParsedMovieInfo AugmentMovieInfo(ParsedMovieInfo minimalInfo, List<object> helpers)
-        {
-            var augmenters = _augmenters.Where(a => helpers.Any(t => a.HelperType.IsInstanceOfType(t)) || a.HelperType == null);
-
-            foreach (var augmenter in augmenters)
-            {
-                minimalInfo = augmenter.AugmentMovieInfo(minimalInfo,
-                    helpers.FirstOrDefault(h => augmenter.HelperType.IsInstanceOfType(h)));
+                foreach (var augmenter in augmenters)
+                {
+                    minimalInfo = augmenter.AugmentMovieInfo(minimalInfo,
+                        helpers.FirstOrDefault(h => augmenter.HelperType.IsInstanceOfType(h)));
+                }
             }
 
             return minimalInfo;
@@ -255,11 +248,11 @@ namespace NzbDrone.Core.Parser
                 possibleTitles.Add(altTitle.CleanTitle);
             }
 
-            string cleanTitle = parsedMovieInfo.MovieTitle.CleanSeriesTitle();
+            string cleanTitle = parsedMovieInfo.MovieTitle.CleanMovieTitle();
 
             foreach (string title in possibleTitles)
             {
-                if (title == parsedMovieInfo.MovieTitle.CleanSeriesTitle())
+                if (title == parsedMovieInfo.MovieTitle.CleanMovieTitle())
                 {
                     possibleMovie = searchCriteria.Movie;
                 }
@@ -270,12 +263,12 @@ namespace NzbDrone.Core.Parser
                     string romanNumeral = numeralMapping.RomanNumeralLowerCase;
 
                     //_logger.Debug(cleanTitle);
-                    if (title.Replace(arabicNumeral, romanNumeral) == parsedMovieInfo.MovieTitle.CleanSeriesTitle())
+                    if (title.Replace(arabicNumeral, romanNumeral) == parsedMovieInfo.MovieTitle.CleanMovieTitle())
                     {
                         possibleMovie = searchCriteria.Movie;
                     }
 
-                    if (title == parsedMovieInfo.MovieTitle.CleanSeriesTitle().Replace(arabicNumeral, romanNumeral))
+                    if (title == parsedMovieInfo.MovieTitle.CleanMovieTitle().Replace(arabicNumeral, romanNumeral))
                     {
                         possibleMovie = searchCriteria.Movie;
                     }

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -115,14 +115,14 @@ namespace NzbDrone.Core.Parser
                 return _movieService.FindByTitle(title);
             }
 
-            var movies = _movieService.FindByTitle(parsedMovieInfo.MovieTitle, parsedMovieInfo.Year);
+            var movie = _movieService.FindByTitle(parsedMovieInfo.MovieTitle, parsedMovieInfo.Year);
 
-            if (movies == null)
+            if (movie == null)
             {
-                movies = _movieService.FindByTitle(parsedMovieInfo.MovieTitle.Replace("DC", "").Trim());
+                movie = _movieService.FindByTitle(parsedMovieInfo.MovieTitle.Replace("DC", "").Trim());
             }
 
-            return movies;
+            return movie;
         }
 
         public MappingResult Map(ParsedMovieInfo parsedMovieInfo, string imdbId, SearchCriteriaBase searchCriteria = null)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
A few improvements to parsing and scanning
- Filter inline extra files so they don't get imported over movies
- Include `Sample` subdirectory in extra folders filter
- Use Translations for Movie Mapping

#### Todos
- [x] Tests
- [x] Add Index to Movie Translation table on MovieId

#### Issues Fixed or Closed by this PR
Fixes #4630 
Fixes #4587
* #
