### PR TITLE
WIP Fixed: Restart/Shutdown from UI

### DIFF
--- a/src/NzbDrone.Common/EnvironmentInfo/RuntimeInfo.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/RuntimeInfo.cs
@@ -28,12 +28,12 @@ namespace NzbDrone.Common.EnvironmentInfo
                                serviceProvider.GetStatus(ServiceProvider.SERVICE_NAME) == ServiceControllerStatus.StartPending;
 
             //Guarded to avoid issues when running in a non-managed process
-            var entry = Assembly.GetEntryAssembly();
+            var entry = Process.GetCurrentProcess().MainModule;
 
             if (entry != null)
             {
-                ExecutingApplication = entry.Location;
-                IsWindowsTray = OsInfo.IsWindows && entry.ManifestModule.Name == $"{ProcessProvider.RADARR_PROCESS_NAME}.exe";
+                ExecutingApplication = entry.FileName;
+                IsWindowsTray = OsInfo.IsWindows && entry.ModuleName == $"{ProcessProvider.RADARR_PROCESS_NAME}.exe";
             }
         }
 

--- a/src/NzbDrone.Host/ApplicationServer.cs
+++ b/src/NzbDrone.Host/ApplicationServer.cs
@@ -1,4 +1,6 @@
+using System;
 using System.ServiceProcess;
+using System.Threading;
 using NLog;
 using NzbDrone.Common.Composition;
 using NzbDrone.Common.EnvironmentInfo;
@@ -127,8 +129,16 @@ namespace Radarr.Host
                     _runtimeInfo.RestartPending = true;
                 }
 
-                LogManager.Configuration = null;
                 Shutdown();
+
+                LogManager.Configuration = null;
+
+                if (_runtimeInfo.IsWindowsTray)
+                {
+                    //Sleep to let other processes close gracefully.
+                    Thread.Sleep(5000);
+                    Environment.Exit(0);
+                }
             }
         }
     }

--- a/src/NzbDrone/SysTray/SysTrayApp.cs
+++ b/src/NzbDrone/SysTray/SysTrayApp.cs
@@ -33,6 +33,7 @@ namespace NzbDrone.SysTray
         {
             Application.ThreadException += OnThreadException;
             Application.ApplicationExit += OnApplicationExit;
+            AppDomain.CurrentDomain.ProcessExit += OnApplicationExit;
 
             _trayMenu.Items.Add(new ToolStripMenuItem("Launch Browser", null, LaunchBrowser));
             _trayMenu.Items.Add(new ToolStripMenuItem("-"));


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Restart using incorrect executable, Assembly.GetEntryAssembly(); was grabbing the dll instead of the executable. 

```
https://github.com/dotnet/runtime/issues/13051
https://github.com/dotnet/runtime/issues/3704
```

#### Todos
- [ ] Tests