### PR TITLE
New: Qbittorrent - Add Stale Download Handling Removal

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -155,6 +155,20 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
                 .Returns(files);
         }
 
+        private void GivenStalledPolicy(IEnumerable<QBittorrentTorrent> torrents)
+        {
+            foreach (var torrent in torrents)
+            {
+                Mocker.GetMock<IQBittorrentStalledPolicy>()
+                    .Setup(s => s.Apply(torrent, It.IsAny<DownloadClientItem>(), It.IsAny<QBittorrentSettings>()))
+                    .Callback<QBittorrentTorrent, DownloadClientItem, QBittorrentSettings>((torr, ditem, _) =>
+                    {
+                        ditem.Status = DownloadItemStatus.Warning;
+                        ditem.Message = $"{torr.Name} Processed by stale download policy";
+                    });
+            }
+        }
+
         [Test]
         public void error_item_should_have_required_properties()
         {
@@ -268,23 +282,29 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         }
 
         [Test]
-        public void stalledDL_item_should_have_required_properties()
+        public void stalledDL_item_should_have_properties_set_by_stale_policy()
         {
-            var torrent = new QBittorrentTorrent
+            var torrents = new List<QBittorrentTorrent>
             {
-                Hash = "HASH",
-                Name = _title,
-                Size = 1000,
-                Progress = 0.7,
-                Eta = 8640000,
-                State = "stalledDL",
-                Label = "",
-                SavePath = ""
+                new QBittorrentTorrent
+                {
+                    Hash = "HASH",
+                    Name = _title,
+                    Size = 1000,
+                    Progress = 0.7,
+                    Eta = 8640000,
+                    State = "stalledDL",
+                    Label = "",
+                    SavePath = "",
+                },
             };
-            GivenTorrents(new List<QBittorrentTorrent> { torrent });
+
+            GivenStalledPolicy(torrents);
+            GivenTorrents(torrents);
 
             var item = Subject.GetItems().Single();
             VerifyWarning(item);
+            item.Message.Should().Be("Droned.1998.1080p.WEB-DL-DRONE Processed by stale download policy");
             item.RemainingTime.Should().NotHaveValue();
         }
 

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/StalledTorrentPolicyFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/StalledTorrentPolicyFixture.cs
@@ -1,0 +1,107 @@
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Download.Clients.QBittorrent;
+
+namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests;
+
+[TestFixture]
+public sealed class StalledTorrentPolicyFixture
+{
+    private static readonly DateTime _defaultDateTime = new DateTime(year: 1991, month: 8, day: 25).ToUniversalTime();
+    private static readonly IDateTimeProvider _defaultProvider = new StubDateTimeProvider { Now = _defaultDateTime };
+
+    private static long ToUnixTimeStamp(DateTime datetime) => ((DateTimeOffset)datetime).ToUnixTimeSeconds();
+
+    [Test]
+    public void ShouldNotIntroduceSideEffectIfNotAStaleDownload()
+    {
+        var config = new QBittorrentSettings { RemoveStalledDownloads = true, };
+        var policy = new QBittorrentStalledPolicy(_defaultProvider);
+        var torrent = new QBittorrentTorrent { };
+        var item = new DownloadClientItem { Status = DownloadItemStatus.Downloading, Message = "placeholder" };
+
+        policy.Apply(torrent, item, config);
+
+        item.Status.Should().Be(DownloadItemStatus.Downloading);
+        item.Message.Should().Be("placeholder");
+    }
+
+    [Test]
+    public void ShouldDefaultIfStaleHandlingIsDisabledEvenIfAllOtherConditionsAreMet()
+    {
+        var queuedThresholdMins = 10;
+        var inactivityThresholdMins = 1;
+        var config = new QBittorrentSettings { RemoveStalledDownloads = false, StalledThreshold = queuedThresholdMins, StalledInactivityThreshold = inactivityThresholdMins };
+        var policy = new QBittorrentStalledPolicy(_defaultProvider);
+        var addedOn = ToUnixTimeStamp(_defaultDateTime - TimeSpan.FromMinutes(queuedThresholdMins) - TimeSpan.FromSeconds(1));
+        var lastActivity = ToUnixTimeStamp(_defaultDateTime - TimeSpan.FromMinutes(inactivityThresholdMins) - TimeSpan.FromSeconds(1));
+        var torrent = new QBittorrentTorrent { State = "stalledDL", AddedOn = addedOn, LastActivity = lastActivity };
+        var item = new DownloadClientItem { Status = DownloadItemStatus.Downloading, Message = "placeholder" };
+
+        policy.Apply(torrent, item, config);
+
+        item.Status.Should().Be(DownloadItemStatus.Warning);
+        item.Message.Should().Be("The download is stalled with no connections");
+    }
+
+    [Test]
+    public void ShouldNotMarkFailedIfNotQueuedLongEnoughEvenIfInactiveBeyondThreshold()
+    {
+        var queuedThresholdMins = 10;
+        var inactivityThresholdMins = 1;
+        var config = new QBittorrentSettings { RemoveStalledDownloads = true, StalledThreshold = queuedThresholdMins, StalledInactivityThreshold = inactivityThresholdMins };
+        var policy = new QBittorrentStalledPolicy(_defaultProvider);
+        var addedOn = ToUnixTimeStamp(_defaultDateTime - TimeSpan.FromMinutes(queuedThresholdMins));
+        var lastActivity = ToUnixTimeStamp(_defaultDateTime - TimeSpan.FromMinutes(queuedThresholdMins) - TimeSpan.FromSeconds(1));
+        var torrent = new QBittorrentTorrent { State = "stalledDL", AddedOn = addedOn, LastActivity = lastActivity };
+        var item = new DownloadClientItem { Status = DownloadItemStatus.Downloading, Message = "placeholder" };
+
+        policy.Apply(torrent, item, config);
+
+        item.Status.Should().Be(DownloadItemStatus.Warning);
+        item.Message.Should().Be("The download is stalled with no connections");
+    }
+
+    [Test]
+    public void ShouldNotMarkFailedIfQueuedLongEnoughButActiveRecentlyEnough()
+    {
+        var queuedThresholdMins = 10;
+        var inactivityThresholdMins = 5;
+        var config = new QBittorrentSettings { RemoveStalledDownloads = true, StalledThreshold = queuedThresholdMins, StalledInactivityThreshold = inactivityThresholdMins };
+        var policy = new QBittorrentStalledPolicy(_defaultProvider);
+        var addedOn = ToUnixTimeStamp(_defaultDateTime - TimeSpan.FromMinutes(queuedThresholdMins) - TimeSpan.FromSeconds(1));
+        var lastActivity = ToUnixTimeStamp(_defaultDateTime - TimeSpan.FromMinutes(inactivityThresholdMins));
+        var torrent = new QBittorrentTorrent { State = "stalledDL", AddedOn = addedOn, LastActivity = lastActivity };
+        var item = new DownloadClientItem { Status = DownloadItemStatus.Downloading, Message = "placeholder" };
+
+        policy.Apply(torrent, item, config);
+
+        item.Status.Should().Be(DownloadItemStatus.Warning);
+        item.Message.Should().Be("The download is stalled with no connections");
+    }
+
+    [Test]
+    public void ShouldMarkFailedIfQueuedLongEnoughAndNotActiveRecentlyEnough()
+    {
+        var queuedThresholdMins = 10;
+        var inactivityThresholdMins = 5;
+        var config = new QBittorrentSettings { RemoveStalledDownloads = true, StalledThreshold = queuedThresholdMins, StalledInactivityThreshold = inactivityThresholdMins };
+        var policy = new QBittorrentStalledPolicy(_defaultProvider);
+        var addedOn = ToUnixTimeStamp(_defaultDateTime - TimeSpan.FromMinutes(queuedThresholdMins) - TimeSpan.FromSeconds(1));
+        var lastActivity = ToUnixTimeStamp(_defaultDateTime - TimeSpan.FromMinutes(inactivityThresholdMins) - TimeSpan.FromSeconds(1));
+        var torrent = new QBittorrentTorrent { State = "stalledDL", AddedOn = addedOn, LastActivity = lastActivity };
+        var item = new DownloadClientItem { Status = DownloadItemStatus.Downloading, Message = "placeholder" };
+
+        policy.Apply(torrent, item, config);
+
+        item.Status.Should().Be(DownloadItemStatus.Failed);
+        item.Message.Should().Be("The download has been stalled with no activity long enough to be considered failed");
+    }
+
+    private sealed class StubDateTimeProvider : IDateTimeProvider
+    {
+        public DateTime Now { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -28,6 +28,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             Host = "localhost";
             Port = 8080;
             MovieCategory = "radarr";
+            StalledThreshold = 604800; // a week
+            StalledInactivityThreshold = 86400; // a day
         }
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox)]
@@ -68,6 +70,15 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
         [FieldDefinition(12, Label = "First and Last First", Type = FieldType.Checkbox, HelpText = "Download first and last pieces first (qBittorrent 4.1.0+)")]
         public bool FirstAndLast { get; set; }
