### PR TITLE
plex: only add new movie dir instead of triggering library scan

### DIFF
--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerProxy.cs
@@ -15,6 +15,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
         List<PlexSection> GetMovieSections(PlexServerSettings settings);
         void Update(int sectionId, PlexServerSettings settings);
         void UpdateMovie(int metadataId, PlexServerSettings settings);
+        void UpdateMovie(string path, int sectionId, PlexServerSettings settings);
         string Version(PlexServerSettings settings);
         List<PlexPreference> Preferences(PlexServerSettings settings);
         int? GetMetadataId(int sectionId, string imdbId, string language, PlexServerSettings settings);
@@ -75,6 +76,18 @@ namespace NzbDrone.Core.Notifications.Plex.Server
         {
             var resource = $"library/metadata/{metadataId}/refresh";
             var request = BuildRequest(resource, HttpMethod.PUT, settings);
+            var response = ProcessRequest(request);
+
+            CheckForError(response);
+        }
+
+        public void UpdateMovie(string path, int sectionId, PlexServerSettings settings)
+        {
+            var resource = $"library/sections/{sectionId}/refresh";
+
+            var request = BuildRequest(resource, HttpMethod.GET, settings);
+            request.AddQueryParam("path", path);
+
             var response = ProcessRequest(request);
 
             CheckForError(response);

--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerSettings.cs
@@ -11,6 +11,8 @@ namespace NzbDrone.Core.Notifications.Plex.Server
         {
             RuleFor(c => c.Host).ValidHost();
             RuleFor(c => c.Port).InclusiveBetween(1, 65535);
+            RuleFor(c => c.MapFrom).NotEmpty().Unless(c => !c.UseMapping);
+            RuleFor(c => c.MapTo).NotEmpty().Unless(c => !c.UseMapping);
         }
     }
 
@@ -42,6 +44,15 @@ namespace NzbDrone.Core.Notifications.Plex.Server
 
         [FieldDefinition(5, Label = "Update Library", Type = FieldType.Checkbox)]
         public bool UpdateLibrary { get; set; }
+
+        [FieldDefinition(6, Label = "Use Mapping", Type = FieldType.Checkbox)]
+        public bool UseMapping { get; set; }
+
+        [FieldDefinition(7, Label = "Map From", Type = FieldType.Textbox)]
+        public string MapFrom { get; set; }
+
+        [FieldDefinition(8, Label = "Map To", Type = FieldType.Textbox)]
+        public string MapTo { get; set; }
 
         public bool IsValid => !string.IsNullOrWhiteSpace(Host);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Update to the Plex notification system: this will only add the new movie directory instead of triggering a full library scan. If it fails to find a matching section, it will resort to the default (current) behaviour.

It's possible to use this with Docker mounts, use the "Map From" and "Map To" settings for this. 

Example:

Map From: /movies
Map To: /data/plex/movies

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR
N/A