### PR TITLE
Fixed: Use audioChannels_Original if it exists in MI

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioChannelsFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioChannelsFixture.cs
@@ -15,9 +15,9 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 6,
+                AudioChannelsContainer = 6,
                 AudioChannelPositions = null,
-                AudioChannelPositionsText = "Front: L C R, Side: L R, LFE"
+                AudioChannelPositionsTextContainer = "Front: L C R, Side: L R, LFE"
             };
 
             MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(5.1m);
@@ -28,9 +28,9 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 2,
+                AudioChannelsContainer = 2,
                 AudioChannelPositions = null,
-                AudioChannelPositionsText = "Front: L R"
+                AudioChannelPositionsTextContainer = "Front: L R"
             };
 
             MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(2);
@@ -41,9 +41,9 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 2,
+                AudioChannelsContainer = 2,
                 AudioChannelPositions = null,
-                AudioChannelPositionsText = null,
+                AudioChannelPositionsTextContainer = null,
                 SchemaRevision = 2
             };
 
@@ -55,9 +55,9 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 2,
+                AudioChannelsContainer = 2,
                 AudioChannelPositions = null,
-                AudioChannelPositionsText = null,
+                AudioChannelPositionsTextContainer = null,
                 SchemaRevision = 3
             };
 
@@ -69,9 +69,9 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 2,
+                AudioChannelsContainer = 2,
                 AudioChannelPositions = "2/0/0",
-                AudioChannelPositionsText = null,
+                AudioChannelPositionsTextContainer = null,
                 SchemaRevision = 3
             };
 
@@ -83,13 +83,49 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 2,
+                AudioChannelsContainer = 2,
                 AudioChannelPositions = "3/2/0.1",
-                AudioChannelPositionsText = null,
+                AudioChannelPositionsTextContainer = null,
                 SchemaRevision = 3
             };
 
             MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(5.1m);
+        }
+
+        [Test]
+        public void should_format_8_channel_object_based_as_71_if_dtsx()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                AudioChannelsContainer = 8,
+                AudioChannelsStream = 0,
+                AudioFormat = "DTS",
+                AudioAdditionalFeatures = "XLL X",
+                AudioChannelPositions = "Object Based",
+                AudioChannelPositionsTextContainer = "Object Based",
+                AudioChannelPositionsTextStream = "Object Based",
+                SchemaRevision = 3
+            };
+
+            MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(7.1m);
+        }
+
+        [Test]
+        public void should_format_8_channel_blank_as_71_if_dtsx()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                AudioChannelsContainer = 8,
+                AudioChannelsStream = 0,
+                AudioFormat = "DTS",
+                AudioAdditionalFeatures = "XLL X",
+                AudioChannelPositions = "",
+                AudioChannelPositionsTextContainer = "",
+                AudioChannelPositionsTextStream = "Object Based",
+                SchemaRevision = 3
+            };
+
+            MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(7.1m);
         }
 
         [Test]
@@ -99,9 +135,9 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
 
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 2,
+                AudioChannelsContainer = 2,
                 AudioChannelPositions = "3/2/0.1",
-                AudioChannelPositionsText = null,
+                AudioChannelPositionsTextContainer = null,
                 SchemaRevision = 3
             };
 
@@ -113,9 +149,9 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 2,
+                AudioChannelsContainer = 2,
                 AudioChannelPositions = "3/2/0.2.1",
-                AudioChannelPositionsText = null,
+                AudioChannelPositionsTextContainer = null,
                 SchemaRevision = 3
             };
 
@@ -127,9 +163,9 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 2,
+                AudioChannelsContainer = 2,
                 AudioChannelPositions = "Object Based / 3/2/2.1",
-                AudioChannelPositionsText = null,
+                AudioChannelPositionsTextContainer = null,
                 SchemaRevision = 3
             };
 
@@ -141,9 +177,9 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 2,
+                AudioChannelsContainer = 2,
                 AudioChannelPositions = " / 2/0/0.0",
-                AudioChannelPositionsText = null,
+                AudioChannelPositionsTextContainer = null,
                 SchemaRevision = 3
             };
 
@@ -155,9 +191,9 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 2,
+                AudioChannelsContainer = 2,
                 AudioChannelPositions = "3/2/2.1 / 3/2/2.1",
-                AudioChannelPositionsText = null,
+                AudioChannelPositionsTextContainer = null,
                 SchemaRevision = 3
             };
 
@@ -169,9 +205,9 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 2,
+                AudioChannelsContainer = 2,
                 AudioChannelPositions = "3/2/0.2.1 / 3/2/0.1",
-                AudioChannelPositionsText = null,
+                AudioChannelPositionsTextContainer = null,
                 SchemaRevision = 3
             };
 
