### PR TITLE
Fix CustomFormat checks for Original Language

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/QueueSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/QueueSpecificationFixture.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                 .Build();
 
             Mocker.GetMock<ICustomFormatCalculationService>()
-                .Setup(x => x.ParseCustomFormat(It.IsAny<ParsedMovieInfo>()))
+                .Setup(x => x.ParseCustomFormat(It.IsAny<ParsedMovieInfo>(), _movie))
                 .Returns(new List<CustomFormat>());
         }
 

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.CustomFormats
 {
     public interface ICustomFormatCalculationService
     {
-        List<CustomFormat> ParseCustomFormat(ParsedMovieInfo movieInfo);
+        List<CustomFormat> ParseCustomFormat(ParsedMovieInfo movieInfo, Movie movie);
         List<CustomFormat> ParseCustomFormat(MovieFile movieFile);
         List<CustomFormat> ParseCustomFormat(Blocklist blocklist);
         List<CustomFormat> ParseCustomFormat(MovieHistory history);
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.CustomFormats
             _movieService = movieService;
         }
 
-        public static List<CustomFormat> ParseCustomFormat(ParsedMovieInfo movieInfo, List<CustomFormat> allCustomFormats)
+        public static List<CustomFormat> ParseCustomFormat(ParsedMovieInfo movieInfo, List<CustomFormat> allCustomFormats, Movie movie)
         {
             var matches = new List<CustomFormat>();
 
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.CustomFormats
                     .GroupBy(t => t.GetType())
                     .Select(g => new SpecificationMatchesGroup
                     {
-                        Matches = g.ToDictionary(t => t, t => t.IsSatisfiedBy(movieInfo))
+                        Matches = g.ToDictionary(t => t, t => t.IsSatisfiedBy(movieInfo, movie))
                     })
                     .ToList();
 
@@ -92,12 +92,12 @@ namespace NzbDrone.Core.CustomFormats
                 }
             };
 
-            return ParseCustomFormat(info, allCustomFormats);
+            return ParseCustomFormat(info, allCustomFormats, movieFile.Movie);
         }
 
-        public List<CustomFormat> ParseCustomFormat(ParsedMovieInfo movieInfo)
+        public List<CustomFormat> ParseCustomFormat(ParsedMovieInfo movieInfo, Movie movie)
         {
-            return ParseCustomFormat(movieInfo, _formatService.All());
+            return ParseCustomFormat(movieInfo, _formatService.All(), movie);
         }
 
         public List<CustomFormat> ParseCustomFormat(MovieFile movieFile)
@@ -127,7 +127,7 @@ namespace NzbDrone.Core.CustomFormats
                 }
             };
 
-            return ParseCustomFormat(info);
+            return ParseCustomFormat(info, movie);
         }
 
         public List<CustomFormat> ParseCustomFormat(MovieHistory history)
@@ -155,7 +155,7 @@ namespace NzbDrone.Core.CustomFormats
                 }
             };
 
-            return ParseCustomFormat(info);
+            return ParseCustomFormat(info, movie);
         }
     }
 }

--- a/src/NzbDrone.Core/CustomFormats/Specifications/CustomFormatSpecificationBase.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/CustomFormatSpecificationBase.cs
@@ -1,3 +1,4 @@
+using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.CustomFormats
@@ -18,9 +19,9 @@ namespace NzbDrone.Core.CustomFormats
             return (ICustomFormatSpecification)MemberwiseClone();
         }
 
-        public bool IsSatisfiedBy(ParsedMovieInfo movieInfo)
+        public bool IsSatisfiedBy(ParsedMovieInfo movieInfo, Movie movie)
         {
-            var match = IsSatisfiedByWithoutNegate(movieInfo);
+            var match = IsSatisfiedByWithoutNegate(movieInfo, movie);
             if (Negate)
             {
                 match = !match;
@@ -29,6 +30,6 @@ namespace NzbDrone.Core.CustomFormats
             return match;
         }
 
-        protected abstract bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo);
+        protected abstract bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo, Movie movie);
     }
 }

