### PR TITLE
Reshuffle the search result list if a lower result is an EXACT match

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -419,7 +419,20 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
                 var httpResponse = _httpClient.Get<List<MovieResource>>(request);
 
-                return httpResponse.Resource.SelectList(MapSearchResult);
+                var result_list = httpResponse.Resource.SelectList(MapSearchResult);
+
+                if (parserResult != null && parserResult.PrimaryMovieTitle != title)
+                {
+                    // check if any result is an EXACT match (title and year), and move it up to the top
+                    var exactMatch = result_list.FindIndex(candidate => candidate.Title == parserResult.PrimaryMovieTitle && candidate.Year == parserResult.Year);
+                    if (exactMatch > 0)
+                    {
+                        result_list.Insert(0, result_list[exactMatch]);
+                        result_list.RemoveAt(exactMatch + 1);
+                    }
+                }
+
+                return result_list;
             }
             catch (HttpException ex)
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
For the special case where a movie search result is an exact match in title and year, prefer that result, and move it to the top of the result list if it isn't already there.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

There are no existing tests for SkyHookProxy, that I could find. Not sure what to do there.

#### Issues Fixed or Closed by this PR

* Fixes #6869
* Fixes #4866 