### PR TITLE
New Language: Spanish (Latin America) - Lang 37

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -189,6 +189,19 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Languages.Should().BeEquivalentTo(Language.PortugueseBR);
         }
 
+        [TestCase("Movie.Title.1994.LAT.1080p.XviD-LOL")]
+        [TestCase("Movie.Title.2.2019.1080p.Bluray.latino.WWW.TPF.GRATIS")]
+        [TestCase("Movie Title (2020)[BDRemux AVC 1080p][E-AC3 DD Plus 5.1 Latino-Inglés Subs]")]
+        [TestCase("Movie Title (2020) [UHDRemux2160p HDR][DTS-HD MA 5.1 AC3 5.1 LAT - True-HD 7.1 Atmos Inglés Subs]")]
+        [TestCase("Movie Title (2016) [UHDRemux 2160p SDR] [Latino DD 5.1 - Inglés DTS-HD MA 5.1 Subs]")]
+        [TestCase("Movie Title (2016) [UHDRemux 2160p SDR] [Latin DD 5.1 - Inglés DTS-HD MA 5.1 Subs]")]
+        public void should_parse_language_spanish_latino(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle, true);
+
+            result.Languages.Should().BeEquivalentTo(Language.SpanishLat);
+        }
+
         [TestCase("Movie.Title.1994.Polish.1080p.XviD-LOL")]
         [TestCase("Movie.Title.1994.PL.1080p.XviD-LOL")]
         [TestCase("Movie.Title.1994.PLDUB.1080p.XviD-LOL")]

--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -107,6 +107,7 @@ namespace NzbDrone.Core.Languages
         public static Language Bengali => new Language(34, "Bengali");
         public static Language Slovak => new Language(35, "Slovak");
         public static Language Latvian => new Language(36, "Latvian");
+        public static Language SpanishLat => new Language(37, "Spanish (Latin America)");
         public static Language Any => new Language(-1, "Any");
         public static Language Original => new Language(-2, "Original");
 
@@ -153,6 +154,7 @@ namespace NzbDrone.Core.Languages
                     Bengali,
                     Slovak,
                     Latvian,
+                    SpanishLat,
                     Any,
                     Original
                 };

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -44,7 +44,8 @@ namespace NzbDrone.Core.Parser
                                                                new IsoLanguage("be", "", "ben", "Bengali", Language.Bengali),
                                                                new IsoLanguage("lt", "", "lit", "Lithuanian", Language.Lithuanian),
                                                                new IsoLanguage("sk", "", "slk", "Slovak", Language.Slovak),
-                                                               new IsoLanguage("lv", "", "lav", "Latvian", Language.Latvian)
+                                                               new IsoLanguage("lv", "", "lav", "Latvian", Language.Latvian),
+                                                               new IsoLanguage("es", "mx", "spa", "Spanish (Latin America)", Language.SpanishLat)
                                                            };
 
         public static IsoLanguage Find(string isoCode)

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -30,7 +30,8 @@ namespace NzbDrone.Core.Parser
                                                                             (?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)|
                                                                             (?<ukrainian>(?:(?:\dx)?UKR))|
                                                                             (?<spanish>\b(?:español|castellano)\b)|
-                                                                            (?<latvian>\bLV\b)",
+                                                                            (?<latvian>\bLV\b)|
+                                                                            (?<latino>\b(?:lat|latino|latin)\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
         private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?:(?i)(?<!SUB[\W|_|^]))(?:(?<lithuanian>\bLT\b)|
@@ -310,6 +311,11 @@ namespace NzbDrone.Core.Parser
                 if (match.Groups["ukrainian"].Success)
                 {
                     languages.Add(Language.Ukrainian);
+                }
+
+                if (match.Groups["latino"].Success)
+                {
+                    languages.Add(Language.SpanishLat);
                 }
 
                 if (match.Groups["latvian"].Success)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Split spanish language into Spanish and Spanish (Latin America), this allows better results when searching in either language 
#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes #3467
