### PR TITLE
Sonarr Pull 'Rename QueryTitles to CleanSceneTitles in SearchCriteriaBase'

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         public void should_replace_some_special_characters(string input, string expected)
         {
             Subject.SceneTitles = new List<string> { input };
-            Subject.QueryTitles.First().Should().Be(expected);
+            Subject.CleanSceneTitles.First().Should().Be(expected);
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -19,9 +19,9 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
         public virtual bool UserInvokedSearch { get; set; }
         public virtual bool InteractiveSearch { get; set; }
 
-        public List<string> QueryTitles => SceneTitles.Select(GetQueryTitle).ToList();
+        public List<string> CleanSceneTitles => SceneTitles.Select(GetCleanSceneTitle).Distinct().ToList();
 
-        public static string GetQueryTitle(string title)
+        public static string GetCleanSceneTitle(string title)
         {
             Ensure.That(title, () => title).IsNotNullOrWhiteSpace();
 

--- a/src/NzbDrone.Core/Indexers/FileList/FileListRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/FileList/FileListRequestGenerator.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Indexers.FileList
             }
             else
             {
-                foreach (var queryTitle in searchCriteria.QueryTitles)
+                foreach (var queryTitle in searchCriteria.CleanSceneTitles)
                 {
                     var titleYearSearchQuery = string.Format("{0}+{1}", queryTitle, searchCriteria.Movie.Year);
                     pageableRequests.Add(GetRequest("search-torrents", string.Format("&type=name&query={0}", titleYearSearchQuery.Trim())));

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -155,7 +155,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             if (SupportsSearch)
             {
                 chain.AddTier();
-                var queryTitles = TextSearchEngine == "raw" ? searchCriteria.SceneTitles : searchCriteria.QueryTitles;
+                var queryTitles = TextSearchEngine == "raw" ? searchCriteria.SceneTitles : searchCriteria.CleanSceneTitles;
                 foreach (var queryTitle in queryTitles)
                 {
                     var searchQuery = queryTitle;

--- a/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
@@ -60,7 +60,7 @@ namespace NzbDrone.Core.Indexers.Nyaa
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            foreach (var queryTitle in searchCriteria.QueryTitles)
+            foreach (var queryTitle in searchCriteria.CleanSceneTitles)
             {
                 pageableRequests.Add(GetPagedRequests(MaxPages, PrepareQuery(string.Format("{0} {1}", queryTitle, searchCriteria.Movie.Year))));
             }

--- a/src/NzbDrone.Core/Indexers/Omgwtfnzbs/OmgwtfnzbsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Omgwtfnzbs/OmgwtfnzbsRequestGenerator.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Indexers.Omgwtfnzbs
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            foreach (var queryTitle in searchCriteria.QueryTitles)
+            foreach (var queryTitle in searchCriteria.CleanSceneTitles)
             {
                 pageableRequests.Add(GetPagedRequests(string.Format("{0}",
                     queryTitle)));

--- a/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornRequestGenerator.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
             }
             else if (searchCriteria.Movie.Year > 0)
             {
-                foreach (var queryTitle in searchCriteria.QueryTitles)
+                foreach (var queryTitle in searchCriteria.CleanSceneTitles)
                 {
                     pageableRequests.Add(GetRequest(string.Format("{0}&year={1}", queryTitle, searchCriteria.Movie.Year)));
                 }


### PR DESCRIPTION
(cherry picked from commit 747a4164e24e9861cacad39cf7d94db398747b38)

#### Database Migration
NO

#### Description
Sonarr pull 'Rename QueryTitles to CleanSceneTitles in SearchCriteriaBase'

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes #6641 