### PR TITLE
Don't call AllMovies twice for each AddMovie validation

### DIFF
--- a/src/NzbDrone.Core.Test/DiskSpace/DiskSpaceServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/DiskSpace/DiskSpaceServiceFixture.cs
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.Test.DiskSpace
         {
             Mocker.GetMock<IMovieService>()
                 .Setup(v => v.AllMoviePaths())
-                .Returns(movies.Select(x => x.Path).ToList());
+                .Returns(movies.ToDictionary(x => x.Id, x => x.Path));
         }
 
         private void GivenExistingFolder(string folder)
@@ -73,7 +73,7 @@ namespace NzbDrone.Core.Test.DiskSpace
         [Test]
         public void should_check_diskspace_for_same_root_folder_only_once()
         {
-            GivenMovies(new Movie { Path = _moviesFolder }, new Movie { Path = _moviesFolder2 });
+            GivenMovies(new Movie { Id = 1, Path = _moviesFolder }, new Movie { Id = 2, Path = _moviesFolder2 });
 
             GivenExistingFolder(_moviesFolder);
             GivenExistingFolder(_moviesFolder2);

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/RootFolderCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/RootFolderCheckFixture.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
 
             Mocker.GetMock<IMovieService>()
                   .Setup(s => s.AllMoviePaths())
-                  .Returns(movies.Select(x => x.Path).ToList());
+                  .Returns(movies.ToDictionary(x => x.Id, x => x.Path));
 
             Mocker.GetMock<IDiskProvider>()
                   .Setup(s => s.GetParentFolder(movies.First().Path))
@@ -46,7 +46,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
         {
             Mocker.GetMock<IMovieService>()
                   .Setup(s => s.AllMoviePaths())
-                  .Returns(new List<string>());
+                  .Returns(new Dictionary<int, string>());
 
             Subject.Check().ShouldBeOk();
         }

--- a/src/NzbDrone.Core.Test/MovieTests/MovieTitleSlugValidatorFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieTitleSlugValidatorFixture.cs
@@ -29,17 +29,21 @@ namespace NzbDrone.Core.Test.MovieTests
                             };
 
             Mocker.GetMock<IMovieService>()
-                  .Setup(s => s.GetAllMovies())
-                  .Returns(_movies);
+                  .Setup(s => s.AllMovieTitleSlugs())
+                  .Returns(_movies.ToDictionary(m => m.Id, m => m.TitleSlug));
         }
 
         [Test]
         public void should_not_be_valid_if_there_is_an_existing_movie_with_the_same_title_slug()
         {
+            Mocker.GetMock<IMovieService>()
+                  .Setup(s => s.GetMovie(_movies.First().Id))
+                  .Returns(_movies.First());
+
             var movie = Builder<Movie>.CreateNew()
-                                        .With(s => s.Id = 100)
-                                        .With(s => s.TitleSlug = _movies.First().TitleSlug)
-                                        .Build();
+                            .With(s => s.Id = 100)
+                            .With(s => s.TitleSlug = _movies.First().TitleSlug)
+                            .Build();
 
             _validator.Validate(movie).IsValid.Should().BeFalse();
         }

