### PR TITLE
Add PTP 'Other' category filtering with supporting release flags functionality

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/ReleaseRestrictionsSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/ReleaseRestrictionsSpecificationFixture.cs
@@ -26,7 +26,8 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                 },
                 Release = new ReleaseInfo
                 {
-                    Title = "Dexter.S08E01.EDITED.WEBRip.x264-KYR"
+                    Title = "Dexter.S08E01.EDITED.WEBRip.x264-KYR",
+                    IndexerFlags = IndexerFlags.PTP_Other
                 }
             };
 
@@ -135,6 +136,38 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenRestictions(pattern, null);
 
             Subject.IsSatisfiedBy(_remoteMovie, null).Accepted.Should().Be(expected);
+        }
+
+        [Test]
+        public void should_be_false_when_indexerflags_contains_ignored_term()
+        {
+            GivenRestictions(null, "other");
+
+            Subject.IsSatisfiedBy(_remoteMovie, null).Accepted.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_be_false_when_indexerflags_doesnt_contain_required_term()
+        {
+            GivenRestictions("required", null);
+
+            Subject.IsSatisfiedBy(_remoteMovie, null).Accepted.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_be_true_when_indexerflags_contains_required_term()
+        {
+            GivenRestictions("other", null);
+
+            Subject.IsSatisfiedBy(_remoteMovie, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_be_true_when_indexerflags_doesnt_contain_unmatched_ignored_term()
+        {
+            GivenRestictions(null, "unmatched");
+
+            Subject.IsSatisfiedBy(_remoteMovie, null).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/IndexerTests/PTPTests/PTPFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/PTPTests/PTPFixture.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -62,6 +62,9 @@ namespace NzbDrone.Core.Test.IndexerTests.PTPTests
             first.Seeders.Should().Be(26);
 
             torrents.Any(t => t.IndexerFlags.HasFlag(IndexerFlags.G_Freeleech)).Should().Be(true);
+
+            torrents.Any(t => t.IndexerFlags.HasFlag(IndexerFlags.PTP_Other)).Should().Be(true);
+            torrents.Any(t => !t.IndexerFlags.HasFlag(IndexerFlags.PTP_Other)).Should().Be(true);
         }
     }
 }

--- a/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornParser.cs
+++ b/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornParser.cs
@@ -85,6 +85,11 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
                         flags |= IndexerFlags.G_Scene;
                     }
 
+                    if (torrent.Quality == "Other")
+                    {
+                        flags |= IndexerFlags.PTP_Other;
+                    }
+
                     // Only add approved torrents
                     try
                     {

--- a/src/NzbDrone.Core/Parser/Model/ReleaseInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ReleaseInfo.cs
@@ -97,6 +97,7 @@ namespace NzbDrone.Core.Parser.Model
         G_Scene = 128, //General, the torrent comes from the "scene"
         G_Freeleech75 = 256, //Currently only used for AHD, signifies a torrent counts towards 75 percent of your download quota.
         G_Freeleech25 = 512, //Currently only used for AHD, signifies a torrent counts towards 25 percent of your download quota.
-        AHD_UserRelease = 1024 // AHD, internal
+        AHD_UserRelease = 1024, // AHD, internal
+        PTP_Other = 2048 // PTP 'Other' Quality Section
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Add PTP_Other tag to allow filtering of PTP's 'other' quality category. This would allow filtering of movies contained within PTP's 'other' quality section, but may not use the 'Extras' notation.

Also adds required functionality to extend release restrictions to flags as well as title.