### PR TITLE
Pull Sonarr commit 'Fixed: Round durationseconds in Kodi metadata'

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -301,7 +301,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                         if (movieFile.MediaInfo.RunTime != default)
                         {
                             video.Add(new XElement("duration", movieFile.MediaInfo.RunTime.TotalMinutes));
-                            video.Add(new XElement("durationinseconds", movieFile.MediaInfo.RunTime.TotalSeconds));
+                            video.Add(new XElement("durationinseconds", Math.Round(movieFile.MediaInfo.RunTime.TotalSeconds)));
                         }
 
                         streamDetails.Add(video);


### PR DESCRIPTION
(cherry picked from commit 6934eafd4416322f4677414d3f7f997e82f1bca8)

#### Database Migration
NO

#### Description
Rounds the duration seconds for Kodi metadata

#### Issues Fixed or Closed by this PR

* Fixes #6199 
