### PR TITLE
Fix: Default states for Show Cinema Release and Show Release Date in Poster View

### DIFF
--- a/frontend/src/Store/Actions/movieIndexActions.js
+++ b/frontend/src/Store/Actions/movieIndexActions.js
@@ -37,6 +37,8 @@ export const defaultState = {
     showTitle: false,
     showMonitored: true,
     showQualityProfile: true,
+    showCinemaRelease: false,
+    showReleaseDate: false,
     showSearchAction: false
   },
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixed bug with no default state in PosterView for showCinemaRelease and showReleaseDate as found by Nit

#### Issues Fixed or Closed by this PR

* No issue raised; information found https://discord.com/channels/264387956343570434/264387994302021632/809967577618317342
