### PR TITLE
Fixed: Correctly Parse Release Groups with a `-` in their name

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/HashedReleaseFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/HashedReleaseFixture.cs
@@ -37,6 +37,13 @@ namespace NzbDrone.Core.Test.ParserTests
                 @"C:\Test\Deadwood.2018.1080p.BluRay.x264-RADARR\Backup_72023S02-12.mkv".AsOsAgnostic(),
                 "Deadwood",
                 Quality.Bluray1080p,
+                "RADARR"
+            },
+            new object[]
+            {
+                @"C:\Test\Deadwood.2018.1080p.BluRay.x264\Backup_72023S02-12.mkv".AsOsAgnostic(),
+                "Deadwood",
+                Quality.Bluray1080p,
                 null
             },
             new object[]

--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -41,6 +41,11 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Kai.Po.Che.2013.1080p.BluRay.REMUX.AVC.DTS-X.MA.5.1", null)]
         [TestCase("Kai.Po.Che.2013.1080p.BluRay.REMUX.AVC.DTS-MA.5.1", null)]
         [TestCase("Kai.Po.Che.2013.1080p.BluRay.REMUX.AVC.DTS-ES.MA.5.1", null)]
+        [TestCase("SomeMovie.1080p.BluRay.DTS-X.264.-D-Z0N3.mkv", "D-Z0N3")]
+        [TestCase("SomeMovie.1080p.BluRay.DTS.x264.-Blu-bits.mkv", "Blu-bits")]
+        [TestCase("SomeMovie.1080p.BluRay.DTS.x264.-DX-TV.mkv", "DX-TV")]
+        [TestCase("SomeMovie.1080p.BluRay.DTS.x264.-FTW-HS.mkv", "FTW-HS")]
+        [TestCase("SomeMovie.1080p.BluRay.DTS.x264.-VH-PROD.mkv", "VH-PROD")]
 
         //[TestCase("", "")]
         public void should_parse_release_group(string title, string expected)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -116,7 +116,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex CleanQualityBracketsRegex = new Regex(@"\[[a-z0-9 ._-]+\]$",
                                                                    RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex ReleaseGroupRegex = new Regex(@"-(?<releasegroup>[a-z0-9]+(?!.+?(?:480p|720p|1080p|2160p)))(?<!.*?WEB-DL|Blu-Ray|480p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
+        private static readonly Regex ReleaseGroupRegex = new Regex(@"-(?<releasegroup>[a-z0-9]+(?<part2>-[a-z0-9]+)?(?!.+?(?:480p|720p|1080p|2160p)))(?<!(?:WEB-DL|Blu-Ray|480p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES|[ ._]\d{4}-\d{2}|-\d{2})(?:\k<part2>)?)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex AnimeReleaseGroupRegex = new Regex(@"^(?:\[(?<subgroup>(?!\s).+?(?<!\s))\](?:_|-|\s|\.)?)",


### PR DESCRIPTION
[common]

#### Database Migration
NO

#### Description
Handle release groups named like `D-Z0N3`
#### Screenshot (if UI related)

#### Todos
- [X] Tests-Added and the old ones didn't break
- [X] Translation Keys-None
- [X] Wiki Updates-None

#### Issues Fixed or Closed by this PR

* Fixes #3273

---
thanks to @Taloth for the Regex help!
