### PR TITLE
Update TraktSettingsBase.cs - Trakt BaseURL pointing to depreciated API link

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktSettingsBase.cs
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.ImportLists.Trakt
             Limit = 100;
         }
 
-        public string Link => "https://api.trakt.tv";
+        public string Link => "https://trakt.tv";
         public virtual string Scope => "";
 
         [FieldDefinition(0, Label = "Access Token", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]


### PR DESCRIPTION
Trakt BaseURL pointing to depreciated API link

Similar to change here:
https://github.com/bakerboy448/Sonarr/commit/a5ddd9404fc4e9ca8145cae7915d4741d2c595a5

#### Database Migration
NO

#### Description
The TRAKT API endpoint has changed and this is required for importing lists 