### PR TITLE
Fixed: Webhook fails due to Frames/Analysis property serialization on MediaInfoModel

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 using FFMpegCore;
 using NzbDrone.Core.Datastore;
 
@@ -11,12 +10,6 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         public string RawStreamData { get; set; }
         public string RawFrameData { get; set; }
         public int SchemaRevision { get; set; }
-
-        [JsonIgnore]
-        public IMediaAnalysis Analysis => FFProbe.Analyse(RawStreamData);
-
-        [JsonIgnore]
-        public IMediaAnalysis Frames => FFProbe.Analyse(RawFrameData);
 
         public string ContainerFormat { get; set; }
         public string VideoFormat { get; set; }

--- a/src/NzbDrone.Core/Notifications/Notifiarr/NotifiarrProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Notifiarr/NotifiarrProxy.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.Collections.Specialized;
 using System.Net;
 using FluentValidation.Results;
 using NLog;
-using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Http;
 
 namespace NzbDrone.Core.Notifications.Notifiarr

--- a/src/NzbDrone.Core/Radarr.Core.csproj
+++ b/src/NzbDrone.Core/Radarr.Core.csproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="MailKit" Version="2.15.0" />
+    <PackageReference Include="Servarr.FFMpegCore" Version="4.5.0-25" />
     <PackageReference Include="Servarr.FFprobe" Version="4.4.1.63" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
@@ -19,7 +20,6 @@
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
     <PackageReference Include="MonoTorrent" Version="2.0.1" />
-    <PackageReference Include="FFMpegCore" Version="4.6.16" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Radarr.Common.csproj" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
These two properties make incorrect use of FFProbe.Analyse() method by passing in Stream as a string thus when serialization happens from Webhook, they fail. They are also not ignored because webhook serialization uses Newtonsoft and they are using STJson ignore attributes.

Given properties are not used, easy fix for 4.0 is to remove them. switching webhook to serialize with STJson may be dangerous for master at this point.
