### PR TITLE
Fixed: Speed up Unmapped Folder fetch for large number of root folders

### DIFF
--- a/src/NzbDrone.Core.Test/RootFolderTests/RootFolderServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/RootFolderTests/RootFolderServiceFixture.cs
@@ -45,6 +45,10 @@ namespace NzbDrone.Core.Test.RootFolderTests
         [TestCase("//server//folder")]
         public void should_be_able_to_add_root_dir(string path)
         {
+            Mocker.GetMock<IMovieRepository>()
+                  .Setup(s => s.AllMoviePaths())
+                  .Returns(new List<string>());
+
             var root = new RootFolder { Path = path.AsOsAgnostic() };
 
             Subject.Add(root);
@@ -134,9 +138,9 @@ namespace NzbDrone.Core.Test.RootFolderTests
                   .Setup(s => s.Get(It.IsAny<int>()))
                   .Returns(rootFolder);
 
-            Mocker.GetMock<IMovieService>()
-                  .Setup(s => s.GetAllMovies())
-                  .Returns(new List<Movie>());
+            Mocker.GetMock<IMovieRepository>()
+                  .Setup(s => s.AllMoviePaths())
+                  .Returns(new List<string>());
 
             Mocker.GetMock<IDiskProvider>()
                   .Setup(s => s.GetDirectories(rootFolder.Path))

--- a/src/NzbDrone.Core/RootFolders/RootFolderService.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolderService.cs
@@ -67,13 +67,15 @@ namespace NzbDrone.Core.RootFolders
         {
             var rootFolders = _rootFolderRepository.All().ToList();
 
+            var moviePaths = _movieRepository.AllMoviePaths().ToList();
+
             rootFolders.ForEach(folder =>
             {
                 try
                 {
                     if (folder.Path.IsPathValid())
                     {
-                        GetDetails(folder, true);
+                        GetDetails(folder, moviePaths, true);
                     }
                 }
 
@@ -114,7 +116,9 @@ namespace NzbDrone.Core.RootFolders
 
             _rootFolderRepository.Insert(rootFolder);
 
-            GetDetails(rootFolder, true);
+            var moviePaths = _movieRepository.AllMoviePaths().ToList();
+
+            GetDetails(rootFolder, moviePaths, true);
 
             return rootFolder;
         }
@@ -124,7 +128,7 @@ namespace NzbDrone.Core.RootFolders
             _rootFolderRepository.Delete(id);
         }
 
-        private List<UnmappedFolder> GetUnmappedFolders(string path)
+        private List<UnmappedFolder> GetUnmappedFolders(string path, List<string> moviePaths)
         {
             _logger.Debug("Generating list of unmapped folders");
 
@@ -134,7 +138,6 @@ namespace NzbDrone.Core.RootFolders
             }
 
             var results = new List<UnmappedFolder>();
-            var movies = _movieRepository.All().ToList();
 
             if (!_diskProvider.FolderExists(path))
             {
@@ -143,7 +146,7 @@ namespace NzbDrone.Core.RootFolders
             }
 
             var possibleMovieFolders = _diskProvider.GetDirectories(path).ToList();
-            var unmappedFolders = possibleMovieFolders.Except(movies.Select(s => s.Path), PathEqualityComparer.Instance).ToList();
+            var unmappedFolders = possibleMovieFolders.Except(moviePaths.Select(s => s), PathEqualityComparer.Instance).ToList();
 
             foreach (string unmappedFolder in unmappedFolders)
             {
@@ -164,7 +167,9 @@ namespace NzbDrone.Core.RootFolders
         public RootFolder Get(int id, bool timeout)
         {
             var rootFolder = _rootFolderRepository.Get(id);
-            GetDetails(rootFolder, timeout);
+            var moviePaths = _movieRepository.AllMoviePaths().ToList();
+
+            GetDetails(rootFolder, moviePaths, timeout);
 
             return rootFolder;
         }
@@ -183,7 +188,7 @@ namespace NzbDrone.Core.RootFolders
             return possibleRootFolder.Path;
         }
 
-        private void GetDetails(RootFolder rootFolder, bool timeout)
+        private void GetDetails(RootFolder rootFolder, List<string> moviePaths, bool timeout)
         {
             Task.Run(() =>
             {
@@ -192,7 +197,7 @@ namespace NzbDrone.Core.RootFolders
                     rootFolder.Accessible = true;
                     rootFolder.FreeSpace = _diskProvider.GetAvailableSpace(rootFolder.Path);
                     rootFolder.TotalSpace = _diskProvider.GetTotalSize(rootFolder.Path);
-                    rootFolder.UnmappedFolders = GetUnmappedFolders(rootFolder.Path);
+                    rootFolder.UnmappedFolders = GetUnmappedFolders(rootFolder.Path, moviePaths);
                 }
             }).Wait(timeout ? 5000 : -1);
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description

- Avoid calling to All() Movies when fetching root folders, use AllMoviePaths() isntead
- Avoid calling to All() on every root folder when getting all root folders (quite slow on 10+ folders)

Performance results: 27 Root Folders (each letter), 450 Movies (rather small)

```
Before
[Debug] Api: [GET] /api/v3/rootFolder: 200.OK (8040 ms)

After
[Debug] Api: [GET] /api/v3/rootFolder: 200.OK (195 ms)
```

#### Todos
- [x] Tests

Likely Fixes #4905 
