### PR TITLE
Fixed: VHS now detected as SDTV rather than Unknown

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -57,6 +57,10 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Some.Movie.S03E06.HDTV-WiDE", false)]
         [TestCase("Movie Name.S10E27.WS.DSR.XviD-2HD", false)]
         [TestCase("Movie Name.S03.TVRip.XviD-NOGRP", false)]
+        [TestCase("Some.Movie.1994.GERMAN.VHSRiP.x264-TAPECRACKERs", false)]
+        [TestCase("Some.Movie.1949.VHSRip.Xvid - UpPTMSNM", false)]
+        [TestCase("Some.Movie.1981.VHSRip.x264 - bigbumbee", false)]
+        [TestCase("Some.Movie.1990.VHSrip.XviD - CG", false)]
         public void should_parse_sdtv_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Source.TV, proper, Resolution.R480p);

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -31,7 +31,7 @@ namespace NzbDrone.Core.Parser
                                                                 (?<cam>CAMRIP|CAM|HDCAM|HD-CAM)|
                                                                 (?<wp>WORKPRINT|WP)|
                                                                 (?<pdtv>PDTV)|
-                                                                (?<sdtv>SDTV)|
+                                                                (?<sdtv>SDTV|VHSRip)|
                                                                 (?<tvrip>TVRip)
                                                                 )(?:\b|$|[ .])",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Detect VHS as SDTV rather than unknown.
Alternative is to add VHS as an explicit quality
#### Screenshot (if UI related)

#### Todos
- [X] Tests
- [X] Translation Keys - N/A
- [X] Wiki Updates -N/A

#### Issues Fixed or Closed by this PR

* Fixes #2551
