### PR TITLE
New: Add {MediaInfo VideoDynamicRangeType} token for renaming

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -147,7 +147,8 @@ class NamingModal extends Component {
 
       { token: '{MediaInfo VideoCodec}', example: 'x264' },
       { token: '{MediaInfo VideoBitDepth}', example: '10' },
-      { token: '{MediaInfo VideoDynamicRange}', example: 'HDR' }
+      { token: '{MediaInfo VideoDynamicRange}', example: 'HDR' },
+      { token: '{MediaInfo VideoDynamicRangeType}', example: 'DV HDR10' }
     ];
 
     const releaseGroupTokens = [

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoDynamicRangeTypeFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoDynamicRangeTypeFixture.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles.MediaInfo;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
+{
+    [TestFixture]
+    public class FormatVideoDynamicRangeTypeFixture : TestBase
+    {
+        [TestCase(HdrFormat.None, "")]
+        [TestCase(HdrFormat.Hlg10, "HLG")]
+        [TestCase(HdrFormat.Pq10, "PQ")]
+        [TestCase(HdrFormat.Hdr10, "HDR10")]
+        [TestCase(HdrFormat.Hdr10Plus, "HDR10Plus")]
+        [TestCase(HdrFormat.DolbyVision, "DV")]
+        [TestCase(HdrFormat.DolbyVisionHdr10, "DV HDR10")]
+        [TestCase(HdrFormat.DolbyVisionHlg, "DV HLG")]
+        [TestCase(HdrFormat.DolbyVisionSdr, "DV SDR")]
+        public void should_format_video_dynamic_range_type(HdrFormat format, string expectedVideoDynamicRangeType)
+        {
+            var mediaInfo = new MediaInfoModel
+            {
+                VideoHdrFormat = format,
+                SchemaRevision = 9
+            };
+
+            MediaInfoFormatter.FormatVideoDynamicRangeType(mediaInfo).Should().Be(expectedVideoDynamicRangeType);
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/HdrFormat.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/HdrFormat.cs
@@ -7,6 +7,9 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         Hdr10,
         Hdr10Plus,
         Hlg10,
-        DolbyVision
+        DolbyVision,
+        DolbyVisionHdr10,
+        DolbyVisionSdr,
+        DolbyVisionHlg
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -303,5 +303,30 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         {
             return mediaInfo.VideoHdrFormat != HdrFormat.None ? VideoDynamicRangeHdr : "";
         }
+
+        public static string FormatVideoDynamicRangeType(MediaInfoModel mediaInfo)
+        {
+            switch (mediaInfo.VideoHdrFormat)
+            {
+                case HdrFormat.DolbyVision:
+                    return "DV";
+                case HdrFormat.DolbyVisionHdr10:
+                    return "DV HDR10";
+                case HdrFormat.DolbyVisionHlg:
+                    return "DV HLG";
+                case HdrFormat.DolbyVisionSdr:
+                    return "DV SDR";
+                case HdrFormat.Hdr10:
+                    return "HDR10";
+                case HdrFormat.Hdr10Plus:
+                    return "HDR10Plus";
+                case HdrFormat.Hlg10:
+                    return "HLG";
+                case HdrFormat.Pq10:
+                    return "PQ";
+            }
+
+            return "";
+        }
     }
 }

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -30,6 +30,7 @@ namespace NzbDrone.Core.Organizer
     public class FileNameBuilder : IBuildFileNames
     {
         private const string MediaInfoVideoDynamicRangeToken = "{MediaInfo VideoDynamicRange}";
+        private const string MediaInfoVideoDynamicRangeTypeToken = "{MediaInfo VideoDynamicRangeType}";
 
         private readonly INamingConfigService _namingConfigService;
         private readonly IQualityDefinitionService _qualityDefinitionService;
@@ -353,7 +354,8 @@ namespace NzbDrone.Core.Organizer
         private static readonly IReadOnlyDictionary<string, int> MinimumMediaInfoSchemaRevisions =
             new Dictionary<string, int>(FileNameBuilderTokenEqualityComparer.Instance)
         {
-            { MediaInfoVideoDynamicRangeToken, 5 }
+            { MediaInfoVideoDynamicRangeToken, 5 },
+            { MediaInfoVideoDynamicRangeTypeToken, 9 }
         };
 
         private void AddMediaInfoTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, MovieFile movieFile)
@@ -418,6 +420,8 @@ namespace NzbDrone.Core.Organizer
 
             tokenHandlers[MediaInfoVideoDynamicRangeToken] =
                 m => MediaInfoFormatter.FormatVideoDynamicRange(movieFile.MediaInfo);
+            tokenHandlers[MediaInfoVideoDynamicRangeTypeToken] =
+                m => MediaInfoFormatter.FormatVideoDynamicRangeType(movieFile.MediaInfo);
         }
 
         private void AddCustomFormats(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Movie movie, MovieFile movieFile, List<CustomFormat> customFormats = null)

--- a/src/Radarr.Api.V3/MovieFiles/MediaInfoResource.cs
+++ b/src/Radarr.Api.V3/MovieFiles/MediaInfoResource.cs
@@ -15,6 +15,7 @@ namespace Radarr.Api.V3.MovieFiles
         public int VideoBitDepth { get; set; }
         public int VideoBitrate { get; set; }
         public string VideoCodec { get; set; }
+        public string VideoDynamicRangeType { get; set; }
         public decimal VideoFps { get; set; }
         public string Resolution { get; set; }
         public string RunTime { get; set; }
@@ -41,6 +42,7 @@ namespace Radarr.Api.V3.MovieFiles
                 VideoBitDepth = model.VideoBitDepth,
                 VideoBitrate = model.VideoBitrate,
                 VideoCodec = MediaInfoFormatter.FormatVideoCodec(model, sceneName),
+                VideoDynamicRangeType = MediaInfoFormatter.FormatVideoDynamicRangeType(model),
                 VideoFps = Math.Round(model.VideoFps, 3),
                 Resolution = $"{model.Width}x{model.Height}",
                 RunTime = FormatRuntime(model.RunTime),


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- New: Add {MediaInfo VideoDynamicRangeType} token for renaming
- New: Detect HDR Type
- Based on Sonarr 7b694ea71d7f78bad5c03393c4cf6f7a28ada1cb
- Bump to CURRENT_MEDIA_INFO_SCHEMA_REVISION to 9

#### Screenshot (if UI related)

#### Todos
- [X] Tests
-  Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)
- [x] Finish Work on Model Extension (need Examples!)
- [x] Rework Tests if needed

