### PR TITLE
New: Added Frontend Placeholders from the Backend

### DIFF
--- a/frontend/src/Components/Form/ProviderFieldFormGroup.js
+++ b/frontend/src/Components/Form/ProviderFieldFormGroup.js
@@ -64,6 +64,7 @@ function ProviderFieldFormGroup(props) {
     label,
     helpText,
     helpLink,
+    placeholder,
     value,
     type,
     advanced,
@@ -96,6 +97,7 @@ function ProviderFieldFormGroup(props) {
         label={label}
         helpText={helpText}
         helpLink={helpLink}
+        placeholder={placeholder}
         value={value}
         values={getSelectValues(selectOptions)}
         errors={errors}
@@ -121,6 +123,7 @@ ProviderFieldFormGroup.propTypes = {
   label: PropTypes.string.isRequired,
   helpText: PropTypes.string,
   helpLink: PropTypes.string,
+  placeholder: PropTypes.string,
   value: PropTypes.any,
   type: PropTypes.string.isRequired,
   advanced: PropTypes.bool.isRequired,

--- a/src/NzbDrone.Core/Annotations/FieldDefinitionAttribute.cs
+++ b/src/NzbDrone.Core/Annotations/FieldDefinitionAttribute.cs
@@ -23,6 +23,7 @@ namespace NzbDrone.Core.Annotations
         public string Section { get; set; }
         public HiddenType Hidden { get; set; }
         public PrivacyLevel Privacy { get; set; }
+        public string Placeholder { get; set; }
     }
 
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]

--- a/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
@@ -32,15 +32,13 @@ namespace NzbDrone.Core.Notifications.Email
 
         public EmailSettings()
         {
-            Server = "smtp.gmail.com";
-            Port = 587;
-
+            Port = 567;
             To = Array.Empty<string>();
             CC = Array.Empty<string>();
             Bcc = Array.Empty<string>();
         }
 
-        [FieldDefinition(0, Label = "Server", HelpText = "Hostname or IP of Email server")]
+        [FieldDefinition(0, Label = "Server", HelpText = "Hostname or IP of Email server", Placeholder = "smtp.gmail.com")]
         public string Server { get; set; }
 
         [FieldDefinition(1, Label = "Port")]
@@ -55,16 +53,16 @@ namespace NzbDrone.Core.Notifications.Email
         [FieldDefinition(4, Label = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
-        [FieldDefinition(5, Label = "From Address")]
+        [FieldDefinition(5, Label = "From Address", Placeholder = "example@email.com")]
         public string From { get; set; }
 
-        [FieldDefinition(6, Label = "Recipient Address(es)", HelpText = "Comma separated list of email recipients")]
+        [FieldDefinition(6, Label = "Recipient Address(es)", HelpText = "Comma separated list of email recipients", Placeholder = "example@email.com,example1@email.com")]
         public IEnumerable<string> To { get; set; }
 
-        [FieldDefinition(7, Label = "CC Address(es)", HelpText = "Comma separated list of email cc recipients", Advanced = true)]
+        [FieldDefinition(7, Label = "CC Address(es)", HelpText = "Comma separated list of email cc recipients", Placeholder = "example@email.com,example1@email.com", Advanced = true)]
         public IEnumerable<string> CC { get; set; }
 
-        [FieldDefinition(8, Label = "BCC Address(es)", HelpText = "Comma separated list of email bcc recipients", Advanced = true)]
+        [FieldDefinition(8, Label = "BCC Address(es)", HelpText = "Comma separated list of email bcc recipients", Placeholder = "example@email.com,example1@email.com", Advanced = true)]
         public IEnumerable<string> Bcc { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Notifications/Mailgun/MailgunSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Mailgun/MailgunSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
@@ -22,7 +23,7 @@ namespace NzbDrone.Core.Notifications.Mailgun
 
       public MailgunSettings()
       {
-          Recipients = new string[] { };
+          Recipients = Array.Empty<string>();
       }
 
       [FieldDefinition(0, Label = "API Key", HelpText = "The API key generated from MailGun")]
@@ -37,7 +38,7 @@ namespace NzbDrone.Core.Notifications.Mailgun
       [FieldDefinition(3, Label = "Sender Domain")]
       public string SenderDomain { get; set; }
 
-      [FieldDefinition(4, Label = "Recipient Address(es)", Type = FieldType.Tag)]
+      [FieldDefinition(4, Label = "Recipient Address(es)", Type = FieldType.Tag, Placeholder = "example@email.com,example1@email.com")]
       public IEnumerable<string> Recipients { get; set; }
 
       public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Notifications/PushBullet/PushBulletSettings.cs
+++ b/src/NzbDrone.Core/Notifications/PushBullet/PushBulletSettings.cs
@@ -28,10 +28,10 @@ namespace NzbDrone.Core.Notifications.PushBullet
         [FieldDefinition(0, Label = "Access Token", Privacy = PrivacyLevel.ApiKey, HelpLink = "https://www.pushbullet.com/#settings/account")]
         public string ApiKey { get; set; }
 
-        [FieldDefinition(1, Label = "Device IDs", HelpText = "List of device IDs (leave blank to send to all devices)", Type = FieldType.Device)]
+        [FieldDefinition(1, Label = "Device IDs", HelpText = "List of device IDs (leave blank to send to all devices)", Type = FieldType.Device, Placeholder = "123456789,987654321")]
         public IEnumerable<string> DeviceIds { get; set; }
 
-        [FieldDefinition(2, Label = "Channel Tags", HelpText = "List of Channel Tags to send notifications to", Type = FieldType.Tag)]
+        [FieldDefinition(2, Label = "Channel Tags", HelpText = "List of Channel Tags to send notifications to", Type = FieldType.Tag, Placeholder = "Channel1234,Channel4321")]
         public IEnumerable<string> ChannelTags { get; set; }
 
         [FieldDefinition(3, Label = "Sender ID", HelpText = "The device ID to send notifications from, use device_iden in the device's URL on pushbullet.com (leave blank to send from yourself)")]

--- a/src/NzbDrone.Core/Notifications/Pushover/PushoverSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Pushover/PushoverSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
@@ -23,7 +24,7 @@ namespace NzbDrone.Core.Notifications.Pushover
         public PushoverSettings()
         {
             Priority = 0;
-            Devices = System.Array.Empty<string>();
+            Devices = Array.Empty<string>();
         }
 
         [FieldDefinition(0, Label = "API Key", Privacy = PrivacyLevel.ApiKey, HelpLink = "https://pushover.net/apps/clone/radarr")]
@@ -32,7 +33,7 @@ namespace NzbDrone.Core.Notifications.Pushover
         [FieldDefinition(1, Label = "User Key", Privacy = PrivacyLevel.UserName, HelpLink = "https://pushover.net/")]
         public string UserKey { get; set; }
 
-        [FieldDefinition(2, Label = "Devices", HelpText = "List of device names (leave blank to send to all devices)", Type = FieldType.Tag)]
+        [FieldDefinition(2, Label = "Devices", HelpText = "List of device names (leave blank to send to all devices)", Type = FieldType.Tag, Placeholder = "device1")]
         public IEnumerable<string> Devices { get; set; }
 
         [FieldDefinition(3, Label = "Priority", Type = FieldType.Select, SelectOptions = typeof(PushoverPriority))]

--- a/src/NzbDrone.Core/Notifications/SendGrid/SendGridSettings.cs
+++ b/src/NzbDrone.Core/Notifications/SendGrid/SendGridSettings.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.Notifications.SendGrid
         [FieldDefinition(2, Label = "From Address")]
         public string From { get; set; }
 
-        [FieldDefinition(3, Label = "Recipient Address(es)", Type = FieldType.Tag)]
+        [FieldDefinition(3, Label = "Recipient Address(es)", Type = FieldType.Tag, Placeholder = "example@email.com,example1@email.com")]
         public IEnumerable<string> Recipients { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/Radarr.Http/ClientSchema/Field.cs
+++ b/src/Radarr.Http/ClientSchema/Field.cs
@@ -18,6 +18,7 @@ namespace Radarr.Http.ClientSchema
         public string SelectOptionsProviderAction { get; set; }
         public string Section { get; set; }
         public string Hidden { get; set; }
+        public string Placeholder { get; set; }
 
         public Field Clone()
         {

--- a/src/Radarr.Http/ClientSchema/SchemaBuilder.cs
+++ b/src/Radarr.Http/ClientSchema/SchemaBuilder.cs
@@ -101,7 +101,8 @@ namespace Radarr.Http.ClientSchema
                         Order = fieldAttribute.Order,
                         Advanced = fieldAttribute.Advanced,
                         Type = fieldAttribute.Type.ToString().FirstCharToLower(),
-                        Section = fieldAttribute.Section
+                        Section = fieldAttribute.Section,
+                        Placeholder = fieldAttribute.Placeholder
                     };
 
                     if (fieldAttribute.Type == FieldType.Select || fieldAttribute.Type == FieldType.TagSelect)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Enables frontend placeholders to be set from the backend. 

Sets placeholders instead of defaults in some notifications


@bakerboy448  wanted better examples of email addresses in help text, this feels more suitable. 