### PR TITLE
Fix: Youtube trailers do not play from scraped data

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -274,7 +274,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 
                     details.Add(new XElement("studio", movie.Studio));
 
-                    details.Add(new XElement("trailer", "https://www.youtube.com/watch?v=" + movie.YouTubeTrailerId));
+                    details.Add(new XElement("trailer", "plugin://plugin.video.youtube/play/?video_id=" + movie.YouTubeTrailerId));
 
                     if (movieFile.MediaInfo != null)
                     {


### PR DESCRIPTION
Currently the scraper puts an https:// link, this is not compatible with the YouTube plugin, it needs to be in plugin format with YouTube ID

#### Database Migration
NO

#### Description
Currently the scraper puts an https:// link, this is not compatible with the YouTube plugin, it needs to be in plugin format with YouTube ID

#### Screenshot (if UI related)
N/A

#### Issues Fixed or Closed by this PR

* Fixes https://github.com/Radarr/Radarr/issues/5796
