### PR TITLE
New: Disable autocomplete of port number

### DIFF
--- a/frontend/src/Settings/General/HostSettings.js
+++ b/frontend/src/Settings/General/HostSettings.js
@@ -53,6 +53,7 @@ function HostSettings(props) {
           name="port"
           min={1}
           max={65535}
+          autocomplete="off"
           helpTextWarning={translate('RestartRequiredHelpTextWarning')}
           onChange={onInputChange}
           {...port}


### PR DESCRIPTION
(cherry picked from commit 943a3d80c4ff37cdffcd840190353d679c979493)

#### Database Migration
NO

#### Description
Disables autofill of the port field within HostSettings (Sonarr Pull)
#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #6611 