### PR TITLE
Update version checks for Mono and SQLite

### DIFF
--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/MonoVersionCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/MonoVersionCheckFixture.cs
@@ -28,9 +28,9 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
                   .Returns(new Version(version));
         }
 
-        [TestCase("5.18")]
         [TestCase("5.20")]
         [TestCase("6.4")]
+        [TestCase("6.12")]
         public void should_return_ok(string version)
         {
             GivenOutput(version);
@@ -71,6 +71,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
         [TestCase("5.12")]
         [TestCase("5.14")]
         [TestCase("5.16")]
+        [TestCase("5.18")]
         public void should_return_error(string version)
         {
             GivenOutput(version);

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/SqliteVersionCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/SqliteVersionCheckFixture.cs
@@ -1,0 +1,57 @@
+using System;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.EnvironmentInfo;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.HealthCheck.Checks;
+using NzbDrone.Core.Localization;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.HealthCheck.Checks
+{
+    [TestFixture]
+    public class SqliteVersionCheckFixture : CoreTest<SqliteVersionCheck>
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Mocker.GetMock<ILocalizationService>()
+                  .Setup(s => s.GetLocalizedString(It.IsAny<string>()))
+                  .Returns("Some Warning Message");
+        }
+
+        private void GivenOutput(string version)
+        {
+            if (!OsInfo.IsLinux)
+            {
+                throw new IgnoreException("linux specific test");
+            }
+
+            Mocker.GetMock<IMainDatabase>()
+                  .SetupGet(s => s.Version)
+                  .Returns(new Version(version));
+        }
+
+        [TestCase("3.9.0")]
+        [TestCase("3.9.1")]
+        [TestCase("3.26.0")]
+        [TestCase("3.34.0")]
+        public void should_return_ok(string version)
+        {
+            GivenOutput(version);
+
+            Subject.Check().ShouldBeOk();
+        }
+
+        [TestCase("3.8.11.1")]
+        [TestCase("3.8.11")]
+        [TestCase("3.3.9")]
+        [TestCase("2.8.12")]
+        public void should_return_error(string version)
+        {
+            GivenOutput(version);
+
+            Subject.Check().ShouldBeError();
+        }
+    }
+}

--- a/src/NzbDrone.Core/HealthCheck/Checks/MonoVersionCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/MonoVersionCheck.cs
@@ -26,19 +26,9 @@ namespace NzbDrone.Core.HealthCheck.Checks
 
             var monoVersion = _platformInfo.Version;
 
-            // Known buggy Mono versions
-            if (monoVersion == new Version("4.4.0") || monoVersion == new Version("4.4.1"))
-            {
-                _logger.Debug("Mono version {0}", monoVersion);
-                return new HealthCheck(GetType(),
-                    HealthCheckResult.Error,
-                    $"Currently installed Mono version {monoVersion} has a bug that causes issues connecting to indexers/download clients. You should upgrade to a higher version",
-                    "#currently_installed_mono_version_is_old_and_unsupported");
-            }
-
             // Currently best stable Mono version (5.18 gets us .net 4.7.2 support)
             var bestVersion = new Version("5.20");
-            var targetVersion = new Version("5.18");
+            var targetVersion = new Version("5.20");
             if (monoVersion >= targetVersion)
             {
                 _logger.Debug("Mono version is {0} or better: {1}", targetVersion, monoVersion);
@@ -46,7 +36,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
             }
 
             // Stable Mono versions
-            var stableVersion = new Version("5.18");
+            var stableVersion = new Version("5.20");
             if (monoVersion >= stableVersion)
             {
                 _logger.Debug("Mono version is {0} or better: {1}", stableVersion, monoVersion);
@@ -56,7 +46,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                     "#currently_installed_mono_version_is_supported_but_upgrading_is_recommended");
             }
 
-            var oldVersion = new Version("5.4");
+            var oldVersion = new Version("5.20");
             if (monoVersion >= oldVersion)
             {
                 return new HealthCheck(GetType(),

--- a/src/NzbDrone.Core/HealthCheck/Checks/SqliteVersionCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/SqliteVersionCheck.cs
@@ -1,0 +1,44 @@
+using System;
+using NLog;
+using NzbDrone.Common.EnvironmentInfo;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Localization;
+
+namespace NzbDrone.Core.HealthCheck.Checks
+{
+    public class SqliteVersionCheck : HealthCheckBase
+    {
+        private readonly IDatabase _database;
+        private readonly Logger _logger;
+
+        public SqliteVersionCheck(IMainDatabase database, ILocalizationService localizationService, Logger logger)
+            : base(localizationService)
+        {
+            _database = database;
+            _logger = logger;
+        }
+
+        public override HealthCheck Check()
+        {
+            if (!OsInfo.IsLinux)
+            {
+                return new HealthCheck(GetType());
+            }
+
+            var sqliteVersion = _database.Version;
+            var supportedVersion = new Version("3.9.0");
+
+            if (sqliteVersion >= supportedVersion)
+            {
+                return new HealthCheck(GetType());
+            }
+
+            return new HealthCheck(GetType(),
+                HealthCheckResult.Error,
+                string.Format(_localizationService.GetLocalizedString("SqliteVersionCheckUpgradeRequiredMessage"), sqliteVersion, supportedVersion),
+                "#currently_installed_sqlite_version_is_not_supported");
+        }
+
+        public override bool CheckOnSchedule => false;
+    }
+}

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -894,6 +894,7 @@
   "SourcePath": "Source Path",
   "SourceRelativePath": "Source Relative Path",
   "SourceTitle": "Source Title",
+  "SqliteVersionCheckUpgradeRequiredMessage": "Currently installed SQLite version {0} is no longer supported. Please upgrade SQLite to at least version {1}.",
   "SSLCertPassword": "SSL Cert Password",
   "SSLCertPasswordHelpText": "Password for pfx file",
   "SSLCertPath": "SSL Cert Path",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Warn on Mono < 5.20 (though in practice it won't start) and SQLite < 3.9.0

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

* Fixes #5785 
