### PR TITLE
add missing quality fixture test case

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -200,6 +200,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie.Name.2016.03.14.2160p.WEB.h264-spamTV", false)]
         [TestCase("Movie.Name.2016.03.14.2160p.WEB.PROPER.h264-spamTV", true)]
         [TestCase("[HorribleSubs] Movie Title! 2018 [Web][MKV][h264][2160p][AAC 2.0][Softsubs (HorribleSubs)]", false)]
+        [TestCase("Movie Name 2020 WEB-DL 4K H265 10bit HDR DDP5.1 Atmos-PTerWEB", false)]
         public void should_parse_webdl2160p_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Source.WEBDL, proper, Resolution.R2160p);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
more test cases are always a good thing

#### Screenshot (if UI related)

#### Todos
N/A

#### Issues Fixed or Closed by this PR

ref #5675  we did not have a test case for the H265 change
Discovered when backporting to sonarr