### PR TITLE
Fixed: Parse standalone UHD as 4K if no other resolution info is present

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -241,9 +241,19 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("John.Carpenter.Live.Retrospective.2016.2018.1080p.MBluRay.x264-CRUELTY.mkv", false)]
         [TestCase("Heart.Live.In.Atlantic.City.2019.1080p.MBLURAY.x264-MBLURAYFANS.mkv", false)]
         [TestCase("Opeth.Garden.Of.The.Titans.Live.At.Red.Rocks.Amphitheatre.2017.1080p.MBluRay.x264-TREBLE.mkv", false)]
+        [TestCase("Rise.Of.The.Planet.Of.The.Apes.2011.UHD.BluRay.DD5.1.HDR.x265-CtrlHD/ctrlhd-rotpota-1080p.mkv", false)]
+        [TestCase("V for Vendetta 2005 1080p UHD BluRay DD+7.1 x264-LoRD.mkv", false)]
+        [TestCase("Rise.Of.The.Planet.Of.The.Apes.2011.1080p.UHD.BluRay.DD5.1.HDR.x265-CtrlHD.mkv", false)]
         public void should_parse_bluray1080p_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Source.BLURAY, proper, Resolution.R1080p);
+        }
+
+        [TestCase("Rise.Of.The.Planet.Of.The.Apes.2011.2160p.UHD.BluRay.DD5.1.HDR.x265-CtrlHD.mkv", false)]
+        [TestCase("X-Men.Days.of.Future.Past.2014.2160p.UHD.BluRay.X265-IAMABLE.mkv", false)]
+        public void should_parse_bluray2160p_quality(string title, bool proper)
+        {
+            ParseAndVerifyQuality(title, Source.BLURAY, proper, Resolution.R2160p);
         }
 
         [TestCase("Movie.Name.2004.576p.BDRip.x264-HANDJOB")]
@@ -267,6 +277,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("27.Dresses.2008.REMUX.2160p.Bluray.AVC.DTS-HR.MA.5.1-LEGi0N")]
         [TestCase("The.Shining.1980.2160p.UHD.BluRay.Remux.HDR.HEVC.DTS-HD.MA.5.1-PmP.mkv")]
         [TestCase("Stranger.Things.2016.T1.UHDRemux.2160p.HEVC.Dual.AC3.5.1-TrueHD.5.1.Sub")]
+        [TestCase("[Dolby Vision] Game.of.Thrones.S07.MULTi.UHD.BLURAY.REMUX.DV-NoTag")]
         public void should_parse_remux2160p_quality(string title)
         {
             ParseAndVerifyQuality(title, Source.BLURAY, false, Resolution.R2160p, Modifier.REMUX);

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -59,6 +59,10 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex ResolutionRegex = new Regex(@"\b(?:(?<R360p>360p)|(?<R480p>480p|640x480|848x480)|(?<R576p>576p)|(?<R720p>720p|1280x720)|(?<R1080p>1080p|1920x1080|1440p|FHD|1080i|4kto1080p)|(?<R2160p>2160p|4k[-_. ](?:UHD|HEVC|BD)|(?:UHD|HEVC|BD)[-_. ]4k))\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+        //Handle cases where no resolution is in the release name; assume if UHD then 4k
+        private static readonly Regex ImpliedResolutionRegex = new Regex(@"\b(?<R2160p>UHD)\b",
+                                                                RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         private static readonly Regex CodecRegex = new Regex(@"\b(?:(?<x264>x264)|(?<h264>h264)|(?<xvidhd>XvidHD)|(?<xvid>X-?vid)|(?<divx>divx))\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
@@ -599,7 +603,9 @@ namespace NzbDrone.Core.Parser
         {
             var match = ResolutionRegex.Match(name);
 
-            if (!match.Success)
+            var matchimplied = ImpliedResolutionRegex.Match(name);
+
+            if (!match.Success & !matchimplied.Success)
             {
                 return Resolution.Unknown;
             }
@@ -629,7 +635,7 @@ namespace NzbDrone.Core.Parser
                 return Resolution.R1080p;
             }
 
-            if (match.Groups["R2160p"].Success)
+            if (match.Groups["R2160p"].Success || matchimplied.Groups["R2160p"].Success)
             {
                 return Resolution.R2160p;
             }


### PR DESCRIPTION
#### Database Migration
NO
#### Description

#### Screenshot (if UI related)

#### Todos
- [X] Tests
-  Translation Keys-N/A
-  Wiki Updates-N/A

#### Issues Fixed or Closed by this PR

* Fixes #XXXX

Sonarr PR https://github.com/Sonarr/Sonarr/pull/4248
