### PR TITLE
Fixed: Naming Token Regex can fail on certain Cultures

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
@@ -562,6 +564,24 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 
             Subject.BuildFileName(_movie, _movieFile)
                    .Should().Be("30 Rock - 30 Rock - S01E01 - Test");
+        }
+
+        [TestCase("en-US")]
+        [TestCase("fr-FR")]
+        [TestCase("az")]
+        [TestCase("tr-TR")]
+        public void should_replace_all_tokens_for_different_cultures(string culture)
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+
+            _movie.TmdbId = 124578;
+            _movie.Year = 2020;
+            GivenMediaInfoModel();
+
+            _namingConfig.StandardMovieFormat = "{Movie CleanTitle} ({Release Year}) [{Quality Title}] [tmdb-{TmdbId}] [{MediaInfo AudioCodec}]";
+
+            Subject.BuildFileName(_movie, _movieFile)
+                   .Should().Be("South Park (2020) [HDTV-720p] [tmdb-124578] [DTS]");
         }
 
         [Test]

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Organizer
         private readonly Logger _logger;
 
         private static readonly Regex TitleRegex = new Regex(@"\{(?<prefix>[- ._\[(]*)(?<token>(?:[a-z0-9]+)(?:(?<separator>[- ._]+)(?:[a-z0-9]+))?)(?::(?<customFormat>[a-z0-9|]+))?(?<suffix>[- ._)\]]*)\}",
-                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
         private static readonly Regex TagsRegex = new Regex(@"(?<tags>\{tags(?:\:0+)?})",
                                                                RegexOptions.Compiled | RegexOptions.IgnoreCase);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Certain cultures like "az" can cause the naming token regex to fail, leaving half of the filename not replaced as seen in the preview below. Ensuring we treat the regex as culture invariant fixes this.

Also adds a test to cycle thru every culture testing a typical naming token string

#### Screenshot (if UI related)

![image](https://user-images.githubusercontent.com/376117/106557876-cb429880-64f0-11eb-8f3f-af0803a82b4d.png)

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
