### PR TITLE
New Language: Chinese (Cantonese) & Chinese (Mandarin) - Lang 35 & 38

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -122,6 +122,22 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Languages.Should().BeEquivalentTo(Language.Chinese);
         }
 
+        [TestCase("Movie.Title.1994.Cantonese.1080p.XviD-LOL")]
+        public void should_parse_language_cantonese(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle, true);
+
+            result.Languages.Should().BeEquivalentTo(Language.Cantonese);
+        }
+
+        [TestCase("Movie.Title.1994.Mandarin.1080p.XviD-LOL")]
+        public void should_parse_language_mandarin(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle, true);
+
+            result.Languages.Should().BeEquivalentTo(Language.Mandarin);
+        }
+
         [TestCase("Movie.Title.1994.Russian.1080p.XviD-LOL")]
         public void should_parse_language_russian(string postTitle)
         {

--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -102,6 +102,8 @@ namespace NzbDrone.Core.Languages
         public static Language Bulgarian => new Language(29, "Bulgarian");
         public static Language PortugueseBR => new Language(30, "Portuguese (Brazil)");
         public static Language Arabic => new Language(31, "Arabic");
+        public static Language Cantonese => new Language(32, "Cantonese");
+        public static Language Mandarin => new Language(33, "Mandarin");
         public static Language Any => new Language(-1, "Any");
         public static Language Original => new Language(-2, "Original");
 
@@ -143,6 +145,8 @@ namespace NzbDrone.Core.Languages
                     Bulgarian,
                     PortugueseBR,
                     Arabic,
+                    Cantonese,
+                    Mandarin,
                     Any,
                     Original
                 };

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -18,6 +18,8 @@ namespace NzbDrone.Core.Parser
                                                                new IsoLanguage("ja", "", "jpn", "Japanese", Language.Japanese),
                                                                new IsoLanguage("is", "", "isl", "Icelandic", Language.Icelandic),
                                                                new IsoLanguage("zh", "cn", "zho", "Chinese", Language.Chinese),
+                                                               new IsoLanguage("cn", "hk", "yue", "Cantonese", Language.Cantonese),
+                                                               new IsoLanguage("zh", "cn", "cmn", "Mandarin", Language.Mandarin),
                                                                new IsoLanguage("ru", "", "rus", "Russian", Language.Russian),
                                                                new IsoLanguage("pl", "", "pol", "Polish", Language.Polish),
                                                                new IsoLanguage("vi", "", "vie", "Vietnamese", Language.Vietnamese),

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Parser
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(LanguageParser));
 
-        private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>\b(?:german|videomann|ger)\b)|(?<flemish>flemish)|(?<bulgarian>bgaudio)|(?<brazilian>dublado)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VO|VFF|VFQ|VFI|VF2|TRUEFRENCH|FRE|FRA)(?:\W|_))|(?<russian>\brus\b)|(?<english>\beng\b)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<polish>\b(?:PL\W?DUB|DUB\W?PL|LEK\W?PL|PL\W?LEK)\b)|(?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)",
+        private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|(?<german>\b(?:german|videomann|ger)\b)|(?<flemish>flemish)|(?<bulgarian>bgaudio)|(?<brazilian>dublado)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VO|VFF|VFQ|VFI|VF2|TRUEFRENCH|FRE|FRA)(?:\W|_))|(?<russian>\brus\b)|(?<english>\beng\b)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<polish>\b(?:PL\W?DUB|DUB\W?PL|LEK\W?PL|PL\W?LEK)\b)|(?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)|(?<cantonese>\b(?:cantonese)\b)|(?<mandarin>\b(?:mandarin)\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?:(?i)(?<!SUB[\W|_|^]))(?:(?<lithuanian>\bLT\b)|(?<czech>\bCZ\b)|(?<polish>\bPL\b))(?:(?i)(?![\W|_|^]SUB))",
@@ -62,7 +62,17 @@ namespace NzbDrone.Core.Parser
                 languages.Add(Language.Icelandic);
             }
 
-            if (lowerTitle.Contains("mandarin") || lowerTitle.Contains("cantonese") || lowerTitle.Contains("chinese"))
+            if (lowerTitle.Contains("mandarin"))
+            {
+                languages.Add(Language.Mandarin);
+            }
+
+            if (lowerTitle.Contains("cantonese"))
+            {
+                languages.Add(Language.Cantonese);
+            }
+
+            if (lowerTitle.Contains("chinese"))
             {
                 languages.Add(Language.Chinese);
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added Cantonese and Mandarin as languages. Removed the mapping of these languages to Chinese.
Chinese still remains (and should remain) a separate language in Radarr, as a lot of releases only specify "Chinese", and not whether they are actually Cantonese or Mandarin.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #5970 