### PR TITLE
Fixed: Give a unique name to the cookie used by Radarr (and other arr apps)

### DIFF
--- a/src/Radarr.Http/Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Radarr.Http/Authentication/AuthenticationBuilderExtensions.cs
@@ -29,6 +29,7 @@ namespace Radarr.Http.Authentication
                 .AddBasic(AuthenticationType.Basic.ToString())
                 .AddCookie(AuthenticationType.Forms.ToString(), options =>
                 {
+                    options.Cookie.Name = "RadarrAuth";
                     options.AccessDeniedPath = "/login?loginFailed=true";
                     options.LoginPath = "/login";
                     options.ExpireTimeSpan = TimeSpan.FromDays(7);


### PR DESCRIPTION
Lidarr, Radarr, and Prowlarr (maybe Readarr too) all use
the same name for their Authentication cookies
.AspNetCore.Forms

Sonarr uses a different name "SonarrAuth"

this commit makes Radarr use "RadarrAuth"...

similar changes should likely be ported to Lidarr, Prowlarr (and possibly Readarr)

#### Database Migration
 NO