### PR TITLE
Fixed: Import single file torrents with a folder from QBittorrent

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -312,6 +312,39 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         }
 
         [Test]
+        public void single_file_torrent_with_folder_should_only_have_first_subfolder()
+        {
+            var torrent = new QBittorrentTorrent
+            {
+                Hash = "HASH",
+                Name = @"Droned.S01E01.Test\'s.1080p.WEB-DL-DRONE",
+                Size = 1000,
+                Progress = 0.7,
+                Eta = 8640000,
+                State = "stalledDL",
+                Label = "",
+                SavePath = @"C:\Torrents".AsOsAgnostic()
+            };
+
+            var file = new QBittorrentTorrentFile
+            {
+                Name = "Folder/Droned.S01E01.Tests.1080p.WEB-DL-DRONE.mkv"
+            };
+
+            GivenTorrents(new List<QBittorrentTorrent> { torrent });
+            GivenTorrentFiles(torrent.Hash, new List<QBittorrentTorrentFile> { file });
+
+            var item = new DownloadClientItem
+            {
+                DownloadId = torrent.Hash
+            };
+
+            var result = Subject.GetImportItem(item, null);
+
+            result.OutputPath.FullPath.Should().Be(Path.Combine(torrent.SavePath, "Folder"));
+        }
+
+        [Test]
         public void multi_file_torrent_outputpath_should_have_sanitised_name()
         {
             var torrent = new QBittorrentTorrent

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -253,23 +253,14 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
             var result = item.Clone();
 
-            OsPath outputPath;
-            if (files.Count == 1)
+            // get the first subdirectory - QBittorrent returns `/` path separators even on windows...
+            var relativePath = new OsPath(files[0].Name);
+            while (!relativePath.Directory.IsEmpty)
             {
-                outputPath = savePath + files[0].Name;
+                relativePath = relativePath.Directory;
             }
-            else
-            {
-                // we have multiple files in the torrent so just get
-                // the first subdirectory
-                var relativePath = new OsPath(files[0].Name);
-                while (!relativePath.Directory.IsEmpty)
-                {
-                    relativePath = relativePath.Directory;
-                }
 
-                outputPath = savePath + relativePath.FileName;
-            }
+            var outputPath = savePath + relativePath.FileName;
 
             result.OutputPath = _remotePathMappingService.RemapRemoteToLocal(Settings.Host, outputPath);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
On windows, qbittorrent uses `/` as a path separator in its `files` API.  This causes issues if the torrent only has one file in a subfolder - in this case we just take the full file path with the bad separator.

To workaround, only take the first subfolder just like a multi-file torrent.

#### Todos
- [x] Tests
- [x] Translation Keys

#### Issues Fixed or Closed by this PR

* Fixes #5362
* Fixes #5364 
