### PR TITLE
Fixed: Improve wording of add movie monitor dropdown

### DIFF
--- a/frontend/src/Components/Form/MovieMonitoredSelectInput.js
+++ b/frontend/src/Components/Form/MovieMonitoredSelectInput.js
@@ -3,8 +3,8 @@ import React from 'react';
 import SelectInput from './SelectInput';
 
 const monitorTypesOptions = [
-  { key: 'true', value: 'True' },
-  { key: 'false', value: 'False' }
+  { key: 'true', value: 'Yes' },
+  { key: 'false', value: 'No' }
 ];
 
 function MovieMonitoredSelectInput(props) {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Change the wording of the `Monitor` dropdown options from the developer-friendly `True` and `False` to a more user-friendly `Yes` and `No`, this keeps consistency with Radarr v0.2.

#### Todos
- [ ] Tests
- [ ] Translation Keys
