### PR TITLE
Fix issue where options button on discover becomes un-usable

### DIFF
--- a/frontend/src/DiscoverMovie/DiscoverMovie.js
+++ b/frontend/src/DiscoverMovie/DiscoverMovie.js
@@ -317,7 +317,6 @@ class DiscoverMovie extends Component {
                 <PageToolbarButton
                   label={translate('Options')}
                   iconName={icons.POSTER}
-                  isDisabled={hasNoMovie}
                   onPress={this.onPosterOptionsPress}
                 /> :
                 null
@@ -328,7 +327,6 @@ class DiscoverMovie extends Component {
                 <PageToolbarButton
                   label={translate('Options')}
                   iconName={icons.OVERVIEW}
-                  isDisabled={hasNoMovie}
                   onPress={this.onOverviewOptionsPress}
                 /> :
                 null


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix issue where options button gets into a state of disabled with no way to re-enable it unless you add a list with movies in it

If you have no lists or a list with no movies in it & disable the use recommendations option the Options button becomes disabled with no way to turn the recommendations back on. Would be forced to add a list and a movie to it just to re-enable the button.

No side effects from simply leaving the button enabled. 