### PR TITLE
New: Handle select groups that do not follow -RlsGrp format

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateReleaseGroupFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateReleaseGroupFixture.cs
@@ -79,5 +79,45 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieImport.Aggregation.Aggregators
 
             localMovie.ReleaseGroup.Should().Be("Wizzy");
         }
+
+        [Test]
+        public void should_not_use_imdbId()
+        {
+            var fileMovieInfo = Parser.Parser.ParseMovieTitle("Lock Stock and Two Smoking Barrels (1998) [imdb-tt0120735][Bluray-1080p][8bit][x264][DTS-HD MA 5.1]-FraMeSToR", false);
+            var folderMovieInfo = Parser.Parser.ParseMovieTitle("Lock Stock and Two Smoking Barrels (1998) {imdb-tt0120735}", false);
+            var downloadClientMovieInfo = Parser.Parser.ParseMovieTitle("Movie.Title.2008.WEB-DL", false);
+            var localMovie = new LocalMovie
+            {
+                FileMovieInfo = fileMovieInfo,
+                FolderMovieInfo = folderMovieInfo,
+                DownloadClientMovieInfo = downloadClientMovieInfo,
+                Path = @"C:\Test\Unsorted Movies\Movie.Title.2008\Movie.Title.2008.mkv".AsOsAgnostic(),
+                Movie = _movie
+            };
+
+            Subject.Aggregate(localMovie, null, false);
+
+            localMovie.ReleaseGroup.Should().Be("FraMeSToR");
+        }
+
+        [Test]
+        public void should_not_use_tmdbbId()
+        {
+            var fileMovieInfo = Parser.Parser.ParseMovieTitle("Lock Stock and Two Smoking Barrels (1998) [tmdb-100][Bluray-1080p][8bit][x264][DTS-HD MA 5.1]-FraMeSToR", false);
+            var folderMovieInfo = Parser.Parser.ParseMovieTitle("Lock Stock and Two Smoking Barrels (1998) {tmdb-100}", false);
+            var downloadClientMovieInfo = Parser.Parser.ParseMovieTitle("Movie.Title.2008.WEB-DL", false);
+            var localMovie = new LocalMovie
+            {
+                FileMovieInfo = fileMovieInfo,
+                FolderMovieInfo = folderMovieInfo,
+                DownloadClientMovieInfo = downloadClientMovieInfo,
+                Path = @"C:\Test\Unsorted Movies\Movie.Title.2008\Movie.Title.2008.mkv".AsOsAgnostic(),
+                Movie = _movie
+            };
+
+            Subject.Aggregate(localMovie, null, false);
+
+            localMovie.ReleaseGroup.Should().Be("FraMeSToR");
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -37,7 +37,6 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("NCIS.S16E04.Third.Wheel.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb-GEROV", "NTb")]
         [TestCase("Will.and.Grace.S10E06.Kid.n.Play.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb-Z0iDS3N", "NTb")]
         [TestCase("Absolute.Power.S02E06.The.House.of.Lords.DVDRip.x264-MaG-Chamele0n", "MaG")]
-        [TestCase("The.Nightingale.2018.1080p.Blu-ray.Remux.AVC.DTS-HD.MA.5.1.KRaLiMaRKo", null)]
         [TestCase("Kai.Po.Che.2013.1080p.BluRay.REMUX.AVC.DTS-X.MA.5.1", null)]
         [TestCase("Kai.Po.Che.2013.1080p.BluRay.REMUX.AVC.DTS-MA.5.1", null)]
         [TestCase("Kai.Po.Che.2013.1080p.BluRay.REMUX.AVC.DTS-ES.MA.5.1", null)]
@@ -48,6 +47,23 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("SomeMovie.1080p.BluRay.DTS.x264.-VH-PROD.mkv", "VH-PROD")]
 
         //[TestCase("", "")]
