### PR TITLE
Fixed: Correctly detect mounts in FreeBSD jails

### DIFF
--- a/src/NzbDrone.Mono/Disk/FindDriveType.cs
+++ b/src/NzbDrone.Mono/Disk/FindDriveType.cs
@@ -12,6 +12,7 @@ namespace NzbDrone.Mono.Disk
                                                                                       { "apfs", DriveType.Fixed },
                                                                                       { "fuse.mergerfs", DriveType.Fixed },
                                                                                       { "fuse.glusterfs", DriveType.Network },
+                                                                                      { "nullfs", DriveType.Fixed },
                                                                                       { "zfs", DriveType.Fixed }
                                                                                   };
 


### PR DESCRIPTION
[common]

#### Database Migration
NO

#### Description
Allow for `nullfs` drives, which is how things mounted in jails appear

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX