### PR TITLE
Fixed: Availability shows incorrect for movies

### DIFF
--- a/src/Radarr.Api.V3/Blacklist/BlacklistResource.cs
+++ b/src/Radarr.Api.V3/Blacklist/BlacklistResource.cs
@@ -48,7 +48,7 @@ namespace Radarr.Api.V3.Blacklist
                 Indexer = model.Indexer,
                 Message = model.Message,
 
-                Movie = model.Movie.ToResource()
+                Movie = model.Movie.ToResource(0)
             };
         }
     }

--- a/src/Radarr.Api.V3/Calendar/CalendarModule.cs
+++ b/src/Radarr.Api.V3/Calendar/CalendarModule.cs
@@ -72,9 +72,10 @@ namespace Radarr.Api.V3.Calendar
                 return null;
             }
 
+            var availDelay = _configService.AvailabilityDelay;
             var translations = _movieTranslationService.GetAllTranslationsForMovie(movie.Id);
             var translation = GetMovieTranslation(translations, movie);
-            var resource = movie.ToResource(_qualityUpgradableSpecification, translation);
+            var resource = movie.ToResource(availDelay, translation, _qualityUpgradableSpecification);
 
             return resource;
         }

--- a/src/Radarr.Api.V3/History/HistoryModule.cs
+++ b/src/Radarr.Api.V3/History/HistoryModule.cs
@@ -52,7 +52,7 @@ namespace Radarr.Api.V3.History
 
             if (includeMovie)
             {
-                resource.Movie = model.Movie.ToResource();
+                resource.Movie = model.Movie.ToResource(0);
             }
 
             if (model.Movie != null)

--- a/src/Radarr.Api.V3/ManualImport/ManualImportModule.cs
+++ b/src/Radarr.Api.V3/ManualImport/ManualImportModule.cs
@@ -39,7 +39,7 @@ namespace Radarr.Api.V3.ManualImport
             {
                 var processedItem = _manualImportService.ReprocessItem(item.Path, item.DownloadId, item.MovieId);
 
-                item.Movie = processedItem.Movie.ToResource();
+                item.Movie = processedItem.Movie.ToResource(0);
                 item.Rejections = processedItem.Rejections;
                 item.Languages = processedItem.Languages;
             }

--- a/src/Radarr.Api.V3/ManualImport/ManualImportResource.cs
+++ b/src/Radarr.Api.V3/ManualImport/ManualImportResource.cs
@@ -42,7 +42,7 @@ namespace Radarr.Api.V3.ManualImport
                 FolderName = model.FolderName,
                 Name = model.Name,
                 Size = model.Size,
-                Movie = model.Movie.ToResource(),
+                Movie = model.Movie.ToResource(0),
                 Quality = model.Quality,
                 Languages = model.Languages,
 

--- a/src/Radarr.Api.V3/MovieFiles/MovieFileResource.cs
+++ b/src/Radarr.Api.V3/MovieFiles/MovieFileResource.cs
@@ -60,33 +60,6 @@ namespace Radarr.Api.V3.MovieFiles
             };
         }
 
-        public static MovieFileResource ToResource(this MovieFile model, NzbDrone.Core.Movies.Movie movie)
-        {
-            if (model == null)
-            {
-                return null;
-            }
-
-            return new MovieFileResource
-            {
-                Id = model.Id,
-
-                MovieId = model.MovieId,
-                RelativePath = model.RelativePath,
-                Path = Path.Combine(movie.Path, model.RelativePath),
-                Size = model.Size,
-                DateAdded = model.DateAdded,
-                SceneName = model.SceneName,
-                IndexerFlags = (int)model.IndexerFlags,
-                Quality = model.Quality,
-                Languages = model.Languages,
-                Edition = model.Edition,
-                ReleaseGroup = model.ReleaseGroup,
-                MediaInfo = model.MediaInfo.ToResource(model.SceneName),
-                OriginalFilePath = model.OriginalFilePath
-            };
-        }
-
         public static MovieFileResource ToResource(this MovieFile model, NzbDrone.Core.Movies.Movie movie, IUpgradableSpecification upgradableSpecification)
         {
             if (model == null)
@@ -110,7 +83,7 @@ namespace Radarr.Api.V3.MovieFiles
                 Edition = model.Edition,
                 ReleaseGroup = model.ReleaseGroup,
                 MediaInfo = model.MediaInfo.ToResource(model.SceneName),
-                QualityCutoffNotMet = upgradableSpecification.QualityCutoffNotMet(movie.Profile, model.Quality),
+                QualityCutoffNotMet = upgradableSpecification?.QualityCutoffNotMet(movie.Profile, model.Quality) ?? false,
                 OriginalFilePath = model.OriginalFilePath
             };
         }

