### PR TITLE
New: Add qBittorrent sequential order and first and last piece priority

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -157,6 +157,16 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 request.AddFormParameter("paused", true);
             }
 
+            if (settings.SequentialOrder)
+            {
+                request.AddFormParameter("sequentialDownload", true);
+            }
+
+            if (settings.FirstAndLast)
+            {
+                request.AddFormParameter("firstLastPiecePrio", true);
+            }
+
             if (seedConfiguration != null)
             {
                 AddTorrentSeedingFormParameters(request, seedConfiguration);
@@ -190,6 +200,16 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             else if ((QBittorrentState)settings.InitialState == QBittorrentState.Pause)
             {
                 request.AddFormParameter("paused", true);
+            }
+
+            if (settings.SequentialOrder)
+            {
+                request.AddFormParameter("sequentialDownload", true);
+            }
+
+            if (settings.FirstAndLast)
+            {
+                request.AddFormParameter("firstLastPiecePrio", true);
             }
 
             if (seedConfiguration != null)

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -63,6 +63,12 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         [FieldDefinition(10, Label = "Initial State", Type = FieldType.Select, SelectOptions = typeof(QBittorrentState), HelpText = "Initial state for torrents added to qBittorrent")]
         public int InitialState { get; set; }
 
+        [FieldDefinition(11, Label = "Sequential Order", Type = FieldType.Checkbox, HelpText = "Download in sequential order (qBittorrent 4.1.0+)")]
+        public bool SequentialOrder { get; set; }
+
+        [FieldDefinition(11, Label = "First and Last First", Type = FieldType.Checkbox, HelpText = "Download first and last pieces first (qBittorrent 4.1.0+)")]
+        public bool FirstAndLast { get; set; }
+
         public NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));


### PR DESCRIPTION
#### Database Migration
NO

#### Description

This PR adds two settings to the download client qBittorrent: download in sequential order and prioritise first and last pieces. 

Those settings were introduced in the qBittorrent API in [4.0.0](https://github.com/qbittorrent/qBittorrent/commit/a0dbb6c97cb8ef9cc760bbf4a8cd0626751c8e77) but until api v2 (4.1.0) they only work if the form is submitted as a `form-data` and not as a `x-www-form-urlencoded` (couldn't find the reason why but their doc says to use `form-data` after qBittorrent 3.3.1 and the tests I did showed this). As earlier versions of the qBittorrent API are only compatible with `x-www-form-urlencoded` and as I don't want to introduce changes to the `HttpRequestBuilder` to change the `ContentType`, this is only available for qBittorrent 4.1.0+.

This change has been tested on qBittorrent 4.1.0 (earliest version compatible with the change) and 4.3.9 (latest version).

#### Screenshot (if UI related)

![image](https://user-images.githubusercontent.com/2262141/150651465-cd1473ef-6463-47ef-917c-e7ebc78845b7.png)

#### Todos
- [x] Tests -> None needed
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) -> None needed
- [x] [Wiki Updates](https://wiki.servarr.com) -> None needed

#### Issues Fixed or Closed by this PR