@@ -183,9 +219,9 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 2,
+                AudioChannelsContainer = 2,
                 AudioChannelPositions = "1+1",
-                AudioChannelPositionsText = null,
+                AudioChannelPositionsTextContainer = null,
                 SchemaRevision = 3
             };
 
@@ -197,9 +233,9 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 6,
+                AudioChannelsContainer = 6,
                 AudioChannelPositions = "15 objects",
-                AudioChannelPositionsText = "15 objects / Front: L C R, Side: L R, LFE",
+                AudioChannelPositionsTextContainer = "15 objects / Front: L C R, Side: L R, LFE",
                 SchemaRevision = 3
             };
 
@@ -211,13 +247,45 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioChannels = 2,
+                AudioChannelsContainer = 2,
                 AudioChannelPositions = "15 objects / 3/2.1",
-                AudioChannelPositionsText = null,
+                AudioChannelPositionsTextContainer = null,
                 SchemaRevision = 3
             };
 
             MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(5.1m);
+        }
+
+        [Test]
+        public void should_use_audio_stream_text_when_exists()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                AudioChannelsContainer = 6,
+                AudioChannelsStream = 8,
+                AudioChannelPositions = null,
+                AudioChannelPositionsTextContainer = null,
+                AudioChannelPositionsTextStream = "Front: L C R, Side: L R, Back: L R, LFE",
+                SchemaRevision = 6
+            };
+
+            MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(7.1m);
+        }
+
+        [Test]
+        public void should_use_audio_stream_channels_when_exists()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                AudioChannelsContainer = 6,
+                AudioChannelsStream = 8,
+                AudioChannelPositions = null,
+                AudioChannelPositionsTextContainer = null,
+                AudioChannelPositionsTextStream = null,
+                SchemaRevision = 6
+            };
+
+            MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(8m);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/VideoFileInfoReaderFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/VideoFileInfoReaderFixture.cs
@@ -50,7 +50,10 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
             info.AudioProfile.Should().BeOneOf("", "LC");
             info.AudioCodecLibrary.Should().Be("");
             info.AudioBitrate.Should().Be(128000);
-            info.AudioChannels.Should().Be(2);
+            info.AudioChannelsContainer.Should().Be(2);
+            info.AudioChannelsStream.Should().Be(0);
+            info.AudioChannelPositionsTextContainer.Should().Be("Front: L R");
+            info.AudioChannelPositionsTextStream.Should().Be("");
             info.AudioLanguages.Should().Be("English");
             info.Height.Should().Be(320);
             info.RunTime.Seconds.Should().Be(10);
@@ -88,7 +91,10 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
             info.AudioProfile.Should().BeOneOf("", "LC");
             info.AudioCodecLibrary.Should().Be("");
             info.AudioBitrate.Should().Be(128000);
