### PR TITLE
Add Option to localize metadata written in .nfo if available

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -118,8 +118,12 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
             {
                 _logger.Debug("Generating Movie Metadata for: {0}", Path.Combine(movie.Path, movieFile.RelativePath));
 
+                var movieMetadataLanguage = (Settings.MovieMetadataLanguage == (int)Language.Original) ?
+                    (int)movie.OriginalLanguage :
+                    Settings.MovieMetadataLanguage;
+
                 var movieTranslations = _movieTranslationsService.GetAllTranslationsForMovie(movie.Id);
-                var selectedSettingsLanguage = Language.FindById(Settings.MovieMetadataLanguage);
+                var selectedSettingsLanguage = Language.FindById(movieMetadataLanguage);
                 var movieTranslation = movieTranslations.FirstOrDefault(mt => mt.Language == selectedSettingsLanguage);
 
                 var watched = GetExistingWatchedStatus(movie, movieFile.RelativePath);

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadataSettings.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadataSettings.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
         {
             MovieMetadata = true;
             MovieMetadataURL = false;
-            MovieMetadataLanguage = 1;
+            MovieMetadataLanguage = (int)Language.English;
             MovieImages = true;
             UseMovieNfo = false;
         }

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadataSettings.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadataSettings.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
@@ -20,6 +21,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
         {
             MovieMetadata = true;
             MovieMetadataURL = false;
+            MovieMetadataLanguage = 1;
             MovieImages = true;
             UseMovieNfo = false;
         }
@@ -30,10 +32,13 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
         [FieldDefinition(1, Label = "Movie Metadata URL", Type = FieldType.Checkbox, HelpText = "Radarr will write the tmdb/imdb url in the .nfo file", Advanced = true)]
         public bool MovieMetadataURL { get; set; }
 
-        [FieldDefinition(2, Label = "Movie Images", Type = FieldType.Checkbox)]
+        [FieldDefinition(2, Label = "Metadata Language", Type = FieldType.Select, SelectOptions = typeof(RealLanguageFieldConverter), HelpText = "Radarr will write metadata in the selected language if available")]
+        public int MovieMetadataLanguage { get; set; }
+
+        [FieldDefinition(3, Label = "Movie Images", Type = FieldType.Checkbox)]
         public bool MovieImages { get; set; }
 
-        [FieldDefinition(3, Label = "Use Movie.nfo", Type = FieldType.Checkbox, HelpText = "Radarr will write metadata to movie.nfo instead of the default <movie-filename>.nfo")]
+        [FieldDefinition(4, Label = "Use Movie.nfo", Type = FieldType.Checkbox, HelpText = "Radarr will write metadata to movie.nfo instead of the default <movie-filename>.nfo")]
         public bool UseMovieNfo { get; set; }
 
         public bool IsValid => true;

--- a/src/NzbDrone.Core/Languages/RealLanguageFieldConverter.cs
+++ b/src/NzbDrone.Core/Languages/RealLanguageFieldConverter.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Linq;
+using NzbDrone.Core.Annotations;
+
+namespace NzbDrone.Core.Languages
+{
+    public class RealLanguageFieldConverter : ISelectOptionsConverter
+    {
+        public List<SelectOption> GetSelectOptions()
+        {
+            return Language.All
+                .Where(l => l != Language.Unknown && l != Language.Any)
+                .ToList()
+                .ConvertAll(v => new SelectOption { Value = v.Id, Name = v.Name });
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added an option in XBMC Metadata settings to localize the Title and Overview metadata written in the .nfo file if available. If not, it takes the movie Title and Overview like before.

#### Todos
- [X] Translation Keys

#### Issues Fixed or Closed by this PR

* #5051 
