### PR TITLE
Fixed: Import RARBG Subtitles

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -298,6 +298,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Pulp Fiction.eng.sub")]
         [TestCase("Pulp.Fiction.eng.forced.sub")]
         [TestCase("Pulp-Fiction-eng-forced.sub")]
+        [TestCase("2_Eng.srt")]
+        [TestCase("2_English.srt")]
         public void should_parse_subtitle_language(string fileName)
         {
             var result = LanguageParser.ParseSubtitleLanguage(fileName);

--- a/src/NzbDrone.Core/Extras/ExtraService.cs
+++ b/src/NzbDrone.Core/Extras/ExtraService.cs
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.Extras
                                                                      .Select(e => e.Trim(' ', '.'))
                                                                      .ToList();
 
-            var matchingFilenames = files.Where(f => Path.GetFileNameWithoutExtension(f).StartsWith(sourceFileName, StringComparison.InvariantCultureIgnoreCase)).ToList();
+            var matchingFilenames = files;
             var filteredFilenames = new List<string>();
             var hasNfo = false;
 

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -96,7 +96,12 @@ namespace NzbDrone.Core.Extras.Subtitles
             if (SubtitleFileExtensions.Extensions.Contains(Path.GetExtension(path)))
             {
                 var language = LanguageParser.ParseSubtitleLanguage(path);
-                var suffix = GetSuffix(language, 1, false);
+                var subtitleFiles = _subtitleFileService.GetFilesByMovie(movie.Id);
+                var existingSrtSubs = subtitleFiles.Where(m => m.MovieFileId == movieFile.Id)
+                    .Where(m => m.Language == language)
+                    .Where(m => m.Extension == extension);
+
+                var suffix = GetSuffix(language, existingSrtSubs.Count() + 1, extension.EqualsIgnoreCase(".srt"));
                 var subtitleFile = ImportFile(movie, movieFile, path, readOnly, extension, suffix);
                 subtitleFile.Language = language;
 

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -64,6 +64,10 @@ namespace NzbDrone.Core.Parser
                 //Lookup ISO639-2T code
                 return All.FirstOrDefault(l => l.ThreeLetterCode == langCode);
             }
+            else if (langCode.Length > 3)
+            {
+                return All.FirstOrDefault(l => l.EnglishName.ToLower() == langCode.Trim());
+            }
 
             return null;
         }

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?:(?i)(?<!SUB[\W|_|^]))(?:(?<lithuanian>\bLT\b)|(?<czech>\bCZ\b)|(?<polish>\bPL\b))(?:(?i)(?![\W|_|^]SUB))",
                                                                 RegexOptions.Compiled);
 
-        private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[A-Za-z]{2,})(?:[-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static List<Language> ParseLanguages(string title)
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
RARBG files are not being imported because of its file naming convention ie 2_English.srt

Note: I initiated this fix again as I've been seeing requests to include this update. Please note that Radarr does not import SRT subtitles as is (or with the original filenames) because it needs to ensure filenames follow naming conventions and so that media players are able to load the subtitles accordingly. See https://support.plex.tv/articles/200471133-adding-local-subtitles-to-your-media/ for details. The end-to-end import logic for SRT subtitles is far from perfect and will have limitations because it caters to the needs of a variety of user scenarios (please see limitations below). Before logging a bug please consider the case of other users who need this update and assess whether the behavior affects the application's functionality (or if it is just cosmetic in nature ie. "I don't like the filename")

Limitations: 
1. There is a need to suffix the subtitles with an index or number to support multiple versions (2_English, 3_English). Otherwise multiple versions will be named the same (movie.en.srt) and will therefore overwrite each other. As a result other versions will be discarded. Solution is to name the 1st substitle it encounters as movie.1.en.srt and so on...
2. Radarr does not contain a comprehensive list of ISO languages so subtitle languages that are not in this list will not be identified. Identified languages will be suffixed accordingly (movie.1.en.srt, movie.1.fr.srt) while unknown languages will follow the movie name (movie.1.srt, movie.2.srt)

#### Screenshot (if UI related)
Not applicable

#### Todos
None

#### Issues Fixed or Closed by this PR

* Fixes #1958, #5378