### PR TITLE
Treat subbed as unknown language

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -172,6 +172,16 @@ namespace NzbDrone.Core.Test.ParserTests
 
             result.Languages.Should().BeEquivalentTo(Language.Polish);
         }
+        
+        [TestCase("Pulp.Fiction.1994.PL-SUB.1080p.XviD-LOL")]
+        [TestCase("Pulp.Fiction.1994.PLSUB.1080p.XviD-LOL")]
+        [TestCase("Pulp.Fiction.1994.SUB-PL.1080p.XviD-LOL")]
+        public void should_parse_language_polish_subbed(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle, true);
+
+            result.Languages.Should().BeEquivalentTo(Language.Unknown);
+        }
 
         [TestCase("Pulp.Fiction.1994.Vietnamese.1080p.XviD-LOL")]
         public void should_parse_language_vietnamese(string postTitle)

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -172,7 +172,7 @@ namespace NzbDrone.Core.Test.ParserTests
 
             result.Languages.Should().BeEquivalentTo(Language.Polish);
         }
-        
+
         [TestCase("Pulp.Fiction.1994.PL-SUB.1080p.XviD-LOL")]
         [TestCase("Pulp.Fiction.1994.PLSUB.1080p.XviD-LOL")]
         [TestCase("Pulp.Fiction.1994.SUB-PL.1080p.XviD-LOL")]

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>\b(?:german|videomann|ger)\b)|(?<flemish>flemish)|(?<bulgarian>bgaudio)|(?<brazilian>dublado)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VO|VFF|VFQ|VFI|VF2|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<english>\beng\b)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<polish>\b(?:PL\W?DUB|DUB\W?PL|LEK\W?PL|PL\W?LEK)\b)|(?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?<lithuanian>\bLT\b)|(?<czech>\bCZ\b)|(?<polish>\bPL\b)",
+        private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?:(?i)(?<!SUB[\W|_|^]))(?:(?<lithuanian>\bLT\b)|(?<czech>\bCZ\b)|(?<polish>\bPL\b))(?:(?i)(?![\W|_|^]SUB))",
                                                                 RegexOptions.Compiled);
 
         private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);


### PR DESCRIPTION
#### Database Migration
 NO

#### Description
Currently subbed releases (Czech, Lithuanian and Polish) reports as having that language, but when the file is downloaded, it is correctly detected with original language. This causes issues with custom format, when for example you are upgrading the release until expected language is found. 

#### Screenshot (if UI related)

#### Todos
- [x] Tests


#### Issues Fixed or Closed by this PR

None
