### PR TITLE
Fixed: When deleting movies, the MovieFileDeletion event

### DIFF
--- a/src/NzbDrone.Api/Movies/MovieModule.cs
+++ b/src/NzbDrone.Api/Movies/MovieModule.cs
@@ -162,7 +162,7 @@ namespace NzbDrone.Api.Movies
 
         public void Handle(MovieFileDeletedEvent message)
         {
-            if (message.Reason == DeleteMediaFileReason.Upgrade)
+            if (message.Reason == DeleteMediaFileReason.Upgrade || message.Reason == DeleteMediaFileReason.MovieDeletion)
             {
                 return;
             }

--- a/src/NzbDrone.Core/Extras/Files/ExtraFileService.cs
+++ b/src/NzbDrone.Core/Extras/Files/ExtraFileService.cs
@@ -96,6 +96,11 @@ namespace NzbDrone.Core.Extras.Files
 
         public void HandleAsync(MovieFileDeletedEvent message)
         {
+            if (message.Reason == DeleteMediaFileReason.MovieDeletion)
+            {
+                return;
+            }
+
             var movieFile = message.MovieFile;
 
             if (message.Reason == DeleteMediaFileReason.NoLinkedEpisodes)

--- a/src/NzbDrone.Core/History/HistoryService.cs
+++ b/src/NzbDrone.Core/History/HistoryService.cs
@@ -209,6 +209,11 @@ namespace NzbDrone.Core.History
 
         public void Handle(MovieFileDeletedEvent message)
         {
+            if (message.Reason == DeleteMediaFileReason.MovieDeletion)
+            {
+                return;
+            }
+
             if (message.Reason == DeleteMediaFileReason.NoLinkedEpisodes)
             {
                 _logger.Debug("Removing movie file from DB as part of cleanup routine, not creating history event.");

--- a/src/NzbDrone.Core/MediaFiles/DeleteMediaFileReason.cs
+++ b/src/NzbDrone.Core/MediaFiles/DeleteMediaFileReason.cs
@@ -6,6 +6,7 @@
         Manual,
         Upgrade,
         NoLinkedEpisodes,
-        ManualOverride
+        ManualOverride,
+        MovieDeletion
     }
 }

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -219,7 +219,6 @@ namespace NzbDrone.Core.Movies
             var moviesToDelete = _movieRepository.Get(movieIds).ToList();
 
             _movieRepository.DeleteMany(movieIds);
-
             _eventAggregator.PublishEvent(new MoviesDeletedEvent(moviesToDelete, deleteFiles, addExclusion));
 
             foreach (var movie in moviesToDelete)
@@ -391,6 +390,11 @@ namespace NzbDrone.Core.Movies
 
         public void Handle(MovieFileDeletedEvent message)
         {
+            if (message.Reason == DeleteMediaFileReason.MovieDeletion)
+            {
+                return;
+            }
+
             foreach (var movie in GetMoviesByFileId(message.MovieFile.Id))
             {
                 _logger.Debug("Detaching movie {0} from file.", movie.Id);

--- a/src/Radarr.Api.V3/MovieFiles/MovieFileModule.cs
+++ b/src/Radarr.Api.V3/MovieFiles/MovieFileModule.cs
@@ -196,6 +196,11 @@ namespace Radarr.Api.V3.MovieFiles
 
         public void Handle(MovieFileDeletedEvent message)
         {
+            if (message.Reason == DeleteMediaFileReason.MovieDeletion)
+            {
+                return;
+            }
+
             BroadcastResourceChange(ModelAction.Deleted, message.MovieFile.Id);
         }
     }

--- a/src/Radarr.Api.V3/Movies/MovieModule.cs
+++ b/src/Radarr.Api.V3/Movies/MovieModule.cs
@@ -259,7 +259,7 @@ namespace Radarr.Api.V3.Movies
 
         public void Handle(MovieFileDeletedEvent message)
         {
-            if (message.Reason == DeleteMediaFileReason.Upgrade)
+            if (message.Reason == DeleteMediaFileReason.Upgrade || message.Reason == DeleteMediaFileReason.MovieDeletion)
             {
                 return;
             }


### PR DESCRIPTION
was not triggered even if delete all movie files option was selected.

#### Database Migration
NO

#### Description
This caused the OnDelete Event notifications not to trigger (i.e. TraktConnection)

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR
no issues opened (bug discovered after merging onDelete feature)

