### PR TITLE
New: Add support for Simplepush notifications

### DIFF
--- a/src/NzbDrone.Core/Notifications/Simplepush/Simplepush.cs
+++ b/src/NzbDrone.Core/Notifications/Simplepush/Simplepush.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using FluentValidation.Results;
+using NzbDrone.Common.Extensions;
+
+namespace NzbDrone.Core.Notifications.Simplepush
+{
+    public class Simplepush : NotificationBase<SimplepushSettings>
+    {
+        private readonly ISimplepushProxy _proxy;
+
+        public Simplepush(ISimplepushProxy proxy)
+        {
+            _proxy = proxy;
+        }
+
+        public override string Name => "Simplepush";
+        public override string Link => "https://simplepush.io/";
+
+        public override void OnGrab(GrabMessage grabMessage)
+        {
+            _proxy.SendNotification(MOVIE_GRABBED_TITLE, grabMessage.Message, Settings);
+        }
+
+        public override void OnDownload(DownloadMessage message)
+        {
+            _proxy.SendNotification(MOVIE_DOWNLOADED_TITLE, message.Message, Settings);
+        }
+
+        public override void OnMovieFileDelete(MovieFileDeleteMessage deleteMessage)
+        {
+            _proxy.SendNotification(MOVIE_FILE_DELETED_TITLE, deleteMessage.Message, Settings);
+        }
+
+        public override void OnMovieDelete(MovieDeleteMessage deleteMessage)
+        {
+            _proxy.SendNotification(MOVIE_DELETED_TITLE, deleteMessage.Message, Settings);
+        }
+
+        public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)
+        {
+            _proxy.SendNotification(HEALTH_ISSUE_TITLE, healthCheck.Message, Settings);
+        }
+
+        public override ValidationResult Test()
+        {
+            var failures = new List<ValidationFailure>();
+
+            failures.AddIfNotNull(_proxy.Test(Settings));
+
+            return new ValidationResult(failures);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Simplepush/SimplepushProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Simplepush/SimplepushProxy.cs
@@ -1,0 +1,59 @@
+using System;
+using FluentValidation.Results;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+
+namespace NzbDrone.Core.Notifications.Simplepush
+{
+    public interface ISimplepushProxy
+    {
+        void SendNotification(string title, string message, SimplepushSettings settings);
+        ValidationFailure Test(SimplepushSettings settings);
+    }
+
+    public class SimplepushProxy : ISimplepushProxy
+    {
+        private const string URL = "https://api.simplepush.io/send";
+        private readonly IHttpClient _httpClient;
+        private readonly Logger _logger;
+
+        public SimplepushProxy(IHttpClient httpClient, Logger logger)
+        {
+            _httpClient = httpClient;
+            _logger = logger;
+        }
+
+        public void SendNotification(string title, string message, SimplepushSettings settings)
+        {
+            var requestBuilder = new HttpRequestBuilder(URL).Post();
+
+            requestBuilder.AddFormParameter("key", settings.Key)
+                .AddFormParameter("event", settings.Event)
+                .AddFormParameter("title", title)
+                .AddFormParameter("msg", message);
+
+            var request = requestBuilder.Build();
+
+            _httpClient.Post(request);
+        }
+
+        public ValidationFailure Test(SimplepushSettings settings)
+        {
+            try
+            {
+                const string title = "Test Notification";
+                const string body = "This is a test message from Radarr";
+
+                SendNotification(title, body, settings);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unable to send test message");
+                return new ValidationFailure("ApiKey", "Unable to send test message");
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Simplepush/SimplepushSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Simplepush/SimplepushSettings.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Notifications.Simplepush
         [FieldDefinition(0, Label = "Key", Privacy = PrivacyLevel.ApiKey, HelpLink = "https://simplepush.io/features")]
         public string Key { get; set; }
 
-        [FieldDefinition(1, Label = "Event", HelpLink = "https://simplepush.io/features")]
+        [FieldDefinition(1, Label = "Event", HelpText = "Customize the behavior of push notifications", HelpLink = "https://simplepush.io/features")]
         public string Event { get; set; }
 
         public bool IsValid => !string.IsNullOrWhiteSpace(Key);

--- a/src/NzbDrone.Core/Notifications/Simplepush/SimplepushSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Simplepush/SimplepushSettings.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using FluentValidation;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.Notifications.Simplepush
+{
+    public class SimplepushSettingsValidator : AbstractValidator<SimplepushSettings>
+    {
+        public SimplepushSettingsValidator()
+        {
+            RuleFor(c => c.Key).NotEmpty();
+        }
+    }
+
+    public class SimplepushSettings : IProviderConfig
+    {
+        private static readonly SimplepushSettingsValidator Validator = new SimplepushSettingsValidator();
+
+        [FieldDefinition(0, Label = "Key", Privacy = PrivacyLevel.ApiKey, HelpLink = "https://simplepush.io/features")]
+        public string Key { get; set; }
+
+        [FieldDefinition(1, Label = "Event", HelpLink = "https://simplepush.io/features")]
+        public string Event { get; set; }
+
+        public bool IsValid => !string.IsNullOrWhiteSpace(Key);
+
+        public NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate(this));
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds support for [Simplepush](https://simplepush.io) notifications on Settings -> Connect.

Simplepush supports end-to-end encrypted notifications.
Once I have the okay from you guys, I would add support for end-to-end encrypted notifications into this PR.
Therefore it would be good to know if you prefer the end-to-end encryption code to be in this codebase or to be included from a library (that I would create)?

#### Screenshot (if UI related)
![connect](https://user-images.githubusercontent.com/28924/133257982-f9b6313b-218f-4021-a55c-408f26be7d84.jpg)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)
- [x] Add support for end-to-end encrypted notifications