### PR TITLE
Fixed: Mailgun On Download Message

### DIFF
--- a/src/NzbDrone.Core/Notifications/Mailgun/Mailgun.cs
+++ b/src/NzbDrone.Core/Notifications/Mailgun/Mailgun.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Notifications.Mailgun
 
         public override void OnDownload(DownloadMessage downloadMessage)
         {
-            _proxy.SendNotification(MOVIE_GRABBED_TITLE, downloadMessage.Message, Settings);
+            _proxy.SendNotification(downloadMessage.OldMovieFiles.Count > 0 ? MOVIE_UPGRADED_TITLE : MOVIE_DOWNLOADED_TITLE, downloadMessage.Message, Settings);
         }
 
         public override void OnMovieFileDelete(MovieFileDeleteMessage deleteMessage)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes wording so that Mailgun now states either "Movie Downloaded" or "Movie Upgraded" instead of "Movie Grabbed"

#### Issues Fixed or Closed by this PR

* Fixes #6667 