### PR TITLE
Fix BasicRepository Tests when not on UTC

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/BasicRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/BasicRepositoryFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FizzWare.NBuilder;
@@ -18,6 +18,12 @@ namespace NzbDrone.Core.Test.Datastore
         [SetUp]
         public void Setup()
         {
+            AssertionOptions.AssertEquivalencyUsing(options =>
+            {
+                options.Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation.ToUniversalTime())).WhenTypeIs<DateTime>();
+                return options;
+            });
+
             _basicList = Builder<ScheduledTask>
                 .CreateListOfSize(5)
                 .All()


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Convert values to UTC during the equivalency assertion so that these tests don't fail when not on UTC 

#### Todos
- [x] Tests

