### PR TITLE
Fixed: Avoid download path check false positives for flood

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Flood/Flood.cs
+++ b/src/NzbDrone.Core/Download/Clients/Flood/Flood.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.Flood.Models;
@@ -233,10 +234,17 @@ namespace NzbDrone.Core.Download.Clients.Flood
 
         public override DownloadClientInfo GetStatus()
         {
+            var destDir = _proxy.GetClientSettings(Settings).DirectoryDefault;
+
+            if (Settings.Destination.IsNotNullOrWhiteSpace())
+            {
+                destDir = Settings.Destination;
+            }
+
             return new DownloadClientInfo
             {
                 IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "::1" || Settings.Host == "localhost",
-                OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, new OsPath(Settings.Destination)) }
+                OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, new OsPath(destDir)) }
             };
         }
 

--- a/src/NzbDrone.Core/Download/Clients/Flood/FloodProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Flood/FloodProxy.cs
@@ -19,6 +19,7 @@ namespace NzbDrone.Core.Download.Clients.Flood
         Dictionary<string, Torrent> GetTorrents(FloodSettings settings);
         List<string> GetTorrentContentPaths(string hash, FloodSettings settings);
         void SetTorrentsTags(string hash, IEnumerable<string> tags, FloodSettings settings);
+        FloodClientSettings GetClientSettings(FloodSettings settings);
     }
 
     public class FloodProxy : IFloodProxy
@@ -209,6 +210,15 @@ namespace NzbDrone.Core.Download.Clients.Flood
             tagsRequest.SetContent(body.ToJson());
 
             HandleRequest(tagsRequest, settings);
+        }
+
+        public FloodClientSettings GetClientSettings(FloodSettings settings)
+        {
+            var contentsRequest = BuildRequest(settings).Resource($"/client/settings").Build();
+
+            contentsRequest.Method = HttpMethod.Get;
+
+            return Json.Deserialize<FloodClientSettings>(HandleRequest(contentsRequest, settings).Content);
         }
     }
 }

--- a/src/NzbDrone.Core/Download/Clients/Flood/Types/FloodClientSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Flood/Types/FloodClientSettings.cs
@@ -1,0 +1,7 @@
+namespace NzbDrone.Core.Download.Clients.Flood.Types
+{
+    public class FloodClientSettings
+    {
+        public string DirectoryDefault { get; set; }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
If Destination is not set for flood, fallback to the default from the client for status checks

#### Todos
- [x] Tests