--- a/src/NzbDrone.Core/CustomFormats/Specifications/EditionSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/EditionSpecification.cs
@@ -1,3 +1,4 @@
+using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.CustomFormats
@@ -8,7 +9,7 @@ namespace NzbDrone.Core.CustomFormats
         public override string ImplementationName => "Edition";
         public override string InfoLink => "https://wiki.servarr.com/radarr/settings#custom-formats-2";
 
-        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo)
+        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo, Movie movie)
         {
             return MatchString(movieInfo.Edition);
         }

--- a/src/NzbDrone.Core/CustomFormats/Specifications/ICustomFormatSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/ICustomFormatSpecification.cs
@@ -1,3 +1,4 @@
+using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.CustomFormats
@@ -12,6 +13,6 @@ namespace NzbDrone.Core.CustomFormats
         bool Required { get; set; }
 
         ICustomFormatSpecification Clone();
-        bool IsSatisfiedBy(ParsedMovieInfo movieInfo);
+        bool IsSatisfiedBy(ParsedMovieInfo movieInfo, Movie movie);
     }
 }

--- a/src/NzbDrone.Core/CustomFormats/Specifications/IndexerFlagSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/IndexerFlagSpecification.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.CustomFormats
@@ -13,7 +14,7 @@ namespace NzbDrone.Core.CustomFormats
         [FieldDefinition(1, Label = "Flag", Type = FieldType.Select, SelectOptions = typeof(IndexerFlags))]
         public int Value { get; set; }
 
-        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo)
+        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo, Movie movie)
         {
             var flags = movieInfo?.ExtraInfo?.GetValueOrDefault("IndexerFlags") as IndexerFlags?;
             return flags?.HasFlag((IndexerFlags)Value) == true;

--- a/src/NzbDrone.Core/CustomFormats/Specifications/LanguageSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/LanguageSpecification.cs
@@ -1,5 +1,6 @@
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Languages;
+using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.CustomFormats
@@ -12,9 +13,19 @@ namespace NzbDrone.Core.CustomFormats
         [FieldDefinition(1, Label = "Language", Type = FieldType.Select, SelectOptions = typeof(LanguageFieldConverter))]
         public int Value { get; set; }
 
-        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo)
+        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo, Movie movie)
         {
-            return movieInfo?.Languages?.Contains((Language)Value) ?? false;
+            Language comparedTitle;
+            if (this.Name == "Original")
+            {
+                comparedTitle = movie.OriginalLanguage;
+            }
+            else
+            {
+                comparedTitle = (Language)Value;
+            }
+
+            return movieInfo?.Languages?.Contains(comparedTitle) ?? false;
         }
     }
 }

--- a/src/NzbDrone.Core/CustomFormats/Specifications/QualityModifierSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/QualityModifierSpecification.cs
@@ -1,4 +1,5 @@
 using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;
 
@@ -12,7 +13,7 @@ namespace NzbDrone.Core.CustomFormats
         [FieldDefinition(1, Label = "Quality Modifier", Type = FieldType.Select, SelectOptions = typeof(Modifier))]
         public int Value { get; set; }
 
-        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo)
+        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo, Movie movie)
         {
             return (movieInfo?.Quality?.Quality?.Modifier ?? (int)Modifier.NONE) == (Modifier)Value;
         }

--- a/src/NzbDrone.Core/CustomFormats/Specifications/ReleaseTitleSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/ReleaseTitleSpecification.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.CustomFormats
@@ -10,7 +11,7 @@ namespace NzbDrone.Core.CustomFormats
         public override string ImplementationName => "Release Title";
         public override string InfoLink => "https://wiki.servarr.com/radarr/settings#custom-formats-2";
 
-        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo)
+        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo, Movie movie)
         {
             var filename = (string)movieInfo?.ExtraInfo?.GetValueOrDefault("Filename");
 

--- a/src/NzbDrone.Core/CustomFormats/Specifications/ResolutionSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/ResolutionSpecification.cs
@@ -1,4 +1,5 @@
 using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 
@@ -12,7 +13,7 @@ namespace NzbDrone.Core.CustomFormats
         [FieldDefinition(1, Label = "Resolution", Type = FieldType.Select, SelectOptions = typeof(Resolution))]
         public int Value { get; set; }
 
-        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo)
+        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo, Movie movie)
         {
             return (movieInfo?.Quality?.Quality?.Resolution ?? (int)Resolution.Unknown) == Value;
         }

