### PR TITLE
Fixed: Adding indexers from presets

### DIFF
--- a/src/NzbDrone.Api/DownloadClient/DownloadClientResource.cs
+++ b/src/NzbDrone.Api/DownloadClient/DownloadClientResource.cs
@@ -2,7 +2,7 @@
 
 namespace NzbDrone.Api.DownloadClient
 {
-    public class DownloadClientResource : ProviderResource
+    public class DownloadClientResource : ProviderResource<DownloadClientResource>
     {
         public bool Enable { get; set; }
         public DownloadProtocol Protocol { get; set; }

--- a/src/NzbDrone.Api/Indexers/IndexerResource.cs
+++ b/src/NzbDrone.Api/Indexers/IndexerResource.cs
@@ -2,7 +2,7 @@
 
 namespace NzbDrone.Api.Indexers
 {
-    public class IndexerResource : ProviderResource
+    public class IndexerResource : ProviderResource<IndexerResource>
     {
         public bool EnableRss { get; set; }
         public bool EnableSearch { get; set; }

--- a/src/NzbDrone.Api/Metadata/MetadataResource.cs
+++ b/src/NzbDrone.Api/Metadata/MetadataResource.cs
@@ -1,6 +1,6 @@
 ﻿namespace NzbDrone.Api.Metadata
 {
-    public class MetadataResource : ProviderResource
+    public class MetadataResource : ProviderResource<MetadataResource>
     {
         public bool Enable { get; set; }
     }

--- a/src/NzbDrone.Api/NetImport/ImportExclusionsResource.cs
+++ b/src/NzbDrone.Api/NetImport/ImportExclusionsResource.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace NzbDrone.Api.ImportList
 {
-    public class ImportExclusionsResource : ProviderResource
+    public class ImportExclusionsResource : ProviderResource<ImportExclusionsResource>
     {
         //public int Id { get; set; }
         public int TmdbId { get; set; }

--- a/src/NzbDrone.Api/NetImport/NetImportResource.cs
+++ b/src/NzbDrone.Api/NetImport/NetImportResource.cs
@@ -3,7 +3,7 @@ using NzbDrone.Core.Movies;
 
 namespace NzbDrone.Api.ImportList
 {
-    public class ImportListResource : ProviderResource
+    public class ImportListResource : ProviderResource<ImportListResource>
     {
         public bool Enabled { get; set; }
         public bool EnableAuto { get; set; }

--- a/src/NzbDrone.Api/Notifications/NotificationResource.cs
+++ b/src/NzbDrone.Api/Notifications/NotificationResource.cs
@@ -2,7 +2,7 @@
 
 namespace NzbDrone.Api.Notifications
 {
-    public class NotificationResource : ProviderResource
+    public class NotificationResource : ProviderResource<NotificationResource>
     {
         public bool OnGrab { get; set; }
         public bool OnDownload { get; set; }

--- a/src/NzbDrone.Api/ProviderModuleBase.cs
+++ b/src/NzbDrone.Api/ProviderModuleBase.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Api
     public abstract class ProviderModuleBase<TProviderResource, TProvider, TProviderDefinition> : RadarrRestModule<TProviderResource>
         where TProviderDefinition : ProviderDefinition, new()
         where TProvider : IProvider
-        where TProviderResource : ProviderResource, new()
+        where TProviderResource : ProviderResource<TProviderResource>, new()
     {
         private readonly IProviderFactory<TProvider, TProviderDefinition> _providerFactory;
 
@@ -160,8 +160,7 @@ namespace NzbDrone.Api
                 {
                     var presetResource = new TProviderResource();
                     MapToResource(presetResource, v);
-
-                    return presetResource as ProviderResource;
+                    return presetResource;
                 }).ToList();
 
                 result.Add(providerResource);

--- a/src/NzbDrone.Api/ProviderResource.cs
+++ b/src/NzbDrone.Api/ProviderResource.cs
@@ -5,7 +5,7 @@ using Radarr.Http.REST;
 
 namespace NzbDrone.Api
 {
-    public class ProviderResource : RestResource
+    public class ProviderResource<T> : RestResource
     {
         public string Name { get; set; }
         public List<Field> Fields { get; set; }
@@ -15,6 +15,6 @@ namespace NzbDrone.Api
         public string InfoLink { get; set; }
         public ProviderMessage Message { get; set; }
 
-        public List<ProviderResource> Presets { get; set; }
+        public List<T> Presets { get; set; }
     }
 }

--- a/src/NzbDrone.Common/Serializer/System.Text.Json/PolymorphicWriteOnlyJsonConverter.cs
+++ b/src/NzbDrone.Common/Serializer/System.Text.Json/PolymorphicWriteOnlyJsonConverter.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Common.Serializer
     {
         public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            throw new NotImplementedException();
+            return JsonSerializer.Deserialize<T>(ref reader, options);
         }
 
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)

--- a/src/NzbDrone.Integration.Test/ApiTests/IndexerFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/IndexerFixture.cs
@@ -54,6 +54,14 @@ namespace NzbDrone.Integration.Test.ApiTests
         }
 
         [Test]
+        public void all_preset_fields_should_be_set_correctly()
+        {
+            var schema = GetNewznabSchemav3();
+
+            schema.Presets.Any(x => x.SupportsRss).Should().BeTrue();
+        }
+
+        [Test]
         public void v2_categories_should_be_array()
         {
             var schema = GetNewznabSchemav2();

--- a/src/Radarr.Api.V3/DownloadClient/DownloadClientResource.cs
+++ b/src/Radarr.Api.V3/DownloadClient/DownloadClientResource.cs
@@ -3,7 +3,7 @@ using NzbDrone.Core.Indexers;
 
 namespace Radarr.Api.V3.DownloadClient
 {
-    public class DownloadClientResource : ProviderResource
+    public class DownloadClientResource : ProviderResource<DownloadClientResource>
     {
         public bool Enable { get; set; }
         public DownloadProtocol Protocol { get; set; }

--- a/src/Radarr.Api.V3/ImportLists/ImportExclusionsResource.cs
+++ b/src/Radarr.Api.V3/ImportLists/ImportExclusionsResource.cs
@@ -4,7 +4,7 @@ using NzbDrone.Core.ImportLists.ImportExclusions;
 
 namespace Radarr.Api.V3.ImportLists
 {
-    public class ImportExclusionsResource : ProviderResource
+    public class ImportExclusionsResource : ProviderResource<ImportExclusionsResource>
     {
         //public int Id { get; set; }
         public int TmdbId { get; set; }

--- a/src/Radarr.Api.V3/ImportLists/ImportListResource.cs
+++ b/src/Radarr.Api.V3/ImportLists/ImportListResource.cs
@@ -3,7 +3,7 @@ using NzbDrone.Core.Movies;
 
 namespace Radarr.Api.V3.ImportLists
 {
-    public class ImportListResource : ProviderResource
+    public class ImportListResource : ProviderResource<ImportListResource>
     {
         public bool Enabled { get; set; }
         public bool EnableAuto { get; set; }

--- a/src/Radarr.Api.V3/Indexers/IndexerResource.cs
+++ b/src/Radarr.Api.V3/Indexers/IndexerResource.cs
@@ -2,7 +2,7 @@ using NzbDrone.Core.Indexers;
 
 namespace Radarr.Api.V3.Indexers
 {
-    public class IndexerResource : ProviderResource
+    public class IndexerResource : ProviderResource<IndexerResource>
     {
         public bool EnableRss { get; set; }
         public bool EnableAutomaticSearch { get; set; }

--- a/src/Radarr.Api.V3/Metadata/MetadataResource.cs
+++ b/src/Radarr.Api.V3/Metadata/MetadataResource.cs
@@ -2,7 +2,7 @@ using NzbDrone.Core.Extras.Metadata;
 
 namespace Radarr.Api.V3.Metadata
 {
-    public class MetadataResource : ProviderResource
+    public class MetadataResource : ProviderResource<MetadataResource>
     {
         public bool Enable { get; set; }
     }

--- a/src/Radarr.Api.V3/Notifications/NotificationResource.cs
+++ b/src/Radarr.Api.V3/Notifications/NotificationResource.cs
@@ -2,7 +2,7 @@ using NzbDrone.Core.Notifications;
 
 namespace Radarr.Api.V3.Notifications
 {
-    public class NotificationResource : ProviderResource
+    public class NotificationResource : ProviderResource<NotificationResource>
     {
         public string Link { get; set; }
         public bool OnGrab { get; set; }

--- a/src/Radarr.Api.V3/ProviderModuleBase.cs
+++ b/src/Radarr.Api.V3/ProviderModuleBase.cs
@@ -14,7 +14,7 @@ namespace Radarr.Api.V3
     public abstract class ProviderModuleBase<TProviderResource, TProvider, TProviderDefinition> : RadarrRestModule<TProviderResource>
         where TProviderDefinition : ProviderDefinition, new()
         where TProvider : IProvider
-        where TProviderResource : ProviderResource, new()
+        where TProviderResource : ProviderResource<TProviderResource>, new()
     {
         private readonly IProviderFactory<TProvider, TProviderDefinition> _providerFactory;
         private readonly ProviderResourceMapper<TProviderResource, TProviderDefinition> _resourceMapper;
@@ -124,12 +124,9 @@ namespace Radarr.Api.V3
                 var providerResource = _resourceMapper.ToResource(providerDefinition);
                 var presetDefinitions = _providerFactory.GetPresetDefinitions(providerDefinition);
 
-                providerResource.Presets = presetDefinitions.Select(v =>
-                {
-                    var presetResource = _resourceMapper.ToResource(v);
-
-                    return presetResource as ProviderResource;
-                }).ToList();
+                providerResource.Presets = presetDefinitions
+                    .Select(v => _resourceMapper.ToResource(v))
+                    .ToList();
 
                 result.Add(providerResource);
             }

--- a/src/Radarr.Api.V3/ProviderResource.cs
+++ b/src/Radarr.Api.V3/ProviderResource.cs
@@ -6,7 +6,7 @@ using Radarr.Http.REST;
 
 namespace Radarr.Api.V3
 {
-    public class ProviderResource : RestResource
+    public class ProviderResource<T> : RestResource
     {
         public string Name { get; set; }
         public List<Field> Fields { get; set; }
@@ -17,11 +17,11 @@ namespace Radarr.Api.V3
         public ProviderMessage Message { get; set; }
         public HashSet<int> Tags { get; set; }
 
-        public List<ProviderResource> Presets { get; set; }
+        public List<T> Presets { get; set; }
     }
 
     public class ProviderResourceMapper<TProviderResource, TProviderDefinition>
-        where TProviderResource : ProviderResource, new()
+        where TProviderResource : ProviderResource<TProviderResource>, new()
         where TProviderDefinition : ProviderDefinition, new()
     {
         public virtual TProviderResource ToResource(TProviderDefinition definition)

--- a/src/Radarr.Http/ErrorManagement/RadarrErrorPipeline.cs
+++ b/src/Radarr.Http/ErrorManagement/RadarrErrorPipeline.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Data.SQLite;
+using System.IO;
 using FluentValidation;
 using Nancy;
+using Nancy.Extensions;
+using Nancy.IO;
 using NLog;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Exceptions;
@@ -26,7 +29,10 @@ namespace Radarr.Http.ErrorManagement
 
             if (exception is ApiException apiException)
             {
-                _logger.Warn(apiException, "API Error");
+                _logger.Warn(apiException, "API Error:\n{0}", apiException.Message);
+                var body = RequestStream.FromStream(context.Request.Body).AsString();
+                _logger.Trace("Request body:\n{0}", body);
+
                 return apiException.ToErrorResponse(context);
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
System.Text.Json doesn't support polymorphic serialization.  PR works around it by changing `ProviderResource` to `ProviderResource<T> : RestResource`, then we can use an explicit `List<T>` for the presets instead of `List<ProviderResource>`.

#### Screenshot (if UI related)

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes issue reported on discord
