### PR TITLE
Fixed: Real IP Logging when IPv4 mapped as IPv6

### DIFF
--- a/src/Radarr.Http/Extensions/RequestExtensions.cs
+++ b/src/Radarr.Http/Extensions/RequestExtensions.cs
@@ -108,6 +108,8 @@ namespace Radarr.Http.Extensions
                 remoteIP = remoteIP.MapToIPv4();
             }
 
+            remoteAddress = remoteIP.ToString();
+
             // Only check if forwarded by a local network reverse proxy
             if (remoteIP.IsLocalAddress())
             {

--- a/src/Radarr.Http/Extensions/RequestExtensions.cs
+++ b/src/Radarr.Http/Extensions/RequestExtensions.cs
@@ -95,10 +95,21 @@ namespace Radarr.Http.Extensions
             }
 
             var remoteAddress = context.Request.UserHostAddress;
-            IPAddress remoteIP;
+
+            IPAddress.TryParse(remoteAddress, out IPAddress remoteIP);
+
+            if (remoteIP == null)
+            {
+                return remoteAddress;
+            }
+
+            if (remoteIP.IsIPv4MappedToIPv6)
+            {
+                remoteIP = remoteIP.MapToIPv4();
+            }
 
             // Only check if forwarded by a local network reverse proxy
-            if (IPAddress.TryParse(remoteAddress, out remoteIP) && remoteIP.IsLocalAddress())
+            if (remoteIP.IsLocalAddress())
             {
                 var realIPHeader = context.Request.Headers["X-Real-IP"];
                 if (realIPHeader.Any())


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes an issue where an IPv6 shows mapped as an IPv6 and so doesn't show as local and so doesn't use x-real-ip or x-forwarded-for in the logs


https://discord.com/channels/264387956343570434/264388019585286144/847485427833372774