### PR TITLE
Fixed: Interactive Search Release Rejected tooltip no longer covers download button

### DIFF
--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.js
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.js
@@ -180,7 +180,7 @@ class InteractiveSearchRow extends Component {
                     }
                   </ul>
                 }
-                position={tooltipPositions.LEFT}
+                position={tooltipPositions.BOTTOM}
               />
           }
         </TableRowCell>
@@ -293,7 +293,7 @@ class InteractiveSearchRow extends Component {
                     }
                   </ul>
                 }
-                position={tooltipPositions.LEFT}
+                position={tooltipPositions.BOTTOM}
               />
           }
         </TableRowCell>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Moves the release rejected tooltip to below the active line

#### Screenshot (if UI related)
![image](https://user-images.githubusercontent.com/19610103/117733083-ddfff400-b1e8-11eb-8c96-f2af33085c9f.png)

#### Issues Fixed or Closed by this PR

* Fixes #6271 
