### PR TITLE
Fix FAQ Link on Add New Movie page

### DIFF
--- a/frontend/src/AddMovie/AddNewMovie/AddNewMovie.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewMovie.js
@@ -161,7 +161,7 @@ class AddNewMovie extends Component {
                   {translate('YouCanAlsoSearch')}
                 </div>
                 <div>
-                  <Link to="https://wiki.servarr.com/radarr/faq#why-cant-i-add-a-new-movie-to-radarr">
+                  <Link to="https://wiki.servarr.com/radarr/faq#why-can-i-not-add-a-new-movie-to-radarr">
                     {translate('CantFindMovie')}
                   </Link>
                 </div>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Correct the FAQ link on the Add New Movie page to go directly to the right section

#### Screenshot (if UI related)