--- a/src/NzbDrone.Core/CustomFormats/Specifications/SizeSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/SizeSpecification.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.CustomFormats
@@ -16,7 +17,7 @@ namespace NzbDrone.Core.CustomFormats
         [FieldDefinition(1, Label = "Maximum Size", HelpText = "Release must be less than or equal to this size", Unit = "GB", Type = FieldType.Number)]
         public double Max { get; set; }
 
-        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo)
+        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo, Movie movie)
         {
             var size = (movieInfo?.ExtraInfo?.GetValueOrDefault("Size", 0.0) as long?) ?? 0;
 

--- a/src/NzbDrone.Core/CustomFormats/Specifications/SourceSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/SourceSpecification.cs
@@ -1,4 +1,5 @@
 using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;
 
@@ -12,7 +13,7 @@ namespace NzbDrone.Core.CustomFormats
         [FieldDefinition(1, Label = "Source", Type = FieldType.Select, SelectOptions = typeof(Source))]
         public int Value { get; set; }
 
-        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo)
+        protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo, Movie movie)
         {
             return (movieInfo?.Quality?.Quality?.Source ?? (int)Source.UNKNOWN) == (Source)Value;
         }

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.DecisionEngine
 
                     result.ReleaseName = report.Title;
                     var remoteMovie = result.RemoteMovie;
-                    remoteMovie.CustomFormats = _formatCalculator.ParseCustomFormat(parsedMovieInfo);
+                    remoteMovie.CustomFormats = _formatCalculator.ParseCustomFormat(parsedMovieInfo, searchCriteria.Movie);
                     remoteMovie.CustomFormatScore = remoteMovie?.Movie?.Profile?.CalculateCustomFormatScore(remoteMovie.CustomFormats) ?? 0;
                     remoteMovie.Release = report;
                     remoteMovie.MappingResult = result.MappingResultType;

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/QueueSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/QueueSpecification.cs
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                     continue;
                 }
 
-                var customFormats = _formatService.ParseCustomFormat(remoteMovie.ParsedMovieInfo);
+                var customFormats = _formatService.ParseCustomFormat(remoteMovie.ParsedMovieInfo, subject.Movie);
 
                 _logger.Debug("Checking if existing release in queue meets cutoff. Queued quality is: {0} - {1}",
                               remoteMovie.ParsedMovieInfo.Quality,

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
@@ -163,7 +163,7 @@ namespace NzbDrone.Core.Download.Pending
             {
                 if (pendingRelease.RemoteMovie != null)
                 {
-                    pendingRelease.RemoteMovie.CustomFormats = _formatCalculator.ParseCustomFormat(pendingRelease.ParsedMovieInfo);
+                    pendingRelease.RemoteMovie.CustomFormats = _formatCalculator.ParseCustomFormat(pendingRelease.ParsedMovieInfo, pendingRelease.RemoteMovie.Movie);
 
                     var ect = pendingRelease.Release.PublishDate.AddMinutes(GetDelay(pendingRelease.RemoteMovie));
 

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -151,7 +151,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                 // Calculate custom formats
                 if (trackedDownload.RemoteMovie != null)
                 {
-                    trackedDownload.RemoteMovie.CustomFormats = _formatCalculator.ParseCustomFormat(parsedMovieInfo);
+                    trackedDownload.RemoteMovie.CustomFormats = _formatCalculator.ParseCustomFormat(parsedMovieInfo, trackedDownload.RemoteMovie.Movie);
                 }
 
                 // Track it so it can be displayed in the queue even though we can't determine which movie it is for


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR fixes the check for Original Language in custom formats.
Before the PR, the custom format will check if the release contains the language "Original" (which of course will fail). This PR will check with the actual original language of the movie.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* Fixes #6395 