-            info.AudioChannels.Should().Be(2);
+            info.AudioChannelsContainer.Should().Be(2);
+            info.AudioChannelsStream.Should().Be(0);
+            info.AudioChannelPositionsTextContainer.Should().Be("Front: L R");
+            info.AudioChannelPositionsTextStream.Should().Be("");
             info.AudioLanguages.Should().Be("English");
             info.Height.Should().Be(320);
             info.RunTime.Seconds.Should().Be(10);

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -387,7 +387,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             {
                 VideoCodec = "AVC",
                 AudioFormat = "DTS",
-                AudioChannels = 6,
+                AudioChannelsContainer = 6,
                 AudioLanguages = "English",
                 Subtitles = language,
                 SchemaRevision = 3
@@ -737,7 +737,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             {
                 VideoCodec = videoCodec,
                 AudioFormat = audioCodec,
-                AudioChannels = audioChannels,
+                AudioChannelsContainer = audioChannels,
                 AudioLanguages = audioLanguages,
                 Subtitles = subtitles,
                 VideoBitDepth = videoBitDepth,

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -260,8 +260,9 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                         streamDetails.Add(video);
 
                         var audio = new XElement("audio");
+                        var audioChannelCount = movieFile.MediaInfo.AudioChannelsStream > 0 ? movieFile.MediaInfo.AudioChannelsStream : movieFile.MediaInfo.AudioChannelsContainer;
                         audio.Add(new XElement("bitrate", movieFile.MediaInfo.AudioBitrate));
-                        audio.Add(new XElement("channels", movieFile.MediaInfo.AudioChannels));
+                        audio.Add(new XElement("channels", audioChannelCount));
                         audio.Add(new XElement("codec", MediaInfoFormatter.FormatAudioCodec(movieFile.MediaInfo, sceneName)));
                         audio.Add(new XElement("language", movieFile.MediaInfo.AudioLanguages));
                         streamDetails.Add(audio);

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -456,6 +456,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         private static decimal? FormatAudioChannelsFromAudioChannelPositions(MediaInfoModel mediaInfo)
         {
             var audioChannelPositions = mediaInfo.AudioChannelPositions;
+            var audioFormat = mediaInfo.AudioFormat;
 
             if (audioChannelPositions.IsNullOrWhiteSpace())
             {
@@ -508,8 +509,8 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             catch (Exception ex)
             {
                 Logger.Warn()
-                      .Message("Unable to format audio channels using 'AudioChannelPositions', with a value of: '{0}' and '{1}'. Error {2}", audioChannelPositions, mediaInfo.AudioChannelPositionsText, ex.Message)
-                      .WriteSentryWarn("UnknownAudioChannelFormat", audioChannelPositions, mediaInfo.AudioChannelPositionsText)
+                      .Message("Unable to format audio channels using 'AudioChannelPositions', with a value of: '{0}' and '{1}'. Error {2}", audioChannelPositions, mediaInfo.AudioChannelPositionsTextContainer, ex.Message)
+                      .WriteSentryWarn("UnknownAudioChannelFormat", audioChannelPositions, mediaInfo.AudioChannelPositionsTextContainer)
                       .Write();
             }
 
@@ -518,21 +519,30 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
         private static decimal? FormatAudioChannelsFromAudioChannelPositionsText(MediaInfoModel mediaInfo)
         {
-            var audioChannelPositionsText = mediaInfo.AudioChannelPositionsText;
-            var audioChannels = mediaInfo.AudioChannels;
+            var audioChannelPositionsTextContainer = mediaInfo.AudioChannelPositionsTextContainer;
+            var audioChannelPositionsTextStream = mediaInfo.AudioChannelPositionsTextStream;
+            var audioChannelsContainer = mediaInfo.AudioChannelsContainer;
+            var audioChannelsStream = mediaInfo.AudioChannelsStream;
 
-            if (audioChannelPositionsText.IsNullOrWhiteSpace())
+            //Skip if the positions texts give us nothing
+            if ((audioChannelPositionsTextContainer.IsNullOrWhiteSpace() || audioChannelPositionsTextContainer == "Object Based") &&
+                    (audioChannelPositionsTextStream.IsNullOrWhiteSpace() || audioChannelPositionsTextStream == "Object Based"))
             {
                 return null;
             }
 
             try
             {
-                return audioChannelPositionsText.ContainsIgnoreCase("LFE") ? audioChannels - 1 + 0.1m : audioChannels;
+                if (audioChannelsStream > 0)
+                {
+                    return audioChannelPositionsTextStream.ContainsIgnoreCase("LFE") ? audioChannelsStream - 1 + 0.1m : audioChannelsStream;
+                }
+
+                return audioChannelPositionsTextContainer.ContainsIgnoreCase("LFE") ? audioChannelsContainer - 1 + 0.1m : audioChannelsContainer;
             }
             catch (Exception e)
             {
-                Logger.Warn(e, "Unable to format audio channels using 'AudioChannelPositionsText', with a value of: '{0}'", audioChannelPositionsText);
+                Logger.Warn(e, "Unable to format audio channels using 'AudioChannelPositionsText' or 'AudioChannelPositionsTextStream', with value of: '{0}' and '{1}", audioChannelPositionsTextContainer, audioChannelPositionsTextStream);
             }
 
             return null;
@@ -540,7 +550,22 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
         private static decimal? FormatAudioChannelsFromAudioChannels(MediaInfoModel mediaInfo)
         {
-            var audioChannels = mediaInfo.AudioChannels;
+            var audioChannels = mediaInfo.AudioChannelsContainer;
+            var audioChannelsStream = mediaInfo.AudioChannelsStream;
+
+            var audioFormat = (mediaInfo.AudioFormat ?? string.Empty).Trim().Split(new[] { " / " }, StringSplitOptions.RemoveEmptyEntries);
+            var splitAdditionalFeatures = (mediaInfo.AudioAdditionalFeatures ?? string.Empty).Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+            // Workaround https://github.com/MediaArea/MediaInfo/issues/299 for DTS-X Audio
+            if (audioFormat.ContainsIgnoreCase("DTS") && splitAdditionalFeatures.ContainsIgnoreCase("XLL") && splitAdditionalFeatures.ContainsIgnoreCase("X"))
+            {
+                return audioChannels - 1 + 0.1m;
+            }
+
+            if (mediaInfo.SchemaRevision > 5)
+            {
+                return audioChannelsStream > 0 ? audioChannelsStream : audioChannels;
+            }
 
             if (mediaInfo.SchemaRevision >= 3)
             {

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NzbDrone.Core.Datastore;
 
 namespace NzbDrone.Core.MediaFiles.MediaInfo
@@ -27,9 +27,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         public int AudioBitrate { get; set; }
         public TimeSpan RunTime { get; set; }
         public int AudioStreamCount { get; set; }
-        public int AudioChannels { get; set; }
+        public int AudioChannelsContainer { get; set; }
+        public int AudioChannelsStream { get; set; }
         public string AudioChannelPositions { get; set; }
-        public string AudioChannelPositionsText { get; set; }
+        public string AudioChannelPositionsTextContainer { get; set; }
+        public string AudioChannelPositionsTextStream { get; set; }
         public string AudioProfile { get; set; }
         public decimal VideoFps { get; set; }
         public string AudioLanguages { get; set; }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         private readonly Logger _logger;
 
         public const int MINIMUM_MEDIA_INFO_SCHEMA_REVISION = 3;
-        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 5;
+        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 6;
 
         public VideoFileInfoReader(IDiskProvider diskProvider, Logger logger)
         {
@@ -108,6 +108,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                     int generalRuntime;
                     int streamCount;
                     int audioChannels;
+                    int audioChannelsOrig;
                     int videoBitDepth;
                     decimal videoFrameRate;
                     int videoMultiViewCount;
@@ -139,8 +140,12 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                     string audioChannelsStr = mediaInfo.Get(StreamKind.Audio, 0, "Channel(s)").Split(new string[] { " /" }, StringSplitOptions.None)[0].Trim();
                     int.TryParse(audioChannelsStr, out audioChannels);
 
-                    var audioChannelPositions = mediaInfo.Get(StreamKind.Audio, 0, "ChannelPositions/String2");
+                    string audioChannelsStrOrig = mediaInfo.Get(StreamKind.Audio, 0, "Channel(s)_Original").Split(new string[] { " /" }, StringSplitOptions.None)[0].Trim();
+                    int.TryParse(audioChannelsStrOrig, out audioChannelsOrig);
+
                     var audioChannelPositionsText = mediaInfo.Get(StreamKind.Audio, 0, "ChannelPositions");
+                    var audioChannelPositionsTextOrig = mediaInfo.Get(StreamKind.Audio, 0, "ChannelPositions_Original");
+                    var audioChannelPositions = mediaInfo.Get(StreamKind.Audio, 0, "ChannelPositions/String2");
 
                     string audioLanguages = mediaInfo.Get(StreamKind.General, 0, "Audio_Language_List");
 
@@ -169,9 +174,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                         AudioBitrate = audioBitRate,
                         RunTime = GetBestRuntime(audioRuntime, videoRuntime, generalRuntime),
                         AudioStreamCount = streamCount,
-                        AudioChannels = audioChannels,
+                        AudioChannelsContainer = audioChannels,
+                        AudioChannelsStream = audioChannelsOrig,
                         AudioChannelPositions = audioChannelPositions,
-                        AudioChannelPositionsText = audioChannelPositionsText,
+                        AudioChannelPositionsTextContainer = audioChannelPositionsText,
+                        AudioChannelPositionsTextStream = audioChannelPositionsTextOrig,
                         VideoFps = videoFrameRate,
                         AudioLanguages = audioLanguages,
                         Subtitles = subtitles,

--- a/src/NzbDrone.Core/Notifications/Trakt/TraktService.cs
+++ b/src/NzbDrone.Core/Notifications/Trakt/TraktService.cs
@@ -252,20 +252,7 @@ namespace NzbDrone.Core.Notifications.Trakt
         {
             var audioChannels = movieFile.MediaInfo != null ? MediaInfoFormatter.FormatAudioChannels(movieFile.MediaInfo).ToString("0.0") : string.Empty;
 
-            // Map cases where Radarr doesn't handle MI correctly, can purge once mediainfo handling is improved
-            if (audioChannels == "8.0")
-            {
-                audioChannels = "7.1";
-            }
-            else if (audioChannels == "6.0" && audioFormat == "dts_ma")
-            {
-                audioChannels = "7.1";
-            }
-            else if (audioChannels == "6.0" && audioFormat != "dts_ma")
-            {
-                audioChannels = "5.1";
-            }
-            else if (audioChannels == "0.0")
+            if (audioChannels == "0.0")
             {
                 audioChannels = string.Empty;
             }

--- a/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Organizer
                 VideoColourPrimaries = "BT.2020",
                 VideoTransferCharacteristics = "HLG",
                 AudioFormat = "DTS",
-                AudioChannels = 6,
+                AudioChannelsContainer = 6,
                 AudioChannelPositions = "3/2/0.1",
                 AudioLanguages = "German",
                 Subtitles = "English/German"


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Use _original property for audioChannels as it seems to be more accurate when it exists.

Also fixes cases where DTS-X channel positions are not parsed correctly due to
<https://github.com/MediaArea/MediaInfo/issues/299>

#### Screenshot (if UI related)

#### Todos
- [X] Tests

#### Issues Fixed or Closed by this PR

* Fixes #4852 
