### PR TITLE
Bump ImageSharp to stable package 1.0.1 [Common]

### DIFF
--- a/src/NzbDrone.Core/MediaCover/ImageResizer.cs
+++ b/src/NzbDrone.Core/MediaCover/ImageResizer.cs
@@ -2,8 +2,8 @@ using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.Processing;
-using SixLabors.Memory;
 
 namespace NzbDrone.Core.MediaCover
 {

--- a/src/NzbDrone.Core/Radarr.Core.csproj
+++ b/src/NzbDrone.Core/Radarr.Core.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="FluentMigrator.Runner" Version="4.0.0-alpha.268" />
     <PackageReference Include="FluentMigrator.Runner.SQLite" Version="4.0.0-alpha.268" />
     <PackageReference Include="FluentValidation" Version="8.6.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NLog" Version="4.7.0" />
     <PackageReference Include="TinyTwitter" Version="1.1.2" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Bumps ImageSharp to 1.0 final instead of using beta package
