### PR TITLE
Fixed: Multi language release being rejected when indexer profile is setup for original and another language

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
@@ -27,6 +27,8 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
         private ParsedMovieInfo _translationTitleInfo;
         private ParsedMovieInfo _umlautInfo;
         private ParsedMovieInfo _umlautAltInfo;
+        private ParsedMovieInfo _multiLanguageInfo;
+        private ParsedMovieInfo _multiLanguageWithOriginalInfo;
         private MovieSearchCriteria _movieSearchCriteria;
 
         [SetUp]
@@ -95,6 +97,18 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
                 MovieTitle = "Fack Ju Goethe 2: Same same",
                 Languages = new List<Language> { Language.English },
                 Year = _movie.Year
+            };
+
+            _multiLanguageInfo = new ParsedMovieInfo
+            {
+                MovieTitle = _movie.Title,
+                Languages = new List<Language> { Language.Original, Language.French }
+            };
+
+            _multiLanguageWithOriginalInfo = new ParsedMovieInfo
+            {
+                MovieTitle = _movie.Title,
+                Languages = new List<Language> { Language.Original, Language.French, Language.English }
             };
 
             _movieSearchCriteria = new MovieSearchCriteria
@@ -179,6 +193,21 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
         {
             Subject.Map(_umlautInfo, "", _movieSearchCriteria).Movie.Should().Be(_movieSearchCriteria.Movie);
             Subject.Map(_umlautAltInfo, "", _movieSearchCriteria).Movie.Should().Be(_movieSearchCriteria.Movie);
+        }
+
+        [Test]
+        public void should_convert_original()
+        {
+            Subject.Map(_multiLanguageInfo, "", _movieSearchCriteria).RemoteMovie.ParsedMovieInfo.Languages.Should().Contain(Language.English);
+            Subject.Map(_multiLanguageInfo, "", _movieSearchCriteria).RemoteMovie.ParsedMovieInfo.Languages.Should().Contain(Language.French);
+        }
+
+        [Test]
+        public void should_remove_original_as_already_exists()
+        {
+            Subject.Map(_multiLanguageWithOriginalInfo, "", _movieSearchCriteria).RemoteMovie.ParsedMovieInfo.Languages.Should().Contain(Language.English);
+            Subject.Map(_multiLanguageWithOriginalInfo, "", _movieSearchCriteria).RemoteMovie.ParsedMovieInfo.Languages.Should().Contain(Language.French);
+            Subject.Map(_multiLanguageWithOriginalInfo, "", _movieSearchCriteria).RemoteMovie.ParsedMovieInfo.Languages.Should().NotContain(Language.Original);
         }
     }
 }

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -139,6 +139,15 @@ namespace NzbDrone.Core.Parser
                 _logger.Debug("Language couldn't be parsed from release, fallback to movie original language: {0}", result.Movie.OriginalLanguage.Name);
             }
 
+            if (parsedMovieInfo.Languages.Contains(Language.Original))
+            {
+                parsedMovieInfo.Languages.Remove(Language.Original);
+                if (!parsedMovieInfo.Languages.Contains(result.Movie.OriginalLanguage))
+                {
+                    parsedMovieInfo.Languages.Add(result.Movie.OriginalLanguage);
+                }
+            }
+
             result.RemoteMovie.ParsedMovieInfo = parsedMovieInfo;
 
             return result;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Resolves rejection of release when it is a Multi Language release, the indexer is set to identify Multi's as  Original and another language and the profile is set to require original. 

#### Todos
- [ ] Tests
- [ ] Translation Keys
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

* Fixes #5786 
