### PR TITLE
New: Include renamed file information for Webhook and Custom Scripts

### DIFF
--- a/src/NzbDrone.Core.Test/NotificationTests/NotificationBaseFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/NotificationBaseFixture.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using FluentValidation.Results;
 using NUnit.Framework;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Notifications;
 using NzbDrone.Core.ThingiProvider;
@@ -57,7 +59,7 @@ namespace NzbDrone.Core.Test.NotificationTests
                 TestLogger.Info("OnDownload was called");
             }
 
-            public override void OnMovieRename(Movie movie)
+            public override void OnMovieRename(Movie movie, List<RenamedMovieFile> renamedFiles)
             {
                 TestLogger.Info("OnRename was called");
             }

--- a/src/NzbDrone.Core.Test/NotificationTests/SynologyIndexerFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/SynologyIndexerFixture.cs
@@ -60,7 +60,7 @@ namespace NzbDrone.Core.Test.NotificationTests
         {
             (Subject.Definition.Settings as SynologyIndexerSettings).UpdateLibrary = false;
 
-            Subject.OnMovieRename(_movie);
+            Subject.OnMovieRename(_movie, new List<RenamedMovieFile>());
 
             Mocker.GetMock<ISynologyIndexerProxy>()
                   .Verify(v => v.UpdateFolder(_movie.Path), Times.Never());
@@ -90,7 +90,7 @@ namespace NzbDrone.Core.Test.NotificationTests
         [Test]
         public void should_update_entire_movie_folder_on_rename()
         {
-            Subject.OnMovieRename(_movie);
+            Subject.OnMovieRename(_movie, new List<RenamedMovieFile>());
 
             Mocker.GetMock<ISynologyIndexerProxy>()
                   .Verify(v => v.UpdateFolder(@"C:\Test\".AsOsAgnostic()), Times.Once());

--- a/src/NzbDrone.Core/MediaFiles/Events/MovieRenamedEvent.cs
+++ b/src/NzbDrone.Core/MediaFiles/Events/MovieRenamedEvent.cs
@@ -1,4 +1,5 @@
-﻿using NzbDrone.Common.Messaging;
+﻿using System.Collections.Generic;
+using NzbDrone.Common.Messaging;
 using NzbDrone.Core.Movies;
 
 namespace NzbDrone.Core.MediaFiles.Events
@@ -6,10 +7,12 @@ namespace NzbDrone.Core.MediaFiles.Events
     public class MovieRenamedEvent : IEvent
     {
         public Movie Movie { get; private set; }
+        public List<RenamedMovieFile> RenamedFiles { get; private set; }
 
-        public MovieRenamedEvent(Movie movie)
+        public MovieRenamedEvent(Movie movie, List<RenamedMovieFile> renamedFiles)
         {
             Movie = movie;
+            RenamedFiles = renamedFiles;
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/RenamedMovieFile.cs
+++ b/src/NzbDrone.Core/MediaFiles/RenamedMovieFile.cs
@@ -1,0 +1,9 @@
+﻿namespace NzbDrone.Core.MediaFiles
+{
+    public class RenamedMovieFile
+    {
+        public MovieFile MovieFile { get; set; }
+        public string PreviousPath { get; set; }
+        public string PreviousRelativePath { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -9,6 +9,7 @@ using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Processes;
 using NzbDrone.Core.HealthCheck;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
@@ -100,7 +101,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             ExecuteScript(environmentVariables);
         }
 
-        public override void OnMovieRename(Movie movie)
+        public override void OnMovieRename(Movie movie, List<RenamedMovieFile> renamedFiles)
         {
             var environmentVariables = new StringDictionary();
 
@@ -113,6 +114,11 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Radarr_Movie_TmdbId", movie.TmdbId.ToString());
             environmentVariables.Add("Radarr_Movie_In_Cinemas_Date", movie.InCinemas.ToString() ?? string.Empty);
             environmentVariables.Add("Radarr_Movie_Physical_Release_Date", movie.PhysicalRelease.ToString() ?? string.Empty);
+            environmentVariables.Add("Radarr_MovieFile_Ids", string.Join(",", renamedFiles.Select(e => e.MovieFile.Id)));
+            environmentVariables.Add("Radarr_MovieFile_RelativePaths", string.Join("|", renamedFiles.Select(e => e.MovieFile.RelativePath)));
+            environmentVariables.Add("Radarr_MovieFile_Paths", string.Join("|", renamedFiles.Select(e => e.MovieFile.Path)));
+            environmentVariables.Add("Radarr_MovieFile_PreviousRelativePaths", string.Join("|", renamedFiles.Select(e => e.PreviousRelativePath)));
+            environmentVariables.Add("Radarr_MovieFile_PreviousPaths", string.Join("|", renamedFiles.Select(e => e.PreviousPath)));
 
             ExecuteScript(environmentVariables);
         }

--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -216,13 +216,16 @@ namespace NzbDrone.Core.Notifications.Discord
 
         public override void OnMovieRename(Movie movie, List<RenamedMovieFile> renamedFiles)
         {
-            var attachments = new List<Embed>
-                              {
-                                  new Embed
-                                  {
-                                      Title = movie.Title,
-                                  }
-                              };
+            var attachments = new List<Embed>();
+
+            foreach (RenamedMovieFile renamedFile in renamedFiles)
+            {
+                attachments.Add(new Embed
+                {
+                    Title = movie.Title,
+                    Description = renamedFile.PreviousRelativePath + " renamed to " + renamedFile.MovieFile.RelativePath,
+                });
+            }
 
             var payload = CreatePayload("Renamed", attachments);
 

--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.MediaCover;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Notifications.Discord.Payloads;
@@ -209,6 +210,21 @@ namespace NzbDrone.Core.Notifications.Discord
             }
 
             var payload = CreatePayload(null, new List<Embed> { embed });
+
+            _proxy.SendPayload(payload, Settings);
+        }
+
+        public override void OnMovieRename(Movie movie, List<RenamedMovieFile> renamedFiles)
+        {
+            var attachments = new List<Embed>
+                              {
+                                  new Embed
+                                  {
+                                      Title = movie.Title,
+                                  }
+                              };
+
+            var payload = CreatePayload("Renamed", attachments);
 
             _proxy.SendPayload(payload, Settings);
         }

--- a/src/NzbDrone.Core/Notifications/INotification.cs
+++ b/src/NzbDrone.Core/Notifications/INotification.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.ThingiProvider;
 
@@ -9,7 +11,7 @@ namespace NzbDrone.Core.Notifications
 
         void OnGrab(GrabMessage grabMessage);
         void OnDownload(DownloadMessage message);
-        void OnMovieRename(Movie movie);
+        void OnMovieRename(Movie movie, List<RenamedMovieFile> renamedFiles);
         void OnMovieFileDelete(MovieFileDeleteMessage deleteMessage);
         void OnMovieDelete(MovieDeleteMessage deleteMessage);
         void OnHealthIssue(HealthCheck.HealthCheck healthCheck);

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
 
 namespace NzbDrone.Core.Notifications.Emby
@@ -38,7 +39,7 @@ namespace NzbDrone.Core.Notifications.Emby
             }
         }
 
-        public override void OnMovieRename(Movie movie)
+        public override void OnMovieRename(Movie movie, List<RenamedMovieFile> renamedFiles)
         {
             if (Settings.UpdateLibrary)
             {

--- a/src/NzbDrone.Core/Notifications/NotificationBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation.Results;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.ThingiProvider;
 
@@ -44,7 +45,7 @@ namespace NzbDrone.Core.Notifications
         {
         }
 
-        public virtual void OnMovieRename(Movie movie)
+        public virtual void OnMovieRename(Movie movie, List<RenamedMovieFile> renamedFiles)
         {
         }
 

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -152,7 +152,7 @@ namespace NzbDrone.Core.Notifications
                 {
                     if (ShouldHandleMovie(notification.Definition, message.Movie))
                     {
-                        notification.OnMovieRename(message.Movie);
+                        notification.OnMovieRename(message.Movie, message.RenamedFiles);
                     }
                 }
                 catch (Exception ex)

--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServer.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServer.cs
@@ -6,6 +6,7 @@ using NLog;
 using NzbDrone.Common.Cache;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Exceptions;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Notifications.Plex.PlexTv;
 using NzbDrone.Core.Validation;
@@ -43,7 +44,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
             UpdateIfEnabled(message.Movie);
         }
 
-        public override void OnMovieRename(Movie movie)
+        public override void OnMovieRename(Movie movie, List<RenamedMovieFile> renamedFiles)
         {
             UpdateIfEnabled(movie);
         }

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Notifications.Slack.Payloads;
 using NzbDrone.Core.Validation;
@@ -56,7 +57,7 @@ namespace NzbDrone.Core.Notifications.Slack
             _proxy.SendPayload(payload, Settings);
         }
 
-        public override void OnMovieRename(Movie movie)
+        public override void OnMovieRename(Movie movie, List<RenamedMovieFile> renamedFiles)
         {
             var attachments = new List<Attachment>
                                 {

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -59,13 +59,16 @@ namespace NzbDrone.Core.Notifications.Slack
 
         public override void OnMovieRename(Movie movie, List<RenamedMovieFile> renamedFiles)
         {
-            var attachments = new List<Attachment>
-                                {
-                                    new Attachment
-                                    {
-                                        Title = movie.Title,
-                                    }
-                                };
+            var attachments = new List<Attachment>();
+
+            foreach (RenamedMovieFile renamedFile in renamedFiles)
+            {
+                attachments.Add(new Attachment
+                {
+                    Title = movie.Title,
+                    Text = renamedFile.PreviousRelativePath + " renamed to " + renamedFile.MovieFile.RelativePath,
+                });
+            }
 
             var payload = CreatePayload("Renamed", attachments);
 

--- a/src/NzbDrone.Core/Notifications/Synology/SynologyIndexer.cs
+++ b/src/NzbDrone.Core/Notifications/Synology/SynologyIndexer.cs
@@ -3,6 +3,7 @@ using System.IO;
 using FluentValidation.Results;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
 
 namespace NzbDrone.Core.Notifications.Synology
@@ -38,7 +39,7 @@ namespace NzbDrone.Core.Notifications.Synology
             }
         }
 
-        public override void OnMovieRename(Movie movie)
+        public override void OnMovieRename(Movie movie, List<RenamedMovieFile> renamedFiles)
         {
             if (Settings.UpdateLibrary)
             {

--- a/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Validation;
 
@@ -64,12 +65,13 @@ namespace NzbDrone.Core.Notifications.Webhook
             _proxy.SendWebhook(payload, Settings);
         }
 
-        public override void OnMovieRename(Movie movie)
+        public override void OnMovieRename(Movie movie, List<RenamedMovieFile> renamedFiles)
         {
             var payload = new WebhookRenamePayload
             {
                 EventType = WebhookEventType.Rename,
-                Movie = new WebhookMovie(movie)
+                Movie = new WebhookMovie(movie),
+                RenamedMovieFiles = renamedFiles.ConvertAll(x => new WebhookRenamedMovieFile(x))
             };
 
             _proxy.SendWebhook(payload, Settings);

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookRenamePayload.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookRenamePayload.cs
@@ -1,7 +1,10 @@
+using System.Collections.Generic;
+
 namespace NzbDrone.Core.Notifications.Webhook
 {
     public class WebhookRenamePayload : WebhookPayload
     {
         public WebhookMovie Movie { get; set; }
+        public List<WebhookRenamedMovieFile> RenamedMovieFiles { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookRenamedMovieFile.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookRenamedMovieFile.cs
@@ -1,0 +1,17 @@
+using NzbDrone.Core.MediaFiles;
+
+namespace NzbDrone.Core.Notifications.Webhook
+{
+    public class WebhookRenamedMovieFile : WebhookMovieFile
+    {
+        public WebhookRenamedMovieFile(RenamedMovieFile renamedMovie)
+            : base(renamedMovie.MovieFile)
+        {
+            PreviousRelativePath = renamedMovie.PreviousRelativePath;
+            PreviousPath = renamedMovie.PreviousPath;
+        }
+
+        public string PreviousRelativePath { get; set; }
+        public string PreviousPath { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Xbmc/Xbmc.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/Xbmc.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
 
 namespace NzbDrone.Core.Notifications.Xbmc
@@ -36,7 +37,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
             UpdateAndCleanMovie(message.Movie, message.OldMovieFiles.Any());
         }
 
-        public override void OnMovieRename(Movie movie)
+        public override void OnMovieRename(Movie movie, List<RenamedMovieFile> renamedFiles)
         {
             UpdateAndCleanMovie(movie);
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR resolves #5934, and pulls in 3c45349404f59064d1c8db0549401189c456e4c0 from the upstream Sonarr repo. It implements the changes from the above commit, renaming Episode -> Movie as required in both class, variable, and file names.

The new JSON events have the following format:
```
{
  "movie": {
    "id": 1,
    "title": "Some Movie Title",
    "year": 2020,
    "releaseDate": "2020-01-01",
    "folderPath": "C:\\Movies\\Some Movie Title (2020)",
    "tmdbId": 0001,
    "imdbId": "tt0000001"
  },
  "renamedMovieFiles": [
    {
      "previousRelativePath": "Some.Movie.Title.2020.mkv",
      "previousPath": "C:\\Movies\\Some Movie Title (2020)\\Some.Movie.Title.2020.mkv",
      "id": 1,
      "relativePath": "Some Movie Title (2020).mkv",
      "quality": "Bluray-1080p",
      "qualityVersion": 1,
      "releaseGroup": "Release Group",
      "indexerFlags": "0",
      "size": 1
    }
  ],
  "eventType": "Rename"
}
```

While merging the above commit, I also discovered that the Discord Notification Provider had diverged from the upstream Sonarr version: the Radarr implementation was missing an implementation of the `OnMovieRenamed()` function. That function was modified in the above commit, so I went and implemented the Discord `OnMovieRenamed()` function to match the upstream implementation. If this was intentionally left out of the Radarr implementation, or if that should be split into another PR, please let me know and I'm happy to split it into another PR.


#### Testing
- All current tests in the test suite pass
- Manual verification that the new webhook is generated by renaming files in an small existing library and monitoring for POST events using a simple Python script
- Manual verification that the new Discord notification is generated successfully by renaming files in an small existing library and observing Discord notification messages in a private server

#### Screenshot (if UI related)
N/A, no UI changes.

#### Todos
- [ ] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #5934