--- a/src/Radarr.Api.V3/Movies/MovieEditorModule.cs
+++ b/src/Radarr.Api.V3/Movies/MovieEditorModule.cs
@@ -86,7 +86,7 @@ namespace Radarr.Api.V3.Movies
             }
 
             return ResponseWithCode(_movieService.UpdateMovie(moviesToUpdate, !resource.MoveFiles)
-                                    .ToResource(),
+                                    .ToResource(0),
                                     HttpStatusCode.Accepted);
         }
 

--- a/src/Radarr.Api.V3/Movies/MovieImportModule.cs
+++ b/src/Radarr.Api.V3/Movies/MovieImportModule.cs
@@ -22,7 +22,7 @@ namespace Radarr.Api.V3.Movies
             var resource = Request.Body.FromJson<List<MovieResource>>();
             var newMovies = resource.ToModel();
 
-            return _addMovieService.AddMovies(newMovies).ToResource();
+            return _addMovieService.AddMovies(newMovies).ToResource(0);
         }
     }
 }

--- a/src/Radarr.Api.V3/Movies/MovieLookupModule.cs
+++ b/src/Radarr.Api.V3/Movies/MovieLookupModule.cs
@@ -42,9 +42,10 @@ namespace Radarr.Api.V3.Movies
             int tmdbId = -1;
             if (int.TryParse(Request.Query.tmdbId, out tmdbId))
             {
+                var availDelay = _configService.AvailabilityDelay;
                 var result = _movieInfo.GetMovieInfo(tmdbId).Item1;
                 var translation = result.Translations.FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
-                return result.ToResource(translation);
+                return result.ToResource(availDelay, translation);
             }
 
             throw new BadRequestException("Tmdb Id was not valid");
@@ -55,8 +56,9 @@ namespace Radarr.Api.V3.Movies
             string imdbId = Request.Query.imdbId;
             var result = _movieInfo.GetMovieByImdbId(imdbId);
 
+            var availDelay = _configService.AvailabilityDelay;
             var translation = result.Translations.FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
-            return result.ToResource(translation);
+            return result.ToResource(availDelay, translation);
         }
 
         private object Search()
