### PR TITLE
Fixed: UI hanging after scrolling movie list too fast

### DIFF
--- a/src/Radarr.Http/ByteArrayResponse.cs
+++ b/src/Radarr.Http/ByteArrayResponse.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using Nancy;
+
+namespace Radarr.Http
+{
+    public class ByteArrayResponse : Response
+    {
+        public ByteArrayResponse(byte[] body, string contentType)
+        {
+            ContentType = contentType;
+
+            Contents = stream =>
+            {
+                using (var writer = new BinaryWriter(stream))
+                {
+                    writer.Write(body);
+                }
+            };
+        }
+    }
+}

--- a/src/Radarr.Http/Frontend/Mappers/HtmlMapperBase.cs
+++ b/src/Radarr.Http/Frontend/Mappers/HtmlMapperBase.cs
@@ -1,6 +1,7 @@
 using System;
-using System.IO;
+using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Nancy;
 using NLog;
 using NzbDrone.Common.Disk;
@@ -28,21 +29,16 @@ namespace Radarr.Http.Frontend.Mappers
         protected string HtmlPath;
         protected string UrlBase;
 
-        protected override Stream GetContentStream(string filePath)
+        protected override Task<byte[]> GetContent(string filePath)
         {
             var text = GetHtmlText();
-
-            var stream = new MemoryStream();
-            var writer = new StreamWriter(stream);
-            writer.Write(text);
-            writer.Flush();
-            stream.Position = 0;
-            return stream;
+            var data = Encoding.UTF8.GetBytes(text);
+            return Task.FromResult(data);
         }
 
-        public override Response GetResponse(string resourceUrl)
+        public async override Task<Response> GetResponse(string resourceUrl)
         {
-            var response = base.GetResponse(resourceUrl);
+            var response = await base.GetResponse(resourceUrl);
             response.Headers["X-UA-Compatible"] = "IE=edge";
 
             return response;

--- a/src/Radarr.Http/Frontend/Mappers/IMapHttpRequestsToDisk.cs
+++ b/src/Radarr.Http/Frontend/Mappers/IMapHttpRequestsToDisk.cs
@@ -1,4 +1,5 @@
-﻿using Nancy;
+﻿using System.Threading.Tasks;
+using Nancy;
 
 namespace Radarr.Http.Frontend.Mappers
 {
@@ -6,6 +7,6 @@ namespace Radarr.Http.Frontend.Mappers
     {
         string Map(string resourceUrl);
         bool CanHandle(string resourceUrl);
-        Response GetResponse(string resourceUrl);
+        Task<Response> GetResponse(string resourceUrl);
     }
 }

--- a/src/Radarr.Http/Frontend/Mappers/MediaCoverProxyMapper.cs
+++ b/src/Radarr.Http/Frontend/Mappers/MediaCoverProxyMapper.cs
@@ -1,8 +1,7 @@
 using System;
-using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Nancy;
-using Nancy.Responses;
 using NzbDrone.Core.MediaCover;
 
 namespace Radarr.Http.Frontend.Mappers
@@ -28,13 +27,13 @@ namespace Radarr.Http.Frontend.Mappers
             return resourceUrl.StartsWith("/MediaCoverProxy/", StringComparison.InvariantCultureIgnoreCase);
         }
 
-        public Response GetResponse(string resourceUrl)
+        public Task<Response> GetResponse(string resourceUrl)
         {
             var match = _regex.Match(resourceUrl);
 
             if (!match.Success)
             {
-                return new NotFoundResponse();
+                return Task.FromResult<Response>(new NotFoundResponse());
             }
 
             var hash = match.Groups["hash"].Value;
@@ -42,7 +41,7 @@ namespace Radarr.Http.Frontend.Mappers
 
             var imageData = _mediaCoverProxy.GetImage(hash);
 
-            return new StreamResponse(() => new MemoryStream(imageData), MimeTypes.GetMimeType(filename));
+            return Task.FromResult<Response>(new ByteArrayResponse(imageData, MimeTypes.GetMimeType(filename)));
         }
     }
 }

--- a/src/Radarr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
+++ b/src/Radarr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Nancy;
-using Nancy.Responses;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
@@ -28,14 +28,15 @@ namespace Radarr.Http.Frontend.Mappers
 
         public abstract bool CanHandle(string resourceUrl);
 
-        public virtual Response GetResponse(string resourceUrl)
+        public async virtual Task<Response> GetResponse(string resourceUrl)
         {
             var filePath = Map(resourceUrl);
 
             if (_diskProvider.FileExists(filePath, _caseSensitive))
             {
-                var response = new StreamResponse(() => GetContentStream(filePath), MimeTypes.GetMimeType(filePath));
-                return new MaterialisingResponse(response);
+                var data = await GetContent(filePath).ConfigureAwait(false);
+
+                return new ByteArrayResponse(data, MimeTypes.GetMimeType(filePath));
             }
 
             _logger.Warn("File {0} not found", filePath);
@@ -43,9 +44,17 @@ namespace Radarr.Http.Frontend.Mappers
             return NotFoundResponse;
         }
 
-        protected virtual Stream GetContentStream(string filePath)
+        protected async virtual Task<byte[]> GetContent(string filePath)
         {
-            return File.OpenRead(filePath);
+            using (var output = new MemoryStream())
+            {
+                using (var file = File.OpenRead(filePath))
+                {
+                    await file.CopyToAsync(output).ConfigureAwait(false);
+                }
+
+                return output.ToArray();
+            }
         }
     }
 }

--- a/src/Radarr.Http/Frontend/StaticResourceModule.cs
+++ b/src/Radarr.Http/Frontend/StaticResourceModule.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Nancy;
 using NLog;
 using Radarr.Http.Frontend.Mappers;
@@ -17,11 +18,11 @@ namespace Radarr.Http.Frontend
             _requestMappers = requestMappers;
             _logger = logger;
 
-            Get("/{resource*}", x => Index());
-            Get("/", x => Index());
+            Get("/{resource*}", async (x, ct) => await Index());
+            Get("/", async (x, ct) => await Index());
         }
 
-        private Response Index()
+        private async Task<Response> Index()
         {
             var path = Request.Url.Path;
 
@@ -37,7 +38,7 @@ namespace Radarr.Http.Frontend
 
             if (mapper != null)
             {
-                return mapper.GetResponse(path);
+                return await mapper.GetResponse(path);
             }
 
             _logger.Warn("Couldn't find handler for {0}", path);


### PR DESCRIPTION
[common]

#### Database Migration
NO

#### Description
Sometimes the server would hang when too many requests arrive at once - the threadpool would be exhausted and create new threads too slowly to catch up.

This swaps the static resource mapper to run async which helps take some of the load off and seems to stop it locking up so badly.

#### Todos
- [ ] Tests

