### PR TITLE
Fixed: Don't ignore default Boolean in db serialization

### DIFF
--- a/src/NzbDrone.Core/Datastore/Converters/EmbeddedDocumentConverter.cs
+++ b/src/NzbDrone.Core/Datastore/Converters/EmbeddedDocumentConverter.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.Datastore.Converters
             var serializerSettings = new JsonSerializerOptions
             {
                 AllowTrailingCommas = true,
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 PropertyNameCaseInsensitive = true,
                 DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,

--- a/src/NzbDrone.Core/ThingiProvider/ProviderRepository.cs
+++ b/src/NzbDrone.Core/ThingiProvider/ProviderRepository.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.ThingiProvider
             var serializerSettings = new JsonSerializerOptions
             {
                 AllowTrailingCommas = true,
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 PropertyNameCaseInsensitive = true,
                 DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Prior to net5 only null values were ignored via ignoreNull = true for embedded doc converter and provider repo. Serialization settings `ignoreNull` was changed to Enum in net5. Original Net5 PR set these to Ignore `WhenWritingDefault` which in the case of booleans is `false` meaning provider settings with `false` values were not written to DB. This was troublesome when the default value of these settings was true meaning they could never be disabled. This change sets serialization settings to `WhenWritingNull` which only ignores if the value is explicitly null (acting like previous behavior). 

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* Fixes #5836 
