### PR TITLE
Fixed: Built-in updater for mono version

### DIFF
--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -22,7 +23,13 @@ namespace Radarr.Host
         {
             try
             {
-                Logger.Info("Starting Radarr - {0} - Version {1}", Assembly.GetCallingAssembly().Location, Assembly.GetExecutingAssembly().GetName().Version);
+                Logger.Info("Starting Radarr - {0} - Version {1}",
+#if NETCOREAPP
+                            Process.GetCurrentProcess().MainModule.FileName,
+#else
+                            Assembly.GetCallingAssembly().Location,
+#endif
+                            Assembly.GetExecutingAssembly().GetName().Version);
 
                 if (!PlatformValidation.IsValidate(userAlert))
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The change to set ExecutingApplication in 26a04c9fd broke mono - it
returned the location of the mono executable and not radarr.

It seems that there was a change in behaviour in net5.0 which means we
can no longer use the same code in both cases.

#### Screenshot (if UI related)

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes: issue reported on discord
