### PR TITLE
Fixed: Prevent conflicts with reserved device names

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/ReservedDeviceNameFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/ReservedDeviceNameFixture.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.MediaFiles.MediaInfo;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
+{
+    [TestFixture]
+
+    public class ReservedDeviceNameFixture : CoreTest<FileNameBuilder>
+    {
+        private Movie _movie;
+        private MovieFile _movieFile;
+        private NamingConfig _namingConfig;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movie = Builder<Movie>
+                    .CreateNew()
+                    .Build();
+
+            _namingConfig = NamingConfig.Default;
+            _namingConfig.RenameMovies = true;
+
+            Mocker.GetMock<INamingConfigService>()
+                  .Setup(c => c.GetConfig()).Returns(_namingConfig);
+
+            _movieFile = new MovieFile { Quality = new QualityModel(Quality.HDTV720p), ReleaseGroup = "SonarrTest" };
+
+            Mocker.GetMock<IQualityDefinitionService>()
+                .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
+                .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+        }
+
+        [Test]
+        public void should_replace_reserved_device_name_in_movies_folder()
+        {
+            _movie.Title = "Con Man";
+            _movie.Year = 2021;
+            _namingConfig.MovieFolderFormat = "{Movie.Title} ({Release Year})";
+
+            Subject.GetMovieFolder(_movie).Should().Be("Con_Man (2021)");
+        }
+
+        [Test]
+        public void should_replace_reserved_device_name_in_file_name()
+        {
+            _movie.Title = "Con Man";
+            _movie.Year = 2021;
+            _namingConfig.StandardMovieFormat = "{Movie.Title} ({Release Year})";
+
+            Subject.BuildFileName(_movie, _movieFile).Should().Be("Con_Man (2021)");
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/ReservedDeviceNameFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/ReservedDeviceNameFixture.cs
@@ -1,19 +1,14 @@
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
 using System.Linq;
-using System.Threading;
 using FizzWare.NBuilder;
 using FluentAssertions;
-using Moq;
 using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.MediaFiles;
-using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Test.Framework;
-using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 {
@@ -43,26 +38,32 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             Mocker.GetMock<IQualityDefinitionService>()
                 .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
                 .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+
+            Mocker.GetMock<ICustomFormatService>()
+                .Setup(v => v.All())
+                .Returns(new List<CustomFormat>());
         }
 
-        [Test]
-        public void should_replace_reserved_device_name_in_movies_folder()
+        [TestCase("Con Game", 2021, "Con_Game (2021)")]
+        [TestCase("Com1 Sat", 2021, "Com1_Sat (2021)")]
+        public void should_replace_reserved_device_name_in_movies_folder(string title, int year, string expected)
         {
-            _movie.Title = "Con Man";
-            _movie.Year = 2021;
+            _movie.Title = title;
+            _movie.Year = year;
             _namingConfig.MovieFolderFormat = "{Movie.Title} ({Release Year})";
 
-            Subject.GetMovieFolder(_movie).Should().Be("Con_Man (2021)");
+            Subject.GetMovieFolder(_movie).Should().Be($"{expected}");
         }
 
-        [Test]
-        public void should_replace_reserved_device_name_in_file_name()
+        [TestCase("Con Game", 2021, "Con_Game (2021)")]
+        [TestCase("Com1 Sat", 2021, "Com1_Sat (2021)")]
+        public void should_replace_reserved_device_name_in_file_name(string title, int year, string expected)
         {
-            _movie.Title = "Con Man";
-            _movie.Year = 2021;
+            _movie.Title = title;
+            _movie.Year = year;
             _namingConfig.StandardMovieFormat = "{Movie.Title} ({Release Year})";
 
-            Subject.BuildFileName(_movie, _movieFile).Should().Be("Con_Man (2021)");
+            Subject.BuildFileName(_movie, _movieFile).Should().Be($"{expected}");
         }
     }
 }

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -67,6 +67,8 @@ namespace NzbDrone.Core.Organizer
 
         private static readonly Regex TitlePrefixRegex = new Regex(@"^(The|An|A) (.*?)((?: *\([^)]+\))*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+        private static readonly Regex ReservedDeviceNamesRegex = new Regex(@"^(?:aux|com1|com2|com3|com4|com5|com6|com7|com8|com9|con|lpt1|lpt2|lpt3|lpt4|lpt5|lpt6|lpt7|lpt8|lpt9|nul|prn)\.", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         public FileNameBuilder(INamingConfigService namingConfigService,
                                IQualityDefinitionService qualityDefinitionService,
                                IUpdateMediaInfo mediaInfoUpdater,
@@ -119,6 +121,7 @@ namespace NzbDrone.Core.Organizer
 
                 component = FileNameCleanupRegex.Replace(component, match => match.Captures[0].Value[0].ToString());
                 component = TrimSeparatorsRegex.Replace(component, string.Empty);
+                component = ReplaceReservedDeviceNames(component);
 
                 if (component.IsNotNullOrWhiteSpace())
                 {
@@ -180,6 +183,7 @@ namespace NzbDrone.Core.Organizer
 
                 var component = ReplaceTokens(splitPattern, tokenHandlers, namingConfig);
                 component = CleanFolderName(component);
+                component = ReplaceReservedDeviceNames(component);
 
                 if (component.IsNotNullOrWhiteSpace())
                 {
@@ -565,6 +569,12 @@ namespace NzbDrone.Core.Organizer
             }
 
             return Path.GetFileNameWithoutExtension(movieFile.RelativePath);
+        }
+
+        private string ReplaceReservedDeviceNames(string input)
+        {
+            // Replace reserved windows device names with an alternative
+            return ReservedDeviceNamesRegex.Replace(input, match => match.Value.Replace(".", "_"));
         }
     }
 

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.Organizer
 
         private static readonly Regex TitlePrefixRegex = new Regex(@"^(The|An|A) (.*?)((?: *\([^)]+\))*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex ReservedDeviceNamesRegex = new Regex(@"^(?:aux|com1|com2|com3|com4|com5|com6|com7|com8|com9|con|lpt1|lpt2|lpt3|lpt4|lpt5|lpt6|lpt7|lpt8|lpt9|nul|prn)\.", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ReservedDeviceNamesRegex = new Regex(@"^(?:aux|com[1-9]|con|lpt[1-9]|nul|prn)\.", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public FileNameBuilder(INamingConfigService namingConfigService,
                                IQualityDefinitionService qualityDefinitionService,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Sonarr Pull for preventing conflicts with reserved device names

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com) @bakerboy448 do you think it is worth adding something for this? 

#### Issues Fixed or Closed by this PR

* Fixes #6517 