### PR TITLE
Fixed: 'iso-8859-2' is not a supported encoding name

### DIFF
--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using NLog;
 using NzbDrone.Common.Composition;
@@ -27,6 +28,8 @@ namespace Radarr.Host
                 {
                     throw new TerminateApplicationException("Missing system requirements");
                 }
+
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
                 _container = MainAppContainerBuilder.BuildContainer(startupContext);
                 _container.Resolve<InitializeLogger>().Initialize();

--- a/src/NzbDrone.Host/Radarr.Host.csproj
+++ b/src/NzbDrone.Host/Radarr.Host.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Api\Radarr.Api.csproj" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Register additional encodings besides the ones baked in netcore... Will add ~1mb to package size with System.Text.Encoding.CodePages dep.

I'm making an assumption Bootstrap is best place for this? 

Tested with a quick unit test in registering in HttpHeader and running GetEncoding('iso-8859-2), fails before with error from issue, passes with the registration. But I assume it's better to register up the stack (which makes a unit test a bit hard without just registering in the testbase as well, defeating the purpose of unit testing the method). 

#### Issues Fixed or Closed by this PR

* Fixes #5049
