### PR TITLE
Set frontend `theme-color` to sidebar color

### DIFF
--- a/frontend/src/index.ejs
+++ b/frontend/src/index.ejs
@@ -6,8 +6,8 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
 
-    <!-- Chrome, Opera, and Firefox OS -->
-    <meta name="theme-color" content="#3a3f51" />
+    <!-- Chrome, Safari, Opera, and Firefox OS -->
+    <meta name="theme-color" content="#ffc230" />
     <!-- Windows Phone -->
     <meta name="msapplication-navbutton-color" content="#3a3f51" />
 

--- a/frontend/src/index.ejs
+++ b/frontend/src/index.ejs
@@ -7,7 +7,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
 
     <!-- Chrome, Safari, Opera, and Firefox OS -->
-    <meta name="theme-color" content="#ffc230" />
+    <meta name="theme-color" content="#595959" />
     <!-- Windows Phone -->
     <meta name="msapplication-navbutton-color" content="#3a3f51" />
 

--- a/frontend/src/login.html
+++ b/frontend/src/login.html
@@ -6,8 +6,8 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
 
-    <!-- Chrome, Opera, and Firefox OS -->
-    <meta name="theme-color" content="#ffc230" />
+    <!-- Chrome, Safari, Opera, and Firefox OS -->
+    <meta name="theme-color" content="#595959" />
     <!-- Windows Phone -->
     <meta name="msapplication-navbutton-color" content="#464b51" />
 

--- a/frontend/src/login.html
+++ b/frontend/src/login.html
@@ -7,7 +7,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
 
     <!-- Chrome, Opera, and Firefox OS -->
-    <meta name="theme-color" content="#464b51" />
+    <meta name="theme-color" content="#ffc230" />
     <!-- Windows Phone -->
     <meta name="msapplication-navbutton-color" content="#464b51" />
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Set `theme-color` to Radarr's web UI sidebar color, like Sonarr.

#### Screenshot (if UI related)

<!--- ![1F9D069B-B1F6-4BFE-8A5A-6AA4D7AC3289](https://user-images.githubusercontent.com/19761269/147900118-60e1b1d1-16ce-43c4-95a2-0b796e3a447a.png) --->

![image](https://user-images.githubusercontent.com/19761269/149988573-8eb958e0-3910-4f48-a116-322a2d3913c2.png)


#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX