### PR TITLE
New: Allow Selection Original Movie Languge in Profile

### DIFF
--- a/frontend/src/InteractiveImport/Language/SelectLanguageModalContentConnector.js
+++ b/frontend/src/InteractiveImport/Language/SelectLanguageModalContentConnector.js
@@ -18,11 +18,14 @@ function createMapStateToProps() {
         items
       } = languages;
 
+      const filterItems = ['Any', 'Original'];
+      const filteredLanguages = items.filter((lang) => !filterItems.includes(lang.name));
+
       return {
         isFetching,
         isPopulated,
         error,
-        items
+        items: filteredLanguages
       };
     }
   );
@@ -54,7 +57,9 @@ class SelectLanguageModalContentConnector extends Component {
       const language = _.find(this.props.items,
         (item) => item.id === parseInt(languageId));
 
-      languages.push(language);
+      if (language !== undefined) {
+        languages.push(language);
+      }
     });
 
     this.props.dispatchUpdateInteractiveImportItems({

--- a/frontend/src/MovieFile/Language/SelectLanguageModalContentConnector.js
+++ b/frontend/src/MovieFile/Language/SelectLanguageModalContentConnector.js
@@ -18,7 +18,7 @@ function createMapStateToProps() {
         items
       } = languages;
 
-      const filterItems = ['Any'];
+      const filterItems = ['Any', 'Original'];
       const filteredLanguages = items.filter((lang) => !filterItems.includes(lang.name));
 
       return {
@@ -57,7 +57,9 @@ class SelectLanguageModalContentConnector extends Component {
       const language = _.find(this.props.items,
         (item) => item.id === parseInt(languageId));
 
-      languages.push(language);
+      if (language !== undefined) {
+        languages.push(language);
+      }
     });
 
     this.props.dispatchupdateMovieFiles({

--- a/frontend/src/Settings/UI/UISettings.js
+++ b/frontend/src/Settings/UI/UISettings.js
@@ -65,6 +65,8 @@ class UISettings extends Component {
       ...otherProps
     } = this.props;
 
+    const uiLanguages = languages.filter((item) => item.value !== 'Original');
+
     return (
       <PageContent title={translate('UISettings')}>
         <SettingsToolbarConnector
@@ -213,7 +215,7 @@ class UISettings extends Component {
                     <FormInputGroup
                       type={inputTypes.SELECT}
                       name="uiLanguage"
-                      values={languages}
+                      values={uiLanguages}
                       helpText={translate('UILanguageHelpText')}
                       helpTextWarning={translate('UILanguageHelpTextWarning')}
                       onChange={onInputChange}

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/LanguageSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/LanguageSpecificationFixture.cs
@@ -30,7 +30,8 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                              Profile = new Profile
                              {
                                  Language = Language.English
-                             }
+                             },
+                             OriginalLanguage = Language.French
                          }
             };
         }
@@ -43,6 +44,11 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         private void WithGermanRelease()
         {
             _remoteMovie.ParsedMovieInfo.Languages = new List<Language> { Language.German };
+        }
+
+        private void WithFrenchRelease()
+        {
+            _remoteMovie.ParsedMovieInfo.Languages = new List<Language> { Language.French };
         }
 
         [Test]
@@ -59,6 +65,26 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithGermanRelease();
 
             Mocker.Resolve<LanguageSpecification>().IsSatisfiedBy(_remoteMovie, null).Accepted.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_return_false_if_release_is_german_and_profile_original()
+        {
+            _remoteMovie.Movie.Profile.Language = Language.Original;
+
+            WithGermanRelease();
+
+            Mocker.Resolve<LanguageSpecification>().IsSatisfiedBy(_remoteMovie, null).Accepted.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_return_true_if_release_is_french_and_profile_original()
+        {
+            _remoteMovie.Movie.Profile.Language = Language.Original;
+
+            WithFrenchRelease();
+
+            Mocker.Resolve<LanguageSpecification>().IsSatisfiedBy(_remoteMovie, null).Accepted.Should().BeTrue();
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -139,6 +139,15 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Languages.Should().BeEquivalentTo(Language.Thai);
         }
 
+        [TestCase("Pulp.Fiction.1994.Bulgarian.1080p.XviD-LOL")]
+        [TestCase("Pulp.Fiction.1994.BGAUDIO.1080p.XviD-LOL")]
+        public void should_parse_language_bulgarian(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle, true);
+
+            result.Languages.Should().BeEquivalentTo(Language.Bulgarian);
+        }
+
         [TestCase("Pulp.Fiction.1994.Polish.1080p.XviD-LOL")]
         public void should_parse_language_polish(string postTitle)
         {

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -115,6 +115,22 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Languages.Should().BeEquivalentTo(Language.Russian);
         }
 
+        [TestCase("Pulp.Fiction.1994.Romanian.1080p.XviD-LOL")]
+        public void should_parse_language_romanian(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle, true);
+
+            result.Languages.Should().BeEquivalentTo(Language.Romanian);
+        }
+
+        [TestCase("Pulp.Fiction.1994.Hindi.1080p.XviD-LOL")]
+        public void should_parse_language_hindi(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle, true);
+
+            result.Languages.Should().BeEquivalentTo(Language.Hindi);
+        }
+
         [TestCase("Pulp.Fiction.1994.Polish.1080p.XviD-LOL")]
         public void should_parse_language_polish(string postTitle)
         {

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -131,6 +131,14 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Languages.Should().BeEquivalentTo(Language.Hindi);
         }
 
+        [TestCase("Pulp.Fiction.1994.Thai.1080p.XviD-LOL")]
+        public void should_parse_language_thai(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle, true);
+
+            result.Languages.Should().BeEquivalentTo(Language.Thai);
+        }
+
         [TestCase("Pulp.Fiction.1994.Polish.1080p.XviD-LOL")]
         public void should_parse_language_polish(string postTitle)
         {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/LanguageSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/LanguageSpecification.cs
@@ -27,6 +27,19 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 return Decision.Accept();
             }
 
+            var originalLanguage = subject.Movie.OriginalLanguage;
+
+            if (wantedLanguage == Language.Original)
+            {
+                if (!subject.ParsedMovieInfo.Languages.Contains(originalLanguage))
+                {
+                    _logger.Debug("Original Language({0}) is wanted, but found {1}", originalLanguage, subject.ParsedMovieInfo.Languages.ToExtendedString());
+                    return Decision.Reject("Original Language ({0}) is wanted, but found {1}", originalLanguage, subject.ParsedMovieInfo.Languages.ToExtendedString());
+                }
+
+                return Decision.Accept();
+            }
+
             _logger.Debug("Checking if report meets language requirements. {0}", subject.ParsedMovieInfo.Languages.ToExtendedString());
 
             if (!subject.ParsedMovieInfo.Languages.Contains(wantedLanguage))

--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -99,6 +99,7 @@ namespace NzbDrone.Core.Languages
         public static Language Hindi => new Language(26, "Hindi");
         public static Language Romanian => new Language(27, "Romanian");
         public static Language Thai => new Language(28, "Thai");
+        public static Language Bulgarian => new Language(29, "Bulgarian");
         public static Language Any => new Language(-1, "Any");
         public static Language Original => new Language(-2, "Original");
 
@@ -137,6 +138,7 @@ namespace NzbDrone.Core.Languages
                     Romanian,
                     Hindi,
                     Thai,
+                    Bulgarian,
                     Any,
                     Original
                 };

--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -97,6 +97,7 @@ namespace NzbDrone.Core.Languages
         public static Language Lithuanian => new Language(24, "Lithuanian");
         public static Language Czech => new Language(25, "Czech");
         public static Language Any => new Language(-1, "Any");
+        public static Language Original => new Language(-2, "Original");
 
         public static List<Language> All
         {
@@ -130,7 +131,8 @@ namespace NzbDrone.Core.Languages
                     Hebrew,
                     Lithuanian,
                     Czech,
-                    Any
+                    Any,
+                    Original
                 };
             }
         }

--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -98,6 +98,7 @@ namespace NzbDrone.Core.Languages
         public static Language Czech => new Language(25, "Czech");
         public static Language Hindi => new Language(26, "Hindi");
         public static Language Romanian => new Language(27, "Romanian");
+        public static Language Thai => new Language(28, "Thai");
         public static Language Any => new Language(-1, "Any");
         public static Language Original => new Language(-2, "Original");
 
@@ -135,6 +136,7 @@ namespace NzbDrone.Core.Languages
                     Czech,
                     Romanian,
                     Hindi,
+                    Thai,
                     Any,
                     Original
                 };

--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -96,6 +96,8 @@ namespace NzbDrone.Core.Languages
         public static Language Hebrew => new Language(23, "Hebrew");
         public static Language Lithuanian => new Language(24, "Lithuanian");
         public static Language Czech => new Language(25, "Czech");
+        public static Language Hindi => new Language(26, "Hindi");
+        public static Language Romanian => new Language(27, "Romanian");
         public static Language Any => new Language(-1, "Any");
         public static Language Original => new Language(-2, "Original");
 
@@ -131,6 +133,8 @@ namespace NzbDrone.Core.Languages
                     Hebrew,
                     Lithuanian,
                     Czech,
+                    Romanian,
+                    Hindi,
                     Any,
                     Original
                 };

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -31,7 +31,9 @@ namespace NzbDrone.Core.Parser
                                                                new IsoLanguage("ko", "", "kor", "Korean", Language.Korean),
                                                                new IsoLanguage("hu", "", "hun", "Hungarian", Language.Hungarian),
                                                                new IsoLanguage("he", "", "heb", "Hebrew", Language.Hebrew),
-                                                               new IsoLanguage("cs", "", "ces", "Czech", Language.Czech)
+                                                               new IsoLanguage("cs", "", "ces", "Czech", Language.Czech),
+                                                               new IsoLanguage("hi", "", "hin", "Hindi", Language.Hindi),
+                                                               new IsoLanguage("ro", "", "ron", "Romanian", Language.Romanian)
                                                            };
 
         public static IsoLanguage Find(string isoCode)

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -33,6 +33,7 @@ namespace NzbDrone.Core.Parser
                                                                new IsoLanguage("he", "", "heb", "Hebrew", Language.Hebrew),
                                                                new IsoLanguage("cs", "", "ces", "Czech", Language.Czech),
                                                                new IsoLanguage("hi", "", "hin", "Hindi", Language.Hindi),
