### PR TITLE
Fixed: Speed up load and RSS

### DIFF
--- a/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
@@ -731,7 +731,7 @@ namespace NzbDrone.Common.Test.DiskTests
 
             // Note: never returns anything.
             Mocker.GetMock<IDiskProvider>()
-               .Setup(v => v.GetFileInfos(It.IsAny<string>()))
+               .Setup(v => v.GetFileInfos(It.IsAny<string>(), SearchOption.TopDirectoryOnly))
                .Returns(new List<FileInfo>());
 
             Mocker.GetMock<IDiskProvider>()
@@ -765,8 +765,8 @@ namespace NzbDrone.Common.Test.DiskTests
                 .Returns<string>(v => new DirectoryInfo(v).GetDirectories().ToList());
 
             Mocker.GetMock<IDiskProvider>()
-                .Setup(v => v.GetFileInfos(It.IsAny<string>()))
-                .Returns<string>(v => new DirectoryInfo(v).GetFiles().ToList());
+                .Setup(v => v.GetFileInfos(It.IsAny<string>(), SearchOption.TopDirectoryOnly))
+                .Returns<string, SearchOption>((v, _) => new DirectoryInfo(v).GetFiles().ToList());
 
             Mocker.GetMock<IDiskProvider>()
                 .Setup(v => v.GetFileSize(It.IsAny<string>()))

--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -505,13 +505,20 @@ namespace NzbDrone.Common.Disk
             return di.GetDirectories().ToList();
         }
 
-        public List<FileInfo> GetFileInfos(string path)
+        public FileInfo GetFileInfo(string path)
+        {
+            Ensure.That(path, () => path).IsValidPath();
+
+            return new FileInfo(path);
+        }
+
+        public List<FileInfo> GetFileInfos(string path, SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
             Ensure.That(path, () => path).IsValidPath();
 
             var di = new DirectoryInfo(path);
 
-            return di.GetFiles().ToList();
+            return di.GetFiles("*", searchOption).ToList();
         }
 
         public void RemoveEmptySubfolders(string path)

--- a/src/NzbDrone.Common/Disk/IDiskProvider.cs
+++ b/src/NzbDrone.Common/Disk/IDiskProvider.cs
@@ -52,7 +52,8 @@ namespace NzbDrone.Common.Disk
         List<IMount> GetMounts();
         IMount GetMount(string path);
         List<DirectoryInfo> GetDirectoryInfos(string path);
-        List<FileInfo> GetFileInfos(string path);
+        FileInfo GetFileInfo(string path);
+        List<FileInfo> GetFileInfos(string path, SearchOption searchOption = SearchOption.TopDirectoryOnly);
         void RemoveEmptySubfolders(string path);
         void SaveStream(Stream stream, string path);
         bool IsValidFilePermissionMask(string mask);

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetMovieFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetMovieFixture.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             Subject.GetMovie(title);
 
             Mocker.GetMock<IMovieService>()
-                  .Verify(s => s.FindByTitle(Parser.Parser.ParseMovieTitle(title, false).MovieTitle), Times.Once());
+                .Verify(s => s.FindByTitle(Parser.Parser.ParseMovieTitle(title, false).MovieTitle, It.IsAny<int>(), null, null, null), Times.Once());
         }
 
         /*[Test]

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
@@ -118,7 +118,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             Subject.Map(_parsedMovieInfo, "", null);
 
             Mocker.GetMock<IMovieService>()
-                  .Verify(v => v.FindByTitle(It.IsAny<string>(), It.IsAny<int>()), Times.Once());
+                .Verify(v => v.FindByTitle(It.IsAny<string>(), It.IsAny<int>(), null, null, null), Times.Once());
         }
 
         [Test]

--- a/src/NzbDrone.Core/Datastore/Migration/185_add_alternative_title_indices.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/185_add_alternative_title_indices.cs
@@ -1,0 +1,15 @@
+﻿using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(185)]
+    public class add_alternative_title_indices : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Create.Index().OnTable("AlternativeTitles").OnColumn("CleanTitle");
+            Create.Index().OnTable("MovieTranslations").OnColumn("CleanTitle");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -201,20 +201,20 @@ namespace NzbDrone.Core.Parser
 
         private bool TryGetMovieByTitleAndOrYear(ParsedMovieInfo parsedMovieInfo, out MappingResult result)
         {
-            Func<Movie, bool> isNotNull = movie => movie != null;
-            Movie movieByTitleAndOrYear;
+            var candidates = _movieService.FindByTitleCandidates(parsedMovieInfo.MovieTitle, out var arabicTitle, out var romanTitle);
 
+            Movie movieByTitleAndOrYear;
             if (parsedMovieInfo.Year > 1800)
             {
-                movieByTitleAndOrYear = _movieService.FindByTitle(parsedMovieInfo.MovieTitle, parsedMovieInfo.Year);
-                if (isNotNull(movieByTitleAndOrYear))
+                movieByTitleAndOrYear = _movieService.FindByTitle(parsedMovieInfo.MovieTitle, parsedMovieInfo.Year, arabicTitle, romanTitle, candidates);
+                if (movieByTitleAndOrYear != null)
                 {
                     result = new MappingResult { Movie = movieByTitleAndOrYear };
                     return true;
                 }
 
-                movieByTitleAndOrYear = _movieService.FindByTitle(parsedMovieInfo.MovieTitle);
-                if (isNotNull(movieByTitleAndOrYear))
+                movieByTitleAndOrYear = _movieService.FindByTitle(parsedMovieInfo.MovieTitle, null, arabicTitle, romanTitle, candidates);
+                if (movieByTitleAndOrYear != null)
                 {
                     result = new MappingResult { Movie = movieByTitleAndOrYear, MappingResultType = MappingResultType.WrongYear };
                     return false;
@@ -224,8 +224,8 @@ namespace NzbDrone.Core.Parser
                 return false;
             }
 
-            movieByTitleAndOrYear = _movieService.FindByTitle(parsedMovieInfo.MovieTitle);
-            if (isNotNull(movieByTitleAndOrYear))
+            movieByTitleAndOrYear = _movieService.FindByTitle(parsedMovieInfo.MovieTitle, null, arabicTitle, romanTitle, candidates);
+            if (movieByTitleAndOrYear != null)
             {
                 result = new MappingResult { Movie = movieByTitleAndOrYear };
                 return true;


### PR DESCRIPTION
#### Database Migration
YES (185, add CleanTitle indices to Alternative Titles and Translations)

#### Description
- Fix language mapping
- Grab mediacover fileinfos in one go instead of one at a time
- Get the movies and other components of the response in parallel
- Fix FindByTitle so it doesn't repeat queries to DB
- Fix FindByTitle so it uses the index instead of a table scan

#### Todos
- [ ] Tests
- [x] Translation Keys

#### Issues Fixed or Closed by this PR

* #
