### PR TITLE
Move edit icon to the left on remote path mappings

### DIFF
--- a/frontend/src/Settings/DownloadClients/RemotePathMappings/RemotePathMapping.css
+++ b/frontend/src/Settings/DownloadClients/RemotePathMappings/RemotePathMapping.css
@@ -1,23 +1,20 @@
 .remotePathMapping {
   display: flex;
-  align-items: stretch;
+  align-items: left;
   margin-bottom: 10px;
   height: 30px;
   border-bottom: 1px solid $borderColor;
   line-height: 30px;
 }
 
+.actions {
+  flex: 0 0 25px;
+}
+
 .host {
-  flex: 0 0 300px;
+  flex: 1 0 300px;
 }
 
 .path {
-  flex: 0 0 400px;
-}
-
-.actions {
-  display: flex;
-  justify-content: flex-end;
-  flex: 1 0 auto;
-  padding-right: 10px;
+  flex: 1 0 400px;
 }

--- a/frontend/src/Settings/DownloadClients/RemotePathMappings/RemotePathMapping.js
+++ b/frontend/src/Settings/DownloadClients/RemotePathMappings/RemotePathMapping.js
@@ -66,9 +66,6 @@ class RemotePathMapping extends Component {
           styles.remotePathMapping
         )}
       >
-        <div className={styles.host}>{host}</div>
-        <div className={styles.path}>{remotePath}</div>
-        <div className={styles.path}>{localPath}</div>
 
         <div className={styles.actions}>
           <Link
@@ -77,6 +74,10 @@ class RemotePathMapping extends Component {
             <Icon name={icons.EDIT} />
           </Link>
         </div>
+
+        <div className={styles.host}>{host}</div>
+        <div className={styles.path}>{remotePath}</div>
+        <div className={styles.path}>{localPath}</div>
 
         <EditRemotePathMappingModalConnector
           id={id}

--- a/frontend/src/Settings/DownloadClients/RemotePathMappings/RemotePathMappings.css
+++ b/frontend/src/Settings/DownloadClients/RemotePathMappings/RemotePathMappings.css
@@ -4,17 +4,19 @@
   font-weight: bold;
 }
 
+.actions {
+  flex: 0 0 25px;
+}
+
 .host {
-  flex: 0 0 300px;
+  flex: 1 0 300px;
 }
 
 .path {
-  flex: 0 0 400px;
+  flex: 1 0 400px;
 }
 
 .addRemotePathMapping {
-  display: flex;
-  justify-content: flex-end;
   padding-right: 10px;
 }
 


### PR DESCRIPTION
Move edit icon to the left on remote path mappings
Fix missing translations on remote path mappings

Fixes: #6686 