### PR TITLE
New: Support On Delete Notifications for Emby

### DIFF
--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
@@ -55,6 +55,35 @@ namespace NzbDrone.Core.Notifications.Emby
             }
         }
 
+        public override void OnMovieDelete(MovieDeleteMessage deleteMessage)
+        {
+            if (deleteMessage.DeletedFiles)
+            {
+                if (Settings.Notify)
+                {
+                    _mediaBrowserService.Notify(Settings, MOVIE_DELETED_TITLE_BRANDED, deleteMessage.Message);
+                }
+
+                if (Settings.UpdateLibrary)
+                {
+                    _mediaBrowserService.UpdateMovies(Settings, deleteMessage.Movie, "Deleted");
+                }
+            }
+        }
+
+        public override void OnMovieFileDelete(MovieFileDeleteMessage deleteMessage)
+        {
+            if (Settings.Notify)
+            {
+                _mediaBrowserService.Notify(Settings, MOVIE_FILE_DELETED_TITLE_BRANDED, deleteMessage.Message);
+            }
+
+            if (Settings.UpdateLibrary)
+            {
+                _mediaBrowserService.UpdateMovies(Settings, deleteMessage.Movie, "Deleted");
+            }
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.Notifications.Emby
         [FieldDefinition(4, Label = "Send Notifications", HelpText = "Have MediaBrowser send notfications to configured providers", Type = FieldType.Checkbox)]
         public bool Notify { get; set; }
 
-        [FieldDefinition(5, Label = "Update Library", HelpText = "Update Library on Import & Rename?", Type = FieldType.Checkbox)]
+        [FieldDefinition(5, Label = "Update Library", HelpText = "Update Library on Import, Rename or Delete?", Type = FieldType.Checkbox)]
         public bool UpdateLibrary { get; set; }
 
         [JsonIgnore]


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds On Delete Notifications for Emby - this ideally needs testing by someone who has Emby/Jellyfin and running NFS/CIFS as their filesystem for movie storage

#### Issues Fixed or Closed by this PR

* Fixes #4181 