### PR TITLE
Fixed: Use QBittorrent category savepath for healthcheck

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -269,9 +269,29 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
         public override DownloadClientInfo GetStatus()
         {
+            var version = Proxy.GetApiVersion(Settings);
             var config = Proxy.GetConfig(Settings);
 
             var destDir = new OsPath(config.SavePath);
+
+            if (Settings.MovieCategory.IsNotNullOrWhiteSpace() && version >= Version.Parse("2.0"))
+            {
+                var label = Proxy.GetLabels(Settings)[Settings.MovieCategory];
+
+                if (label.SavePath.IsNotNullOrWhiteSpace())
+                {
+                    var labelDir = new OsPath(label.SavePath);
+
+                    if (labelDir.IsRooted)
+                    {
+                        destDir = labelDir;
+                    }
+                    else
+                    {
+                        destDir = destDir + labelDir;
+                    }
+                }
+            }
 
             return new DownloadClientInfo
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix false positives for remote path health check for qbittorrent - make sure to use category save path if set.


#### Issues Fixed or Closed by this PR

* Fixes #5457 