### PR TITLE
Handle ratelimit api response for newznab caps endpoint on certain newznab indexers that have caps behind the apikey

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabCapabilitiesProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabCapabilitiesProviderFixture.cs
@@ -94,8 +94,6 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
             var result = Subject.GetCapabilities(_settings);
 
             result.Should().NotBeNull();
-
-            ExceptionVerification.ExpectedErrors(1);
         }
     }
 }

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -328,15 +328,15 @@ namespace NzbDrone.Core.Indexers
                     return new ValidationFailure(string.Empty, "Query successful, but no results were returned from your indexer. This may be an issue with the indexer or your indexer category settings.");
                 }
             }
-            catch (ApiKeyException)
+            catch (ApiKeyException ex)
             {
-                _logger.Warn("Indexer returned result for RSS URL, API Key appears to be invalid");
+                _logger.Warn("Indexer returned result for RSS URL, API Key appears to be invalid: " + ex.Message);
 
                 return new ValidationFailure("ApiKey", "Invalid API Key");
             }
-            catch (RequestLimitReachedException)
+            catch (RequestLimitReachedException ex)
             {
-                _logger.Warn("Request limit reached");
+                _logger.Warn("Request limit reached: " + ex.Message);
             }
             catch (CloudFlareCaptchaException ex)
             {

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabCapabilitiesProvider.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabCapabilitiesProvider.cs
@@ -67,14 +67,15 @@ namespace NzbDrone.Core.Indexers.Newznab
             }
             catch (XmlException ex)
             {
+                ex.WithData(response, 128 * 1024);
+                _logger.Trace("Unexpected Response content ({0} bytes): {1}", response.ResponseData.Length, response.Content);
                 _logger.Debug(ex, "Failed to parse newznab api capabilities for {0}", indexerSettings.BaseUrl);
-
-                ex.WithData(response);
                 throw;
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Failed to determine newznab api capabilities for {0}, using the defaults instead till Radarr restarts", indexerSettings.BaseUrl);
+                ex.WithData(response, 128 * 1024);
+                _logger.Trace("Unexpected Response content ({0} bytes): {1}", response.ResponseData.Length, response.Content);
             }
 
             return capabilities;
@@ -88,14 +89,16 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             if (xDoc == null)
             {
-                throw new XmlException("Invalid XML");
+                throw new XmlException("Invalid XML").WithData(response);
             }
+
+            NewznabRssParser.CheckError(xDoc, new IndexerResponse(new IndexerRequest(response.Request), response));
 
             var xmlRoot = xDoc.Element("caps");
 
             if (xmlRoot == null)
             {
-                throw new XmlException("Unexpected XML");
+                throw new XmlException("Unexpected XML").WithData(response);
             }
 
             var xmlLimits = xmlRoot.Element("limits");

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRssParser.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
 using NzbDrone.Core.Indexers.Exceptions;
 using NzbDrone.Core.Parser.Model;
 
@@ -22,14 +23,13 @@ namespace NzbDrone.Core.Indexers.Newznab
             _settings = settings;
         }
 
-        protected override bool PreProcess(IndexerResponse indexerResponse)
+        public static void CheckError(XDocument xdoc, IndexerResponse indexerResponse)
         {
-            var xdoc = LoadXmlDocument(indexerResponse);
             var error = xdoc.Descendants("error").FirstOrDefault();
 
             if (error == null)
             {
-                return true;
+                return;
             }
 
             var code = Convert.ToInt32(error.Attribute("code").Value);
@@ -37,8 +37,7 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             if (code >= 100 && code <= 199)
             {
-                _logger.Warn("Invalid API Key: {0}", errorMessage);
-                throw new ApiKeyException("Invalid API key");
+                throw new ApiKeyException(errorMessage);
             }
 
             if (!indexerResponse.Request.Url.FullUri.Contains("apikey=") && (errorMessage == "Missing parameter" || errorMessage.Contains("apikey")))
@@ -52,6 +51,15 @@ namespace NzbDrone.Core.Indexers.Newznab
             }
 
             throw new NewznabException(indexerResponse, errorMessage);
+        }
+
+        protected override bool PreProcess(IndexerResponse indexerResponse)
+        {
+            var xdoc = LoadXmlDocument(indexerResponse);
+
+            CheckError(xdoc, indexerResponse);
+
+            return true;
         }
 
         protected override bool PostProcess(IndexerResponse indexerResponse, List<XElement> items, List<ReleaseInfo> releases)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Handle ratelimit api response for newznab caps endpoint on certain newznab indexers that have caps behind the apikey

PS: I dont think this one cherry-picked right but im not gonna mess with it so, sorry Taloth! Def not trying to take credit :)

Fixes: #5054 