### PR TITLE
Workaround .net error serializing new object()

### DIFF
--- a/src/Radarr.Api.V3/Blocklist/BlocklistController.cs
+++ b/src/Radarr.Api.V3/Blocklist/BlocklistController.cs
@@ -49,7 +49,7 @@ namespace Radarr.Api.V3.Blocklist
         {
             _blocklistService.Delete(resource.Ids);
 
-            return new object();
+            return new { };
         }
     }
 }

--- a/src/Radarr.Api.V3/History/HistoryController.cs
+++ b/src/Radarr.Api.V3/History/HistoryController.cs
@@ -98,7 +98,7 @@ namespace Radarr.Api.V3.History
         public object MarkAsFailed([FromRoute] int id)
         {
             _failedDownloadService.MarkAsFailed(id);
-            return new object();
+            return new { };
         }
     }
 }

--- a/src/Radarr.Api.V3/MovieFiles/MovieFileController.cs
+++ b/src/Radarr.Api.V3/MovieFiles/MovieFileController.cs
@@ -187,7 +187,7 @@ namespace Radarr.Api.V3.MovieFiles
                 _mediaFileDeletionService.DeleteMovieFile(movie, movieFile);
             }
 
-            return new object();
+            return new { };
         }
 
         [NonAction]

--- a/src/Radarr.Api.V3/Movies/MovieEditorController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieEditorController.cs
@@ -94,7 +94,7 @@ namespace Radarr.Api.V3.Movies
         {
             _movieService.DeleteMovies(resource.MovieIds, resource.DeleteFiles, resource.AddImportExclusion);
 
-            return new object();
+            return new { };
         }
     }
 }

--- a/src/Radarr.Api.V3/ProviderControllerBase.cs
+++ b/src/Radarr.Api.V3/ProviderControllerBase.cs
@@ -103,9 +103,10 @@ namespace Radarr.Api.V3
         }
 
         [RestDeleteById]
-        public void DeleteProvider(int id)
+        public object DeleteProvider(int id)
         {
             _providerFactory.Delete(id);
+            return new { };
         }
 
         [HttpGet("schema")]

--- a/src/Radarr.Api.V3/Queue/QueueActionController.cs
+++ b/src/Radarr.Api.V3/Queue/QueueActionController.cs
@@ -31,7 +31,7 @@ namespace Radarr.Api.V3.Queue
 
             _downloadService.DownloadReport(pendingRelease.RemoteMovie);
 
-            return new object();
+            return new { };
         }
 
         [HttpPost("grab/bulk")]
@@ -49,7 +49,7 @@ namespace Radarr.Api.V3.Queue
                 _downloadService.DownloadReport(pendingRelease.RemoteMovie);
             }
 
-            return new object();
+            return new { };
         }
     }
 }

--- a/src/Radarr.Api.V3/Queue/QueueController.cs
+++ b/src/Radarr.Api.V3/Queue/QueueController.cs
@@ -91,7 +91,7 @@ namespace Radarr.Api.V3.Queue
 
             _trackedDownloadService.StopTracking(trackedDownloadIds);
 
-            return new object();
+            return new { };
         }
 
         [HttpGet]


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/61995

#### Database Migration
NO

#### Description
.NET 6 throws an error returning `new object()`, so return `new { }` instead

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #6483 
* possibly others