### PR TITLE
Add option to import from any user's personal list

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserRequestGenerator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Notifications.Trakt;
 
@@ -26,17 +27,18 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
         private IEnumerable<ImportListRequest> GetMoviesRequest()
         {
             var link = string.Empty;
+            var userName = Settings.Username.IsNotNullOrWhiteSpace() ? Settings.Username.Trim() : Settings.AuthUser.Trim();
 
             switch (Settings.TraktListType)
             {
                 case (int)TraktUserListType.UserWatchList:
-                    link += $"users/{Settings.AuthUser.Trim()}/watchlist/movies?limit={Settings.Limit}";
+                    link += $"users/{userName}/watchlist/movies?limit={Settings.Limit}";
                     break;
                 case (int)TraktUserListType.UserWatchedList:
-                    link += $"users/{Settings.AuthUser.Trim()}/watched/movies?limit={Settings.Limit}";
+                    link += $"users/{userName}/watched/movies?limit={Settings.Limit}";
                     break;
                 case (int)TraktUserListType.UserCollectionList:
-                    link += $"users/{Settings.AuthUser.Trim()}/collection/movies?limit={Settings.Limit}";
+                    link += $"users/{userName}/collection/movies?limit={Settings.Limit}";
                     break;
             }
 

--- a/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserSettings.cs
@@ -24,5 +24,8 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
 
         [FieldDefinition(1, Label = "List Type", Type = FieldType.Select, SelectOptions = typeof(TraktUserListType), HelpText = "Type of list you're seeking to import from")]
         public int TraktListType { get; set; }
+
+        [FieldDefinition(2, Label = "Username", HelpText = "Username for the List to import from (empty to use Auth User)")]
+        public string Username { get; set; }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Actually, Trakt Import List feature only allows personal list from authenticated user. This new option allow the user to set any user to import his lists.