### PR TITLE
Add noreferrer to links in interactive search results

### DIFF
--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.js
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.js
@@ -149,6 +149,7 @@ class InteractiveSearchRow extends Component {
           <Link
             to={infoUrl}
             title={title}
+            rel='noreferrer'
           >
             <div>
               {title}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Links for interactive search results (Jackett + RARBG) don't open (HTTP 429 is returned). Adding `rel='noreferrer'` to the results links fixes the issue.

#### Screenshot (if UI related)

#### Todos

#### Issues Fixed or Closed by this PR
