### PR TITLE
Fix issue with marking things as failed

### DIFF
--- a/frontend/src/Store/Actions/movieHistoryActions.js
+++ b/frontend/src/Store/Actions/movieHistoryActions.js
@@ -79,6 +79,7 @@ export const actionHandlers = handleThunks({
     const promise = createAjaxRequest({
       url: '/history/failed',
       method: 'POST',
+      contentType: 'application/x-www-form-urlencoded; charset=UTF-8',
       data: {
         id: historyId
       }


### PR DESCRIPTION
Fix issue with marking things as failed by setting a contentType since a previous change defaults to json instead of form when no contentType is set

Fixes: #5938 