### PR TITLE
New: Added Genres to Movie Details page

### DIFF
--- a/frontend/src/Movie/Details/MovieDetails.css
+++ b/frontend/src/Movie/Details/MovieDetails.css
@@ -151,7 +151,8 @@
 .qualityProfileName,
 .statusName,
 .studio,
-.collection {
+.collection,
+.genres {
   font-weight: 300;
   font-size: 17px;
 }

--- a/frontend/src/Movie/Details/MovieDetails.js
+++ b/frontend/src/Movie/Details/MovieDetails.js
@@ -266,6 +266,7 @@ class MovieDetails extends Component {
       qualityProfileId,
       monitored,
       studio,
+      genres,
       collection,
       overview,
       youTubeTrailerId,
@@ -582,6 +583,19 @@ class MovieDetails extends Component {
                         </span>
                       </InfoLabel>
                   }
+
+                  {
+                    !!genres.length && !isSmallScreen &&
+                      <InfoLabel
+                        className={styles.detailsInfoLabel}
+                        title={translate('Genres')}
+                        size={sizes.LARGE}
+                      >
+                        <span className={styles.genres}>
+                          {genres.join(', ')}
+                        </span>
+                      </InfoLabel>
+                  }
                 </div>
 
                 <Measure onMeasure={this.onMeasure}>
@@ -766,6 +780,7 @@ MovieDetails.propTypes = {
   monitored: PropTypes.bool.isRequired,
   status: PropTypes.string.isRequired,
   studio: PropTypes.string,
+  genres: PropTypes.arrayOf(PropTypes.string).isRequired,
   collection: PropTypes.object,
   youTubeTrailerId: PropTypes.string,
   isAvailable: PropTypes.bool.isRequired,
@@ -798,6 +813,7 @@ MovieDetails.propTypes = {
 };
 
 MovieDetails.defaultProps = {
+  genres: [],
   tags: [],
   isSaving: false,
   sizeOnDisk: 0


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds a list of genres to the movies details page, only shows when not in mobile view. 

#### Screenshot (if UI related)
![image](https://user-images.githubusercontent.com/19610103/138562687-6224a26d-4619-423b-b0bf-a7ac1cf7fcf2.png)

#### Todos
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)

#### Issues Fixed or Closed by this PR

* Fixes #5657 