+
+        [FieldDefinition(13, Label = "Remove stalled downloads", Type = FieldType.Checkbox, Advanced = true, HelpText = "Remove stalled downloads from the client. BEWARE: This could get you banned from trackers!")]
+        public bool RemoveStalledDownloads { get; set; }
+
+        [FieldDefinition(14, Label = "Stalled age threshold", Type = FieldType.Textbox, Advanced = true, Unit = "Minute", HelpText = "Age threshold before a stalled torrent is considered for deletion")]
+        public long StalledThreshold { get; set; }
+
+        [FieldDefinition(15, Label = "Stalled inactivity threshold", Type = FieldType.Textbox, Advanced = true, Unit = "Minute", HelpText = "Inactivity threshold before a stalled torrent is considered for deletion")]
+        public long StalledInactivityThreshold { get; set; }
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentStalledPolicy.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentStalledPolicy.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace NzbDrone.Core.Download.Clients.QBittorrent;
+
+public interface IQBittorrentStalledPolicy
+{
+    void Apply(QBittorrentTorrent torrent, DownloadClientItem ditem, QBittorrentSettings settings);
+}
+
+public interface IDateTimeProvider
+{
+    DateTime Now { get; }
+}
+
+internal sealed class DateTimeProvider : IDateTimeProvider
+{
+    public DateTime Now => DateTime.Now;
+}
+
+public sealed class QBittorrentStalledPolicy : IQBittorrentStalledPolicy
+{
+    private readonly IDateTimeProvider _dateTime;
+
+    public QBittorrentStalledPolicy(IDateTimeProvider dateTime)
+    {
+        _dateTime = dateTime;
+    }
+
+    public void Apply(QBittorrentTorrent torrent, DownloadClientItem ditem, QBittorrentSettings settings)
+    {
+        if (torrent.State != "stalledDL")
+        {
+            return;
+        }
+
+        if (this.ApplyPolicy(torrent, settings))
+        {
+            ditem.Status = DownloadItemStatus.Failed;
+            ditem.Message = "The download has been stalled with no activity long enough to be considered failed";
+            return;
+        }
+
+        ditem.Status = DownloadItemStatus.Warning;
+        ditem.Message = "The download is stalled with no connections";
+    }
+
+    private bool ApplyPolicy(QBittorrentTorrent torrent, QBittorrentSettings settings)
+        => settings.RemoveStalledDownloads
+        && HasBeenInQueueLongEnough(torrent, settings)
+        && HasNotBeenActive(torrent, settings);
+
+    private bool HasNotBeenActive(QBittorrentTorrent torrent, QBittorrentSettings settings)
+    {
+        var lastActivity = DateTimeOffset.FromUnixTimeSeconds(torrent.LastActivity).DateTime;
+        var threshold = TimeSpan.FromMinutes(settings.StalledInactivityThreshold);
+
+        return _dateTime.Now - lastActivity > threshold;
+    }
+
+    private bool HasBeenInQueueLongEnough(QBittorrentTorrent torrent, QBittorrentSettings settings)
+    {
+        var addedOn = DateTimeOffset.FromUnixTimeSeconds(torrent.AddedOn).DateTime;
+        var threshold = TimeSpan.FromMinutes(settings.StalledThreshold);
+
+        return _dateTime.Now - addedOn > threshold;
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentTorrent.cs
@@ -37,6 +37,12 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
         [JsonProperty(PropertyName = "seeding_time_limit")] // Per torrent seeding time limit (-2 = use global, -1 = unlimited)
         public long SeedingTimeLimit { get; set; } = -2;
+
+        [JsonProperty(PropertyName = "last_activity")]
+        public long LastActivity { get; set; }
+
+        [JsonProperty(PropertyName = "added_on")]
+        public long AddedOn { get; set; }
     }
 
     public class QBittorrentTorrentProperties


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add a feature to set QBittorrent downloads as failed if the client deems them stale AND a time based heuristic is met. The policy allows setting thresholds for the time since the torrent was added to the queue, and how long since its last moment of activity (up or down, according to QBT's API), i.e., _only consider this download failed once the downloader considers it stale, AND it has been in queue for t0 seconds, AND it has been inactive for t1 seconds_. The entire feature is behind a flag, hidden as advanced, and the user is warned that mishandling this setting might cause early abandoning of torrents.

#### Screenshot (if UI related)

![image](https://user-images.githubusercontent.com/3632440/149848143-a2d79a2a-43bd-476b-a08a-1d29d3ee4cd7.png)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com) -> PENDING REVIEW

#### Issues Fixed or Closed by this PR

* Fixes #5407