### PR TITLE
Fix an issue where lowercase paths can cause media deletion

### DIFF
--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -258,17 +258,6 @@ namespace NzbDrone.Common.Disk
             Ensure.That(source, () => source).IsValidPath();
             Ensure.That(destination, () => destination).IsValidPath();
 
-            if (source.PathEquals(destination))
-            {
-                throw new IOException(string.Format("Source and destination can't be the same {0}", source));
-            }
-
-            if (FolderExists(destination) && overwrite)
-            {
-                DeleteFolder(destination, true);
-            }
-
-            RemoveReadOnlyFolder(source);
             Directory.Move(source, destination);
         }
 

--- a/src/NzbDrone.Common/Disk/DiskTransferService.cs
+++ b/src/NzbDrone.Common/Disk/DiskTransferService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading;
 using NLog;
 using NzbDrone.Common.EnsureThat;
-using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Common.Disk
@@ -27,10 +26,55 @@ namespace NzbDrone.Common.Disk
             _logger = logger;
         }
 
+        private string ResolveRealParentPath(string path)
+        {
+            var parentPath = path.GetParentPath();
+            if (!_diskProvider.FolderExists(parentPath))
+            {
+                return path;
+            }
+
+            var realParentPath = parentPath.GetActualCasing();
+
+            var partialChildPath = path.Substring(parentPath.Length);
+
+            return realParentPath + partialChildPath;
+        }
+
         public TransferMode TransferFolder(string sourcePath, string targetPath, TransferMode mode)
         {
             Ensure.That(sourcePath, () => sourcePath).IsValidPath();
             Ensure.That(targetPath, () => targetPath).IsValidPath();
+
+            sourcePath = ResolveRealParentPath(sourcePath);
+            targetPath = ResolveRealParentPath(targetPath);
+
+            _logger.Debug("{0} Directory [{1}] > [{2}]", mode, sourcePath, targetPath);
+
+            if (sourcePath == targetPath)
+            {
+                throw new IOException(string.Format("Source and destination can't be the same {0}", sourcePath));
+            }
+
+            if (mode == TransferMode.Move && sourcePath.PathEquals(targetPath, StringComparison.InvariantCultureIgnoreCase) && _diskProvider.FolderExists(targetPath))
+            {
+                // Move folder out of the way to allow case-insensitive renames
+                var tempPath = sourcePath + ".backup~";
+                _logger.Trace("Rename Intermediate Directory [{0}] > [{1}]", sourcePath, tempPath);
+                _diskProvider.MoveFolder(sourcePath, tempPath);
+
+                if (!_diskProvider.FolderExists(targetPath))
+                {
+                    _logger.Trace("Rename Intermediate Directory [{0}] > [{1}]", tempPath, targetPath);
+                    _logger.Debug("Rename Directory [{0}] > [{1}]", sourcePath, targetPath);
+                    _diskProvider.MoveFolder(tempPath, targetPath);
+                    return mode;
+                }
+
+                // There were two separate folders, revert the intermediate rename and let the recursion deal with it
+                _logger.Trace("Rename Intermediate Directory [{0}] > [{1}]", tempPath, sourcePath);
+                _diskProvider.MoveFolder(tempPath, sourcePath);
+            }
 
             if (mode == TransferMode.Move && !_diskProvider.FolderExists(targetPath))
             {
@@ -40,7 +84,7 @@ namespace NzbDrone.Common.Disk
                 // If we're on the same mount, do a simple folder move.
                 if (sourceMount != null && targetMount != null && sourceMount.RootDirectory == targetMount.RootDirectory)
                 {
-                    _logger.Debug("Move Directory [{0}] > [{1}]", sourcePath, targetPath);
+                    _logger.Debug("Rename Directory [{0}] > [{1}]", sourcePath, targetPath);
                     _diskProvider.MoveFolder(sourcePath, targetPath);
                     return mode;
                 }
@@ -79,6 +123,13 @@ namespace NzbDrone.Common.Disk
 
             if (mode.HasFlag(TransferMode.Move))
             {
+                var totalSize = _diskProvider.GetFileInfos(sourcePath).Sum(v => v.Length);
+
+                if (totalSize > (100 * 1024L * 1024L))
+                {
+                    throw new IOException($"Large files still exist in {sourcePath} after folder move, not deleting source folder");
+                }
+
                 _diskProvider.DeleteFolder(sourcePath, true);
             }
 
@@ -92,7 +143,10 @@ namespace NzbDrone.Common.Disk
             Ensure.That(sourcePath, () => sourcePath).IsValidPath();
             Ensure.That(targetPath, () => targetPath).IsValidPath();
 
-            _logger.Debug("Mirror [{0}] > [{1}]", sourcePath, targetPath);
+            sourcePath = ResolveRealParentPath(sourcePath);
+            targetPath = ResolveRealParentPath(targetPath);
+
+            _logger.Debug("Mirror Folder [{0}] > [{1}]", sourcePath, targetPath);
 
             if (!_diskProvider.FolderExists(targetPath))
             {
@@ -203,6 +257,9 @@ namespace NzbDrone.Common.Disk
         {
             Ensure.That(sourcePath, () => sourcePath).IsValidPath();
             Ensure.That(targetPath, () => targetPath).IsValidPath();
+
+            sourcePath = ResolveRealParentPath(sourcePath);
+            targetPath = ResolveRealParentPath(targetPath);
 
             _logger.Debug("{0} [{1}] > [{2}]", mode, sourcePath, targetPath);
 

--- a/src/NzbDrone.Update/UpdateEngine/InstallUpdateService.cs
+++ b/src/NzbDrone.Update/UpdateEngine/InstallUpdateService.cs
@@ -90,6 +90,12 @@ namespace NzbDrone.Update.UpdateEngine
 
             Verify(installationFolder, processId);
 
+            if (installationFolder.EndsWith(@"\bin\Radarr") || installationFolder.EndsWith(@"/bin/Radarr"))
+            {
+                installationFolder = installationFolder.GetParentPath();
+                _logger.Info("Fixed Installation Folder: {0}", installationFolder);
+            }
+
             var appType = _detectApplicationType.GetAppType();
 
             _processProvider.FindProcessByName(ProcessProvider.RADARR_CONSOLE_PROCESS_NAME);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix: Fixes an issue where paths somehow got stored in the db as lowercase paths which causes a folder to be completely deleted in a case of trying to move the root folder to the same path (used for folder renaming)

Note: This is going to also be an issue in v0.2 but as it is an edge case it isn't being addressed at this time

Fixes #5184 
Fixes #5190 