### PR TITLE
Fixed: Set musl status at compile time

### DIFF
--- a/src/NzbDrone.Common/EnvironmentInfo/OsInfo.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/OsInfo.cs
@@ -97,14 +97,12 @@ namespace NzbDrone.Common.EnvironmentInfo
             }
             else
             {
-                return IsMusl() ? Os.LinuxMusl : Os.Linux;
+#if ISMUSL
+                return Os.LinuxMusl;
+#else
+                return Os.Linux;
+#endif
             }
-        }
-
-        private static bool IsMusl()
-        {
-            var output = RunAndCapture("ldd", "/bin/ls");
-            return output.Contains("libc.musl");
         }
 
         private static string RunAndCapture(string filename, string args)

--- a/src/NzbDrone.Common/Radarr.Common.csproj
+++ b/src/NzbDrone.Common/Radarr.Common.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net5.0;net472</TargetFrameworks>
+    <DefineConstants Condition="'$(RuntimeIdentifier)' == 'linux-musl-x64' or '$(RuntimeIdentifier)' == 'linux-musl-arm64'">ISMUSL</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DotNet4.SocksProxy" Version="1.4.0.1" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Set musl status at compile time instead of relying on `ldd` and `/bin/ls` existing, which it may not.

#### Screenshot (if UI related)

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes #4890 
