### PR TITLE
Fix: Update default Jackett torznab link to api v2.0

### DIFF
--- a/src/NzbDrone.Core/Indexers/Torznab/Torznab.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/Torznab.cs
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Indexers.Torznab
         {
             get
             {
-                yield return GetDefinition("Jackett", GetSettings("http://localhost:9117/torznab/YOURINDEXER"));
+                yield return GetDefinition("Jackett", GetSettings("http://localhost:9117/api/v2.0/indexers/YOURINDEXER/results/torznab/"));
                 yield return GetDefinition("HD4Free.xyz", GetSettings("http://hd4free.xyz"));
             }
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Updated the default Jackett link to use the new api.

**Fixed version of PR #4790** 
