### PR TITLE
Fixed: Time column is first column on events page

### DIFF
--- a/frontend/src/Store/Actions/systemActions.js
+++ b/frontend/src/Store/Actions/systemActions.js
@@ -88,6 +88,13 @@ export const defaultState = {
         isModifiable: false
       },
       {
+        name: 'time',
+        label: translate('Time'),
+        isSortable: true,
+        isVisible: true,
+        isModifiable: false
+      },
+      {
         name: 'logger',
         label: translate('Component'),
         isSortable: false,
@@ -97,13 +104,6 @@ export const defaultState = {
       {
         name: 'message',
         label: translate('Message'),
-        isVisible: true,
-        isModifiable: false
-      },
-      {
-        name: 'time',
-        label: translate('Time'),
-        isSortable: true,
         isVisible: true,
         isModifiable: false
       },

--- a/frontend/src/System/Events/LogsTableRow.js
+++ b/frontend/src/System/Events/LogsTableRow.js
@@ -58,9 +58,9 @@ class LogsTableRow extends Component {
   render() {
     const {
       level,
+      time,
       logger,
       message,
-      time,
       exception,
       columns
     } = this.props;
@@ -96,6 +96,15 @@ class LogsTableRow extends Component {
               );
             }
 
+            if (name === 'time') {
+              return (
+                <RelativeDateCellConnector
+                  key={name}
+                  date={time}
+                />
+              );
+            }
+
             if (name === 'logger') {
               return (
                 <TableRowCell key={name}>
@@ -109,15 +118,6 @@ class LogsTableRow extends Component {
                 <TableRowCell key={name}>
                   {message}
                 </TableRowCell>
-              );
-            }
-
-            if (name === 'time') {
-              return (
-                <RelativeDateCellConnector
-                  key={name}
-                  date={time}
-                />
               );
             }
 
@@ -148,9 +148,9 @@ class LogsTableRow extends Component {
 
 LogsTableRow.propTypes = {
   level: PropTypes.string.isRequired,
+  time: PropTypes.string.isRequired,
   logger: PropTypes.string.isRequired,
   message: PropTypes.string.isRequired,
-  time: PropTypes.string.isRequired,
   exception: PropTypes.string,
   columns: PropTypes.arrayOf(PropTypes.object).isRequired
 };


### PR DESCRIPTION
#### Database Migration
YES - XXXX | NO

#### Description
Have Time as the first field after the level icon

#### Screenshot (if UI related)
![image](https://user-images.githubusercontent.com/19610103/138570983-b125c92d-93fd-4b79-849d-60289d2f2d3a.png)

#### Issues Fixed or Closed by this PR

* Fixes #6484 