### PR TITLE
Add refresh all to migration 177 for v0.2 migrations

### DIFF
--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/ReleaseBranchCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/ReleaseBranchCheckFixture.cs
@@ -25,24 +25,20 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
                     .Returns(branch);
         }
 
-        [Test]
-        public void should_return_warning_when_branch_not_valid()
+        [TestCase("aphrodite")]
+        [TestCase("qbit-fix")]
+        [TestCase("phantom")]
+        public void should_return_warning_when_branch_is_not_valid(string branch)
         {
-            GivenValidBranch("master");
+            GivenValidBranch(branch);
 
             Subject.Check().ShouldBeWarning();
         }
 
-        [TestCase("develop")]
-        public void should_return_error_when_branch_is_v1(string branch)
-        {
-            GivenValidBranch(branch);
-
-            Subject.Check().ShouldBeError();
-        }
-
         [TestCase("nightly")]
         [TestCase("Nightly")]
+        [TestCase("develop")]
+        [TestCase("master")]
         public void should_return_no_warning_when_branch_valid(string branch)
         {
             GivenValidBranch(branch);

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -178,7 +178,7 @@ namespace NzbDrone.Core.Configuration
         public bool AnalyticsEnabled => GetValueBoolean("AnalyticsEnabled", true, persist: false);
 
         // TODO: Change back to "master" for the first stable release.
-        public string Branch => GetValue("Branch", "nightly").ToLowerInvariant();
+        public string Branch => GetValue("Branch", "master").ToLowerInvariant();
 
         public string LogLevel => GetValue("LogLevel", "info").ToLowerInvariant();
         public string ConsoleLogLevel => GetValue("ConsoleLogLevel", string.Empty, persist: false);

--- a/src/NzbDrone.Core/Configuration/DeploymentInfoProvider.cs
+++ b/src/NzbDrone.Core/Configuration/DeploymentInfoProvider.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Configuration
             var releaseInfoPath = Path.Combine(bin, "release_info");
 
             PackageUpdateMechanism = UpdateMechanism.BuiltIn;
-            DefaultBranch = "nightly";
+            DefaultBranch = "master";
 
             if (Path.GetFileName(bin) == "bin" && diskProvider.FileExists(packageInfoPath))
             {

--- a/src/NzbDrone.Core/Datastore/Migration/177_language_improvements.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/177_language_improvements.cs
@@ -59,6 +59,15 @@ namespace NzbDrone.Core.Datastore.Migration
 
             Execute.WithConnection(FixLanguagesMoveFile);
             Execute.WithConnection(FixLanguagesHistory);
+
+            //Force refresh all movies in library
+            Update.Table("ScheduledTasks")
+                .Set(new { LastExecution = "2014-01-01 00:00:00" })
+                .Where(new { TypeName = "NzbDrone.Core.Movies.Commands.RefreshMovieCommand" });
+
+            Update.Table("Movies")
+                .Set(new { LastInfoSync = "2014-01-01 00:00:00" })
+                .AllRows();
         }
 
         private void FixLanguagesMoveFile(IDbConnection conn, IDbTransaction tran)

--- a/src/NzbDrone.Core/HealthCheck/Checks/ReleaseBranchCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/ReleaseBranchCheck.cs
@@ -23,11 +23,6 @@ namespace NzbDrone.Core.HealthCheck.Checks
 
             if (!Enum.GetNames(typeof(ReleaseBranches)).Any(x => x.ToLower() == currentBranch))
             {
-                if (currentBranch == "develop")
-                {
-                    return new HealthCheck(GetType(), HealthCheckResult.Error, string.Format(_localizationService.GetLocalizedString("ReleaseBranchCheckPreviousVersionMessage"), _configFileService.Branch), "#branch-is-for-a-previous-version");
-                }
-
                 return new HealthCheck(GetType(), HealthCheckResult.Warning, string.Format(_localizationService.GetLocalizedString("ReleaseBranchCheckOfficialBranchMessage"), _configFileService.Branch), "#branch-is-not-a-valid-release-branch");
             }
 
@@ -36,6 +31,8 @@ namespace NzbDrone.Core.HealthCheck.Checks
 
         public enum ReleaseBranches
         {
+            Master,
+            Develop,
             Nightly
         }
     }

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -732,7 +732,6 @@
   "RejectionCount": "Rejection Count",
   "RelativePath": "Relative Path",
   "ReleaseBranchCheckOfficialBranchMessage": "Branch {0} is not a valid Radarr release branch, you will not receive updates",
-  "ReleaseBranchCheckPreviousVersionMessage": "Branch {0} is for a previous version of Radarr, set branch to 'Nightly' for further updates",
   "Released": "Released",
   "ReleaseDates": "Release Dates",
   "ReleasedMsg": "Movie is released",


### PR DESCRIPTION
#### Database Migration
YES 

#### Description
Add a migration to force library refresh to migration 177. Should result in library refresh for future libraries migrated from v0.2 to grab all new metadata

#### Todos
- [ ] Tests

