### PR TITLE
Fixed: Search Missing Movies on Calendar

### DIFF
--- a/frontend/src/Calendar/CalendarPageConnector.js
+++ b/frontend/src/Calendar/CalendarPageConnector.js
@@ -24,7 +24,7 @@ function createMissingMovieIdsSelector() {
         const inCinemas = movie.inCinemas;
 
         if (
-          !movie.movieFileId &&
+          !movie.hasFile &&
           moment(inCinemas).isAfter(start) &&
           moment(inCinemas).isBefore(end) &&
           isBefore(movie.inCinemas) &&


### PR DESCRIPTION
#### Database Migration
NO

#### Description
missingMovieIds was originally picking up movies that had movies; by switching to "hasFile" this should no longer be the case (based on my testing) 

#### Issues Fixed or Closed by this PR

* Fixes #6165
