### PR TITLE
New: Custom Format - Indexer Name

### DIFF
--- a/src/NzbDrone.Core/CustomFormats/Specifications/IndexerSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/IndexerSpecification.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.CustomFormats
+{
+    public class IndexerSpecification : RegexSpecificationBase
+    {
+        public override int Order => 9;
+        public override string ImplementationName => "Indexer Name";
+
+        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo)
+        {
+            var indexerName = movieInfo?.ExtraInfo?.GetValueOrDefault("IndexerName") as string;
+            return MatchString(indexerName);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Parser/Augmenters/AugmentWithReleaseInfo.cs
+++ b/src/NzbDrone.Core/Parser/Augmenters/AugmentWithReleaseInfo.cs
@@ -61,6 +61,11 @@ namespace NzbDrone.Core.Parser.Augmenters
                 }
 
                 movieInfo.ExtraInfo["IndexerFlags"] = releaseInfo.IndexerFlags;
+
+                if (releaseInfo.Indexer != null && releaseInfo.Indexer.IsNotNullOrWhiteSpace())
+                {
+                    movieInfo.ExtraInfo["IndexerName"] = releaseInfo.Indexer;
+                }
             }
 
             return movieInfo;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Allow to set a Custom Format using an Indexer Name. 

Use, I prefer an Indexer that in actual version has less punctuation because of another custom formats, but I want to have these custom formats to priorize releases in the same Indexer.

Example: 
  - Indexer1: Movie Title (Year) x264 1080p ac3
  - Indexer2: Movie Title (Year) x265 1080p DTS

I prefer Indexer 1 in this case, but Indexer 2 or another (and then priorize by another custom formats) if there is no movie in 1080p in Indexer 1.

#### Todos
- [ ] Tests
- [ ] Translation Keys
- [ ] Wiki Updates
