### PR TITLE
Add compatibility with the new Download Station API 'SYNO.DownloadStation2.Task'

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
@@ -288,6 +288,10 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             Mocker.GetMock<IDownloadStationInfoProxy>()
               .Setup(v => v.GetConfig(It.IsAny<DownloadStationSettings>()))
               .Returns(_downloadStationConfigItems);
+
+            Mocker.GetMock<IDownloadStationTaskProxySelector>()
+                  .Setup(s => s.GetProxy(It.IsAny<DownloadStationSettings>()))
+                  .Returns(Mocker.GetMock<IDownloadStationTaskProxy>().Object);
         }
 
         protected void GivenSharedFolder()

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
@@ -180,6 +180,10 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             Mocker.GetMock<IDownloadStationInfoProxy>()
               .Setup(v => v.GetConfig(It.IsAny<DownloadStationSettings>()))
               .Returns(_downloadStationConfigItems);
+
+            Mocker.GetMock<IDownloadStationTaskProxySelector>()
+                  .Setup(s => s.GetProxy(It.IsAny<DownloadStationSettings>()))
+                  .Returns(Mocker.GetMock<IDownloadStationTaskProxy>().Object);
         }
 
         protected void GivenSharedFolder()

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/DiskStationApi.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/DiskStationApi.cs
@@ -1,4 +1,4 @@
-﻿namespace NzbDrone.Core.Download.Clients.DownloadStation
+namespace NzbDrone.Core.Download.Clients.DownloadStation
 {
     public enum DiskStationApi
     {
@@ -6,6 +6,7 @@
         Auth,
         DownloadStationInfo,
         DownloadStationTask,
+        DownloadStation2Task,
         FileStationList,
         DSMInfo,
     }

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStation2Task.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStation2Task.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using NzbDrone.Common.Serializer;
+
+namespace NzbDrone.Core.Download.Clients.DownloadStation
+{
+    public class DownloadStation2Task
+    {
+        public string Username { get; set; }
+
+        public string Id { get; set; }
+
+        public string Title { get; set; }
+
+        public long Size { get; set; }
+
+        /// <summary>
+        /// /// Possible values are: BT, NZB, http, ftp, eMule and https
+        /// </summary>
+        public string Type { get; set; }
+
+        public int Status { get; set; }
+
+        public DownloadStationTaskAdditional Additional { get; set; }
+
+        public override string ToString()
+        {
+            return Title;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using NLog;
@@ -167,7 +167,14 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
             {
                 if (apiInfo.NeedsAuthentication)
                 {
-                    requestBuilder.AddFormParameter("_sid", _sessionCache.Get(GenerateSessionCacheKey(settings), () => AuthenticateClient(settings), TimeSpan.FromHours(6)));
+                    if (_apiType == DiskStationApi.DownloadStation2Task)
+                    {
+                        requestBuilder.AddQueryParam("_sid", _sessionCache.Get(GenerateSessionCacheKey(settings), () => AuthenticateClient(settings), TimeSpan.FromHours(6)));
+                    }
+                    else
+                    {
+                        requestBuilder.AddFormParameter("_sid", _sessionCache.Get(GenerateSessionCacheKey(settings), () => AuthenticateClient(settings), TimeSpan.FromHours(6)));
+                    }
                 }
 
                 requestBuilder.AddFormParameter("api", apiInfo.Name);
@@ -237,7 +244,14 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
 
                 if (info == null)
                 {
-                    throw new DownloadClientException("Info of {0} not found on {1}:{2}", api, settings.Host, settings.Port);
+                    if (api == DiskStationApi.DownloadStation2Task)
+                    {
+                        _logger.Warn("Info of {0} not found on {1}:{2}", api, settings.Host, settings.Port);
+                    }
+                    else
+                    {
+                        throw new DownloadClientException("Info of {0} not found on {1}:{2}", api, settings.Host, settings.Port);
+                    }
                 }
             }
 

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationTaskProxySelector.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationTaskProxySelector.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using NLog;
+using NzbDrone.Common.Cache;
+using NzbDrone.Common.Http;
+
+namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
+{
+    public interface IDownloadStationTaskProxy : IDiskStationProxy
+    {
+        bool IsApiSupported(DownloadStationSettings settings);
+        IEnumerable<DownloadStationTask> GetTasks(DownloadStationSettings settings);
+        void RemoveTask(string downloadId, DownloadStationSettings settings);
+        void AddTaskFromUrl(string url, string downloadDirectory, DownloadStationSettings settings);
+        void AddTaskFromData(byte[] data, string filename, string downloadDirectory, DownloadStationSettings settings);
+    }
+
+    public interface IDownloadStationTaskProxySelector
+    {
+        IDownloadStationTaskProxy GetProxy(DownloadStationSettings settings);
+    }
+
+    public class DownloadStationTaskProxySelector : IDownloadStationTaskProxySelector
+    {
+        private readonly ICached<IDownloadStationTaskProxy> _proxyCache;
+        private readonly Logger _logger;
+
+        private readonly IDownloadStationTaskProxy _proxyV1;
+        private readonly IDownloadStationTaskProxy _proxyV2;
+
+        public DownloadStationTaskProxySelector(DownloadStationTaskProxyV1 proxyV1, DownloadStationTaskProxyV2 proxyV2, ICacheManager cacheManager, Logger logger)
+        {
+            _proxyCache = cacheManager.GetCache<IDownloadStationTaskProxy>(GetType(), "taskProxy");
+            _logger = logger;
+
+            _proxyV1 = proxyV1;
+            _proxyV2 = proxyV2;
+        }
+
+        public IDownloadStationTaskProxy GetProxy(DownloadStationSettings settings)
+        {
+            return GetProxyCache(settings);
+        }
+
+        private IDownloadStationTaskProxy GetProxyCache(DownloadStationSettings settings)
+        {
+            var propKey = $"{settings.Host}_{settings.Port}";
+
+            return _proxyCache.Get(propKey, () => FetchProxy(settings), TimeSpan.FromMinutes(10.0));
+        }
+
+        private IDownloadStationTaskProxy FetchProxy(DownloadStationSettings settings)
+        {
+            if (_proxyV2.IsApiSupported(settings))
+            {
+                _logger.Trace("Using DownloadStation Task API v2");
+                return _proxyV2;
+            }
+
+            if (_proxyV1.IsApiSupported(settings))
+            {
+                _logger.Trace("Using DownloadStation Task API v1");
+                return _proxyV1;
+            }
+
+            throw new DownloadClientException("Unable to determine DownloadStations Task API version");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationTaskProxyV1.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationTaskProxyV1.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using NLog;
 using NzbDrone.Common.Cache;
 using NzbDrone.Common.Extensions;
@@ -7,19 +7,16 @@ using NzbDrone.Core.Download.Clients.DownloadStation.Responses;
 
 namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
 {
-    public interface IDownloadStationTaskProxy : IDiskStationProxy
+    public class DownloadStationTaskProxyV1 : DiskStationProxyBase, IDownloadStationTaskProxy
     {
-        IEnumerable<DownloadStationTask> GetTasks(DownloadStationSettings settings);
-        void RemoveTask(string downloadId, DownloadStationSettings settings);
-        void AddTaskFromUrl(string url, string downloadDirectory, DownloadStationSettings settings);
-        void AddTaskFromData(byte[] data, string filename, string downloadDirectory, DownloadStationSettings settings);
-    }
-
-    public class DownloadStationTaskProxy : DiskStationProxyBase, IDownloadStationTaskProxy
-    {
-        public DownloadStationTaskProxy(IHttpClient httpClient, ICacheManager cacheManager, Logger logger)
+        public DownloadStationTaskProxyV1(IHttpClient httpClient, ICacheManager cacheManager, Logger logger)
             : base(DiskStationApi.DownloadStationTask, "SYNO.DownloadStation.Task", httpClient, cacheManager, logger)
         {
+        }
+
+        public bool IsApiSupported(DownloadStationSettings settings)
+        {
+            return GetApiInfo(settings) != null;
         }
 
         public void AddTaskFromData(byte[] data, string filename, string downloadDirectory, DownloadStationSettings settings)

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationTaskProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationTaskProxyV2.cs
@@ -1,0 +1,117 @@
+using System.Collections.Generic;
+using System.Linq;
+using NLog;
+using NzbDrone.Common.Cache;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Download.Clients.DownloadStation.Responses;
+
+namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
+{
+    public class DownloadStationTaskProxyV2 : DiskStationProxyBase, IDownloadStationTaskProxy
+    {
+        public DownloadStationTaskProxyV2(IHttpClient httpClient, ICacheManager cacheManager, Logger logger)
+            : base(DiskStationApi.DownloadStation2Task, "SYNO.DownloadStation2.Task", httpClient, cacheManager, logger)
+        {
+        }
+
+        public bool IsApiSupported(DownloadStationSettings settings)
+        {
+            return GetApiInfo(settings) != null;
+        }
+
+        public void AddTaskFromData(byte[] data, string filename, string downloadDirectory, DownloadStationSettings settings)
+        {
+            var requestBuilder = BuildRequest(settings, "create", 2, HttpMethod.POST);
+
+            requestBuilder.AddFormParameter("type", "\"file\"");
+            requestBuilder.AddFormParameter("file", "[\"fileData\"]");
+            requestBuilder.AddFormParameter("create_list", "false");
+
+            if (downloadDirectory.IsNotNullOrWhiteSpace())
+            {
+                requestBuilder.AddFormParameter("destination", $"\"{downloadDirectory}\"");
+            }
+
+            requestBuilder.AddFormUpload("fileData", filename, data);
+
+            ProcessRequest<object>(requestBuilder, $"add task from data {filename}", settings);
+        }
+
+        public void AddTaskFromUrl(string url, string downloadDirectory, DownloadStationSettings settings)
+        {
+            var requestBuilder = BuildRequest(settings, "create", 2);
+
+            requestBuilder.AddQueryParam("type", "url");
+            requestBuilder.AddQueryParam("url", url);
+            requestBuilder.AddQueryParam("create_list", "false");
+
+            if (downloadDirectory.IsNotNullOrWhiteSpace())
+            {
+                requestBuilder.AddQueryParam("destination", downloadDirectory);
+            }
+
+            ProcessRequest<object>(requestBuilder, $"add task from url {url}", settings);
+        }
+
+        public IEnumerable<DownloadStationTask> GetTasks(DownloadStationSettings settings)
+        {
+            try
+            {
+                var result = new List<DownloadStationTask>();
+
+                var requestBuilder = BuildRequest(settings, "list", 1);
+                requestBuilder.AddQueryParam("additional", "detail");
+
+                var response = ProcessRequest<DownloadStation2TaskInfoResponse>(requestBuilder, "get tasks with additional detail", settings);
+
+                if (response.Success && response.Data.Total > 0)
+                {
+                    requestBuilder.AddQueryParam("additional", "transfer");
+                    var responseTransfer = ProcessRequest<DownloadStation2TaskInfoResponse>(requestBuilder, "get tasks with additional transfer", settings);
+
+                    if (responseTransfer.Success)
+                    {
+                        foreach (var task in response.Data.Task)
+                        {
+                            var taskTransfer = responseTransfer.Data.Task.Where(t => t.Id == task.Id).First();
+
+                            var combinedTask = new DownloadStationTask
+                            {
+                                Username = task.Username,
+                                Id = task.Id,
+                                Title = task.Title,
+                                Size = task.Size,
+                                Status = (DownloadStationTaskStatus)task.Status,
+                                Type = task.Type,
+                                Additional = new DownloadStationTaskAdditional
+                                {
+                                    Detail = task.Additional.Detail,
+                                    Transfer = taskTransfer.Additional.Transfer
+                                }
+                            };
+
+                            result.Add(combinedTask);
+                        }
+                    }
+                }
+
+                return result;
+            }
+            catch (DownloadClientException e)
+            {
+                _logger.Error(e);
+                return new List<DownloadStationTask>();
+            }
+        }
+
+        public void RemoveTask(string downloadId, DownloadStationSettings settings)
+        {
+            var requestBuilder = BuildRequest(settings, "delete", 2);
+            requestBuilder.AddQueryParam("id", downloadId);
+            requestBuilder.AddQueryParam("force_complete", "false");
+
+            ProcessRequest<object>(requestBuilder, $"remove item {downloadId}", settings);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Responses/DiskStationError.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Responses/DiskStationError.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace NzbDrone.Core.Download.Clients.DownloadStation.Responses
 {
@@ -85,7 +85,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Responses
                 return AuthMessages[Code];
             }
 
-            if (api == DiskStationApi.DownloadStationTask && DownloadStationTaskMessages.ContainsKey(Code))
+            if ((api == DiskStationApi.DownloadStationTask || api == DiskStationApi.DownloadStation2Task) && DownloadStationTaskMessages.ContainsKey(Code))
             {
                 return DownloadStationTaskMessages[Code];
             }

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Responses/DownloadStation2TaskInfoResponse.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Responses/DownloadStation2TaskInfoResponse.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace NzbDrone.Core.Download.Clients.DownloadStation.Responses
+{
+    public class DownloadStation2TaskInfoResponse
+    {
+        public int Offset { get; set; }
+        public List<DownloadStation2Task> Task { get; set; }
+        public int Total { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
     public class UsenetDownloadStation : UsenetClientBase<DownloadStationSettings>
     {
         protected readonly IDownloadStationInfoProxy _dsInfoProxy;
-        protected readonly IDownloadStationTaskProxy _dsTaskProxy;
+        protected readonly IDownloadStationTaskProxySelector _dsTaskProxySelector;
         protected readonly ISharedFolderResolver _sharedFolderResolver;
         protected readonly ISerialNumberProvider _serialNumberProvider;
         protected readonly IFileStationProxy _fileStationProxy;
@@ -29,7 +29,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                                      ISerialNumberProvider serialNumberProvider,
                                      IFileStationProxy fileStationProxy,
                                      IDownloadStationInfoProxy dsInfoProxy,
-                                     IDownloadStationTaskProxy dsTaskProxy,
+                                     IDownloadStationTaskProxySelector dsTaskProxySelector,
                                      IHttpClient httpClient,
                                      IConfigService configService,
                                      INamingConfigService namingConfigService,
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         : base(httpClient, configService, namingConfigService, diskProvider, remotePathMappingService, nzbValidationService, logger)
         {
             _dsInfoProxy = dsInfoProxy;
-            _dsTaskProxy = dsTaskProxy;
+            _dsTaskProxySelector = dsTaskProxySelector;
             _fileStationProxy = fileStationProxy;
             _sharedFolderResolver = sharedFolderResolver;
             _serialNumberProvider = serialNumberProvider;
@@ -50,9 +50,11 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
         public override ProviderMessage Message => new ProviderMessage("Radarr is unable to connect to Download Station if 2-Factor Authentication is enabled on your DSM account", ProviderMessageType.Warning);
 
+        private IDownloadStationTaskProxy DsTaskProxy => _dsTaskProxySelector.GetProxy(Settings);
+
         protected IEnumerable<DownloadStationTask> GetTasks()
         {
-            return _dsTaskProxy.GetTasks(Settings).Where(v => v.Type.ToLower() == DownloadStationTaskType.NZB.ToString().ToLower());
+            return DsTaskProxy.GetTasks(Settings).Where(v => v.Type.ToLower() == DownloadStationTaskType.NZB.ToString().ToLower());
         }
 
         public override IEnumerable<DownloadClientItem> GetItems()
@@ -165,7 +167,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                 DeleteItemData(item);
             }
 
-            _dsTaskProxy.RemoveTask(ParseDownloadId(item.DownloadId), Settings);
+            DsTaskProxy.RemoveTask(ParseDownloadId(item.DownloadId), Settings);
             _logger.Debug("{0} removed correctly", item.DownloadId);
         }
 
@@ -173,7 +175,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         {
             var hashedSerialNumber = _serialNumberProvider.GetSerialNumber(Settings);
 
-            _dsTaskProxy.AddTaskFromData(fileContent, filename, GetDownloadDirectory(), Settings);
+            DsTaskProxy.AddTaskFromData(fileContent, filename, GetDownloadDirectory(), Settings);
 
             var items = GetTasks().Where(t => t.Additional.Detail["uri"] == filename);
 
@@ -297,7 +299,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
         protected ValidationFailure ValidateVersion()
         {
-            var info = _dsTaskProxy.GetApiInfo(Settings);
+            var info = DsTaskProxy.GetApiInfo(Settings);
 
             _logger.Debug("Download Station api version information: Min {0} - Max {1}", info.MinVersion, info.MaxVersion);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added compatibility with the new Download Station API 'SYNO.DownloadStation2.Task'.

This will resolve the compatibility issue with the new version of Synology Download Stations 3.8.16-3566.
If the new 'SYNO.DownloadStation2.Task' API is available, use it, otherwise use the old 'SYNO.DownloadStation.Task'.

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes #6062
* Fixes #6402