### PR TITLE
Added new PTP releasename

### DIFF
--- a/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornApi.cs
+++ b/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornApi.cs
@@ -25,6 +25,8 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
         public string Seeders { get; set; }
         public string Leechers { get; set; }
         public string ReleaseName { get; set; }
+        public string ReleaseGroup { get; set; }
+
         public bool Checked { get; set; }
         public bool GoldenPopcorn { get; set; }
         public string FreeleechType { get; set; }

--- a/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornApi.cs
+++ b/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornApi.cs
@@ -26,7 +26,6 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
         public string Leechers { get; set; }
         public string ReleaseName { get; set; }
         public string ReleaseGroup { get; set; }
-
         public bool Checked { get; set; }
         public bool GoldenPopcorn { get; set; }
         public string FreeleechType { get; set; }

--- a/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornParser.cs
+++ b/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornParser.cs
@@ -65,6 +65,27 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
                     var title = torrent.ReleaseName;
                     IndexerFlags flags = 0;
 
+                    if (_settings.NewReleaseName)
+                    {
+                        if (!string.IsNullOrEmpty(torrent.RemasterTitle))
+                        {
+                            char[] charsToTrim = { '.', ' ' };
+                            torrent.RemasterTitle = torrent.RemasterTitle.Replace("With Commentary", "").Replace(" / ", ".").Trim(charsToTrim);
+                        }
+
+                        if (string.IsNullOrEmpty(torrent.ReleaseGroup))
+                        {
+                            title = $"{result.Title}.{result.Year}.{torrent.Resolution}.{torrent.Source}.{torrent.Codec}.{torrent.RemasterTitle}";
+                        }
+                        else
+                        {
+                            title = $"{result.Title}.{result.Year}.{torrent.Resolution}.{torrent.Source}.{torrent.Codec}.{torrent.RemasterTitle}-{torrent.ReleaseGroup}";
+                        }
+
+                        title = title.Replace(" ", ".");
+                    }
+
+
                     if (torrent.GoldenPopcorn)
                     {
                         flags |= IndexerFlags.PTP_Golden; //title = $"{title} 🍿";

--- a/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornParser.cs
+++ b/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornParser.cs
@@ -85,7 +85,6 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
                         title = title.Replace(" ", ".");
                     }
 
-
                     if (torrent.GoldenPopcorn)
                     {
                         flags |= IndexerFlags.PTP_Golden; //title = $"{title} 🍿";

--- a/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornSettings.cs
+++ b/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornSettings.cs
@@ -52,6 +52,9 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
         [FieldDefinition(6, Type = FieldType.TagSelect, SelectOptions = typeof(IndexerFlags), Label = "Required Flags", HelpText = "What indexer flags are required?", HelpLink = "https://wiki.servarr.com/Definitions#Indexer_Flags", Advanced = true)]
         public IEnumerable<int> RequiredFlags { get; set; }
 
+        [FieldDefinition(7, Type = FieldType.Checkbox, Label = "New ReleaseTitle", HelpText = "Use the new releasetitle.")]
+        public bool NewReleaseName { get; set; }
+
         public NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR changes the PTP indexer so that the Releasename is more "consistent", much like how the AHD parser works. The reason for this is because PTP's releasenames tend to be pretty unorganized, especially older torrents, while the website itself is extremely organized. It uses the PTP API's "RemasterTitle" field which includes a lot of information about the movie such as HDR, Dolby Atmos, etc.

I also included a new toggle in the PTP Indexer settings, which turns the new ReleaseName on and off. It seems to be working with existing indexer settings.
#### Screenshot (if UI related)
[New](https://i.imgur.com/DVtvTOz.png) and [old](https://i.imgur.com/n19cN8x.png)
#### Todos
- [ ] Tests
- [ ] Translation Keys
- [ ] Wiki Updates

edit: I should mention this is my first time with C# (and a pretty new programmer in general), so it's very possible I might have made some rookie mistake somewhere.