### PR TITLE
Fixed: issue with DownloadStationTaskProxyV2 if no destination folder…

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/DiskStationApi.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/DiskStationApi.cs
@@ -7,6 +7,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         DownloadStationInfo,
         DownloadStationTask,
         DownloadStation2Task,
+        DownloadStation2SettingsLocation,
         FileStationList,
         DSMInfo,
     }

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStation2SettingsLocationProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStation2SettingsLocationProxy.cs
@@ -1,0 +1,31 @@
+using NLog;
+using NzbDrone.Common.Cache;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Download.Clients.DownloadStation.Responses;
+
+namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
+{
+    public interface IDownloadStation2SettingsLocationProxy
+    {
+        string GetDefaultDestination(DownloadStationSettings settings);
+    }
+
+    public class DownloadStation2SettingsLocationProxy : DiskStationProxyBase, IDownloadStation2SettingsLocationProxy
+    {
+        public DownloadStation2SettingsLocationProxy(IHttpClient httpClient, ICacheManager cacheManager, Logger logger)
+            : base(DiskStationApi.DownloadStation2SettingsLocation, "SYNO.DownloadStation2.Settings.Location", httpClient, cacheManager, logger)
+        {
+        }
+
+        public string GetDefaultDestination(DownloadStationSettings settings)
+        {
+            var info = GetApiInfo(settings);
+
+            var requestBuilder = BuildRequest(settings, "get", info.MinVersion);
+
+            var response = ProcessRequest<DownloadStation2SettingsLocationResponse>(requestBuilder, "get default destination folder", settings);
+
+            return response.Data.Default_Destination;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Responses/DownloadStation2SettingsLocationResponse.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Responses/DownloadStation2SettingsLocationResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace NzbDrone.Core.Download.Clients.DownloadStation.Responses
+{
+    public class DownloadStation2SettingsLocationResponse
+    {
+        public string Default_Destination { get; set; }
+    }
+}


### PR DESCRIPTION
… specified in settings

#### Database Migration
NO

#### Description
Use the new DownloadStation2 API to retrieve the default destination folder if it is not configured in the download client settings, as the setting is now mandatory with the new API.

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes Sonarr/Sonarr#4562
