### PR TITLE
Jackett All healthcheck and verification

### DIFF
--- a/frontend/src/System/Status/Health/Health.js
+++ b/frontend/src/System/Status/Health/Health.js
@@ -19,6 +19,7 @@ function getInternalLink(source) {
     case 'IndexerRssCheck':
     case 'IndexerSearchCheck':
     case 'IndexerStatusCheck':
+    case 'IndexerJackettAllCheck':
     case 'IndexerLongTermStatusCheck':
       return (
         <IconButton

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/IndexerJackettAllCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/IndexerJackettAllCheckFixture.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.HealthCheck.Checks;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Indexers.Torznab;
+using NzbDrone.Core.Localization;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.HealthCheck.Checks
+{
+    [TestFixture]
+    public class IndexerJackettAllCheckFixture : CoreTest<IndexerJackettAllCheck>
+    {
+        private List<IndexerDefinition> _indexers = new List<IndexerDefinition>();
+        private IndexerDefinition _definition;
+
+        [SetUp]
+        public void SetUp()
+        {
+            Mocker.GetMock<IIndexerFactory>()
+                  .Setup(v => v.All())
+                  .Returns(_indexers);
+
+            Mocker.GetMock<ILocalizationService>()
+                  .Setup(s => s.GetLocalizedString(It.IsAny<string>()))
+                  .Returns("Some Warning Message");
+        }
+
+        private void GivenIndexer(string baseUrl, string apiPath)
+        {
+            var torznabSettings = new TorznabSettings
+            {
+                BaseUrl = baseUrl,
+                ApiPath = apiPath
+            };
+
+            _definition = new IndexerDefinition
+            {
+                Name = "Indexer",
+                ConfigContract = "TorznabSettings",
+                Settings = torznabSettings
+            };
+
+            _indexers.Add(_definition);
+        }
+
+        [Test]
+        public void should_not_return_error_when_no_indexers()
+        {
+            Subject.Check().ShouldBeOk();
+        }
+
+        [TestCase("http://localhost:9117/", "api")]
+        public void should_not_return_error_when_no_jackett_all_indexers(string baseUrl, string apiPath)
+        {
+            GivenIndexer(baseUrl, apiPath);
+
+            Subject.Check().ShouldBeOk();
+        }
+
+        [TestCase("http://localhost:9117/torznab/all/api", "api")]
+        [TestCase("http://localhost:9117/api/v2.0/indexers/all/results/torznab", "api")]
+        [TestCase("http://localhost:9117/", "/torznab/all/api")]
+        [TestCase("http://localhost:9117/", "/api/v2.0/indexers/all/results/torznab")]
+        public void should_return_warning_if_any_jackett_all_indexer_exists(string baseUrl, string apiPath)
+        {
+            GivenIndexer(baseUrl, apiPath);
+
+            Subject.Check().ShouldBeWarning();
+        }
+    }
+}

--- a/src/NzbDrone.Core/HealthCheck/Checks/IndexerJackettAllCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/IndexerJackettAllCheck.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Indexers.Torznab;
+using NzbDrone.Core.Localization;
+using NzbDrone.Core.ThingiProvider.Events;
+
+namespace NzbDrone.Core.HealthCheck.Checks
+{
+    [CheckOn(typeof(ProviderUpdatedEvent<IIndexer>))]
+    [CheckOn(typeof(ProviderDeletedEvent<IIndexer>))]
+    [CheckOn(typeof(ProviderStatusChangedEvent<IIndexer>))]
+    public class IndexerJackettAllCheck : HealthCheckBase
+    {
+        private readonly IIndexerFactory _providerFactory;
+
+        public IndexerJackettAllCheck(IIndexerFactory providerFactory, ILocalizationService localizationService)
+            : base(localizationService)
+        {
+            _providerFactory = providerFactory;
+        }
+
+        public override HealthCheck Check()
+        {
+            var jackettAllProviders = _providerFactory.All().Where(
+                i => i.ConfigContract.Equals("TorznabSettings") &&
+                ((i.Settings as TorznabSettings).BaseUrl.Contains("/torznab/all/api", StringComparison.InvariantCultureIgnoreCase) ||
+                (i.Settings as TorznabSettings).BaseUrl.Contains("/api/v2.0/indexers/all/results/torznab", StringComparison.InvariantCultureIgnoreCase) ||
+                (i.Settings as TorznabSettings).ApiPath.Contains("/torznab/all/api", StringComparison.InvariantCultureIgnoreCase) ||
+                (i.Settings as TorznabSettings).ApiPath.Contains("/api/v2.0/indexers/all/results/torznab", StringComparison.InvariantCultureIgnoreCase)));
+
+            if (jackettAllProviders.Empty())
+            {
+                return new HealthCheck(GetType());
+            }
+
+            return new HealthCheck(GetType(),
+                HealthCheckResult.Warning,
+                string.Format(_localizationService.GetLocalizedString("IndexerJackettAll"),
+                    string.Join(", ", jackettAllProviders.Select(i => i.Name))),
+                "#jackett-all-endpoint-used");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/Torznab/Torznab.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/Torznab.cs
@@ -92,6 +92,7 @@ namespace NzbDrone.Core.Indexers.Torznab
                 return;
             }
 
+            failures.AddIfNotNull(JackettAll());
             failures.AddIfNotNull(TestCapabilities());
         }
 
@@ -147,6 +148,23 @@ namespace NzbDrone.Core.Indexers.Torznab
 
                 return new ValidationFailure(string.Empty, "Unable to connect to indexer, check the log for more details");
             }
+        }
+
+        protected virtual ValidationFailure JackettAll()
+        {
+            if (Settings.ApiPath.Contains("/torznab/all", StringComparison.InvariantCultureIgnoreCase) ||
+                Settings.ApiPath.Contains("/api/v2.0/indexers/all/results/torznab", StringComparison.InvariantCultureIgnoreCase) ||
+                Settings.BaseUrl.Contains("/torznab/all", StringComparison.InvariantCultureIgnoreCase) ||
+                Settings.BaseUrl.Contains("/api/v2.0/indexers/all/results/torznab", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return new NzbDroneValidationFailure("ApiPath", "Jackett's all endpoint is not supported, please add indexers individually")
+                {
+                    IsWarning = true,
+                    DetailedDescription = "Jackett's all endpoint is not supported, please add indexers individually"
+                };
+            }
+
+            return null;
         }
 
         public override object RequestAction(string action, IDictionary<string, string> query)

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -434,6 +434,7 @@
   "IndexerStatusCheckAllClientMessage": "All indexers are unavailable due to failures",
   "IndexerStatusCheckSingleClientMessage": "Indexers unavailable due to failures: {0}",
   "IndexerTagHelpText": "Only use this indexer for movies with at least one matching tag. Leave blank to use with all movies.",
+  "IndexerJackettAll": "Indexers using the unsupported Jackett 'all' endpoint: {0}",
   "Info": "Info",
   "InstallLatest": "Install Latest",
   "InteractiveImport": "Interactive Import",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Jackett all is bad - stopping adding/editing indexers that have this and calls a health check for those that have the all endpoint configured! 

#### Todos
- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)
- [x] Verification for indexer settings