+
+        //Exception Cases
+        public void should_parse_exception_release_group(string title, string expected)
+        {
+            Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
+        }
+
+        [TestCase("Stargirl (2020) [2160p x265 10bit S82 Joy]", "Joy")]
+        [TestCase("The Matrix Revolutions (2003) (2160p BluRay X265 HEVC 10bit HDR AAC 7.1 Tigole) [QxR]", "Tigole")]
+        [TestCase("Ode To Joy (2009) (2160p BluRay x265 10bit HDR Joy)", "Joy")]
+        [TestCase("Shingeki No Kyojin a.k.a. Attack on Titan S04E03 The Door of Hope 1080p NF WEB-DL DDP2.0 x264-E.N.D", "E.N.D")]
+        [TestCase("The Curse of Audrey Earnshaw (2020) [1080p] [WEBRip] [5.1] [YTS.MX]", "YTS.MX")]
+        [TestCase("The.Nightingale.2018.1080p.Blu-ray.Remux.AVC.DTS-HD.MA.5.1.KRaLiMaRKo", "KRaLiMaRKo")]
+        [TestCase("Ode To Joy (2009) (2160p BluRay x265 10bit HDR FreetheFish)", "FreetheFish")]
+        [TestCase("Ode To Joy (2009) (2160p BluRay x265 10bit HDR afm72)", "afm72")]
+        [TestCase("Ode To Joy (2009) (2160p BluRay x265 10bit HDR)", null)]
+
         public void should_parse_release_group(string title, string expected)
         {
             Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -116,7 +116,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex CleanQualityBracketsRegex = new Regex(@"\[[a-z0-9 ._-]+\]$",
                                                                    RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex ReleaseGroupRegex = new Regex(@"-(?<releasegroup>[a-z0-9]+(?<part2>-[a-z0-9]+)?(?!.+?(?:480p|720p|1080p|2160p)))(?<!(?:WEB-DL|Blu-Ray|480p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES|[ ._]\d{4}-\d{2}|-\d{2})(?:\k<part2>)?)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
+        private static readonly Regex ReleaseGroupRegex = new Regex(@"-(?<releasegroup>[a-z0-9]+(?<part2>-[a-z0-9]+)?(?!.+?(?:480p|720p|1080p|2160p)))(?<!(?:WEB-DL|Blu-Ray|480p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES|[ ._]\d{4}-\d{2}|-\d{2}|tmdb(id)?-(?<tmdbid>\d+)|(?<imdbid>tt\d{7,8}))(?:\k<part2>)?)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex AnimeReleaseGroupRegex = new Regex(@"^(?:\[(?<subgroup>(?!\s).+?(?<!\s))\](?:_|-|\s|\.)?)",

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -125,6 +125,11 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex YearInTitleRegex = new Regex(@"^(?<title>.+?)(?:\W|_)?(?<year>\d{4})",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+        //Handle Exception Release Groups that don't follow -RlsGrp; Manual List
+        //First Group is groups whose releases end with RlsGroup) or RlsGroup]  second group (entries after `(?=\]|\))|`) is name only...BE VERY CAREFUL WITH THIS, HIGH CHANCE OF FALSE POSITIVES
+        private static readonly Regex ExceptionReleaseGroupRegex = new Regex(@"(?<releasegroup>(Tigole|Joy|YIFY|YTS.MX|FreetheFish|afm72)(?=\]|\))|KRaLiMaRKo|E\.N\.D)",
+                                                        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         private static readonly Regex WordDelimiterRegex = new Regex(@"(\s|\.|,|_|-|=|'|\|)+", RegexOptions.Compiled);
         private static readonly Regex SpecialCharRegex = new Regex(@"(\&|\:|\\|\/)+", RegexOptions.Compiled);
         private static readonly Regex PunctuationRegex = new Regex(@"[^\w\s]", RegexOptions.Compiled);
@@ -449,6 +454,13 @@ namespace NzbDrone.Core.Parser
             }
 
             title = CleanReleaseGroupRegex.Replace(title);
+
+            var exceptionMatch = ExceptionReleaseGroupRegex.Matches(title);
+
+            if (exceptionMatch.Count != 0)
+            {
+                return exceptionMatch.OfType<Match>().Last().Groups["releasegroup"].Value;
+            }
 
             var matches = ReleaseGroupRegex.Matches(title);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Handle a handful of groups who don't follow standard naming.
These are manual exceptions and any additions will need to be manually added.

Currently this will handle the following groups that follow the format of `GroupName)` or `GroupName]`

- Tigole
- Joy
- YIFY
- YTS.MX
- FreetheFish
- afm72

It will also handle the following groups by checking for a Case Insensitive match against the exact name
- KRaLiMaRKo
- E.N.D

For future requests, a GHI should be opened with the release name and I should be pinged.

#### Screenshot (if UI related)

#### Todos
- [X] Tests
- [x] Translation Keys N/A
- [x] Wiki Updates N/A

#### Issues Fixed or Closed by this PR

* Fixes #3550
* Fixes #5804 (see further comments)