### PR TITLE
Fixed: Get full path for download station instead of shared folder

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -118,14 +118,17 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             try
             {
                 var serialNumber = _serialNumberProvider.GetSerialNumber(Settings);
-                var sharedFolder = GetDownloadDirectory() ?? GetDefaultDir();
-                var outputPath = new OsPath($"/{sharedFolder.TrimStart('/')}");
-                var path = _sharedFolderResolver.RemapToFullPath(outputPath, Settings, serialNumber);
+
+                // Download station returns the path without the leading `/`, but the leading
+                // slash is required to get the full path back from download station.
+                var path = new OsPath($"/{GetDownloadDirectory()}");
+
+                var fullPath = _sharedFolderResolver.RemapToFullPath(path, Settings, serialNumber);
 
                 return new DownloadClientInfo
                 {
                     IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost",
-                    OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, path) }
+                    OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, fullPath) }
                 };
             }
             catch (DownloadClientException e)

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -142,14 +142,17 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             try
             {
                 var serialNumber = _serialNumberProvider.GetSerialNumber(Settings);
-                var sharedFolder = GetDownloadDirectory() ?? GetDefaultDir();
-                var outputPath = new OsPath($"/{sharedFolder.TrimStart('/')}");
-                var path = _sharedFolderResolver.RemapToFullPath(outputPath, Settings, serialNumber);
+
+                // Download station returns the path without the leading `/`, but the leading
+                // slash is required to get the full path back from download station.
+                var path = new OsPath($"/{GetDownloadDirectory()}");
+
+                var fullPath = _sharedFolderResolver.RemapToFullPath(path, Settings, serialNumber);
 
                 return new DownloadClientInfo
                 {
                     IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost",
-                    OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, path) }
+                    OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, fullPath) }
                 };
             }
             catch (DownloadClientException e)


### PR DESCRIPTION
Closes #6751
Fixes #6818

(cherry picked from commit b184e62fa7dd7ecd089619f176e6388c1c3be25d)

#### Database Migration
NO

#### Description
A few sentences describing the overall goals of the pull request's commits.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX