### PR TITLE
New: reset/set a tag during cleanLibrary

### DIFF
--- a/frontend/src/Settings/ImportLists/Options/ImportListOptions.js
+++ b/frontend/src/Settings/ImportLists/Options/ImportListOptions.js
@@ -78,6 +78,18 @@ function ImportListOptions(props) {
                   {...settings.listSyncLevel}
                 />
               </FormGroup>
+
+              <FormGroup>
+                <FormLabel>{translate('CleanLibraryTags')}</FormLabel>
+
+                <FormInputGroup
+                  type={inputTypes.TAG}
+                  name="cleanLibraryTags"
+                  helpText={translate('TagsHelpText')}
+                  {...settings.cleanLibraryTags}
+                  onChange={onInputChange}
+                />
+              </FormGroup>
             </Form>
         }
       </FieldSet>

--- a/frontend/src/Settings/Tags/Details/TagDetailsModalContent.js
+++ b/frontend/src/Settings/Tags/Details/TagDetailsModalContent.js
@@ -24,6 +24,7 @@ function TagDetailsModalContent(props) {
     importLists,
     indexers,
     onModalClose,
+    isCleanLibraryTag,
     onDeleteTagPress
   } = props;
 
@@ -180,6 +181,10 @@ function TagDetailsModalContent(props) {
               }
             </FieldSet>
         }
+        {
+          !!isCleanLibraryTag &&
+            <FieldSet legend={translate('CleanLibraryTag')} />
+        }
       </ModalBody>
 
       <ModalFooter>
@@ -214,6 +219,7 @@ TagDetailsModalContent.propTypes = {
   restrictions: PropTypes.arrayOf(PropTypes.object).isRequired,
   importLists: PropTypes.arrayOf(PropTypes.object).isRequired,
   indexers: PropTypes.arrayOf(PropTypes.object).isRequired,
+  isCleanLibraryTag: PropTypes.bool.isRequired,
   onModalClose: PropTypes.func.isRequired,
   onDeleteTagPress: PropTypes.func.isRequired
 };

--- a/frontend/src/Settings/Tags/Tag.js
+++ b/frontend/src/Settings/Tags/Tag.js
@@ -57,6 +57,7 @@ class Tag extends Component {
       notificationIds,
       restrictionIds,
       importListIds,
+      isCleanLibraryTag,
       movieIds,
       indexerIds
     } = this.props;
@@ -71,6 +72,7 @@ class Tag extends Component {
       notificationIds.length ||
       restrictionIds.length ||
       importListIds.length ||
+      isCleanLibraryTag ||
       movieIds.length ||
       indexerIds.length
     );
@@ -124,6 +126,13 @@ class Tag extends Component {
               }
 
               {
+                !!isCleanLibraryTag &&
+                  <div>
+                    CleanLibraryTag
+                  </div>
+              }
+
+              {
                 indexerIds.length ?
                   <div>
                     {indexerIds.length} indexer{indexerIds.length > 1 && 's'}
@@ -149,6 +158,7 @@ class Tag extends Component {
           restrictionIds={restrictionIds}
           importListIds={importListIds}
           indexerIds={indexerIds}
+          isCleanLibraryTag={isCleanLibraryTag}
           isOpen={isDetailsModalOpen}
           onModalClose={this.onDetailsModalClose}
           onDeleteTagPress={this.onDeleteTagPress}
@@ -177,6 +187,7 @@ Tag.propTypes = {
   importListIds: PropTypes.arrayOf(PropTypes.number).isRequired,
   movieIds: PropTypes.arrayOf(PropTypes.number).isRequired,
   indexerIds: PropTypes.arrayOf(PropTypes.number).isRequired,
+  isCleanLibraryTag: PropTypes.bool.isRequired,
   onConfirmDeleteTag: PropTypes.func.isRequired
 };
 
@@ -185,6 +196,7 @@ Tag.defaultProps = {
   notificationIds: [],
   restrictionIds: [],
   importListIds: [],
+  isCleanLibraryTag: false,
   movieIds: [],
   indexerIds: []
 };

--- a/src/NzbDrone.Core.Test/Configuration/ConfigServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Configuration/ConfigServiceFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -88,6 +88,10 @@ namespace NzbDrone.Core.Test.Configuration
                 else if (propertyInfo.PropertyType == typeof(bool))
                 {
                     value = true;
+                }
+                else if (propertyInfo.Name.Equals("CleanLibraryTags"))
+                {
+                    continue;
                 }
                 else if (propertyInfo.PropertyType.BaseType == typeof(Enum))
                 {

--- a/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
@@ -24,6 +24,8 @@ namespace NzbDrone.Core.Test.ImportList
         private ImportListSyncCommand _commandAll;
         private ImportListSyncCommand _commandSingle;
 
+        private HashSet<int> _cleanLibraryTags;
+
         [SetUp]
         public void Setup()
         {
@@ -55,6 +57,8 @@ namespace NzbDrone.Core.Test.ImportList
                 .With(s => s.TmdbId = 8)
                 .With(s => s.ImdbId = "8")
                 .Build().ToList();
+
+            _cleanLibraryTags = new HashSet<int>();
 
             _importListFetch = new ImportListFetchResult
             {
@@ -90,6 +94,10 @@ namespace NzbDrone.Core.Test.ImportList
             Mocker.GetMock<IFetchAndParseImportList>()
                   .Setup(v => v.Fetch())
                   .Returns(_importListFetch);
+
+            Mocker.GetMock<IConfigService>()
+                  .Setup(v => v.CleanLibraryTags)
+                  .Returns(_cleanLibraryTags);
         }
 
         private void GivenListFailure()
@@ -165,7 +173,7 @@ namespace NzbDrone.Core.Test.ImportList
                   .Verify(v => v.DeleteMovie(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never());
 
             Mocker.GetMock<IMovieService>()
-                  .Verify(v => v.UpdateMovie(new List<Movie>(), true), Times.Once());
+                  .Verify(v => v.UpdateMovie(new List<Movie>(), true), Times.Never());
         }
 
         [Test]

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -65,11 +65,22 @@ namespace NzbDrone.Core.Configuration
                     continue;
                 }
 
-                var equal = configValue.Value.ToString().Equals(currentValue.ToString());
-
-                if (!equal)
+                if (configValue.Key.Equals("CleanLibraryTags"))
                 {
-                    SetValue(configValue.Key, configValue.Value.ToString());
+                    var equal = ConvertToString((HashSet<int>)configValue.Value).Equals(ConvertToString((HashSet<int>)currentValue));
+                    if (!equal)
+                    {
+                        SetValue(configValue.Key, ConvertToString((HashSet<int>)configValue.Value));
+                    }
+                }
+                else
+                {
+                    var equal = configValue.Value.ToString().Equals(currentValue.ToString());
+
+                    if (!equal)
+                    {
+                        SetValue(configValue.Key, configValue.Value.ToString());
+                    }
                 }
             }
 
@@ -135,6 +146,12 @@ namespace NzbDrone.Core.Configuration
         {
             get { return GetValue("ImportExclusions", string.Empty); }
             set { SetValue("ImportExclusions", value); }
+        }
+
+        public HashSet<int> CleanLibraryTags
+        {
+            get { return GetValueHashSet("CleanLibraryTags"); }
+            set { SetValue("CleanLibraryTags", value); }
         }
 
         public TMDbCountryCode CertificationCountry
@@ -456,6 +473,27 @@ namespace NzbDrone.Core.Configuration
         private int GetValueInt(string key, int defaultValue = 0)
         {
             return Convert.ToInt32(GetValue(key, defaultValue));
+        }
+
+        private HashSet<int> GetValueHashSet(string key)
+        {
+            string t1 = GetValue(key, string.Empty);
+            if (string.IsNullOrEmpty(t1) || t1.Equals("[]"))
+            {
+                return new HashSet<int>();
+            }
+
+            return new HashSet<int>(Array.ConvertAll(t1.Replace("[", "").Replace("]", "").Split(' '), s => int.Parse(s)));
+        }
+
+        private string ConvertToString(HashSet<int> value)
+        {
+            return "[" + string.Join(" ", value.ToArray()) + "]";
+        }
+
+        private void SetValue(string key, HashSet<int> value)
+        {
+            SetValue(key, ConvertToString(value));
         }
 
         private T GetValueEnum<T>(string key, T defaultValue)

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -64,6 +64,7 @@ namespace NzbDrone.Core.Configuration
         int ImportListSyncInterval { get; set; }
         string ListSyncLevel { get; set; }
         string ImportExclusions { get; set; }
+        HashSet<int> CleanLibraryTags { get; set; }
 
         //Metadata Provider
         TMDbCountryCode CertificationCountry { get; set; }

--- a/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupUnusedTags.cs
+++ b/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupUnusedTags.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -26,6 +27,18 @@ namespace NzbDrone.Core.Housekeeping.Housekeepers
                 .ToList();
 
             var usedTagsList = usedTags.Select(d => d.ToString()).Join(",");
+
+            var cleanLibraryTags = mapper.Query<string>($"SELECT Value FROM Config WHERE Config.Key='cleanlibrarytags'");
+            foreach (var t1 in cleanLibraryTags)
+            {
+                var cleanLibraryTagsList = string.Empty;
+                if (!(string.IsNullOrEmpty(t1) || t1.Equals("[]")))
+                {
+                    cleanLibraryTagsList = string.Join(",", Array.ConvertAll(t1.Replace("[", "").Replace("]", "").Split(' '), s => int.Parse(s)));
+                }
+
+                usedTagsList = usedTagsList + cleanLibraryTagsList;
+            }
 
             mapper.Execute($"DELETE FROM Tags WHERE NOT Id IN ({usedTagsList})");
         }

--- a/src/NzbDrone.Core/Tags/TagDetails.cs
+++ b/src/NzbDrone.Core/Tags/TagDetails.cs
@@ -13,12 +13,13 @@ namespace NzbDrone.Core.Tags
         public List<int> ImportListIds { get; set; }
         public List<int> DelayProfileIds { get; set; }
         public List<int> IndexerIds { get; set; }
+        public bool IsCleanLibraryTag { get; set; }
 
         public bool InUse
         {
             get
             {
-                return MovieIds.Any() || NotificationIds.Any() || RestrictionIds.Any() || DelayProfileIds.Any() || ImportListIds.Any() || IndexerIds.Any();
+                return MovieIds.Any() || NotificationIds.Any() || RestrictionIds.Any() || DelayProfileIds.Any() || ImportListIds.Any() || IndexerIds.Any() || IsCleanLibraryTag;
             }
         }
     }

--- a/src/NzbDrone.Core/Tags/TagService.cs
+++ b/src/NzbDrone.Core/Tags/TagService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.ImportLists;
 using NzbDrone.Core.Indexers;
@@ -34,6 +35,7 @@ namespace NzbDrone.Core.Tags
         private readonly IRestrictionService _restrictionService;
         private readonly IMovieService _movieService;
         private readonly IIndexerFactory _indexerService;
+        private readonly IConfigService _configService;
 
         public TagService(ITagRepository repo,
                           IEventAggregator eventAggregator,
@@ -41,6 +43,7 @@ namespace NzbDrone.Core.Tags
                           IImportListFactory importListFactory,
                           INotificationFactory notificationFactory,
                           IRestrictionService restrictionService,
+                          IConfigService configService,
                           IMovieService movieService,
                           IIndexerFactory indexerService)
         {
@@ -52,6 +55,7 @@ namespace NzbDrone.Core.Tags
             _restrictionService = restrictionService;
             _movieService = movieService;
             _indexerService = indexerService;
+            _configService = configService;
         }
 
         public Tag GetTag(int tagId)
@@ -94,6 +98,7 @@ namespace NzbDrone.Core.Tags
                 ImportListIds = importLists.Select(c => c.Id).ToList(),
                 NotificationIds = notifications.Select(c => c.Id).ToList(),
                 RestrictionIds = restrictions.Select(c => c.Id).ToList(),
