### PR TITLE
Connect - Jellyfin/Emby/Plex - Update Library Delay setting

### DIFF
--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using FluentValidation.Results;
+using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Movies;
 
@@ -8,14 +10,16 @@ namespace NzbDrone.Core.Notifications.Emby
     public class MediaBrowser : NotificationBase<MediaBrowserSettings>
     {
         private readonly IMediaBrowserService _mediaBrowserService;
+        private readonly Logger _logger;
 
-        public MediaBrowser(IMediaBrowserService mediaBrowserService)
+        public MediaBrowser(IMediaBrowserService mediaBrowserService, Logger logger)
         {
             _mediaBrowserService = mediaBrowserService;
+            _logger = logger;
         }
 
         public override string Link => "https://emby.media/";
-        public override string Name => "Emby";
+        public override string Name => "Jellyfin/Emby";
 
         public override void OnGrab(GrabMessage grabMessage)
         {
@@ -34,6 +38,14 @@ namespace NzbDrone.Core.Notifications.Emby
 
             if (Settings.UpdateLibrary)
             {
+                if (Settings.UpdateLibraryDelay > 0)
+                {
+                    var timeSpan = new TimeSpan(0, Settings.UpdateLibraryDelay, 0);
+                    System.Threading.Thread.Sleep(timeSpan);
+                }
+
+                _logger.Debug("{0} - Scheduling library update for created movie {1} {2}", Name, message.Movie.Id, message.Movie.Title);
+
                 _mediaBrowserService.UpdateMovies(Settings, message.Movie, "Created");
             }
         }
@@ -42,6 +54,14 @@ namespace NzbDrone.Core.Notifications.Emby
         {
             if (Settings.UpdateLibrary)
             {
+                if (Settings.UpdateLibraryDelay > 0)
+                {
+                    var timeSpan = new TimeSpan(0, Settings.UpdateLibraryDelay, 0);
+                    System.Threading.Thread.Sleep(timeSpan);
+                }
+
+                _logger.Debug("{0} - Scheduling library update for modified movie {1} {2}", Name, movie.Id, movie.Title);
+
                 _mediaBrowserService.UpdateMovies(Settings, movie, "Modified");
             }
         }

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
@@ -12,6 +12,7 @@ namespace NzbDrone.Core.Notifications.Emby
         {
             RuleFor(c => c.Host).ValidHost();
             RuleFor(c => c.ApiKey).NotEmpty();
+            RuleFor(c => c.UpdateLibraryDelay).GreaterThanOrEqualTo(0);
         }
     }
 
@@ -22,6 +23,7 @@ namespace NzbDrone.Core.Notifications.Emby
         public MediaBrowserSettings()
         {
             Port = 8096;
+            UpdateLibraryDelay = 0;
         }
 
         [FieldDefinition(0, Label = "Host")]
@@ -41,6 +43,9 @@ namespace NzbDrone.Core.Notifications.Emby
 
         [FieldDefinition(5, Label = "Update Library", HelpText = "Update Library on Import & Rename?", Type = FieldType.Checkbox)]
         public bool UpdateLibrary { get; set; }
+
+        [FieldDefinition(6, Label = "Update Library Delay", HelpText = "Delay in Minutes to request Library Update", Type = FieldType.Number)]
+        public int UpdateLibraryDelay { get; set; }
 
         [JsonIgnore]
         public string Address => $"{Host}:{Port}";

--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServer.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServer.cs
@@ -65,7 +65,14 @@ namespace NzbDrone.Core.Notifications.Plex.Server
         {
             if (Settings.UpdateLibrary)
             {
-                _logger.Debug("Scheduling library update for movie {0} {1}", movie.Id, movie.Title);
+                if (Settings.UpdateLibraryDelay > 0)
+                {
+                    var timeSpan = new TimeSpan(0, Settings.UpdateLibraryDelay, 0);
+                    System.Threading.Thread.Sleep(timeSpan);
+                }
+
+                _logger.Debug("{0} - Scheduling library update for movie {1} {2}", Name, movie.Id, movie.Title);
+
                 var queue = _pendingMoviesCache.Get(Settings.Host, () => new PlexUpdateQueue());
                 lock (queue)
                 {
@@ -111,7 +118,14 @@ namespace NzbDrone.Core.Notifications.Plex.Server
 
                     if (Settings.UpdateLibrary)
                     {
-                        _logger.Debug("Performing library update for {0} movies", refreshingMovies.Count);
+                        if (Settings.UpdateLibraryDelay > 0)
+                        {
+                            var timeSpan = new TimeSpan(0, Settings.UpdateLibraryDelay, 0);
+                            System.Threading.Thread.Sleep(timeSpan);
+                        }
+
+                        _logger.Debug("{0} - Performing library update for {1} movies", Name, refreshingMovies.Count);
+
                         _plexServerService.UpdateLibrary(refreshingMovies, Settings);
                     }
                 }

--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerSettings.cs
@@ -11,6 +11,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
         {
             RuleFor(c => c.Host).ValidHost();
             RuleFor(c => c.Port).InclusiveBetween(1, 65535);
+            RuleFor(c => c.UpdateLibraryDelay).GreaterThanOrEqualTo(0);
         }
     }
 
@@ -23,6 +24,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
             Port = 32400;
             UpdateLibrary = true;
             SignIn = "startOAuth";
+            UpdateLibraryDelay = 0;
         }
 
         [FieldDefinition(0, Label = "Host")]
@@ -42,6 +44,9 @@ namespace NzbDrone.Core.Notifications.Plex.Server
 
         [FieldDefinition(5, Label = "Update Library", Type = FieldType.Checkbox)]
         public bool UpdateLibrary { get; set; }
+
+        [FieldDefinition(6, Label = "Update Library Delay", HelpText = "Delay in Minutes to request Library Update", Type = FieldType.Number)]
+        public int UpdateLibraryDelay { get; set; }
 
         public bool IsValid => !string.IsNullOrWhiteSpace(Host);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When a Movie is created/updated in Radarr and Jellyfin/Emby/Plex are notified to update their libraries, sometimes, the metadata and images are not created yet by the Metadata Consumer. This feature adds an optional minutes delay yo avoid this issue.

#### Screenshot (if UI related)
![image](https://user-images.githubusercontent.com/5982912/101295172-4c94ec00-381c-11eb-8428-a67d97d3b26d.png)
