### PR TITLE
Fixed: Escape Characters as needed for *znab queries

### DIFF
--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -204,7 +204,8 @@ namespace NzbDrone.Core.Indexers.Newznab
 
         private static string NewsnabifyTitle(string title)
         {
-            return title.Replace("+", "%20");
+            var newtitle = title.Replace("+", " ");
+            return Uri.EscapeDataString(newtitle);
         }
 
         public Func<IDictionary<string, string>> GetCookies { get; set; }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- In NewsnabifyTitle we now encode the url which will handle escaping any special characters (e.g. `&`)
- changes the replace from encoded space to actual space
- Per @markus101 he does not believe changing NewsnabifyTitle should have a negative impact
- common commit

#### Screenshot (if UI related)

#### Todos
- [X] Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [Wiki Updates](https://wiki.servarr.com)
- [ ] Backport to Sonarr

#### Issues Fixed or Closed by this PR

* Fixes #6799
* Resolves https://github.com/Prowlarr/Prowlarr/issues/683