### PR TITLE
New: Avoid cache on IMDb user lists

### DIFF
--- a/src/NzbDrone.Core/ImportLists/RadarrList2/IMDb/IMDbListImport.cs
+++ b/src/NzbDrone.Core/ImportLists/RadarrList2/IMDb/IMDbListImport.cs
@@ -72,7 +72,7 @@ namespace NzbDrone.Core.ImportLists.RadarrList2.IMDbList
 
         public override IParseImportListResponse GetParser()
         {
-            return new RadarrList2Parser();
+            return new IMDbListParser(Settings);
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/RadarrList2/IMDb/IMDbListParser.cs
+++ b/src/NzbDrone.Core/ImportLists/RadarrList2/IMDb/IMDbListParser.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.ImportLists.ImportListMovies;
+using NzbDrone.Core.MetadataSource.SkyHook.Resource;
+
+namespace NzbDrone.Core.ImportLists.RadarrList2.IMDbList
+{
+    public class IMDbListParser : RadarrList2Parser
+    {
+        private readonly IMDbListSettings _settings;
+
+        public IMDbListParser(IMDbListSettings settings)
+            : base()
+        {
+            _settings = settings;
+        }
+
+        public override IList<ImportListMovie> ParseResponse(ImportListResponse importListResponse)
+        {
+            var importResponse = importListResponse;
+
+            var movies = new List<ImportListMovie>();
+
+            if (!PreProcess(importResponse))
+            {
+                return movies;
+            }
+
+            if (_settings.ListId.StartsWith("ls", StringComparison.OrdinalIgnoreCase))
+            {
+                //Parse TSV response from IMDB export
+                var row = importResponse.Content.Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
+                movies = row.Skip(1).SelectList(m => new ImportListMovie { ImdbId = m.Split(',')[1] });
+
+                return movies;
+            }
+            else
+            {
+                var jsonResponse = JsonConvert.DeserializeObject<List<MovieResource>>(importResponse.Content);
+
+                if (jsonResponse == null)
+                {
+                    return movies;
+                }
+
+                return jsonResponse.SelectList(m => new ImportListMovie { TmdbId = m.TmdbId });
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/RadarrList2/IMDb/IMDbListRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/RadarrList2/IMDb/IMDbListRequestGenerator.cs
@@ -1,4 +1,5 @@
-﻿using NzbDrone.Common.Http;
+using System;
+using NzbDrone.Common.Http;
 
 namespace NzbDrone.Core.ImportLists.RadarrList2.IMDbList
 {
@@ -8,8 +9,15 @@ namespace NzbDrone.Core.ImportLists.RadarrList2.IMDbList
 
         protected override HttpRequest GetHttpRequest()
         {
+            //Use IMDb list Export for user lists to bypass RadarrAPI caching
+            if (Settings.ListId.StartsWith("ls", StringComparison.OrdinalIgnoreCase))
+            {
+                return new HttpRequest($"https://www.imdb.com/list/{Settings.ListId}/export", new HttpAccept("*/*"));
+            }
+
             return RequestBuilder.Create()
                 .SetSegment("route", $"list/imdb/{Settings.ListId}")
+                .Accept(HttpAccept.Json)
                 .Build();
         }
     }

--- a/src/NzbDrone.Core/ImportLists/RadarrList2/RadarrList2Parser.cs
+++ b/src/NzbDrone.Core/ImportLists/RadarrList2/RadarrList2Parser.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.ImportLists.RadarrList2
 {
     public class RadarrList2Parser : IParseImportListResponse
     {
-        public IList<ImportListMovie> ParseResponse(ImportListResponse importListResponse)
+        public virtual IList<ImportListMovie> ParseResponse(ImportListResponse importListResponse)
         {
             var importResponse = importListResponse;
 

--- a/src/NzbDrone.Core/ImportLists/RadarrList2/RadarrList2RequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/RadarrList2/RadarrList2RequestGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using NLog;
 using NzbDrone.Common.Http;
 
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.ImportLists.RadarrList2
 
             var httpRequest = GetHttpRequest();
 
-            var request = new ImportListRequest(httpRequest.Url.ToString(), HttpAccept.Json);
+            var request = new ImportListRequest(httpRequest.Url.ToString(), new HttpAccept(httpRequest.Headers.Accept));
 
             request.HttpRequest.SuppressHttpError = true;
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Use IMDB /export tsv for user lists to avoid our 12 hour cache