### PR TITLE
Parser improvements 2

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
@@ -8,6 +8,7 @@ using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.AlternativeTitles;
+using NzbDrone.Core.Movies.Translations;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Test.Common;
@@ -23,6 +24,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
         private ParsedMovieInfo _wrongTitleInfo;
         private ParsedMovieInfo _romanTitleInfo;
         private ParsedMovieInfo _alternativeTitleInfo;
+        private ParsedMovieInfo _translationTitleInfo;
         private ParsedMovieInfo _umlautInfo;
         private ParsedMovieInfo _umlautAltInfo;
         private MovieSearchCriteria _movieSearchCriteria;
@@ -35,6 +37,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
                                    .With(m => m.CleanTitle = "fackjugoethe2")
                                    .With(m => m.Year = 2015)
                                    .With(m => m.AlternativeTitles = new List<AlternativeTitle> { new AlternativeTitle("Fack Ju Göthe 2: Same same") })
+                                   .With(m => m.Translations = new List<MovieTranslation> { new MovieTranslation { Title = "Translated Title", CleanTitle = "translatedtitle" } })
                                    .With(m => m.OriginalLanguage = Language.English)
                                    .Build();
 
@@ -62,6 +65,13 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             _alternativeTitleInfo = new ParsedMovieInfo
             {
                 MovieTitle = _movie.AlternativeTitles.First().Title,
+                Languages = new List<Language> { Language.English },
+                Year = _movie.Year,
+            };
+
+            _translationTitleInfo = new ParsedMovieInfo
+            {
+                MovieTitle = _movie.Translations.First().Title,
                 Languages = new List<Language> { Language.English },
                 Year = _movie.Year,
             };
@@ -150,6 +160,12 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
         public void should_match_alternative_title()
         {
             Subject.Map(_alternativeTitleInfo, "", _movieSearchCriteria).Movie.Should().Be(_movieSearchCriteria.Movie);
+        }
+
+        [Test]
+        public void should_match_translation_title()
+        {
+            Subject.Map(_translationTitleInfo, "", _movieSearchCriteria).Movie.Should().Be(_movieSearchCriteria.Movie);
         }
 
         [Test]

--- a/src/NzbDrone.Core/Extras/ExtraService.cs
+++ b/src/NzbDrone.Core/Extras/ExtraService.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.Extras
             var sourcePath = localMovie.Path;
             var sourceFolder = _diskProvider.GetParentFolder(sourcePath);
             var sourceFileName = Path.GetFileNameWithoutExtension(sourcePath);
-            var files = _diskProvider.GetFiles(sourceFolder, SearchOption.TopDirectoryOnly);
+            var files = _diskProvider.GetFiles(sourceFolder, SearchOption.TopDirectoryOnly).Where(f => f != localMovie.Path);
 
             var wantedExtensions = _configService.ExtraFileExtensions.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                                                                      .Select(e => e.Trim(' ', '.'))

--- a/src/NzbDrone.Core/Extras/Files/ExtraFileManager.cs
+++ b/src/NzbDrone.Core/Extras/Files/ExtraFileManager.cs
@@ -49,7 +49,8 @@ namespace NzbDrone.Core.Extras.Files
 
         protected TExtraFile ImportFile(Movie movie, MovieFile movieFile, string path, bool readOnly, string extension, string fileNameSuffix = null)
         {
-            var newFolder = Path.GetDirectoryName(Path.Combine(movie.Path, movieFile.RelativePath));
+            var movieFilePath = Path.Combine(movie.Path, movieFile.RelativePath);
+            var newFolder = Path.GetDirectoryName(movieFilePath);
             var filenameBuilder = new StringBuilder(Path.GetFileNameWithoutExtension(movieFile.RelativePath));
 
             if (fileNameSuffix.IsNotNullOrWhiteSpace())
@@ -60,6 +61,13 @@ namespace NzbDrone.Core.Extras.Files
             filenameBuilder.Append(extension);
 
             var newFileName = Path.Combine(newFolder, filenameBuilder.ToString());
+
+            if (newFileName == movieFilePath)
+            {
+                _logger.Debug("Extra file {0} not imported, due to naming interference with movie file", path);
+                return null;
+            }
+
             var transferMode = TransferMode.Move;
 
             if (readOnly)

--- a/src/NzbDrone.Core/Extras/Others/OtherExtraService.cs
+++ b/src/NzbDrone.Core/Extras/Others/OtherExtraService.cs
@@ -68,8 +68,11 @@ namespace NzbDrone.Core.Extras.Others
         {
             var extraFile = ImportFile(movie, movieFile, path, readOnly, extension, null);
 
-            _mediaFileAttributeService.SetFilePermissions(path);
-            _otherExtraFileService.Upsert(extraFile);
+            if (extraFile != null)
+            {
+                _mediaFileAttributeService.SetFilePermissions(path);
+                _otherExtraFileService.Upsert(extraFile);
+            }
 
             return extraFile;
         }

--- a/src/NzbDrone.Core/IndexerSearch/NzbSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/NzbSearchService.cs
@@ -49,6 +49,7 @@ namespace NzbDrone.Core.IndexerSearch
         public List<DownloadDecision> MovieSearch(int movieId, bool userInvokedSearch, bool interactiveSearch)
         {
             var movie = _movieService.GetMovie(movieId);
+            movie.Translations = _movieTranslationService.GetAllTranslationsForMovie(movie.Id);
 
             return MovieSearch(movie, userInvokedSearch, interactiveSearch);
         }

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -114,14 +114,12 @@ namespace NzbDrone.Core.Parser
                 return _movieService.FindByTitle(title);
             }
 
-            var movie = _movieService.FindByTitle(parsedMovieInfo.MovieTitle, parsedMovieInfo.Year);
-
-            if (movie == null)
+            if (TryGetMovieByTitleAndOrYear(parsedMovieInfo, out var result) && result.MappingResultType == MappingResultType.Success)
             {
-                movie = _movieService.FindByTitle(parsedMovieInfo.MovieTitle.Replace("DC", "").Trim());
+                return result.Movie;
             }
 
-            return movie;
+            return null;
         }
 
         public MappingResult Map(ParsedMovieInfo parsedMovieInfo, string imdbId, SearchCriteriaBase searchCriteria = null)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Use translations when parsing by search criteria so we don't miss anything. Also, ensure that we don't accept a movie if it is a year mismatch in some cases. 

Ex. Wrath of God 1968 vs The Wrath of God 1972
`The.Wrath.Of.God.1968.DVDRIP.XVID-CG` gets matched to the 1972 version and imported despite the year mismatch.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR
Fixes #4794 
Fixes #3006
Fixes #4824 
* #
