### PR TITLE
Fix Ukrainian language mappings

### DIFF
--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -102,7 +102,7 @@ namespace NzbDrone.Core.Languages
         public static Language Bulgarian => new Language(29, "Bulgarian");
         public static Language PortugueseBR => new Language(30, "Portuguese (Brazil)");
         public static Language Arabic => new Language(31, "Arabic");
-        public static Language Ukrainian => new Language(32, "Unkrainian");
+        public static Language Ukrainian => new Language(32, "Ukrainian");
         public static Language Persian => new Language(33, "Persian");
         public static Language Bengali => new Language(34, "Bengali");
         public static Language Any => new Language(-1, "Any");

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Parser
                                                                new IsoLanguage("ro", "", "ron", "Romanian", Language.Romanian),
                                                                new IsoLanguage("pt", "br", "", "Portuguese (Brazil)", Language.PortugueseBR),
                                                                new IsoLanguage("ar", "", "ara", "Arabic", Language.Arabic),
-                                                               new IsoLanguage("uk", "", "uar", "Ukrainian", Language.Ukrainian),
+                                                               new IsoLanguage("uk", "", "ukr", "Ukrainian", Language.Ukrainian),
                                                                new IsoLanguage("fa", "", "fas", "Persian", Language.Persian),
                                                                new IsoLanguage("be", "", "ben", "Bengali", Language.Bengali)
                                                            };


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix the name of the Ukrainian language in the UI.
Also, fix the 3-letter ISO language mapping to correctly parse filenames with [UKR] suffix.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX