### PR TITLE
Sonarr import processing pulls

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedMoviesFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedMoviesFixture.cs
@@ -380,5 +380,20 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Mocker.GetMock<IMediaFileService>().Verify(v => v.Add(It.Is<MovieFile>(c => c.OriginalFilePath == $"subfolder\\{name}.mkv".AsOsAgnostic())));
         }
+
+        [Test]
+        public void should_use_folder_info_original_title_to_find_relative_path_when_download_client_item_has_an_empty_output_path()
+        {
+            var name = "Transformers.2007.720p.BluRay.x264-Radarr";
+            var outputPath = Path.Combine(@"C:\Test\Unsorted\movies\".AsOsAgnostic(), name);
+            var localMovie = _approvedDecisions.First().LocalMovie;
+
+            localMovie.FolderMovieInfo = new ParsedMovieInfo { ReleaseTitle = name };
+            localMovie.Path = Path.Combine(outputPath, "subfolder", name + ".mkv");
+
+            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, _downloadClientItem);
+
+            Mocker.GetMock<IMediaFileService>().Verify(v => v.Add(It.Is<MovieFile>(c => c.OriginalFilePath == $"subfolder\\{name}.mkv".AsOsAgnostic())));
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedMoviesFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedMoviesFixture.cs
@@ -314,5 +314,37 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Mocker.GetMock<IMediaFileService>().Verify(v => v.Add(It.Is<MovieFile>(c => c.OriginalFilePath == $"{name}\\subfolder\\{name}.mkv".AsOsAgnostic())));
         }
+
+        [Test]
+        public void should_get_relative_path_when_there_is_no_grandparent()
+        {
+            var name = "Transformers.2007.720p.BluRay.x264-Radarr";
+            var outputPath = @"C:\".AsOsAgnostic();
+            var localMovie = _approvedDecisions.First().LocalMovie;
+
+            localMovie.FolderMovieInfo = new ParsedMovieInfo { ReleaseTitle = name };
+            localMovie.Path = Path.Combine(outputPath, name + ".mkv");
+
+            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, null);
+
+            Mocker.GetMock<IMediaFileService>().Verify(v => v.Add(It.Is<MovieFile>(c => c.OriginalFilePath == $"{name}.mkv".AsOsAgnostic())));
+        }
+
+        [Test]
+        public void should_get_relative_path_when_there_is_no_grandparent_for_UNC_path()
+        {
+            WindowsOnly();
+
+            var name = "Transformers.2007.720p.BluRay.x264-Radarr";
+            var outputPath = @"\\server\share";
+            var localMovie = _approvedDecisions.First().LocalMovie;
+
+            localMovie.FolderMovieInfo = new ParsedMovieInfo { ReleaseTitle = name };
+            localMovie.Path = Path.Combine(outputPath, name + ".mkv");
+
+            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, null);
+
+            Mocker.GetMock<IMediaFileService>().Verify(v => v.Add(It.Is<MovieFile>(c => c.OriginalFilePath == $"{name}.mkv")));
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedMoviesFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedMoviesFixture.cs
@@ -364,5 +364,21 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Mocker.GetMock<IMediaFileService>().Verify(v => v.Add(It.Is<MovieFile>(c => c.OriginalFilePath == $"{name}.mkv")));
         }
+
+        [Test]
+        public void should_use_folder_info_original_title_to_find_relative_path_when_file_is_not_in_download_client_item_output_directory()
+        {
+            var name = "Transformers.2007.720p.BluRay.x264-Radarr";
+            var outputPath = Path.Combine(@"C:\Test\Unsorted\movie\".AsOsAgnostic(), name);
+            var localMovie = _approvedDecisions.First().LocalMovie;
+
+            _downloadClientItem.OutputPath = new OsPath(Path.Combine(@"C:\Test\Unsorted\movie-Other\".AsOsAgnostic(), name));
+            localMovie.FolderMovieInfo = new ParsedMovieInfo { ReleaseTitle = name };
+            localMovie.Path = Path.Combine(outputPath, "subfolder", name + ".mkv");
+
+            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, _downloadClientItem);
+
+            Mocker.GetMock<IMediaFileService>().Verify(v => v.Add(It.Is<MovieFile>(c => c.OriginalFilePath == $"subfolder\\{name}.mkv".AsOsAgnostic())));
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedMoviesFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedMoviesFixture.cs
@@ -316,10 +316,28 @@ namespace NzbDrone.Core.Test.MediaFiles
         }
 
         [Test]
-        public void should_get_relative_path_when_there_is_no_grandparent()
+        public void should_get_relative_path_when_there_is_no_grandparent_windows()
         {
+            WindowsOnly();
+
             var name = "Transformers.2007.720p.BluRay.x264-Radarr";
             var outputPath = @"C:\".AsOsAgnostic();
+            var localMovie = _approvedDecisions.First().LocalMovie;
+            localMovie.FolderMovieInfo = new ParsedMovieInfo { ReleaseTitle = name };
+            localMovie.Path = Path.Combine(outputPath, name + ".mkv");
+
+            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, null);
+
+            Mocker.GetMock<IMediaFileService>().Verify(v => v.Add(It.Is<MovieFile>(c => c.OriginalFilePath == $"{name}.mkv".AsOsAgnostic())));
+        }
+
+        [Test]
+        public void should_get_relative_path_when_there_is_no_grandparent_mono()
+        {
+            MonoOnly();
+
+            var name = "Transformers.2007.720p.BluRay.x264-Radarr";
+            var outputPath = "/";
             var localMovie = _approvedDecisions.First().LocalMovie;
 
             localMovie.FolderMovieInfo = new ParsedMovieInfo { ReleaseTitle = name };

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
@@ -180,7 +180,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
         {
             var path = localMovie.Path;
 
-            if (downloadClientItem != null)
+            if (downloadClientItem != null && !downloadClientItem.OutputPath.IsEmpty)
             {
                 var outputDirectory = downloadClientItem.OutputPath.Directory.ToString();
 

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
@@ -178,12 +178,18 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
 
         private string GetOriginalFilePath(DownloadClientItem downloadClientItem, LocalMovie localMovie)
         {
+            var path = localMovie.Path;
+
             if (downloadClientItem != null)
             {
-                return downloadClientItem.OutputPath.Directory.ToString().GetRelativePath(localMovie.Path);
+                var outputDirectory = downloadClientItem.OutputPath.Directory.ToString();
+
+                if (outputDirectory.IsParentPath(path))
+                {
+                    return outputDirectory.GetRelativePath(path);
+                }
             }
 
-            var path = localMovie.Path;
             var folderMovieInfo = localMovie.FolderMovieInfo;
 
             if (folderMovieInfo != null)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add some older commits to fix case where an API call is made to trigger import of a tracked download from a directory that's not a child of the tracked download output folder I.e. where a post processing script has moved things around

#### Todos
- [x] Tests
