### PR TITLE
Fixed: FolderWritable check for CIFS shares mounted in Unix

### DIFF
--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -131,7 +131,7 @@ namespace NzbDrone.Common.Disk
             {
                 var testPath = Path.Combine(path, "radarr_write_test.txt");
                 var testContent = string.Format("This file was created to verify if '{0}' is writable. It should've been automatically deleted. Feel free to delete it.", path);
-                File.WriteAllText(testPath, testContent);
+                WriteAllText(testPath, testContent);
                 File.Delete(testPath);
                 return true;
             }
@@ -300,7 +300,16 @@ namespace NzbDrone.Common.Disk
         {
             Ensure.That(filename, () => filename).IsValidPath();
             RemoveReadOnly(filename);
-            File.WriteAllText(filename, contents);
+
+            // File.WriteAllText is broken on net core when writing to some CIFS mounts
+            // This workaround from https://github.com/dotnet/runtime/issues/42790#issuecomment-700362617
+            using (var fs = new FileStream(filename, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None))
+            {
+                using (var writer = new StreamWriter(fs))
+                {
+                    writer.Write(contents);
+                }
+            }
         }
 
         public void FolderSetLastWriteTime(string path, DateTime dateTime)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Workaround net core bug checking folder writable for CIFS shares on linux

#### Issues Fixed or Closed by this PR

* Fixes #5554 