#### Issues Fixed or Closed by this PR
* Closes #6789
* Fixes #4844

#### Referneces


- [Related Message](https://discord.com/channels/264387956343570434/264387994302021632/923981553896423464)
- [Example JSON FFProbe Dumps](https://gist.github.com/bakerboy448/023c6ba3ee09d7db61b57f2175d396f9) thanks TRaSH

For Posterity - References (thanks Ta)

```
dv_bl_signal_compatibility_id – specifies a particular form of a
base-layer sub-stream that can be decoded to a signal compliant with a
particular set of standards, if any.
```
- https://professional.dolby.com/siteassets/content-creation/dolby-vision-for-content-creators/dolby_vision_bitstreams_within_the_iso_base_media_file_format_dec2017.pdf
```
if (conf.dv_profile == 4)
  139     conf.dv_bl_signal_compatibility_id = 2;
  140 
  141   else if (conf.dv_profile == 5)
  142     conf.dv_bl_signal_compatibility_id = 0;
  143 
  144   else if (conf.dv_profile == 8) {
  145     auto trc = vui.transfer_characteristics;
  146 
  147     // WCG
  148     if (vui.colour_primaries == 9 && vui.matrix_coefficients == 9) {
  149       if (trc == 16)                       // ST2084, HDR10 base layer
  150         conf.dv_bl_signal_compatibility_id = 1;
  151       else if ((trc == 14) || (trc == 18)) // ARIB STD-B67, HLG base layer
  152         conf.dv_bl_signal_compatibility_id = 4;
  153       else                                 // undefined
  154         conf.dv_bl_signal_compatibility_id = 0;
  155 
  156     } else                                 // BT.709, BT.1886, SDR
  157       conf.dv_bl_signal_compatibility_id = 2;
  158 
  159   } else if (conf.dv_profile == 7)
  160     conf.dv_bl_signal_compatibility_id = 6;
  161 
  162   else if (conf.dv_profile == 9)
  163     conf.dv_bl_signal_compatibility_id = 2;
```
- https://fossies.org/linux/mkvtoolnix/src/common/dovi_meta.cpp
```
extern const char* DolbyVision_Compatibility[DolbyVision_Compatibility_Size] =
{
    "",
    "HDR10",
    "SDR",
    NULL,
    "HLG",
    NULL,
    "Blu-ray",
};
```
- that's the mapping (0 - 6) for hdr compatibility
- https://github.com/MediaArea/MediaInfoLib/blob/9bdf5ef2ce6116b08cea2600abc23e944a4cb62f/Source/MediaInfo/File__Analyze_Streams.cpp