### PR TITLE
Fixed: False Positives for RemotePath check with Deluge

### DIFF
--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/RemotePathMappingCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/RemotePathMappingCheckFixture.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnsureThat;
 using NzbDrone.Common.EnvironmentInfo;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.Clients;
 using NzbDrone.Core.HealthCheck.Checks;
@@ -63,6 +64,10 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
             Mocker.GetMock<IProvideDownloadClient>()
                   .Setup(s => s.GetDownloadClients())
                   .Returns(new IDownloadClient[] { _downloadClient.Object });
+
+            Mocker.GetMock<IConfigService>()
+                  .Setup(s => s.EnableCompletedDownloadHandling)
+                  .Returns(true);
 
             Mocker.GetMock<IDiskProvider>()
                 .Setup(x => x.FolderExists(It.IsAny<string>()))

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -198,12 +198,21 @@ namespace NzbDrone.Core.Download.Clients.Deluge
         public override DownloadClientInfo GetStatus()
         {
             var config = _proxy.GetConfig(Settings);
+            var label = _proxy.GetLabelOptions(Settings);
+            OsPath destDir;
 
-            var destDir = new OsPath(config.GetValueOrDefault("download_location") as string);
-
-            if (config.GetValueOrDefault("move_completed", false).ToString() == "True")
+            if (label != null && label.ApplyMoveCompleted && label.MoveCompleted)
+            {
+                // if label exists and a label completed path exists and is enabled use it instead of global
+                destDir = new OsPath(label.MoveCompletedPath);
+            }
+            else if (config.GetValueOrDefault("move_completed", false).ToString() == "True")
             {
                 destDir = new OsPath(config.GetValueOrDefault("move_completed_path") as string);
+            }
+            else
+            {
+                destDir = new OsPath(config.GetValueOrDefault("download_location") as string);
             }
 
             var status = new DownloadClientInfo

--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeLabel.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeLabel.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace NzbDrone.Core.Download.Clients.Deluge
+{
+    public class DelugeLabel
+    {
+        [JsonProperty(PropertyName = "apply_move_completed")]
+        public bool ApplyMoveCompleted { get; set; }
+
+        [JsonProperty(PropertyName = "move_completed")]
+        public bool MoveCompleted { get; set; }
+
+        [JsonProperty(PropertyName = "move_completed_path")]
+        public string MoveCompletedPath { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeProxy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -19,6 +19,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
         string[] GetAvailablePlugins(DelugeSettings settings);
         string[] GetEnabledPlugins(DelugeSettings settings);
         string[] GetAvailableLabels(DelugeSettings settings);
+        DelugeLabel GetLabelOptions(DelugeSettings settings);
         void SetTorrentLabel(string hash, string label, DelugeSettings settings);
         void SetTorrentConfiguration(string hash, string key, object value, DelugeSettings settings);
         void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfiguration, DelugeSettings settings);
@@ -153,6 +154,13 @@ namespace NzbDrone.Core.Download.Clients.Deluge
         public string[] GetAvailableLabels(DelugeSettings settings)
         {
             var response = ProcessRequest<string[]>(settings, "label.get_labels");
+
+            return response;
+        }
+
+        public DelugeLabel GetLabelOptions(DelugeSettings settings)
+        {
+            var response = ProcessRequest<DelugeLabel>(settings, "label.get_options", settings.MovieCategory);
 
             return response;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Only run remote path checks when completed download handling is enabled
- Check deluge label for path before falling back to global path for remote mapping checks

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR
Fixes #4803 
Fixes #5251