### PR TITLE
Fixed: Migrate fails for Sonarr contaminated DBs

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/153_indexer_client_status_search_changes.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/153_indexer_client_status_search_changes.cs
@@ -8,6 +8,12 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
+            //Cleanup cases of Sonarr Interference with Radarr db
+            if (Schema.Table("PendingReleases").Column("Reason").Exists())
+            {
+                Delete.Column("Reason").FromTable("PendingReleases");
+            }
+
             Alter.Table("PendingReleases").AddColumn("Reason").AsInt32().WithDefaultValue(0);
 
             Rename.Column("IndexerId").OnTable("IndexerStatus").To("ProviderId");


### PR DESCRIPTION
#### Database Migration
YES (Fix 153)

#### Description
Migration fails if Sonarr and Radarr have been crossed at some point

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

* Fixes #5441 
