### PR TITLE
Add app shortcuts to Android PWA

### DIFF
--- a/frontend/src/Content/Images/Icons/manifest.json
+++ b/frontend/src/Content/Images/Icons/manifest.json
@@ -21,22 +21,22 @@
         {
             "name": "Add new...",
             "url": "/add/new",
-            "icons": [{ "src": "/Content/Images/Icons/android-chrome-192x192.png", "sizes": "196x196" }]
+            "icons": [{ "src": "/Content/Images/Icons/android-chrome-192x192.png", "sizes": "192x192" }]
         },
         {
             "name": "Calendar",
             "url": "/calendar",
-            "icons": [{ "src": "/Content/Images/Icons/android-chrome-192x192.png", "sizes": "196x196" }]
+            "icons": [{ "src": "/Content/Images/Icons/android-chrome-192x192.png", "sizes": "192x192" }]
         },
         {
             "name": "Queue",
             "url": "/activity/queue",
-            "icons": [{ "src": "/Content/Images/Icons/android-chrome-192x192.png", "sizes": "196x196" }]
+            "icons": [{ "src": "/Content/Images/Icons/android-chrome-192x192.png", "sizes": "192x192" }]
         },
         {
             "name": "Status",
             "url": "/system/status",
-            "icons": [{ "src": "/Content/Images/Icons/android-chrome-192x192.png", "sizes": "196x196" }]
+            "icons": [{ "src": "/Content/Images/Icons/android-chrome-192x192.png", "sizes": "192x192" }]
         }
     ]
 }

--- a/frontend/src/Content/Images/Icons/manifest.json
+++ b/frontend/src/Content/Images/Icons/manifest.json
@@ -14,6 +14,7 @@
         }
     ],
     "theme_color": "#3a3f51",
+    "background_color": "#eeeeee"
     "start_url": "/",
     "scope": "/",
     "display": "standalone",

--- a/frontend/src/Content/Images/Icons/manifest.json
+++ b/frontend/src/Content/Images/Icons/manifest.json
@@ -14,7 +14,6 @@
         }
     ],
     "theme_color": "#3a3f51",
-    "background_color": "#eeeeee"
     "start_url": "/",
     "scope": "/",
     "display": "standalone",

--- a/frontend/src/Content/Images/Icons/manifest.json
+++ b/frontend/src/Content/Images/Icons/manifest.json
@@ -1,5 +1,6 @@
 {
-    "name": "",
+    "name": "Radarr",
+    "description": "Automated movie downloader",
     "icons": [
         {
             "src": "/Content/Images/Icons/android-chrome-192x192.png",
@@ -13,6 +14,29 @@
         }
     ],
     "theme_color": "#3a3f51",
-    "background_color": "#3a3f51",
-    "display": "standalone"
+    "start_url": "/",
+    "scope": "/",
+    "display": "standalone",
+    "shortcuts": [
+        {
+            "name": "Add new...",
+            "url": "/add/new",
+            "icons": [{ "src": "/Content/Images/Icons/android-chrome-192x192.png", "sizes": "196x196" }]
+        },
+        {
+            "name": "Calendar",
+            "url": "/calendar",
+            "icons": [{ "src": "/Content/Images/Icons/android-chrome-192x192.png", "sizes": "196x196" }]
+        },
+        {
+            "name": "Queue",
+            "url": "/activity/queue",
+            "icons": [{ "src": "/Content/Images/Icons/android-chrome-192x192.png", "sizes": "196x196" }]
+        },
+        {
+            "name": "Status",
+            "url": "/system/status",
+            "icons": [{ "src": "/Content/Images/Icons/android-chrome-192x192.png", "sizes": "196x196" }]
+        }
+    ]
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR adds app shortcuts to Sonarr Android PWA app.
That way users can hold the app icon and navigate to common destinations easily.

Also, sets the correct splash screen background color.

#### Todos
- [ ] Tests
- [ ] Translation Keys

#### Issues Fixed or Closed by this PR

* #
