### PR TITLE
Handle additional groups/encoders that do not follow -RlsGrp format

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -79,7 +79,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("The.Silence.of.the.Lambs.1991.REMASTERED.720p.10bit.BluRay.6CH.x265.HEVC-PSA", "PSA")]
         [TestCase("Seoul Station 2016 (1080p BluRay x265 HEVC 10bit DDP 5.1 theincognito)", "theincognito")]
         [TestCase("Harry Potter - A History of Magic (2017) (1080p AMZN WEB-DL x265 HEVC 10bit EAC3 2.0 t3nzin)", "t3nzin")]
-        [TestCaes("John Wick Chapter 3 Parabellum (2019) (1080p BluRay x265 HEVC 10bit AAC 7.1 Vyndros)", "Vyndros")]
+        [TestCase("John Wick Chapter 3 Parabellum (2019) (1080p BluRay x265 HEVC 10bit AAC 7.1 Vyndros)", "Vyndros")]
 
         public void should_parse_release_group(string title, string expected)
         {

--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -63,6 +63,23 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Ode To Joy (2009) (2160p BluRay x265 10bit HDR FreetheFish)", "FreetheFish")]
         [TestCase("Ode To Joy (2009) (2160p BluRay x265 10bit HDR afm72)", "afm72")]
         [TestCase("Ode To Joy (2009) (2160p BluRay x265 10bit HDR)", null)]
+        [TestCase("Marvel One Shot - Item 47 (2012) (1080p BluRay x265 HEVC 10bit AC3 2.0 Anna)", "Anna")]
+        [TestCase("Anna (2019) (1080p BluRay x265 HEVC 10bit AAC 7.1 Q22 Joy)", "Joy")]
+        [TestCase("Parasite (2019) (2160p BluRay x265 HEVC 10bit HDR AAC 7.1 Bandi)", "Bandi")]
+        [TestCase("Robin Williams - Weapons of Self Destruction (2009) (1080p HDTV x265 HEVC 10bit AAC 2.0 Ghost)", "Ghost")]
+        [TestCase("Ghost in the Shell (2017) (1080p BluRay x265 HEVC 10bit AAC 7.1 Tigole)", "Tigole")]
+        [TestCase("Mission - Impossible - Ghost Protocol (2011) (1080p BluRay x265 HEVC 10bit AAC 7.1 Tigole)", "Tigole")]
+        [TestCase("Ghost (1990) (1080p BluRay x265 HEVC 10bit AAC 5.1 Silence)", "Silence")]
+        [TestCase("Happy End (1999) (1080p BluRay x265 HEVC 10bit AAC 5.1 Korean Kappa)", "Kappa")]
+        [TestCase("Harry Potter and the Order of the Phoenix (2007) Open Matte (1080p AMZN WEB-DL x265 HEVC 10bit AAC 5.1 MONOLITH)", "MONOLITH")]
+        [TestCase("Spider-Man Far from Home (2019) (1080p BluRay x265 HEVC 10bit DTS 7.1 Qman)", "Qman")]
+        [TestCase("Suicide Squad - Hell to Pay (2018) + Extras (1080p BluRay x265 HEVC 10bit AAC 5.1 RZeroX)", "RZeroX")]
+        [TestCase("Gravity (2013) (Diamond Luxe Edition) + Extras (1080p BluRay x265 HEVC 10bit EAC3 7.1 SAMPA)", "SAMPA")]
+        [TestCase("Wonder Woman 1984 (2020) (1080p AMZN WEB-DL x265 HEVC 10bit EAC3 5.1 Silence)", "Silence")]
+        [TestCase("The.Silence.of.the.Lambs.1991.REMASTERED.720p.10bit.BluRay.6CH.x265.HEVC-PSA", "PSA")]
+        [TestCase("Seoul Station 2016 (1080p BluRay x265 HEVC 10bit DDP 5.1 theincognito)", "theincognito")]
+        [TestCase("Harry Potter - A History of Magic (2017) (1080p AMZN WEB-DL x265 HEVC 10bit EAC3 2.0 t3nzin)", "t3nzin")]
+        [TestCaes("John Wick Chapter 3 Parabellum (2019) (1080p BluRay x265 HEVC 10bit AAC 7.1 Vyndros)", "Vyndros")]
 
         public void should_parse_release_group(string title, string expected)
         {

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -127,7 +127,7 @@ namespace NzbDrone.Core.Parser
 
         //Handle Exception Release Groups that don't follow -RlsGrp; Manual List
         //First Group is groups whose releases end with RlsGroup) or RlsGroup]  second group (entries after `(?=\]|\))|`) is name only...BE VERY CAREFUL WITH THIS, HIGH CHANCE OF FALSE POSITIVES
-        private static readonly Regex ExceptionReleaseGroupRegex = new Regex(@"(?<releasegroup>(Tigole|Joy|YIFY|YTS.MX|FreetheFish|afm72)(?=\]|\))|KRaLiMaRKo|E\.N\.D)",
+        private static readonly Regex ExceptionReleaseGroupRegex = new Regex(@"(?<releasegroup>(Tigole|Joy|YIFY|YTS.MX|FreetheFish|afm72|Anna|Bandi|Ghost|Kappa|MONOLITH|Qman|RZeroX|SAMPA|Silence|theincognito|t3nzin|Vyndros)(?=\]|\))|KRaLiMaRKo|E\.N\.D)",
                                                         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex WordDelimiterRegex = new Regex(@"(\s|\.|,|_|-|=|'|\|)+", RegexOptions.Compiled);


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Adds additional release groups that were not included in #5612:
- Anna
- Bandi
- Ghost
- Kappa
- MONOLITH
- Qman
- RZeroX
- SAMPA
- Silence
- theincognito
- t3nzin
- Vyndros

#### Screenshot (if UI related)

#### Todos
- [x] Tests