+                IsCleanLibraryTag = _configService.CleanLibraryTags.Contains(tag.Id),
                 MovieIds = movies,
                 IndexerIds = indexers.Select(c => c.Id).ToList()
             };
@@ -121,6 +126,7 @@ namespace NzbDrone.Core.Tags
                     ImportListIds = importLists.Where(c => c.Tags.Contains(tag.Id)).Select(c => c.Id).ToList(),
                     NotificationIds = notifications.Where(c => c.Tags.Contains(tag.Id)).Select(c => c.Id).ToList(),
                     RestrictionIds = restrictions.Where(c => c.Tags.Contains(tag.Id)).Select(c => c.Id).ToList(),
+                    IsCleanLibraryTag = _configService.CleanLibraryTags.Contains(tag.Id),
                     MovieIds = movies.Where(c => c.Value.Contains(tag.Id)).Select(c => c.Key).ToList(),
                     IndexerIds = indexers.Where(c => c.Tags.Contains(tag.Id)).Select(c => c.Id).ToList()
                 });

--- a/src/Radarr.Api.V3/Config/ImportListConfigResource.cs
+++ b/src/Radarr.Api.V3/Config/ImportListConfigResource.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Tags;
 using Radarr.Http.REST;
 
 namespace Radarr.Api.V3.Config
@@ -8,6 +10,7 @@ namespace Radarr.Api.V3.Config
         public int ImportListSyncInterval { get; set; }
         public string ListSyncLevel { get; set; }
         public string ImportExclusions { get; set; }
+        public HashSet<int> CleanLibraryTags { get; set; }
     }
 
     public static class ImportListConfigResourceMapper
@@ -18,7 +21,8 @@ namespace Radarr.Api.V3.Config
             {
                 ImportListSyncInterval = model.ImportListSyncInterval,
                 ListSyncLevel = model.ListSyncLevel,
-                ImportExclusions = model.ImportExclusions
+                ImportExclusions = model.ImportExclusions,
+                CleanLibraryTags = model.CleanLibraryTags
             };
         }
     }

--- a/src/Radarr.Api.V3/Tags/TagDetailsResource.cs
+++ b/src/Radarr.Api.V3/Tags/TagDetailsResource.cs
@@ -14,6 +14,7 @@ namespace Radarr.Api.V3.Tags
         public List<int> ImportListIds { get; set; }
         public List<int> MovieIds { get; set; }
         public List<int> IndexerIds { get; set; }
+        public bool IsCleanLibraryTag { get; set; }
     }
 
     public static class TagDetailsResourceMapper
@@ -33,6 +34,7 @@ namespace Radarr.Api.V3.Tags
                 NotificationIds = model.NotificationIds,
                 RestrictionIds = model.RestrictionIds,
                 ImportListIds = model.ImportListIds,
+                IsCleanLibraryTag = model.IsCleanLibraryTag,
                 MovieIds = model.MovieIds,
                 IndexerIds = model.IndexerIds
             };


### PR DESCRIPTION
#### Database Migration
NO

#### Description
reset/set tag during ImportListSync-CleanLibrary so that items can be filtered with custom filter etc.
Its much better than just having the log info message.

Plans/ToDos before completing this PR:
I'm thinking that perhaps the tag used should be user specifiable in the List Settings Page where the CleanSync level option is. If no tag is specified, tagging is not performed on CleanLibrary
Im also thinking to rename LogOnly option to TagOnly, and keepAndUnmonitor to TagAndUnmonitor. if no Tag is specifed in the user speciable tag, then the entire thing functions like it did before this feature was implemented.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #
