### PR TITLE
emby connection string refactor

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/193_replace_emby_connection_string.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/193_replace_emby_connection_string.cs
@@ -1,0 +1,64 @@
+using System.Data;
+using FluentMigrator;
+using Newtonsoft.Json.Linq;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(193)]
+    public class replace_emby_connection_string : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Execute.WithConnection(SetConnectionAddress);
+        }
+
+        private void SetConnectionAddress(IDbConnection conn, IDbTransaction tran)
+        {
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.Transaction = tran;
+                cmd.CommandText = "SELECT Id, Settings FROM Notifications WHERE ConfigContract IN ('MediaBrowserSettings')";
+
+                using (var reader = cmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        var id = reader.GetInt32(0);
+                        var settings = reader.GetString(1);
+
+                        if (settings.IsNotNullOrWhiteSpace())
+                        {
+                            var jsonObject = Json.Deserialize<JObject>(settings);
+
+                            var scheme = jsonObject["useSsl"].Value<bool>() ? "https" : "http";
+                            var host = jsonObject["host"].Value<string>();
+                            var port = jsonObject["port"].Value<int>();
+
+                            // TODO if port 80 or 443 handle specially?
+                            var url = $@"{scheme}://{host}:{port}";
+
+                            jsonObject.Remove("host");
+                            jsonObject.Remove("port");
+                            jsonObject.Remove("useSsl");
+                            jsonObject.Remove("address");
+                            jsonObject.AddFirst(new JProperty("address", url));
+                            settings = jsonObject.ToJson();
+
+                            using (var updateCmd = conn.CreateCommand())
+                            {
+                                updateCmd.Transaction = tran;
+                                updateCmd.CommandText = "UPDATE Notifications SET Settings = ? WHERE Id = ?";
+                                updateCmd.AddParameter(settings);
+                                updateCmd.AddParameter(id);
+                                updateCmd.ExecuteNonQuery();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
@@ -66,8 +66,7 @@ namespace NzbDrone.Core.Notifications.Emby
 
         private HttpRequest BuildRequest(string path, MediaBrowserSettings settings)
         {
-            var scheme = settings.UseSsl ? "https" : "http";
-            var url = $@"{scheme}://{settings.Address}/mediabrowser";
+            var url = $@"{settings.Address}/mediabrowser";
 
             return new HttpRequestBuilder(url).Resource(path).Build();
         }

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using Newtonsoft.Json;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
@@ -10,8 +11,7 @@ namespace NzbDrone.Core.Notifications.Emby
     {
         public MediaBrowserSettingsValidator()
         {
-            RuleFor(c => c.Host).ValidHost();
-            RuleFor(c => c.ApiKey).NotEmpty();
+            RuleFor(c => c.Address).ValidRootUrl();
         }
     }
 
@@ -21,31 +21,22 @@ namespace NzbDrone.Core.Notifications.Emby
 
         public MediaBrowserSettings()
         {
-            Port = 8096;
+            Address = "http://localhost:8096";
         }
 
-        [FieldDefinition(0, Label = "Host")]
-        public string Host { get; set; }
+        [FieldDefinition(0, Label = "Address", HelpText = "Emby address with protocol and port, eg: http://localhost:8096")]
+        public string Address { get; set; }
 
-        [FieldDefinition(1, Label = "Port")]
-        public int Port { get; set; }
-
-        [FieldDefinition(2, Label = "Use SSL", Type = FieldType.Checkbox, HelpText = "Connect to Emby over HTTPS instead of HTTP")]
-        public bool UseSsl { get; set; }
-
-        [FieldDefinition(3, Label = "API Key", Privacy = PrivacyLevel.ApiKey)]
+        [FieldDefinition(1, Label = "API Key", Privacy = PrivacyLevel.ApiKey)]
         public string ApiKey { get; set; }
 
-        [FieldDefinition(4, Label = "Send Notifications", HelpText = "Have MediaBrowser send notfications to configured providers", Type = FieldType.Checkbox)]
+        [FieldDefinition(2, Label = "Send Notifications", HelpText = "Have MediaBrowser send notfications to configured providers", Type = FieldType.Checkbox)]
         public bool Notify { get; set; }
 
-        [FieldDefinition(5, Label = "Update Library", HelpText = "Update Library on Import & Rename?", Type = FieldType.Checkbox)]
+        [FieldDefinition(3, Label = "Update Library", HelpText = "Update Library on Import & Rename?", Type = FieldType.Checkbox)]
         public bool UpdateLibrary { get; set; }
 
-        [JsonIgnore]
-        public string Address => $"{Host}:{Port}";
-
-        public bool IsValid => !string.IsNullOrWhiteSpace(Host) && Port > 0;
+        public bool IsValid => !string.IsNullOrWhiteSpace(Address);
 
         public NzbDroneValidationResult Validate()
         {


### PR DESCRIPTION
Instead of ssl+host+port use full connection string.
Allows the usage of subdirectories in the emby connection

#### Database Migration
YES - 193

#### Description
Now the emby connection uses a full url ( example: http://localhost:8096 ) instead of 3 separate configs.

#### Screenshot (if UI related)
![image](https://user-images.githubusercontent.com/12481929/112908181-5904c380-90ef-11eb-8f6f-2ece5003f0e6.png)

#### Todos
- [ ] Tests // Only manual tests, found no unittests for Notifications.
- [ ] Translation Keys // TODO, there is a new sentence on the GUI, need help how to handle it
- [ ] Wiki Updates // Didn't find anything specific on the wiki. (https://wiki.servarr.com/Radarr_Settings#Connections)

#### Issues Fixed or Closed by this PR

* Fixes #6124
