### PR TITLE
Migration and Health Check for Discord Notifications setup as Slack

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/Migration/201_migrate_discord_from_slackFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/201_migrate_discord_from_slackFixture.cs
@@ -1,0 +1,71 @@
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Datastore.Migration;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Datastore.Migration
+{
+    [TestFixture]
+    public class migrate_discord_from_slackFixture : MigrationTest<migrate_discord_from_slack>
+    {
+        private readonly JsonSerializerOptions _serializerSettings;
+
+        public migrate_discord_from_slackFixture()
+        {
+            _serializerSettings = new JsonSerializerOptions
+            {
+                AllowTrailingCommas = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+                PropertyNameCaseInsensitive = true,
+                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            };
+
+            _serializerSettings.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, true));
+        }
+
+        [Test]
+        public void should_replace_old_url()
+        {
+            var webhookUrl = "https://discord.com/api/webhooks/922499153416847361/f9CAcD5i_E_-0AoPfMVa8igVK8h271HpJDbd6euUrPh9KonWlMCziLOSMmD-2SQ4CHmX/slack";
+            var db = WithMigrationTestDb(c =>
+            {
+                c.Insert.IntoTable("Notifications").Row(new
+                {
+                    Name = "SlackDiscord",
+                    Implementation = "Slack",
+                    Settings = new SlackNotificationSettings201
+                    {
+                        Icon = "TestURL",
+                        Username = "TestUsername",
+                        WebHookUrl = webhookUrl
+                    }.ToJson(),
+                    ConfigContract = "SlackSettings",
+                    OnGrab = true,
+                    OnDownload = true,
+                    OnUpgrade = true,
+                    OnRename = true,
+                    OnHealthIssue = true,
+                    OnMovieDelete = true,
+                    OnMovieFileDelete = true,
+                    OnMovieFileDeleteForUpgrade = true,
+                    IncludeHealthWarnings = true
+                });
+            });
+
+            var items = db.Query<NotificationEntity201>("SELECT Id,ConfigContract,Implementation,Name,Settings FROM Notifications");
+
+            items.Should().HaveCount(1);
+            items.First().ConfigContract.Should().Be("DiscordSettings");
+            var settings = JsonSerializer.Deserialize<DiscordNotificationSettings201>(items.First().Settings, _serializerSettings);
+            settings.Avatar.Should().Be("TestURL");
+            settings.Username.Should().Be("TestUsername");
+            settings.WebHookUrl.Should().Be(webhookUrl.Replace("/slack", ""));
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/201_migrate_discord_from_slack.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/201_migrate_discord_from_slack.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Dapper;
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(201)]
+    public class migrate_discord_from_slack : NzbDroneMigrationBase
+    {
+        private readonly JsonSerializerOptions _serializerSettings;
+
+        public migrate_discord_from_slack()
+        {
+            _serializerSettings = new JsonSerializerOptions
+            {
+                AllowTrailingCommas = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+                PropertyNameCaseInsensitive = true,
+                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            };
+
+            _serializerSettings.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, true));
+        }
+
+        protected override void MainDbUpgrade()
+        {
+            Execute.WithConnection(MigrateDiscordFromSlack);
+        }
+
+        private void MigrateDiscordFromSlack(IDbConnection conn, IDbTransaction tran)
+        {
+            var notificationRows = conn.Query<NotificationEntity201>($"SELECT Id,ConfigContract,Implementation,Name,Settings FROM Notifications WHERE Implementation = 'Slack'");
+
+            var discordSlackNotifications = notificationRows.Where(n => JsonSerializer.Deserialize<SlackNotificationSettings201>(n.Settings, _serializerSettings).WebHookUrl.Contains("discord"));
+
+            if (!discordSlackNotifications.Any())
+            {
+                return;
+            }
+
+            foreach (NotificationEntity201 notification in discordSlackNotifications)
+            {
+                SlackNotificationSettings201 settings = JsonSerializer.Deserialize<SlackNotificationSettings201>(notification.Settings, _serializerSettings);
+                DiscordNotificationSettings201 discordSettings = new DiscordNotificationSettings201
+                {
+                    Avatar = settings.Icon,
+                    GrabFields = new List<int> { 0, 1, 2, 3, 5, 6, 7, 8, 9 },
+                    ImportFields = new List<int> { 0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12 },
+                    Username = settings.Username,
+                    WebHookUrl = settings.WebHookUrl.Replace("/slack", "")
+                };
+
+                notification.ConfigContract = "DiscordSettings";
+                notification.Implementation = "Discord";
+                notification.Name = $"{notification.Name}-Slack_Migrated";
+                notification.Settings = JsonSerializer.Serialize(discordSettings, _serializerSettings);
+            }
+
+            var updateSql = "UPDATE Notifications SET ConfigContract = @ConfigContract, " +
+                "Implementation = @Implementation, " +
+                "Name = @Name, " +
+                "Settings = @Settings " +
+                "WHERE Id = @Id";
+
+            conn.Execute(updateSql, discordSlackNotifications, transaction: tran);
+        }
+    }
+
+    public class NotificationEntity201
+    {
+        public int Id { get; set; }
+        public string ConfigContract { get; set; }
+        public string Implementation { get; set; }
+        public string Name { get; set; }
+        public string Settings { get; set; }
+    }
+
+    public class SlackNotificationSettings201
+    {
+        public string Channel { get; set; }
+        public string Icon { get; set; }
+        public string Username { get; set; }
+        public string WebHookUrl { get; set; }
+    }
+
+    public class DiscordNotificationSettings201
+    {
+        public string Avatar { get; set; }
+        public string Username { get; set; }
+        public string WebHookUrl { get; set; }
+        public IEnumerable<int> GrabFields { get; set; }
+        public IEnumerable<int> ImportFields { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/HealthCheck/Checks/SlackUrlCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/SlackUrlCheck.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Localization;
+using NzbDrone.Core.Notifications;
+using NzbDrone.Core.Notifications.Slack;
+using NzbDrone.Core.ThingiProvider.Events;
+
+namespace NzbDrone.Core.HealthCheck.Checks
+{
+    [CheckOn(typeof(ProviderUpdatedEvent<INotificationFactory>))]
+    [CheckOn(typeof(ProviderDeletedEvent<INotificationFactory>))]
+    [CheckOn(typeof(ProviderStatusChangedEvent<INotificationFactory>))]
+    public class SlackUrlCheck : HealthCheckBase
+    {
+        private readonly INotificationFactory _notificationFactory;
+
+        public SlackUrlCheck(INotificationFactory notificationFactory, ILocalizationService localizationService)
+            : base(localizationService)
+        {
+            _notificationFactory = notificationFactory;
+        }
+
+        public override HealthCheck Check()
+        {
+            var discordSlackNotifications = _notificationFactory.GetAvailableProviders().Where(n => n.ConfigContract.Equals("SlackSettings") && (n.Definition.Settings as SlackSettings).WebHookUrl.Contains("discord"));
+
+            if (discordSlackNotifications.Empty())
+            {
+                return new HealthCheck(GetType());
+            }
+
+            return new HealthCheck(GetType(),
+                HealthCheckResult.Warning,
+                string.Format(_localizationService.GetLocalizedString("DiscordUrlInSlackNotification"),
+                    string.Join(", ", discordSlackNotifications.Select(n => n.Name))),
+                "#discord-as-slack-notification");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -230,6 +230,7 @@
   "DigitalRelease": "Digital Release",
   "Disabled": "Disabled",
   "Discord": "Discord",
+  "DiscordUrlInSlackNotification": "You have a Discord notification setup as a Slack notification. Set this up as a Discord notification for better functionality. The effected notifications are: {0}",
   "Discover": "Discover",
   "DiskSpace": "Disk Space",
   "Docker": "Docker",


### PR DESCRIPTION
#### Database Migration
YES - 201

#### Description
Health check for discord notifications setup as a slack notification. This is a warning message as users will get a better experience setting it up as a Discord Notification. 

@Qstick recommended that this is a healthcheck that we needed on [discord](https://discordapp.com/channels/264387956343570434/269962130982174720/910972822447341568)

#### Todos
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)