### PR TITLE
New poster view release date

### DIFF
--- a/frontend/src/Movie/Index/Menus/MovieIndexSortMenu.js
+++ b/frontend/src/Movie/Index/Menus/MovieIndexSortMenu.js
@@ -75,15 +75,6 @@ function MovieIndexSortMenu(props) {
         </SortMenuItem>
 
         <SortMenuItem
-          name="releaseDate"
-          sortKey={sortKey}
-          sortDirection={sortDirection}
-          onPress={onSortSelect}
-        >
-          {translate('ReleaseDate')}
-        </SortMenuItem>
-
-        <SortMenuItem
           name="inCinemas"
           sortKey={sortKey}
           sortDirection={sortDirection}

--- a/frontend/src/Movie/Index/Menus/MovieIndexSortMenu.js
+++ b/frontend/src/Movie/Index/Menus/MovieIndexSortMenu.js
@@ -75,6 +75,15 @@ function MovieIndexSortMenu(props) {
         </SortMenuItem>
 
         <SortMenuItem
+          name="releaseDate"
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          onPress={onSortSelect}
+        >
+          {translate('ReleaseDate')}
+        </SortMenuItem>
+
+        <SortMenuItem
           name="inCinemas"
           sortKey={sortKey}
           sortDirection={sortDirection}

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
@@ -13,6 +13,7 @@ import MovieDetailsLinks from 'Movie/Details/MovieDetailsLinks';
 import EditMovieModalConnector from 'Movie/Edit/EditMovieModalConnector';
 import MovieIndexProgressBar from 'Movie/Index/ProgressBar/MovieIndexProgressBar';
 import MoviePoster from 'Movie/MoviePoster';
+import getRelativeDate from 'Utilities/Date/getRelativeDate';
 import translate from 'Utilities/String/translate';
 import MovieIndexPosterInfo from './MovieIndexPosterInfo';
 import styles from './MovieIndexPoster.css';
@@ -316,12 +317,9 @@ class MovieIndexPoster extends Component {
 
         {
           showReleaseDate &&
-          <RelativeDateCellConnector
-            key={releaseDate}
-            className={styles.title}
-            date={releaseDate}
-            component={VirtualTableRowCell}
-          />
+            <div className={styles.title}>
+              {releaseDate}
+            </div>
         }
 
         <MovieIndexPosterInfo

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
@@ -275,7 +275,9 @@ class MovieIndexPoster extends Component {
         {
           showCinemaRelease && inCinemas &&
             <div className={styles.title}>
-              {translate('InCinemas')}: {getRelativeDate(
+              <Icon
+                name={icons.IN_CINEMAS}
+              /> {getRelativeDate(
                 inCinemas,
                 shortDateFormat,
                 showRelativeDates,
@@ -288,16 +290,28 @@ class MovieIndexPoster extends Component {
         }
 
         {
-          showCinemaRelease && !inCinemas &&
+          showReleaseDate && releaseDateType === 'Released' &&
             <div className={styles.title}>
-              {translate('NoCinemaRelease')}
+              <Icon
+                name={icons.DISC}
+              /> {getRelativeDate(
+                releaseDate,
+                shortDateFormat,
+                showRelativeDates,
+                {
+                  timeFormat,
+                  timeForToday: false
+                }
+              )}
             </div>
         }
 
         {
-          showReleaseDate &&
+          showReleaseDate && releaseDateType === 'Digital' &&
             <div className={styles.title}>
-              {translate(releaseDateType)}: {getRelativeDate(
+              <Icon
+                name={icons.MOVIE_FILE}
+              /> {getRelativeDate(
                 releaseDate,
                 shortDateFormat,
                 showRelativeDates,

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
@@ -288,12 +288,14 @@ class MovieIndexPoster extends Component {
         <MovieIndexPosterInfo
           qualityProfile={qualityProfile}
           showQualityProfile={showQualityProfile}
+          showReleaseDate={showReleaseDate}
           showRelativeDates={showRelativeDates}
           shortDateFormat={shortDateFormat}
           timeFormat={timeFormat}
           inCinemas={inCinemas}
           physicalRelease={physicalRelease}
           digitalRelease={digitalRelease}
+          releaseDate={releaseDate}
           {...otherProps}
         />
 

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
@@ -135,12 +135,14 @@ class MovieIndexPoster extends Component {
     let releaseDate = '';
     if (showReleaseDate) {
       releaseDate = inCinemas;
-      if (physicalRelease && digitalRelease) {
-        releaseDate = (physicalRelease < digitalRelease) ? physicalRelease : digitalRelease;
-      } else if (physicalRelease && !digitalRelease) {
-        releaseDate = physicalRelease;
-      } else if (digitalRelease && !physicalRelease) {
-        releaseDate = digitalRelease;
+      if (!inCinemas) {
+        if (physicalRelease && digitalRelease) {
+          releaseDate = (physicalRelease < digitalRelease) ? physicalRelease : digitalRelease;
+        } else if (physicalRelease && !digitalRelease) {
+          releaseDate = physicalRelease;
+        } else if (digitalRelease && !physicalRelease) {
+          releaseDate = digitalRelease;
+        }
       }
     }
 

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
@@ -270,18 +270,18 @@ class MovieIndexPoster extends Component {
         }
 
         {
-          showCinemaRelease && 
+          showCinemaRelease &&
             <div className={styles.title}>
-            {getRelativeDate(
-              inCinemas,
-              shortDateFormat,
-              showRelativeDates,
-              {
-                timeFormat,
-                timeForToday: false
-              }
-            )}
-          </div>
+              {getRelativeDate(
+                inCinemas,
+                shortDateFormat,
+                showRelativeDates,
+                {
+                  timeFormat,
+                  timeForToday: false
+                }
+              )}
+            </div>
         }
 
         {

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
@@ -297,7 +297,6 @@ class MovieIndexPoster extends Component {
           inCinemas={inCinemas}
           physicalRelease={physicalRelease}
           digitalRelease={digitalRelease}
-          releaseDate={releaseDate}
           {...otherProps}
         />
 

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
@@ -140,7 +140,7 @@ class MovieIndexPoster extends Component {
       releaseDateType = (physicalRelease < digitalRelease) ? 'Released' : 'Digital';
     } else if (physicalRelease && !digitalRelease) {
       releaseDate = physicalRelease;
-      releaseDateType = 'released';
+      releaseDateType = 'Released';
     } else if (digitalRelease && !physicalRelease) {
       releaseDate = digitalRelease;
       releaseDateType = 'Digital';

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
@@ -103,6 +103,7 @@ class MovieIndexPoster extends Component {
       showRelativeDates,
       shortDateFormat,
       showReleaseDate,
+      showCinemaRelease,
       inCinemas,
       physicalRelease,
       digitalRelease,
@@ -133,17 +134,13 @@ class MovieIndexPoster extends Component {
     };
 
     let releaseDate = '';
-    if (showReleaseDate) {
-      releaseDate = inCinemas;
-      if (!inCinemas) {
-        if (physicalRelease && digitalRelease) {
-          releaseDate = (physicalRelease < digitalRelease) ? physicalRelease : digitalRelease;
-        } else if (physicalRelease && !digitalRelease) {
-          releaseDate = physicalRelease;
-        } else if (digitalRelease && !physicalRelease) {
-          releaseDate = digitalRelease;
-        }
-      }
+
+    if (physicalRelease && digitalRelease) {
+      releaseDate = (physicalRelease < digitalRelease) ? physicalRelease : digitalRelease;
+    } else if (physicalRelease && !digitalRelease) {
+      releaseDate = physicalRelease;
+    } else if (digitalRelease && !physicalRelease) {
+      releaseDate = digitalRelease;
     }
 
     return (
@@ -273,6 +270,21 @@ class MovieIndexPoster extends Component {
         }
 
         {
+          showCinemaRelease && 
+            <div className={styles.title}>
+            {getRelativeDate(
+              inCinemas,
+              shortDateFormat,
+              showRelativeDates,
+              {
+                timeFormat,
+                timeForToday: false
+              }
+            )}
+          </div>
+        }
+
+        {
           showReleaseDate &&
             <div className={styles.title}>
               {getRelativeDate(
@@ -336,6 +348,7 @@ MovieIndexPoster.propTypes = {
   showSearchAction: PropTypes.bool.isRequired,
   showRelativeDates: PropTypes.bool.isRequired,
   shortDateFormat: PropTypes.string.isRequired,
+  showCinemaRelease: PropTypes.bool.isRequired,
   showReleaseDate: PropTypes.bool.isRequired,
   inCinemas: PropTypes.string,
   physicalRelease: PropTypes.string,

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
@@ -134,13 +134,16 @@ class MovieIndexPoster extends Component {
     };
 
     let releaseDate = '';
-
+    let releaseDateType = '';
     if (physicalRelease && digitalRelease) {
       releaseDate = (physicalRelease < digitalRelease) ? physicalRelease : digitalRelease;
+      releaseDateType = (physicalRelease < digitalRelease) ? 'Released' : 'Digital';
     } else if (physicalRelease && !digitalRelease) {
       releaseDate = physicalRelease;
+      releaseDateType = 'released';
     } else if (digitalRelease && !physicalRelease) {
       releaseDate = digitalRelease;
+      releaseDateType = 'Digital';
     }
 
     return (
@@ -270,9 +273,9 @@ class MovieIndexPoster extends Component {
         }
 
         {
-          showCinemaRelease &&
+          showCinemaRelease && inCinemas &&
             <div className={styles.title}>
-              {getRelativeDate(
+              {translate('InCinemas')}: {getRelativeDate(
                 inCinemas,
                 shortDateFormat,
                 showRelativeDates,
@@ -285,9 +288,16 @@ class MovieIndexPoster extends Component {
         }
 
         {
+          showCinemaRelease && !inCinemas &&
+            <div className={styles.title}>
+              {translate('NoCinemaRelease')}
+            </div>
+        }
+
+        {
           showReleaseDate &&
             <div className={styles.title}>
-              {getRelativeDate(
+              {translate(releaseDateType)}: {getRelativeDate(
                 releaseDate,
                 shortDateFormat,
                 showRelativeDates,

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
@@ -101,6 +101,10 @@ class MovieIndexPoster extends Component {
       showSearchAction,
       showRelativeDates,
       shortDateFormat,
+      showReleaseDate,
+      inCinemas,
+      physicalRelease,
+      digitalRelease,
       timeFormat,
       isRefreshingMovie,
       isSearchingMovie,
@@ -126,6 +130,19 @@ class MovieIndexPoster extends Component {
       width: `${posterWidth}px`,
       height: `${posterHeight}px`
     };
+
+    let releaseDate = '';
+    if (showReleaseDate) {
+      if (physicalRelease && digitalRelease) {
+        releaseDate = '';
+      } else if (physicalRelease && !digitalRelease) {
+        releaseDate = physicalRelease;
+      } else if (digitalRelease && !physicalRelease) {
+        releaseDate = digitalRelease;
+      } else {
+        releaseDate = inCinemas;
+      }
+    }
 
     return (
       <div className={styles.content}>
@@ -253,9 +270,17 @@ class MovieIndexPoster extends Component {
             </div>
         }
 
+        {
+          showReleaseDate &&
+            <div className={styles.title}>
+              {releaseDate}
+            </div>
+        }
+
         <MovieIndexPosterInfo
           qualityProfile={qualityProfile}
           showQualityProfile={showQualityProfile}
+          showReleaseDate={showReleaseDate}
           showRelativeDates={showRelativeDates}
           shortDateFormat={shortDateFormat}
           timeFormat={timeFormat}
@@ -298,6 +323,10 @@ MovieIndexPoster.propTypes = {
   showSearchAction: PropTypes.bool.isRequired,
   showRelativeDates: PropTypes.bool.isRequired,
   shortDateFormat: PropTypes.string.isRequired,
+  showReleaseDate: PropTypes.bool.isRequired,
+  inCinemas: PropTypes.string,
+  physicalRelease: PropTypes.string,
+  digitalRelease: PropTypes.string,
   timeFormat: PropTypes.string.isRequired,
   isRefreshingMovie: PropTypes.bool.isRequired,
   isSearchingMovie: PropTypes.bool.isRequired,

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
@@ -136,56 +136,16 @@ class MovieIndexPoster extends Component {
     if (showReleaseDate) {
       if (physicalRelease && digitalRelease) {
         if (physicalRelease < digitalRelease) {
-          releaseDate = getRelativeDate(
-            physicalRelease,
-            shortDateFormat,
-            showRelativeDates,
-            {
-              timeFormat,
-              timeForToday: false
-            }
-          );
+          releaseDate = physicalRelease;
         } else {
-          getRelativeDate(
-            digitalRelease,
-            shortDateFormat,
-            showRelativeDates,
-            {
-              timeFormat,
-              timeForToday: false
-            }
-          );
+          releaseDate = digitalRelease;
         }
       } else if (physicalRelease && !digitalRelease) {
-        releaseDate = getRelativeDate(
-          physicalRelease,
-          shortDateFormat,
-          showRelativeDates,
-          {
-            timeFormat,
-            timeForToday: false
-          }
-        );
+        releaseDate = physicalRelease;
       } else if (digitalRelease && !physicalRelease) {
-        releaseDate = getRelativeDate(
-          digitalRelease,
-          shortDateFormat,
-          showRelativeDates,
-          {
-            timeFormat,
-            timeForToday: false
-          }
-        );
+        releaseDate = digitalRelease;
       } else {
-        releaseDate = getRelativeDate(
-          inCinemas,
-          shortDateFormat,
-          showRelativeDates,
-          {
-            timeFormat,
-            timeForToday: false
-          }
-        );
+        releaseDate = inCinemas;
       }
     }
 
@@ -318,7 +278,15 @@ class MovieIndexPoster extends Component {
         {
           showReleaseDate &&
             <div className={styles.title}>
-              {releaseDate}
+              {getRelativeDate(
+                releaseDate,
+                shortDateFormat,
+                showRelativeDates,
+                {
+                  timeFormat,
+                  timeForToday: false
+                }
+              )}
             </div>
         }
 

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
@@ -134,13 +134,57 @@ class MovieIndexPoster extends Component {
     let releaseDate = '';
     if (showReleaseDate) {
       if (physicalRelease && digitalRelease) {
-        releaseDate = '';
+        if (physicalRelease < digitalRelease) {
+          releaseDate = getRelativeDate(
+            physicalRelease,
+            shortDateFormat,
+            showRelativeDates,
+            {
+              timeFormat,
+              timeForToday: false
+            }
+          );
+        } else {
+          getRelativeDate(
+            digitalRelease,
+            shortDateFormat,
+            showRelativeDates,
+            {
+              timeFormat,
+              timeForToday: false
+            }
+          );
+        }
       } else if (physicalRelease && !digitalRelease) {
-        releaseDate = physicalRelease;
+        releaseDate = getRelativeDate(
+          physicalRelease,
+          shortDateFormat,
+          showRelativeDates,
+          {
+            timeFormat,
+            timeForToday: false
+          }
+        );
       } else if (digitalRelease && !physicalRelease) {
-        releaseDate = digitalRelease;
+        releaseDate = getRelativeDate(
+          digitalRelease,
+          shortDateFormat,
+          showRelativeDates,
+          {
+            timeFormat,
+            timeForToday: false
+          }
+        );
       } else {
-        releaseDate = inCinemas;
+        releaseDate = getRelativeDate(
+          inCinemas,
+          shortDateFormat,
+          showRelativeDates,
+          {
+            timeFormat,
+            timeForToday: false
+          }
+        );
       }
     }
 
@@ -272,9 +316,12 @@ class MovieIndexPoster extends Component {
 
         {
           showReleaseDate &&
-            <div className={styles.title}>
-              {releaseDate}
-            </div>
+          <RelativeDateCellConnector
+            key={releaseDate}
+            className={styles.title}
+            date={releaseDate}
+            component={VirtualTableRowCell}
+          />
         }
 
         <MovieIndexPosterInfo

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
@@ -288,10 +288,12 @@ class MovieIndexPoster extends Component {
         <MovieIndexPosterInfo
           qualityProfile={qualityProfile}
           showQualityProfile={showQualityProfile}
-          showReleaseDate={showReleaseDate}
           showRelativeDates={showRelativeDates}
           shortDateFormat={shortDateFormat}
           timeFormat={timeFormat}
+          inCinemas={inCinemas}
+          physicalRelease={physicalRelease}
+          digitalRelease={digitalRelease}
           {...otherProps}
         />
 

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.js
@@ -134,18 +134,13 @@ class MovieIndexPoster extends Component {
 
     let releaseDate = '';
     if (showReleaseDate) {
+      releaseDate = inCinemas;
       if (physicalRelease && digitalRelease) {
-        if (physicalRelease < digitalRelease) {
-          releaseDate = physicalRelease;
-        } else {
-          releaseDate = digitalRelease;
-        }
+        releaseDate = (physicalRelease < digitalRelease) ? physicalRelease : digitalRelease;
       } else if (physicalRelease && !digitalRelease) {
         releaseDate = physicalRelease;
       } else if (digitalRelease && !physicalRelease) {
         releaseDate = digitalRelease;
-      } else {
-        releaseDate = inCinemas;
       }
     }
 

--- a/frontend/src/Movie/Index/Posters/MovieIndexPosterInfo.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPosterInfo.js
@@ -10,10 +10,12 @@ function MovieIndexPosterInfo(props) {
     studio,
     qualityProfile,
     showQualityProfile,
+    showReleaseDate,
     added,
     inCinemas,
     digitalRelease,
     physicalRelease,
+    releaseDate,
     certification,
     path,
     sizeOnDisk,
@@ -57,7 +59,25 @@ function MovieIndexPosterInfo(props) {
     );
   }
 
-  if (sortKey === 'inCinemas' && inCinemas) {
+  if (sortKey === 'releaseDate' && !showReleaseDate) {
+    const relativeReleaseDate = getRelativeDate(
+      releaseDate,
+      shortDateFormat,
+      showRelativeDates,
+      {
+        timeFormat,
+        timeForToday: false
+      }
+    );
+
+    return (
+      <div className={styles.info}>
+        {translate('releaseDate')}: {relativeReleaseDate}
+      </div>
+    );
+  }
+
+  if (sortKey === 'inCinemas' && inCinemas && !showReleaseDate) {
     const inCinemasDate = getRelativeDate(
       inCinemas,
       shortDateFormat,
@@ -75,7 +95,7 @@ function MovieIndexPosterInfo(props) {
     );
   }
 
-  if (sortKey === 'digitalRelease' && digitalRelease) {
+  if (sortKey === 'digitalRelease' && digitalRelease && !showReleaseDate) {
     const digitalReleaseDate = getRelativeDate(
       digitalRelease,
       shortDateFormat,
@@ -93,7 +113,7 @@ function MovieIndexPosterInfo(props) {
     );
   }
 
-  if (sortKey === 'physicalRelease' && physicalRelease) {
+  if (sortKey === 'physicalRelease' && physicalRelease && !showReleaseDate) {
     const physicalReleaseDate = getRelativeDate(
       physicalRelease,
       shortDateFormat,
@@ -147,9 +167,11 @@ MovieIndexPosterInfo.propTypes = {
   certification: PropTypes.string,
   digitalRelease: PropTypes.string,
   physicalRelease: PropTypes.string,
+  releaseDate: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,
   sizeOnDisk: PropTypes.number,
   sortKey: PropTypes.string.isRequired,
+  showReleaseDate: PropTypes.bool.isRequired,
   showRelativeDates: PropTypes.bool.isRequired,
   shortDateFormat: PropTypes.string.isRequired,
   timeFormat: PropTypes.string.isRequired

--- a/frontend/src/Movie/Index/Posters/MovieIndexPosterInfo.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPosterInfo.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import Icon from 'Components/Icon';
+import { icons } from 'Helpers/Props';
 import getRelativeDate from 'Utilities/Date/getRelativeDate';
 import formatBytes from 'Utilities/Number/formatBytes';
 import translate from 'Utilities/String/translate';
@@ -71,7 +73,9 @@ function MovieIndexPosterInfo(props) {
 
     return (
       <div className={styles.info}>
-        {translate('InCinemas')}: {inCinemasDate}
+        <Icon
+          name={icons.IN_CINEMAS}
+        /> {inCinemasDate}
       </div>
     );
   }
@@ -89,7 +93,9 @@ function MovieIndexPosterInfo(props) {
 
     return (
       <div className={styles.info}>
-        {translate('Digital')}: {digitalReleaseDate}
+        <Icon
+          name={icons.MOVIE_FILE}
+        /> {digitalReleaseDate}
       </div>
     );
   }
@@ -107,7 +113,9 @@ function MovieIndexPosterInfo(props) {
 
     return (
       <div className={styles.info}>
-        {translate('Released')}: {physicalReleaseDate}
+        <Icon
+          name={icons.DISC}
+        /> {physicalReleaseDate}
       </div>
     );
   }

--- a/frontend/src/Movie/Index/Posters/MovieIndexPosterInfo.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPosterInfo.js
@@ -15,7 +15,6 @@ function MovieIndexPosterInfo(props) {
     inCinemas,
     digitalRelease,
     physicalRelease,
-    releaseDate,
     certification,
     path,
     sizeOnDisk,
@@ -55,24 +54,6 @@ function MovieIndexPosterInfo(props) {
     return (
       <div className={styles.info}>
         {translate('Added')}: {addedDate}
-      </div>
-    );
-  }
-
-  if (sortKey === 'releaseDate' && !showReleaseDate) {
-    const relativeReleaseDate = getRelativeDate(
-      releaseDate,
-      shortDateFormat,
-      showRelativeDates,
-      {
-        timeFormat,
-        timeForToday: false
-      }
-    );
-
-    return (
-      <div className={styles.info}>
-        {translate('releaseDate')}: {relativeReleaseDate}
       </div>
     );
   }
@@ -167,7 +148,6 @@ MovieIndexPosterInfo.propTypes = {
   certification: PropTypes.string,
   digitalRelease: PropTypes.string,
   physicalRelease: PropTypes.string,
-  releaseDate: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,
   sizeOnDisk: PropTypes.number,
   sortKey: PropTypes.string.isRequired,

--- a/frontend/src/Movie/Index/Posters/MovieIndexPosters.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPosters.js
@@ -38,7 +38,8 @@ function calculateRowHeight(posterHeight, sortKey, isSmallScreen, posterOptions)
     detailedProgressBar,
     showTitle,
     showMonitored,
-    showQualityProfile
+    showQualityProfile,
+    showReleaseDate
   } = posterOptions;
 
   const nextAiringHeight = 19;
@@ -59,6 +60,10 @@ function calculateRowHeight(posterHeight, sortKey, isSmallScreen, posterOptions)
   }
 
   if (showQualityProfile) {
+    heights.push(19);
+  }
+
+  if (showReleaseDate) {
     heights.push(19);
   }
 
@@ -206,7 +211,8 @@ class MovieIndexPosters extends Component {
       detailedProgressBar,
       showTitle,
       showMonitored,
-      showQualityProfile
+      showQualityProfile,
+      showReleaseDate
     } = posterOptions;
 
     const movieIdx = rowIndex * columnCount + columnIndex;
@@ -235,6 +241,7 @@ class MovieIndexPosters extends Component {
           showTitle={showTitle}
           showMonitored={showMonitored}
           showQualityProfile={showQualityProfile}
+          showReleaseDate={showReleaseDate}
           showRelativeDates={showRelativeDates}
           shortDateFormat={shortDateFormat}
           timeFormat={timeFormat}

--- a/frontend/src/Movie/Index/Posters/MovieIndexPosters.js
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPosters.js
@@ -212,6 +212,7 @@ class MovieIndexPosters extends Component {
       showTitle,
       showMonitored,
       showQualityProfile,
+      showCinemaRelease,
       showReleaseDate
     } = posterOptions;
 
@@ -242,6 +243,7 @@ class MovieIndexPosters extends Component {
           showMonitored={showMonitored}
           showQualityProfile={showQualityProfile}
           showReleaseDate={showReleaseDate}
+          showCinemaRelease={showCinemaRelease}
           showRelativeDates={showRelativeDates}
           shortDateFormat={shortDateFormat}
           timeFormat={timeFormat}

--- a/frontend/src/Movie/Index/Posters/Options/MovieIndexPosterOptionsModalContent.js
+++ b/frontend/src/Movie/Index/Posters/Options/MovieIndexPosterOptionsModalContent.js
@@ -73,7 +73,7 @@ class MovieIndexPosterOptionsModalContent extends Component {
       state.showQualityProfile = showQualityProfile;
     }
 
-    if (showCinemaRelease != prevProps.showCinemaRelease) {
+    if (showCinemaRelease !== prevProps.showCinemaRelease) {
       state.showCinemaRelease = showCinemaRelease;
     }
 

--- a/frontend/src/Movie/Index/Posters/Options/MovieIndexPosterOptionsModalContent.js
+++ b/frontend/src/Movie/Index/Posters/Options/MovieIndexPosterOptionsModalContent.js
@@ -46,6 +46,7 @@ class MovieIndexPosterOptionsModalContent extends Component {
       showTitle,
       showMonitored,
       showQualityProfile,
+      showCinemaRelease,
       showReleaseDate,
       showSearchAction
     } = this.props;

--- a/frontend/src/Movie/Index/Posters/Options/MovieIndexPosterOptionsModalContent.js
+++ b/frontend/src/Movie/Index/Posters/Options/MovieIndexPosterOptionsModalContent.js
@@ -33,6 +33,7 @@ class MovieIndexPosterOptionsModalContent extends Component {
       showTitle: props.showTitle,
       showMonitored: props.showMonitored,
       showQualityProfile: props.showQualityProfile,
+      showCinemaRelease: props.showCinemaRelease,
       showReleaseDate: props.showReleaseDate,
       showSearchAction: props.showSearchAction
     };
@@ -69,6 +70,10 @@ class MovieIndexPosterOptionsModalContent extends Component {
 
     if (showQualityProfile !== prevProps.showQualityProfile) {
       state.showQualityProfile = showQualityProfile;
+    }
+
+    if (showCinemaRelease != prevProps.showCinemaRelease) {
+      state.showCinemaRelease = showCinemaRelease;
     }
 
     if (showReleaseDate !== prevProps.showReleaseDate) {
@@ -109,6 +114,7 @@ class MovieIndexPosterOptionsModalContent extends Component {
       showTitle,
       showMonitored,
       showQualityProfile,
+      showCinemaRelease,
       showReleaseDate,
       showSearchAction
     } = this.state;
@@ -182,6 +188,18 @@ class MovieIndexPosterOptionsModalContent extends Component {
             </FormGroup>
 
             <FormGroup>
+              <FormLabel>{translate('ShowCinemaRelease')}</FormLabel>
+
+              <FormInputGroup
+                type={inputTypes.CHECK}
+                name="showCinemaRelease"
+                value={showCinemaRelease}
+                helpText={translate('showCinemaReleaseHelpText')}
+                onChange={this.onChangePosterOption}
+              />
+            </FormGroup>
+
+            <FormGroup>
               <FormLabel>{translate('ShowReleaseDate')}</FormLabel>
 
               <FormInputGroup
@@ -225,6 +243,7 @@ MovieIndexPosterOptionsModalContent.propTypes = {
   showMonitored: PropTypes.bool.isRequired,
   showQualityProfile: PropTypes.bool.isRequired,
   detailedProgressBar: PropTypes.bool.isRequired,
+  showCinemaRelease: PropTypes.bool.isRequired,
   showReleaseDate: PropTypes.bool.isRequired,
   showSearchAction: PropTypes.bool.isRequired,
   onChangePosterOption: PropTypes.func.isRequired,

--- a/frontend/src/Movie/Index/Posters/Options/MovieIndexPosterOptionsModalContent.js
+++ b/frontend/src/Movie/Index/Posters/Options/MovieIndexPosterOptionsModalContent.js
@@ -33,6 +33,7 @@ class MovieIndexPosterOptionsModalContent extends Component {
       showTitle: props.showTitle,
       showMonitored: props.showMonitored,
       showQualityProfile: props.showQualityProfile,
+      showReleaseDate: props.showReleaseDate,
       showSearchAction: props.showSearchAction
     };
   }
@@ -44,6 +45,7 @@ class MovieIndexPosterOptionsModalContent extends Component {
       showTitle,
       showMonitored,
       showQualityProfile,
+      showReleaseDate,
       showSearchAction
     } = this.props;
 
@@ -67,6 +69,10 @@ class MovieIndexPosterOptionsModalContent extends Component {
 
     if (showQualityProfile !== prevProps.showQualityProfile) {
       state.showQualityProfile = showQualityProfile;
+    }
+
+    if (showReleaseDate !== prevProps.showReleaseDate) {
+      state.showReleaseDate = showReleaseDate;
     }
 
     if (showSearchAction !== prevProps.showSearchAction) {
@@ -103,6 +109,7 @@ class MovieIndexPosterOptionsModalContent extends Component {
       showTitle,
       showMonitored,
       showQualityProfile,
+      showReleaseDate,
       showSearchAction
     } = this.state;
 
@@ -175,6 +182,18 @@ class MovieIndexPosterOptionsModalContent extends Component {
             </FormGroup>
 
             <FormGroup>
+              <FormLabel>{translate('ShowReleaseDate')}</FormLabel>
+
+              <FormInputGroup
+                type={inputTypes.CHECK}
+                name="showReleaseDate"
+                value={showReleaseDate}
+                helpText={translate('ShowReleaseDateHelpText')}
+                onChange={this.onChangePosterOption}
+              />
+            </FormGroup>
+
+            <FormGroup>
               <FormLabel>{translate('ShowSearch')}</FormLabel>
 
               <FormInputGroup
@@ -206,6 +225,7 @@ MovieIndexPosterOptionsModalContent.propTypes = {
   showMonitored: PropTypes.bool.isRequired,
   showQualityProfile: PropTypes.bool.isRequired,
   detailedProgressBar: PropTypes.bool.isRequired,
+  showReleaseDate: PropTypes.bool.isRequired,
   showSearchAction: PropTypes.bool.isRequired,
   onChangePosterOption: PropTypes.func.isRequired,
   onModalClose: PropTypes.func.isRequired

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -871,6 +871,7 @@
   "ShowQualityProfile": "Show Quality Profile",
   "ShowQualityProfileHelpText": "Show quality profile under poster",
   "ShowRatings": "Show Ratings",
+  "ShowReleaseDateHelpText": "Show release date under poster",
   "ShowSearch": "Show Search",
   "ShowSearchHelpText": "Show search button on hover",
   "ShowSizeOnDisk": "Show Size on Disk",

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -860,6 +860,8 @@
   "ShowAdvanced": "Show Advanced",
   "ShowAsAllDayEvents": "Show as All-Day Events",
   "ShowCertification": "Show Certification",
+  "ShowCinemaRelease": "Show Cinema Release Date",
+  "showCinemaReleaseHelpText": "Show cinema release date under poster",
   "ShowCutoffUnmetIconHelpText": "Show icon for files when the cutoff hasn't been met",
   "ShowDateAdded": "Show Date Added",
   "ShowGenres": "Show Genres",

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -736,6 +736,7 @@
   "RelativePath": "Relative Path",
   "ReleaseBranchCheckOfficialBranchMessage": "Branch {0} is not a valid Radarr release branch, you will not receive updates",
   "Released": "Released",
+  "ReleaseDate": "Release Date",
   "ReleaseDates": "Release Dates",
   "ReleasedMsg": "Movie is released",
   "ReleaseGroup": "Release Group",

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -589,6 +589,7 @@
   "NoBackupsAreAvailable": "No backups are available",
   "NoChange": "No Change",
   "NoChanges": "No Changes",
+  "NoCinemaRelease": "No Cinema Release",
   "NoEventsFound": "No events found",
   "NoHistory": "No history",
   "NoLeaveIt": "No, Leave It",

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -871,6 +871,7 @@
   "ShowQualityProfile": "Show Quality Profile",
   "ShowQualityProfileHelpText": "Show quality profile under poster",
   "ShowRatings": "Show Ratings",
+  "ShowReleaseDate": "Show Release Date",
   "ShowReleaseDateHelpText": "Show release date under poster",
   "ShowSearch": "Show Search",
   "ShowSearchHelpText": "Show search button on hover",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Release date as a calculated value as an option on the Poster View - uses dates in this order

1. Earliest of physical/digital release (if both specified)
2. digital/physical release (if only one specified)
3. cinema release date

#### Screenshot (if UI related)
![image](https://user-images.githubusercontent.com/19610103/103716954-2cdc1980-4fbc-11eb-98fc-cb08842f2f71.png)

#### Todos
- [x] Translation Keys

#### Issues Fixed or Closed by this PR

* Fixes #5656 