@@ -70,8 +72,9 @@ namespace Radarr.Api.V3.Movies
         {
             foreach (var currentMovie in movies)
             {
+                var availDelay = _configService.AvailabilityDelay;
                 var translation = currentMovie.Translations.FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
-                var resource = currentMovie.ToResource(translation);
+                var resource = currentMovie.ToResource(availDelay, translation);
 
                 _coverMapper.ConvertToLocalUrls(resource.Id, resource.Images);
 

--- a/src/Radarr.Api.V3/Movies/MovieModule.cs
+++ b/src/Radarr.Api.V3/Movies/MovieModule.cs
@@ -119,6 +119,7 @@ namespace Radarr.Api.V3.Movies
             else
             {
                 var configLanguage = (Language)_configService.MovieInfoLanguage;
+                var availDelay = _configService.AvailabilityDelay;
                 var movieTask = Task.Run(() => _moviesService.GetAllMovies());
 
                 var translations = _movieTranslationService
@@ -134,7 +135,7 @@ namespace Radarr.Api.V3.Movies
                 foreach (var movie in movies)
                 {
                     var translation = GetTranslationFromDict(translations, movie, configLanguage);
-                    var resource = movie.ToResource(_qualityUpgradableSpecification, translation);
+                    var resource = movie.ToResource(availDelay, translation, _qualityUpgradableSpecification);
                     _coverMapper.ConvertToLocalUrls(resource.Id, resource.Images, coverFileInfos);
                     moviesResources.Add(resource);
                 }
@@ -156,10 +157,12 @@ namespace Radarr.Api.V3.Movies
                 return null;
             }
 
+            var availDelay = _configService.AvailabilityDelay;
+
             var translations = _movieTranslationService.GetAllTranslationsForMovie(movie.Id);
             var translation = GetMovieTranslation(translations, movie, (Language)_configService.MovieInfoLanguage);
 
-            var resource = movie.ToResource(_qualityUpgradableSpecification, translation);
+            var resource = movie.ToResource(availDelay, translation, _qualityUpgradableSpecification);
             MapCoversToLocal(resource);
 
             return resource;
@@ -223,10 +226,12 @@ namespace Radarr.Api.V3.Movies
             var model = moviesResource.ToModel(movie);
 
             var updatedMovie = _moviesService.UpdateMovie(model);
+            var availDelay = _configService.AvailabilityDelay;
+
             var translations = _movieTranslationService.GetAllTranslationsForMovie(movie.Id);
             var translation = GetMovieTranslation(translations, movie, (Language)_configService.MovieInfoLanguage);
 
-            BroadcastResourceChange(ModelAction.Updated, updatedMovie.ToResource(_qualityUpgradableSpecification, translation));
+            BroadcastResourceChange(ModelAction.Updated, updatedMovie.ToResource(availDelay, translation, _qualityUpgradableSpecification));
         }
 
         private void DeleteMovie(int id)
@@ -244,9 +249,10 @@ namespace Radarr.Api.V3.Movies
 
         public void Handle(MovieImportedEvent message)
         {
+            var availDelay = _configService.AvailabilityDelay;
             var translations = _movieTranslationService.GetAllTranslationsForMovie(message.ImportedMovie.Movie.Id);
             var translation = GetMovieTranslation(translations, message.ImportedMovie.Movie, (Language)_configService.MovieInfoLanguage);
-            BroadcastResourceChange(ModelAction.Updated, message.ImportedMovie.Movie.ToResource(_qualityUpgradableSpecification, translation));
+            BroadcastResourceChange(ModelAction.Updated, message.ImportedMovie.Movie.ToResource(availDelay, translation, _qualityUpgradableSpecification));
         }
 
         public void Handle(MovieFileDeletedEvent message)
@@ -261,16 +267,18 @@ namespace Radarr.Api.V3.Movies
 
         public void Handle(MovieUpdatedEvent message)
         {
+            var availDelay = _configService.AvailabilityDelay;
             var translations = _movieTranslationService.GetAllTranslationsForMovie(message.Movie.Id);
             var translation = GetMovieTranslation(translations, message.Movie, (Language)_configService.MovieInfoLanguage);
-            BroadcastResourceChange(ModelAction.Updated, message.Movie.ToResource(_qualityUpgradableSpecification, translation));
+            BroadcastResourceChange(ModelAction.Updated, message.Movie.ToResource(availDelay, translation, _qualityUpgradableSpecification));
         }
 
         public void Handle(MovieEditedEvent message)
         {
+            var availDelay = _configService.AvailabilityDelay;
             var translations = _movieTranslationService.GetAllTranslationsForMovie(message.Movie.Id);
             var translation = GetMovieTranslation(translations, message.Movie, (Language)_configService.MovieInfoLanguage);
-            BroadcastResourceChange(ModelAction.Updated, message.Movie.ToResource(_qualityUpgradableSpecification, translation));
+            BroadcastResourceChange(ModelAction.Updated, message.Movie.ToResource(availDelay, translation, _qualityUpgradableSpecification));
         }
 
         public void Handle(MoviesDeletedEvent message)
@@ -283,9 +291,10 @@ namespace Radarr.Api.V3.Movies
 
         public void Handle(MovieRenamedEvent message)
         {
+            var availDelay = _configService.AvailabilityDelay;
             var translations = _movieTranslationService.GetAllTranslationsForMovie(message.Movie.Id);
             var translation = GetMovieTranslation(translations, message.Movie, (Language)_configService.MovieInfoLanguage);
-            BroadcastResourceChange(ModelAction.Updated, message.Movie.ToResource(_qualityUpgradableSpecification, translation));
+            BroadcastResourceChange(ModelAction.Updated, message.Movie.ToResource(availDelay, translation, _qualityUpgradableSpecification));
         }
 
         public void Handle(MediaCoversUpdatedEvent message)

--- a/src/Radarr.Api.V3/Movies/MovieResource.cs
+++ b/src/Radarr.Api.V3/Movies/MovieResource.cs
@@ -75,7 +75,7 @@ namespace Radarr.Api.V3.Movies
 
     public static class MovieResourceMapper
     {
-        public static MovieResource ToResource(this Movie model)
+        public static MovieResource ToResource(this Movie model, int availDelay, MovieTranslation movieTranslation = null, IUpgradableSpecification upgradableSpecification = null)
         {
             if (model == null)
             {
@@ -83,129 +83,7 @@ namespace Radarr.Api.V3.Movies
             }
 
             long size = model.MovieFile?.Size ?? 0;
-            MovieFileResource movieFile = model.MovieFile?.ToResource(model);
 
-            return new MovieResource
-            {
-                Id = model.Id,
-                TmdbId = model.TmdbId,
-                Title = model.Title,
-                OriginalTitle = model.OriginalTitle,
-                SortTitle = model.SortTitle,
-                InCinemas = model.InCinemas,
-                PhysicalRelease = model.PhysicalRelease,
-                DigitalRelease = model.DigitalRelease,
-                HasFile = model.HasFile,
-
-                SizeOnDisk = size,
-                Status = model.Status,
-                Overview = model.Overview,
-
-                Images = model.Images,
-
-                Year = model.Year,
-                SecondaryYear = model.SecondaryYear,
-
-                Path = model.Path,
-                QualityProfileId = model.ProfileId,
-
-                Monitored = model.Monitored,
-                MinimumAvailability = model.MinimumAvailability,
-
-                IsAvailable = model.IsAvailable(),
-                FolderName = model.FolderName(),
-
-                Runtime = model.Runtime,
-                CleanTitle = model.CleanTitle,
-                ImdbId = model.ImdbId,
-                TitleSlug = model.TitleSlug,
-                RootFolderPath = model.RootFolderPath,
-                Certification = model.Certification,
-                Website = model.Website,
-                Genres = model.Genres,
-                Tags = model.Tags,
-                Added = model.Added,
-                AddOptions = model.AddOptions,
-                AlternateTitles = model.AlternativeTitles.ToResource(),
-                Ratings = model.Ratings,
-                MovieFile = movieFile,
-                YouTubeTrailerId = model.YouTubeTrailerId,
-                Studio = model.Studio,
-                Collection = model.Collection
-            };
-        }
-
-        public static MovieResource ToResource(this Movie model, MovieTranslation movieTranslation)
-        {
-            if (model == null)
-            {
-                return null;
-            }
-
-            long size = model.MovieFile?.Size ?? 0;
-            MovieFileResource movieFile = model.MovieFile?.ToResource(model);
-
-            var translatedTitle = movieTranslation?.Title ?? model.Title;
-            var translatedOverview = movieTranslation?.Overview ?? model.Overview;
-
-            return new MovieResource
-            {
-                Id = model.Id,
-                TmdbId = model.TmdbId,
-                Title = translatedTitle,
-                OriginalTitle = model.OriginalTitle,
-                SortTitle = translatedTitle.NormalizeTitle(),
-                InCinemas = model.InCinemas,
-                PhysicalRelease = model.PhysicalRelease,
-                DigitalRelease = model.DigitalRelease,
-                HasFile = model.HasFile,
-
-                SizeOnDisk = size,
-                Status = model.Status,
-                Overview = translatedOverview,
-
-                Images = model.Images,
-
-                Year = model.Year,
-                SecondaryYear = model.SecondaryYear,
-
-                Path = model.Path,
-                QualityProfileId = model.ProfileId,
-
-                Monitored = model.Monitored,
-                MinimumAvailability = model.MinimumAvailability,
-
-                IsAvailable = model.IsAvailable(),
-                FolderName = model.FolderName(),
-
-                Runtime = model.Runtime,
-                CleanTitle = model.CleanTitle,
-                ImdbId = model.ImdbId,
-                TitleSlug = model.TitleSlug,
-                RootFolderPath = model.RootFolderPath,
-                Certification = model.Certification,
-                Website = model.Website,
-                Genres = model.Genres,
-                Tags = model.Tags,
-                Added = model.Added,
-                AddOptions = model.AddOptions,
-                AlternateTitles = model.AlternativeTitles.ToResource(),
-                Ratings = model.Ratings,
-                MovieFile = movieFile,
-                YouTubeTrailerId = model.YouTubeTrailerId,
-                Studio = model.Studio,
-                Collection = model.Collection
-            };
-        }
-
-        public static MovieResource ToResource(this Movie model, IUpgradableSpecification upgradableSpecification, MovieTranslation movieTranslation)
-        {
-            if (model == null)
-            {
-                return null;
-            }
-
-            long size = model.MovieFile?.Size ?? 0;
             MovieFileResource movieFile = model.MovieFile?.ToResource(model, upgradableSpecification);
 
             var translatedTitle = movieTranslation?.Title ?? model.Title;
@@ -238,7 +116,7 @@ namespace Radarr.Api.V3.Movies
                 Monitored = model.Monitored,
                 MinimumAvailability = model.MinimumAvailability,
 
-                IsAvailable = model.IsAvailable(),
+                IsAvailable = model.IsAvailable(availDelay),
                 FolderName = model.FolderName(),
 
                 Runtime = model.Runtime,
@@ -318,9 +196,9 @@ namespace Radarr.Api.V3.Movies
             return movie;
         }
 
-        public static List<MovieResource> ToResource(this IEnumerable<Movie> movies)
+        public static List<MovieResource> ToResource(this IEnumerable<Movie> movies, int availDelay)
         {
-            return movies.Select(ToResource).ToList();
+            return movies.Select(x => ToResource(x, availDelay)).ToList();
         }
 
         public static List<Movie> ToModel(this IEnumerable<MovieResource> resources)

--- a/src/Radarr.Api.V3/Queue/QueueResource.cs
+++ b/src/Radarr.Api.V3/Queue/QueueResource.cs
@@ -49,7 +49,7 @@ namespace Radarr.Api.V3.Queue
             {
                 Id = model.Id,
                 MovieId = model.Movie?.Id,
-                Movie = includeMovie && model.Movie != null ? model.Movie.ToResource() : null,
+                Movie = includeMovie && model.Movie != null ? model.Movie.ToResource(0) : null,
                 Languages = model.Languages,
                 Quality = model.Quality,
                 CustomFormats = model.RemoteMovie?.CustomFormats.ToResource(),


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When using availability delay setting in Indexer Settings, movies showing in UI as missing vs not-available were not considering the delay setting value. Thus if a movie was releasing in 15 days and delay was set to (-30) Radarr would consider it available and begin looking for it, however this was not reflected in the UI due to IsAvailable not being set correctly when resource mapping.

This changes passes the setting to IsAvailable when its set in the resource mapper to fix UI availability based on the setting used.

#### Screenshot (if UI related)

#### Todos
~~Tests~~
~~Translation Keys~~
~~Wiki Updates~~
