### PR TITLE
Add option to prefix the movie filename to the images in XBMC

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/MediaBrowser/MediaBrowserMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/MediaBrowser/MediaBrowserMetadata.cs
@@ -90,7 +90,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.MediaBrowser
             }
         }
 
-        public override List<ImageFileResult> MovieImages(Movie movie)
+        public override List<ImageFileResult> MovieImages(Movie movie, MovieFile movieFile)
         {
             return new List<ImageFileResult>();
         }

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
@@ -133,7 +133,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
             return new MetadataFileResult(GetMovieFileMetadataFilename(movieFile.RelativePath), xmlResult.Trim(Environment.NewLine.ToCharArray()));
         }
 
-        public override List<ImageFileResult> MovieImages(Movie movie)
+        public override List<ImageFileResult> MovieImages(Movie movie, MovieFile movieFile)
         {
             if (!Settings.MovieImages)
             {

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Wdtv/WdtvMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Wdtv/WdtvMetadata.cs
@@ -128,7 +128,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
             return new MetadataFileResult(filename, xmlResult.Trim(Environment.NewLine.ToCharArray()));
         }
 
-        public override List<ImageFileResult> MovieImages(Movie movie)
+        public override List<ImageFileResult> MovieImages(Movie movie, MovieFile movieFile)
         {
             if (!Settings.MovieImages)
             {

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadataSettings.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadataSettings.cs
@@ -42,6 +42,9 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
         [FieldDefinition(5, Label = "Collection Name", Type = FieldType.Checkbox, HelpText = "Radarr will write the collection name to the .nfo file", Advanced = true)]
         public bool AddCollectionName { get; set; }
 
+        [FieldDefinition(6, Label = "Use <image>.jpg", Type = FieldType.Checkbox, HelpText = "Radarr will write images to <image>.jpg instead of the default <movie-filename>-<image>.jpg")]
+        public bool UseMovieImages { get; set; }
+
         public bool IsValid => true;
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Extras/Metadata/IMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/IMetadata.cs
@@ -11,6 +11,6 @@ namespace NzbDrone.Core.Extras.Metadata
         string GetFilenameAfterMove(Movie movie, MovieFile movieFile, MetadataFile metadataFile);
         MetadataFile FindMetadataFile(Movie movie, string path);
         MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile);
-        List<ImageFileResult> MovieImages(Movie movie);
+        List<ImageFileResult> MovieImages(Movie movie, MovieFile movieFile);
     }
 }

--- a/src/NzbDrone.Core/Extras/Metadata/MetadataBase.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/MetadataBase.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.Extras.Metadata
         public abstract MetadataFile FindMetadataFile(Movie movie, string path);
 
         public abstract MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile);
-        public abstract List<ImageFileResult> MovieImages(Movie movie);
+        public abstract List<ImageFileResult> MovieImages(Movie movie, MovieFile movieFile);
 
         public virtual object RequestAction(string action, IDictionary<string, string> query)
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add an option in Metadata - Kodi (XBMC) / Emby to prefix the movie filename to the images.

By default, in new versions of Kodi, the <movie-filename>-<image>.jpg specification is correct, and the <image>.jpg is wrong. So I have set by default the option to prefix the filename.

#### Todos
- [x] Translation Keys

#### Issues Fixed or Closed by this PR

* #5050 
