### PR TITLE
Fix: Update default Jackett torznab link to api v2.0

### DIFF
--- a/src/NzbDrone.Core/Indexers/Torznab/Torznab.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/Torznab.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.Indexers.Torznab
 
         public override IEnumerable<ProviderDefinition> GetDefaultDefinitions()
         {
-            yield return GetDefinition("Jackett", GetSettings("http://localhost:9117/torznab/YOURINDEXER"));
+            yield return GetDefinition("Jackett", GetSettings("http://localhost:9117/api/v2.0/indexers/YOURINDEXER/results/torznab/"));
             yield return GetDefinition("HD4Free.xyz", GetSettings("http://hd4free.xyz"));
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Updated the default Jackett link to use the new api. 
Possibly change "YOURINDEXER" to "all" to make user able to easily set up one indexer in Radarr to use all indexers in Jackett?

