### PR TITLE
Fixed: If v0.2 DB Exists back it up during update

### DIFF
--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -12,6 +12,7 @@ namespace NzbDrone.Common.Extensions
     {
         private const string APP_CONFIG_FILE = "config.xml";
         private const string DB = "radarr.db";
+        private const string DB_OLD = "nzbdrone.db";
         private const string DB_RESTORE = "radarr.restore";
         private const string LOG_DB = "logs.db";
         private const string NLOG_CONFIG_FILE = "nlog.config";
@@ -303,6 +304,11 @@ namespace NzbDrone.Common.Extensions
             return Path.Combine(GetUpdateBackUpAppDataFolder(appFolderInfo), DB);
         }
 
+        public static string GetV0UpdateBackupDatabase(this IAppFolderInfo appFolderInfo)
+        {
+            return Path.Combine(GetUpdateBackUpAppDataFolder(appFolderInfo), DB_OLD);
+        }
+
         public static string GetUpdatePackageFolder(this IAppFolderInfo appFolderInfo)
         {
             return Path.Combine(GetUpdateSandboxFolder(appFolderInfo), UPDATE_PACKAGE_FOLDER_NAME);
@@ -321,6 +327,11 @@ namespace NzbDrone.Common.Extensions
         public static string GetDatabase(this IAppFolderInfo appFolderInfo)
         {
             return Path.Combine(GetAppDataPath(appFolderInfo), DB);
+        }
+
+        public static string GetV0Database(this IAppFolderInfo appFolderInfo)
+        {
+            return Path.Combine(GetAppDataPath(appFolderInfo), DB_OLD);
         }
 
         public static string GetDatabaseRestore(this IAppFolderInfo appFolderInfo)

--- a/src/NzbDrone.Update/UpdateEngine/BackupAppData.cs
+++ b/src/NzbDrone.Update/UpdateEngine/BackupAppData.cs
@@ -46,7 +46,16 @@ namespace NzbDrone.Update.UpdateEngine
             try
             {
                 _diskTransferService.TransferFile(_appFolderInfo.GetConfigPath(), _appFolderInfo.GetUpdateBackupConfigFile(), TransferMode.Copy);
-                _diskTransferService.TransferFile(_appFolderInfo.GetDatabase(), _appFolderInfo.GetUpdateBackupDatabase(), TransferMode.Copy);
+
+                //Backup new db if exists, else try old then fail
+                if (_diskProvider.FileExists(_appFolderInfo.GetDatabase()))
+                {
+                    _diskTransferService.TransferFile(_appFolderInfo.GetDatabase(), _appFolderInfo.GetUpdateBackupDatabase(), TransferMode.Copy);
+                }
+                else
+                {
+                    _diskTransferService.TransferFile(_appFolderInfo.GetV0Database(), _appFolderInfo.GetV0UpdateBackupDatabase(), TransferMode.Copy);
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
#### Database Migration
No

#### Description
On migration we fail to make a backup (but continue with update) if we cannot find radarr.db, this also throws error and pings sentry. We should look for nzbdrone.db if it exists as well 

#### Todos
- [ ] Tests
