### PR TITLE
Fixed: Nested Folder in MovieFolder Naming not created automatically

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MovieFileMovingServiceTests/MoveMovieFileFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MovieFileMovingServiceTests/MoveMovieFileFixture.cs
@@ -10,6 +10,7 @@ using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.RootFolders;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Test.Common;
 
@@ -54,6 +55,10 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieFileMovingServiceTests
             Mocker.GetMock<IDiskProvider>()
                   .Setup(s => s.FileExists(It.IsAny<string>()))
                   .Returns(true);
+
+            Mocker.GetMock<IRootFolderService>()
+                  .Setup(s => s.GetBestRootFolderPath(It.IsAny<string>()))
+                  .Returns(rootFolder);
         }
 
         [Test]

--- a/src/NzbDrone.Core/MediaFiles/MovieFileMovingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieFileMovingService.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.RootFolders;
 
 namespace NzbDrone.Core.MediaFiles
 {
@@ -30,6 +31,7 @@ namespace NzbDrone.Core.MediaFiles
         private readonly IMediaFileAttributeService _mediaFileAttributeService;
         private readonly IEventAggregator _eventAggregator;
         private readonly IConfigService _configService;
+        private readonly IRootFolderService _rootFolderService;
         private readonly Logger _logger;
 
         public MovieFileMovingService(IUpdateMovieFileService updateMovieFileService,
@@ -39,6 +41,7 @@ namespace NzbDrone.Core.MediaFiles
                                 IMediaFileAttributeService mediaFileAttributeService,
                                 IEventAggregator eventAggregator,
                                 IConfigService configService,
+                                IRootFolderService rootFolderService,
                                 Logger logger)
         {
             _updateMovieFileService = updateMovieFileService;
@@ -48,6 +51,7 @@ namespace NzbDrone.Core.MediaFiles
             _mediaFileAttributeService = mediaFileAttributeService;
             _eventAggregator = eventAggregator;
             _configService = configService;
+            _rootFolderService = rootFolderService;
             _logger = logger;
         }
 
@@ -140,7 +144,7 @@ namespace NzbDrone.Core.MediaFiles
             var movieFileFolder = Path.GetDirectoryName(filePath);
 
             var movieFolder = movie.Path;
-            var rootFolder = new OsPath(movieFolder).Directory.FullPath;
+            var rootFolder = _rootFolderService.GetBestRootFolderPath(movieFolder);
 
             if (!_diskProvider.FolderExists(rootFolder))
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
EnsureFolder in MoveMovieService made assumption that the parent was always the root, thus would fail thinking the root didn't exist when there is nesting in MovieFolder naming. This change calls to the GetBestRootFolderPath to find the root folder instead of assuming the parent.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* Fixes #5247
