### PR TITLE
Fixed: Restoring large database backups

### DIFF
--- a/src/NzbDrone.Host/WebHost/WebHostController.cs
+++ b/src/NzbDrone.Host/WebHost/WebHostController.cs
@@ -95,9 +95,10 @@ namespace Radarr.Host
                     }
                 })
                 .ConfigureKestrel(serverOptions =>
-                    {
-                        serverOptions.AllowSynchronousIO = true;
-                    })
+                {
+                    serverOptions.AllowSynchronousIO = true;
+                    serverOptions.Limits.MaxRequestBodySize = null;
+                })
                 .ConfigureLogging(logging =>
                 {
                     logging.AddProvider(new NLogLoggerProvider());


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Remove Kestrel's default 28.6MB upload limit

#### Issues Fixed or Closed by this PR

* Fixes #5593 