+                                                               new IsoLanguage("th", "", "tha", "Thai", Language.Thai),
                                                                new IsoLanguage("ro", "", "ron", "Romanian", Language.Romanian)
                                                            };
 

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -34,6 +34,7 @@ namespace NzbDrone.Core.Parser
                                                                new IsoLanguage("cs", "", "ces", "Czech", Language.Czech),
                                                                new IsoLanguage("hi", "", "hin", "Hindi", Language.Hindi),
                                                                new IsoLanguage("th", "", "tha", "Thai", Language.Thai),
+                                                               new IsoLanguage("bg", "", "bul", "Bulgarian", Language.Bulgarian),
                                                                new IsoLanguage("ro", "", "ron", "Romanian", Language.Romanian)
                                                            };
 

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Parser
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(LanguageParser));
 
-        private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>\b(?:german|videomann|ger)\b)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VO|VFF|VFQ|VFI|VF2|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<english>\beng\b)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)",
+        private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>\b(?:german|videomann|ger)\b)|(?<flemish>flemish)|(?<bulgarian>bgaudio)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VO|VFF|VFQ|VFI|VF2|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<english>\beng\b)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?<lithuanian>\bLT\b)|(?<czech>\bCZ\b)",
@@ -90,6 +90,11 @@ namespace NzbDrone.Core.Parser
             if (lowerTitle.Contains("thai"))
             {
                 languages.Add(Language.Thai);
+            }
+
+            if (lowerTitle.Contains("bulgarian"))
+            {
+                languages.Add(Language.Bulgarian);
             }
 
             if (lowerTitle.Contains("polish"))
@@ -187,6 +192,11 @@ namespace NzbDrone.Core.Parser
                 if (match.Groups["english"].Success)
                 {
                     languages.Add(Language.English);
+                }
+
+                if (match.Groups["bulgarian"].Success)
+                {
+                    languages.Add(Language.Bulgarian);
                 }
 
                 if (match.Groups["dutch"].Success)

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -87,6 +87,11 @@ namespace NzbDrone.Core.Parser
                 languages.Add(Language.Hindi);
             }
 
+            if (lowerTitle.Contains("thai"))
+            {
+                languages.Add(Language.Thai);
+            }
+
             if (lowerTitle.Contains("polish"))
             {
                 languages.Add(Language.Polish);

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -77,6 +77,16 @@ namespace NzbDrone.Core.Parser
                 languages.Add(Language.Russian);
             }
 
+            if (lowerTitle.Contains("romanian"))
+            {
+                languages.Add(Language.Romanian);
+            }
+
+            if (lowerTitle.Contains("hindi"))
+            {
+                languages.Add(Language.Hindi);
+            }
+
             if (lowerTitle.Contains("polish"))
             {
                 languages.Add(Language.Polish);

--- a/src/Radarr.Api.V3/Calendar/CalendarModule.cs
+++ b/src/Radarr.Api.V3/Calendar/CalendarModule.cs
@@ -72,10 +72,25 @@ namespace Radarr.Api.V3.Calendar
                 return null;
             }
 
-            var translation = _movieTranslationService.GetAllTranslationsForMovie(movie.Id).FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
+            var translations = _movieTranslationService.GetAllTranslationsForMovie(movie.Id);
+            var translation = GetMovieTranslation(translations, movie);
             var resource = movie.ToResource(_qualityUpgradableSpecification, translation);
 
             return resource;
+        }
+
+        private MovieTranslation GetMovieTranslation(List<MovieTranslation> translations, Movie movie)
+        {
+            if ((Language)_configService.MovieInfoLanguage == Language.Original)
+            {
+                return new MovieTranslation
+                {
+                    Title = movie.OriginalTitle,
+                    Overview = movie.Overview
+                };
+            }
+
+            return translations.FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage && t.MovieId == movie.Id);
         }
     }
 }

--- a/src/Radarr.Api.V3/MovieFiles/MovieFileModule.cs
+++ b/src/Radarr.Api.V3/MovieFiles/MovieFileModule.cs
@@ -6,6 +6,7 @@ using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.Exceptions;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
@@ -129,7 +130,8 @@ namespace Radarr.Api.V3.MovieFiles
 
                 if (resource.Languages != null)
                 {
-                    movieFile.Languages = resource.Languages;
+                    // Don't allow user to set movieFile with 'Any' or 'Original' language
+                    movieFile.Languages = resource.Languages.Where(l => l != Language.Any || l != Language.Original || l != null).ToList();
                 }
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Allow user to select original movie language as wanted language in profile.

#### Todos
- [x] Tests
- [x] Allow Movie Info Select Original Language to show the Original Title
- [x] Disallow selecting original for movie files and UI language 

#### Issues Fixed or Closed by this PR

Fixes #568
Fixes #3081 
Fixes #5069 
Fixes #3597 
Fixes #4111 