### PR TITLE
FIXED: Updated Import for Discord Notifications to use 'Success' Colour

### DIFF
--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -122,7 +122,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 Url = $"https://www.themoviedb.org/movie/{message.Movie.TmdbId}",
                 Description = isUpgrade ? "Movie Upgraded" : "Movie Imported",
                 Title = message.Movie.Year > 0 ? $"{message.Movie.Title} ({message.Movie.Year})" : message.Movie.Title,
-                Color = isUpgrade ? (int)DiscordColors.Upgrade : (int)DiscordColors.Standard,
+                Color = isUpgrade ? (int)DiscordColors.Upgrade : (int)DiscordColors.Success,
                 Fields = new List<DiscordField>(),
                 Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
             };


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Updated Discord.OnDownload to use Success Colour (green) as per PR [4037](https://github.com/Sonarr/Sonarr/pull/4037) for Sonarr 

#### Issues Fixed or Closed by this PR

* Fixes #5270 
* Fixes #5269 
