### PR TITLE
New: Improved Discover recommendations

### DIFF
--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -286,7 +286,7 @@ namespace NzbDrone.Core.Movies
         public void SetFileId(Movie movie, MovieFile movieFile)
         {
             _movieRepository.SetFileId(movieFile.Id, movie.Id);
-            _logger.Info("Linking [{0}] > [{1}]", movieFile.RelativePath, movie);
+            _logger.Info("Assigning file [{0}] to movie [{1}]", movieFile.RelativePath, movie);
         }
 
         public List<Movie> GetMoviesByFileId(int fileId)
@@ -386,7 +386,7 @@ namespace NzbDrone.Core.Movies
             _movieRepository.Update(movie);
 
             //_movieRepository.SetFileId(message.MovieFile.Id, message.MovieFile.Movie.Value.Id);
-            _logger.Info("Linking [{0}] > [{1}]", message.MovieFile.RelativePath, message.MovieFile.Movie);
+            _logger.Info("Assigning file [{0}] to movie [{1}]", message.MovieFile.RelativePath, message.MovieFile.Movie);
         }
 
         public void Handle(MovieFileDeletedEvent message)


### PR DESCRIPTION
New: Movies existing in Library no longer show as a Discover Recommendation
New: Improved Discover recommendations
#### Database Migration
NO

#### Description
Improved Discover Recommendations so that it returns the 100 most frequently recommended movies from the user's library. This is much better than grabbing the literal `top` 100 recommendations from the table. This will also exclude existing movies in the library from being recommended...that was kinda dumb.
#### Screenshot (if UI related)

#### Todos
- [X] Tests (None)
- [X] Translation Keys (None)
- [X] Wiki Updates (None; Not yet built out)
- [ ] Test With Large Library @Qstick <<<

### Testing
967 Movies
0 Lists
Baseline SQL: 5ms
UI Load (no cache):  2.68s
New SQL: 24ms
UI Load (no cache) : 2.33s

#### Issues Fixed or Closed by this PR

* Fixes #5590 