--- a/src/NzbDrone.Core.Test/RootFolderTests/RootFolderServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/RootFolderTests/RootFolderServiceFixture.cs
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Test.RootFolderTests
         {
             Mocker.GetMock<IMovieRepository>()
                   .Setup(s => s.AllMoviePaths())
-                  .Returns(new List<string>());
+                  .Returns(new Dictionary<int, string>());
 
             var root = new RootFolder { Path = path.AsOsAgnostic() };
 
@@ -140,7 +140,7 @@ namespace NzbDrone.Core.Test.RootFolderTests
 
             Mocker.GetMock<IMovieRepository>()
                   .Setup(s => s.AllMoviePaths())
-                  .Returns(new List<string>());
+                  .Returns(new Dictionary<int, string>());
 
             Mocker.GetMock<IDiskProvider>()
                   .Setup(s => s.GetDirectories(rootFolder.Path))

--- a/src/NzbDrone.Core/DiskSpace/DiskSpaceService.cs
+++ b/src/NzbDrone.Core/DiskSpace/DiskSpaceService.cs
@@ -43,8 +43,8 @@ namespace NzbDrone.Core.DiskSpace
         private IEnumerable<string> GetMoviesRootPaths()
         {
             return _movieService.AllMoviePaths()
-                .Where(s => _diskProvider.FolderExists(s))
-                .Select(s => _diskProvider.GetPathRoot(s))
+                .Where(s => _diskProvider.FolderExists(s.Value))
+                .Select(s => _diskProvider.GetPathRoot(s.Value))
                 .Distinct();
         }
 

--- a/src/NzbDrone.Core/HealthCheck/Checks/MountCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/MountCheck.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
         {
             // Not best for optimization but due to possible symlinks and junctions, we get mounts based on series path so internals can handle mount resolution.
             var mounts = _movieService.AllMoviePaths()
-                                      .Select(p => _diskProvider.GetMount(p))
+                                      .Select(p => _diskProvider.GetMount(p.Value))
                                       .Where(m => m != null && m.MountOptions != null && m.MountOptions.IsReadOnly)
                                       .DistinctBy(m => m.RootDirectory)
                                       .ToList();

--- a/src/NzbDrone.Core/HealthCheck/Checks/RootFolderCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/RootFolderCheck.cs
@@ -29,7 +29,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
         public override HealthCheck Check()
         {
             var rootFolders = _movieService.AllMoviePaths()
-                                                           .Select(s => _rootFolderService.GetBestRootFolderPath(s))
+                                                           .Select(s => _rootFolderService.GetBestRootFolderPath(s.Value))
                                                            .Distinct();
 
             var missingRootFolders = rootFolders.Where(s => !_diskProvider.FolderExists(s))

--- a/src/NzbDrone.Core/Movies/MovieRepository.cs
+++ b/src/NzbDrone.Core/Movies/MovieRepository.cs
@@ -27,7 +27,8 @@ namespace NzbDrone.Core.Movies
         void SetFileId(int fileId, int movieId);
         PagingSpec<Movie> MoviesWhereCutoffUnmet(PagingSpec<Movie> pagingSpec, List<QualitiesBelowCutoff> qualitiesBelowCutoff);
         Movie FindByPath(string path);
-        List<string> AllMoviePaths();
+        Dictionary<int, string> AllMoviePaths();
+        Dictionary<int, string> AllMovieTitleSlugs();
         List<int> AllMovieTmdbIds();
         Dictionary<int, List<int>> AllMovieTags();
         List<int> GetRecommendations();
@@ -275,11 +276,21 @@ namespace NzbDrone.Core.Movies
             return Query(x => x.Path == path).FirstOrDefault();
         }
 
-        public List<string> AllMoviePaths()
+        public Dictionary<int, string> AllMoviePaths()
         {
             using (var conn = _database.OpenConnection())
             {
-                return conn.Query<string>("SELECT Path FROM Movies").ToList();
+                var strSql = "SELECT Id AS [Key], Path AS [Value] FROM Movies";
+                return conn.Query<KeyValuePair<int, string>>(strSql).ToDictionary(x => x.Key, x => x.Value);
+            }
+        }
+
+        public Dictionary<int, string> AllMovieTitleSlugs()
+        {
+            using (var conn = _database.OpenConnection())
+            {
+                var strSql = "SELECT Id AS [Key], TitleSlug AS [Value] FROM Movies";
+                return conn.Query<KeyValuePair<int, string>>(strSql).ToDictionary(x => x.Key, x => x.Value);
             }
         }
 
@@ -295,9 +306,8 @@ namespace NzbDrone.Core.Movies
         {
             using (var conn = _database.OpenConnection())
             {
-                string strSql = "SELECT Id AS [Key], Tags AS [Value] FROM Movies";
-                var tags = conn.Query<KeyValuePair<int, List<int>>>(strSql).ToDictionary(x => x.Key, x => x.Value);
-                return tags;
+                var strSql = "SELECT Id AS [Key], Tags AS [Value] FROM Movies";
+                return conn.Query<KeyValuePair<int, List<int>>>(strSql).ToDictionary(x => x.Key, x => x.Value);
             }
         }
 

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -31,8 +31,9 @@ namespace NzbDrone.Core.Movies
         List<Movie> FindByTitleCandidates(string title, out string roman, out string arabic);
         Movie FindByTitleSlug(string slug);
         Movie FindByPath(string path);
-        List<string> AllMoviePaths();
+        Dictionary<int, string> AllMoviePaths();
         List<int> AllMovieTmdbIds();
+        Dictionary<int, string> AllMovieTitleSlugs();
         bool MovieExists(Movie movie);
         List<Movie> GetMoviesByFileId(int fileId);
         List<Movie> GetMoviesBetweenDates(DateTime start, DateTime end, bool includeUnmonitored);
@@ -189,9 +190,14 @@ namespace NzbDrone.Core.Movies
             return _movieRepository.FindByPath(path);
         }
 
-        public List<string> AllMoviePaths()
+        public Dictionary<int, string> AllMoviePaths()
         {
             return _movieRepository.AllMoviePaths();
+        }
+
+        public Dictionary<int, string> AllMovieTitleSlugs()
+        {
+            return _movieRepository.AllMovieTitleSlugs();
         }
 
         public List<int> AllMovieTmdbIds()

--- a/src/NzbDrone.Core/Movies/MovieTitleSlugValidator.cs
+++ b/src/NzbDrone.Core/Movies/MovieTitleSlugValidator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
@@ -25,15 +26,17 @@ namespace NzbDrone.Core.Movies
             var instanceId = (int)instance.Id;
             var slug = context.PropertyValue.ToString();
 
-            var conflictingMovie = _movieService.GetAllMovies()
-                                                  .FirstOrDefault(s => s.TitleSlug.IsNotNullOrWhiteSpace() &&
-                                                              s.TitleSlug.Equals(context.PropertyValue.ToString()) &&
-                                                              s.Id != instanceId);
+            var conflictingId = _movieService.AllMovieTitleSlugs()
+                                                  .FirstOrDefault(s => s.Value.IsNotNullOrWhiteSpace() &&
+                                                                  s.Value.Equals(context.PropertyValue.ToString()) &&
+                                                                  s.Key != instanceId);
 
-            if (conflictingMovie == null)
+            if (conflictingId.Equals(default(KeyValuePair<int, string>)))
             {
                 return true;
             }
+
+            var conflictingMovie = _movieService.GetMovie(conflictingId.Key);
 
             context.MessageFormatter.AppendArgument("slug", slug);
             context.MessageFormatter.AppendArgument("movieTitle", conflictingMovie.Title);

--- a/src/NzbDrone.Core/RootFolders/RootFolderService.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolderService.cs
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.RootFolders
         {
             var rootFolders = _rootFolderRepository.All().ToList();
 
-            var moviePaths = _movieRepository.AllMoviePaths().ToList();
+            var moviePaths = _movieRepository.AllMoviePaths();
 
             rootFolders.ForEach(folder =>
             {
@@ -116,7 +116,7 @@ namespace NzbDrone.Core.RootFolders
 
             _rootFolderRepository.Insert(rootFolder);
 
-            var moviePaths = _movieRepository.AllMoviePaths().ToList();
+            var moviePaths = _movieRepository.AllMoviePaths();
 
             GetDetails(rootFolder, moviePaths, true);
 
@@ -128,7 +128,7 @@ namespace NzbDrone.Core.RootFolders
             _rootFolderRepository.Delete(id);
         }
 
-        private List<UnmappedFolder> GetUnmappedFolders(string path, List<string> moviePaths)
+        private List<UnmappedFolder> GetUnmappedFolders(string path, Dictionary<int, string> moviePaths)
         {
             _logger.Debug("Generating list of unmapped folders");
 
@@ -146,7 +146,7 @@ namespace NzbDrone.Core.RootFolders
             }
 
             var possibleMovieFolders = _diskProvider.GetDirectories(path).ToList();
-            var unmappedFolders = possibleMovieFolders.Except(moviePaths.Select(s => s), PathEqualityComparer.Instance).ToList();
+            var unmappedFolders = possibleMovieFolders.Except(moviePaths.Select(s => s.Value), PathEqualityComparer.Instance).ToList();
 
             foreach (string unmappedFolder in unmappedFolders)
             {
@@ -167,7 +167,7 @@ namespace NzbDrone.Core.RootFolders
         public RootFolder Get(int id, bool timeout)
         {
             var rootFolder = _rootFolderRepository.Get(id);
-            var moviePaths = _movieRepository.AllMoviePaths().ToList();
+            var moviePaths = _movieRepository.AllMoviePaths();
 
             GetDetails(rootFolder, moviePaths, timeout);
 
@@ -188,7 +188,7 @@ namespace NzbDrone.Core.RootFolders
             return possibleRootFolder.Path;
         }
 
-        private void GetDetails(RootFolder rootFolder, List<string> moviePaths, bool timeout)
+        private void GetDetails(RootFolder rootFolder, Dictionary<int, string> moviePaths, bool timeout)
         {
             Task.Run(() =>
             {

--- a/src/NzbDrone.Core/Validation/Paths/MovieAncestorValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/MovieAncestorValidator.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Validation.Paths
                 return true;
             }
 
-            return !_movieService.AllMoviePaths().Any(s => context.PropertyValue.ToString().IsParentPath(s));
+            return !_movieService.AllMoviePaths().Any(s => context.PropertyValue.ToString().IsParentPath(s.Value));
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/MoviePathValidation.cs
+++ b/src/NzbDrone.Core/Validation/Paths/MoviePathValidation.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Movies;
@@ -26,7 +27,7 @@ namespace NzbDrone.Core.Validation.Paths
 
             context.MessageFormatter.AppendArgument("moviePath", context.PropertyValue.ToString());
 
-            return !_moviesService.GetAllMovies().Exists(s => s.Path.PathEquals(context.PropertyValue.ToString()) && s.Id != instanceId);
+            return !_moviesService.AllMoviePaths().Any(s => s.Value.PathEquals(context.PropertyValue.ToString()) && s.Key != instanceId);
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
MovieTitleSlugValidator and MoviePathValidator in AddMovieService both used AllMovies() call to fetch movies and then use one property for validation. This PR changes that by doing the following:

- Change AllMoviePaths() to Dictionary<id, path> so that uses are id aware
- Create AllTitleSlugs() to query the db for just title slugs and avoid the full move deserialization
- Use these functions for validation in lieu of the AllMovie() call

#### Todos
- [x] Tests
