### PR TITLE
Check "Original" language Custom Format with the real original language

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/QueueSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/QueueSpecificationFixture.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                 .Build();
 
             Mocker.GetMock<ICustomFormatCalculationService>()
-                .Setup(x => x.ParseCustomFormat(It.IsAny<ParsedMovieInfo>()))
+                .Setup(x => x.ParseCustomFormat(It.IsAny<ParsedMovieInfo>(), _movie))
                 .Returns(new List<CustomFormat>());
         }
 

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/AugmentersTests/AugmentWithOriginalLanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/AugmentersTests/AugmentWithOriginalLanguageFixture.cs
@@ -1,0 +1,26 @@
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.Parser.Augmenters;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests.AugmentersTests
+{
+    [TestFixture]
+    public class AugmentWithOriginalLanguageFixture : AugmentMovieInfoFixture<AugmentWithOriginalLanguage>
+    {
+        [Test]
+        public void should_add_movie_original_language()
+        {
+            var releaseInfo = new ParsedMovieInfo();
+            var movie = new Movies.Movie
+            {
+                OriginalLanguage = Language.English
+            };
+            var result = Subject.AugmentMovieInfo(releaseInfo, movie);
+            result.ExtraInfo.Should().ContainKey("OriginalLanguage");
+            result.ExtraInfo["OriginalLanguage"].Should().Be(Language.English);
+        }
+    }
+}

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.CustomFormats
 {
     public interface ICustomFormatCalculationService
     {
-        List<CustomFormat> ParseCustomFormat(ParsedMovieInfo movieInfo);
+        List<CustomFormat> ParseCustomFormat(ParsedMovieInfo movieInfo, Movie movie);
         List<CustomFormat> ParseCustomFormat(MovieFile movieFile);
         List<CustomFormat> ParseCustomFormat(Blocklist blocklist);
         List<CustomFormat> ParseCustomFormat(MovieHistory history);
@@ -88,15 +88,17 @@ namespace NzbDrone.Core.CustomFormats
                 {
                     { "IndexerFlags", movieFile.IndexerFlags },
                     { "Size", movieFile.Size },
-                    { "Filename", System.IO.Path.GetFileName(movieFile.RelativePath) }
+                    { "Filename", Path.GetFileName(movieFile.RelativePath) },
+                    { "OriginalLanguage", movieFile.Movie.OriginalLanguage }
                 }
             };
 
             return ParseCustomFormat(info, allCustomFormats);
         }
 
-        public List<CustomFormat> ParseCustomFormat(ParsedMovieInfo movieInfo)
+        public List<CustomFormat> ParseCustomFormat(ParsedMovieInfo movieInfo, Movie movie)
         {
+            movieInfo = _parsingService.EnhanceMovieInfo(movieInfo, new List<object> { movie }) ?? movieInfo;
             return ParseCustomFormat(movieInfo, _formatService.All());
         }
 
@@ -127,7 +129,7 @@ namespace NzbDrone.Core.CustomFormats
                 }
             };
 
-            return ParseCustomFormat(info);
+            return ParseCustomFormat(info, movie);
         }
 
         public List<CustomFormat> ParseCustomFormat(MovieHistory history)
@@ -155,7 +157,7 @@ namespace NzbDrone.Core.CustomFormats
                 }
             };
 
-            return ParseCustomFormat(info);
+            return ParseCustomFormat(info, movie);
         }
     }
 }

--- a/src/NzbDrone.Core/CustomFormats/Specifications/LanguageSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/LanguageSpecification.cs
@@ -14,7 +14,10 @@ namespace NzbDrone.Core.CustomFormats
 
         protected override bool IsSatisfiedByWithoutNegate(ParsedMovieInfo movieInfo)
         {
-            return movieInfo?.Languages?.Contains((Language)Value) ?? false;
+            var comparedLanguage = movieInfo != null && Name == "Original" && movieInfo.ExtraInfo.ContainsKey("OriginalLanguage")
+                ? (Language)movieInfo.ExtraInfo["OriginalLanguage"]
+                : (Language)Value;
+            return movieInfo?.Languages?.Contains(comparedLanguage) ?? false;
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.DecisionEngine
 
                     result.ReleaseName = report.Title;
                     var remoteMovie = result.RemoteMovie;
-                    remoteMovie.CustomFormats = _formatCalculator.ParseCustomFormat(parsedMovieInfo);
+                    remoteMovie.CustomFormats = _formatCalculator.ParseCustomFormat(parsedMovieInfo, result?.Movie);
                     remoteMovie.CustomFormatScore = remoteMovie?.Movie?.Profile?.CalculateCustomFormatScore(remoteMovie.CustomFormats) ?? 0;
                     remoteMovie.Release = report;
                     remoteMovie.MappingResult = result.MappingResultType;

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/QueueSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/QueueSpecification.cs
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                     continue;
                 }
 
-                var customFormats = _formatService.ParseCustomFormat(remoteMovie.ParsedMovieInfo);
+                var customFormats = _formatService.ParseCustomFormat(remoteMovie.ParsedMovieInfo, subject.Movie);
 
                 _logger.Debug("Checking if existing release in queue meets cutoff. Queued quality is: {0} - {1}",
                               remoteMovie.ParsedMovieInfo.Quality,

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
@@ -163,7 +163,7 @@ namespace NzbDrone.Core.Download.Pending
             {
                 if (pendingRelease.RemoteMovie != null)
                 {
-                    pendingRelease.RemoteMovie.CustomFormats = _formatCalculator.ParseCustomFormat(pendingRelease.ParsedMovieInfo);
+                    pendingRelease.RemoteMovie.CustomFormats = _formatCalculator.ParseCustomFormat(pendingRelease.ParsedMovieInfo, pendingRelease.RemoteMovie.Movie);
 
                     var ect = pendingRelease.Release.PublishDate.AddMinutes(GetDelay(pendingRelease.RemoteMovie));
 

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -151,7 +151,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                 // Calculate custom formats
                 if (trackedDownload.RemoteMovie != null)
                 {
-                    trackedDownload.RemoteMovie.CustomFormats = _formatCalculator.ParseCustomFormat(parsedMovieInfo);
+                    trackedDownload.RemoteMovie.CustomFormats = _formatCalculator.ParseCustomFormat(parsedMovieInfo, trackedDownload.RemoteMovie.Movie);
                 }
 
                 // Track it so it can be displayed in the queue even though we can't determine which movie it is for

--- a/src/NzbDrone.Core/Parser/Augmenters/AugmentWithOriginalLanguage.cs
+++ b/src/NzbDrone.Core/Parser/Augmenters/AugmentWithOriginalLanguage.cs
@@ -1,0 +1,27 @@
+using System;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.Parser.Augmenters
+{
+    public class AugmentWithOriginalLanguage : IAugmentParsedMovieInfo
+    {
+        public Type HelperType
+        {
+            get
+            {
+                return typeof(Movie);
+            }
+        }
+
+        public ParsedMovieInfo AugmentMovieInfo(ParsedMovieInfo movieInfo, object helper)
+        {
+            if (helper is Movie movie && movie?.OriginalLanguage != null && movieInfo != null)
+            {
+                movieInfo.ExtraInfo["OriginalLanguage"] = movie.OriginalLanguage;
+            }
+
+            return movieInfo;
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR fixes the check for Original Language in custom formats.
Before the PR, the custom format will check if the release contains the language "Original" (which of course will fail). This PR will check with the actual original language of the movie.

#### Todos
- [X] Tests

#### Issues Fixed or Closed by this PR

* Fixes #6395
* Closes #6992