### PR TITLE
fixed wrong type for Movie->titleSlug and Rating->value in swagger.json

### DIFF
--- a/src/Radarr.Api.V3/swagger.json
+++ b/src/Radarr.Api.V3/swagger.json
@@ -3383,7 +3383,7 @@
             "type": "integer"
           },
           "titleSlug": {
-            "type": "integer"
+            "type": "string"
           },
           "certification": {
             "type": "string"
@@ -3470,7 +3470,7 @@
             "type": "integer"
           },
           "value": {
-            "type": "integer"
+            "type": "number"
           }
         },
         "xml": {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
fixed wrong type for Movie->titleSlug and Rating->value in swagger.json
#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys
- [x] Wiki Updates

