### PR TITLE
Allow to set all logging levels in the settings

### DIFF
--- a/frontend/src/Settings/General/LoggingSettings.js
+++ b/frontend/src/Settings/General/LoggingSettings.js
@@ -8,6 +8,9 @@ import { inputTypes } from 'Helpers/Props';
 import translate from 'Utilities/String/translate';
 
 const logLevelOptions = [
+  { key: 'fatal', value: translate('Fatal') },
+  { key: 'error', value: translate('Error') },
+  { key: 'warn', value: translate('Warn') },
   { key: 'info', value: translate('Info') },
   { key: 'debug', value: translate('Debug') },
   { key: 'trace', value: translate('Trace') }

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -314,6 +314,7 @@
   "FailedLoadingSearchResults": "Failed to load search results, please try again.",
   "FailedToLoadMovieFromAPI": "Failed to load movie from API",
   "FailedToLoadQueue": "Failed to load Queue",
+  "Fatal": "Fatal",
   "FeatureRequests": "Feature Requests",
   "FileDateHelpText": "Change file date on import/rescan",
   "FileManagement": "File Management",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently, the frontend only allows to set 3 of the 6 available logging levels. This PR adds the missing ones.

#### Screenshot
![screenshot](https://fb.hash.works/zuLq0Bxg/)

#### Todos
- [X] Tests (is this tested at all?)
- [X] Translation Keys
- [ ] Wiki Updates