### PR TITLE
Update swagger.json

### DIFF
--- a/src/Radarr.Api.V3/swagger.json
+++ b/src/Radarr.Api.V3/swagger.json
@@ -3994,7 +3994,7 @@
         "description": "Used when not providing the key via URL"
       },
       "apikey": {
-        "name": "API Key",
+        "name": "apikey",
         "type": "apiKey",
         "in": "query",
         "description": "Used when not providing the key via header"


### PR DESCRIPTION
Fix: /API Key/apikey generation when using the https://radarr.video/docs/api/ and setting an api key.

It currently generates this output which will not work with Radarr v3

```
curl -X GET "http://localhost:7878/api/v3/system/status?API%20Key=awawfaw" -H "accept: application/json"
```

#### Database Migration
NO

#### Description

Api docs fix

#### Screenshot (if UI related)

![image](https://user-images.githubusercontent.com/16525024/100635415-6750f780-3328-11eb-884b-4694485f8c1a.png)

#### Todos
- [ ] Tests
- [ ] Translation Keys
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

* Fixes #none
