### PR TITLE
Parser improvements for German Scene

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/EditionParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/EditionParserFixture.cs
@@ -42,6 +42,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Fake Movie 2016 Final Cut ", "Final Cut")]
         [TestCase("My Movie GERMAN Extended Cut 2016", "Extended Cut")]
         [TestCase("My.Movie.GERMAN.Extended.Cut.2016", "Extended Cut")]
+        [TestCase("My.Movie.Extended.Cut.GERMAN.2016", "Extended Cut")]
         [TestCase("My.Movie.GERMAN.Extended.Cut", "Extended Cut")]
         [TestCase("My.Movie.Assembly.Cut.1992.REPACK.1080p.BluRay.DD5.1.x264-Group", "Assembly Cut")]
         [TestCase("Movie.1987.Ultimate.Hunter.Edition.DTS-HD.DTS.MULTISUBS.1080p.BluRay.x264.HQ-TUSAHD", "Ultimate Hunter Edition")]

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -125,6 +125,17 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Die.fantastische.Reise.des.Dr.Dolittle.2020.German.DL.LD.1080p.WEBRip.x264-PRD", "Die fantastische Reise des Dr. Dolittle", "", 2020, Description = "dot after dr")]
         [TestCase("Der.Film.deines.Lebens.German.2011.PAL.DVDR-ETM", "Der Film deines Lebens", "", 2011, Description = "year at wrong position")]
         [TestCase("Kick.Ass.2.2013.German.DTS.DL.720p.BluRay.x264-Pate_", "Kick Ass 2", "", 2013, Description = "underscore at the end")]
+
+        // German in the title
+        [TestCase("The.Good.German.2006.GERMAN.720p.HDTV.x264-TVP", "The Good German", "", 2006)]
+        [TestCase("The.Good.German.German.2006.DVDRiP.SVCD-ATS", "The Good German", "", 2006)]
+        [TestCase("The.German.German.2006.DVDRiP.SVCD-ATS", "The German", "", 2006)]
+        [TestCase("The.German.2006.DVDRiP.SVCD-ATS", "The German", "", 2006)]
+        [TestCase("The.German.Doctor.2013.LIMITED.DVDRip.x264-RedBlade", "The German Doctor", "", 2013, Description = "German in the middle of the title")]
+        [TestCase("Movie.Title.German.2019.GERMAN.720p.BluRay.x264-UNiVERSUM", "Movie Title German", "", 2019)]
+        [TestCase("Movie.Title.German.GERMAN.2019.720p.BluRay.x264-UNiVERSUM", "Movie Title German", "", 2019)]
+        [TestCase("Movie.Title.on.German.DVD.2006.720p.HDTV.x264-TVP", "Movie Title on German DVD", "", 2006, Description = "should not match german before DVD when there comes a year afterwards")]
+        [TestCase("Movie.Title.German.PAL.DVDR-ETM", "Movie Title", "", 0, Description = "should match German without year but followed by scene word")]
         public void should_parse_german_movie(string postTitle, string title, string edition, int year)
         {
             ParsedMovieInfo movie = Parser.Parser.ParseMovieTitle(postTitle);
@@ -231,6 +242,11 @@ namespace NzbDrone.Core.Test.ParserTests
 
         [TestCase("The.Italian.Movie.2025.720p.BluRay.X264-AMIABLE")]
         [TestCase("The.French.Movie.2013.720p.BluRay.x264 - ROUGH[PublicHD]")]
+        [TestCase("Wakolda.German.Subbed.2013.AC3.DVDRiP.x264-ETM")]
+        [TestCase("The.German.Doctor.2013.LIMITED.DVDRip.x264-RedBlade")] // When German is not followed by a year or a SCENE word it is not matched
+        [TestCase("The.Good.German.2006.720p.HDTV.x264-TVP")] // The Good German is hardcoded not to match
+        [TestCase("German.Lancers.2019.720p.BluRay.x264-UNiVERSUM")] // German at the beginning is never matched
+        [TestCase("The.German.2019.720p.BluRay.x264-UNiVERSUM")] // The German is hardcoded not to match
         public void should_not_parse_wrong_language_in_title(string postTitle)
         {
             var parsed = Parser.Parser.ParseMovieTitle(postTitle, true);

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -23,7 +23,9 @@ namespace NzbDrone.Core.Test.ParserTests
          * Superman.-.The.Man.of.Steel.1994-06.34.hybrid.DreamGirl-Novus-HD
          * Superman.-.The.Man.of.Steel.1994-05.33.hybrid.DreamGirl-Novus-HD
          * Constantine S1-E1-WEB-DL-1080p-NZBgeek
-         * [TestCase("Valana la Movie FRENCH BluRay 720p 2016 kjhlj", "Valana la Movie")]  Removed 2021-12-19 as this / the regex for this was breaking all movies w/ french in title
+         * Valana la Movie FRENCH BluRay 720p 2016 kjhlj
+         * Valana la Movie TRUEFRENCH BluRay 720p 2016 kjhlj
+         * Der.Movie.James.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998
          */
 
         [Test]
@@ -49,9 +51,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("www.5MovieRulz.tc - Movie (2000) Malayalam HQ HDRip - x264 - AAC - 700MB.mkv", "Movie")]
         [TestCase("Movie: The Movie World 2013", "Movie: The Movie World")]
         [TestCase("Movie.The.Final.Chapter.2016", "Movie The Final Chapter")]
-        [TestCase("Der.Movie.James.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998", "Der Movie James")]
         [TestCase("Movie.German.DL.AC3.Dubbed..BluRay.x264-PsO", "Movie")]
-        [TestCase("Valana la Movie TRUEFRENCH BluRay 720p 2016 kjhlj", "Valana la Movie")]
         [TestCase("Mission Movie: Rogue Movie (2015)�[XviD - Ita Ac3 - SoftSub Ita]azione, spionaggio, thriller *Prima Visione* Team mulnic Tom Cruise", "Mission Movie: Rogue Movie")]
         [TestCase("Movie.Movie.2000.FRENCH..BluRay.-AiRLiNE", "Movie Movie")]
         [TestCase("My Movie 1999 German Bluray", "My Movie")]
@@ -114,7 +114,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie.Klasse.von.1999.1990.German.720p.HDTV.x264-NORETAiL", "Movie Klasse von 1999", "", 1990, Description = "year in the title")]
         [TestCase("Movie.Squad.2016.EXTENDED.German.DL.AC3.BDRip.x264-hqc", "Movie Squad", "EXTENDED", 2016, Description = "edition after year")]
         [TestCase("Movie.and.Movie.2010.Extended.Cut.German.DTS.DL.720p.BluRay.x264-HDS", "Movie and Movie", "Extended Cut", 2010, Description = "edition after year")]
-        [TestCase("Der.Movie.James.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998", "Der Movie James", "", 1998, Description = "year at the end")]
+
         [TestCase("Der.Movie.Eine.Unerwartete.Reise.Extended.German.720p.BluRay.x264-EXQUiSiTE", "Der Movie Eine Unerwartete Reise", "Extended", 0, Description = "no year & edition")]
         [TestCase("Movie.Weg.des.Kriegers.EXTENDED.German.720p.BluRay.x264-EXQUiSiTE", "Movie Weg des Kriegers", "EXTENDED", 0, Description = "no year & edition")]
         [TestCase("Die.Unfassbaren.Movie.Name.EXTENDED.German.DTS.720p.BluRay.x264-RHD", "Die Unfassbaren Movie Name", "EXTENDED", 0, Description = "no year & edition")]
@@ -243,10 +243,10 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("The.Italian.Movie.2025.720p.BluRay.X264-AMIABLE")]
         [TestCase("The.French.Movie.2013.720p.BluRay.x264 - ROUGH[PublicHD]")]
         [TestCase("Wakolda.German.Subbed.2013.AC3.DVDRiP.x264-ETM")]
-        [TestCase("The.German.Doctor.2013.LIMITED.DVDRip.x264-RedBlade")] // When German is not followed by a year or a SCENE word it is not matched
-        [TestCase("The.Good.German.2006.720p.HDTV.x264-TVP")] // The Good German is hardcoded not to match
-        [TestCase("German.Lancers.2019.720p.BluRay.x264-UNiVERSUM")] // German at the beginning is never matched
-        [TestCase("The.German.2019.720p.BluRay.x264-UNiVERSUM")] // The German is hardcoded not to match
+        [TestCase("The.German.Doctor.2013.LIMITED.DVDRip.x264-RedBlade", Description = "When German is not followed by a year or a SCENE word it is not matched")]
+        [TestCase("The.Good.German.2006.720p.HDTV.x264-TVP", Description = "The Good German is hardcoded not to match")]
+        [TestCase("German.Lancers.2019.720p.BluRay.x264-UNiVERSUM", Description = "German at the beginning is never matched")]
+        [TestCase("The.German.2019.720p.BluRay.x264-UNiVERSUM", Description = "The German is hardcoded not to match")]
         public void should_not_parse_wrong_language_in_title(string postTitle)
         {
             var parsed = Parser.Parser.ParseMovieTitle(postTitle, true);

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/AugmentersTests/AugmentWithHistoryFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/AugmentersTests/AugmentWithHistoryFixture.cs
@@ -99,6 +99,19 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests.AugmentersTests
         }
 
         [Test]
+        public void should_use_settings_languages_when_necessary_for_german_dual_language_releases()
+        {
+            var history = HistoryWithData("IndexerId", 1.ToString());
+
+            var movieInfo = Subject.AugmentMovieInfo(MovieInfo, history);
+            movieInfo.Languages.Should().BeEquivalentTo();
+
+            MovieInfo.SimpleReleaseTitle = "A Movie 1998 German DL Bluray 1080p";
+            var multiInfo = Subject.AugmentMovieInfo(MovieInfo, history);
+            multiInfo.Languages.Should().BeEquivalentTo(Language.English, Language.French);
+        }
+
+        [Test]
         public void should_not_use_settings_languages()
         {
             var unknownIndexer = HistoryWithData();

--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -161,6 +161,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("[HorribleSubs] Movie Title! 2018 [Web][MKV][h264][AAC 2.0][Softsubs (HorribleSubs)]", false)]
         [TestCase("Movie.Title.2013.960p.WEB-DL.AAC2.0.H.264-squalor", false)]
         [TestCase("Movie.Title.2021.DP.WEB.720p.DDP.5.1.H.264.PLEX", false)]
+        [TestCase("Movie.Title.REPACK.German.DD20.Dubbed.DL.720p.iTunesHD.AVC-TVS", true)]
         public void should_parse_webdl720p_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Source.WEBDL, proper, Resolution.R720p);
@@ -319,6 +320,11 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie.Title.II.2003.4K.BluRay.Remux.1080p.AVC.DTS-HD.MA.5.1-BMF")]
         [TestCase("Movie Title 2022 (BDRemux 1080p HEVC FLAC) [Netaro]")]
         [TestCase("[Vodes] Movie Title - Other Title (2020) [BDRemux 1080p HEVC Dual-Audio]")]
+        [TestCase("Movie.Title.2021.German.DL.1080p.BluRay.AVC-UNTAVC")]
+        [TestCase("German.Only.Movie.2021.German.1080p.BluRay.AVC-UNTAVC")]
+        [TestCase("German.Only.Movie.2021.Ger.1080p.BluRay.AVC-UNTAVC")]
+        [TestCase("Movie.Title.1998.German.DL.1080p.BluRay.VC1-SAViOURHD")]
+        [TestCase("Movie.Title.1999.German.1080p.DL.AC3.BluRay.VC-1.Remux-pmHD")]
         public void should_parse_remux1080p_quality(string title)
         {
             ParseAndVerifyQuality(title, Source.BLURAY, false, Resolution.R1080p, Modifier.REMUX);
@@ -331,6 +337,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("[Dolby Vision] Movie.Title.S07.MULTi.UHD.BLURAY.REMUX.DV-NoTag")]
         [TestCase("Movie.Name.2020.German.UHDBD.2160p.HDR10.HEVC.EAC3.DL.Remux-pmHD.mkv")]
         [TestCase("Movie Name (2021) [Remux-2160p x265 HDR 10-BIT DTS-HD MA 7.1]-FraMeSToR.mkv")]
+        [TestCase("Movie.Title.2021.German.DL.2160p.UHD.BluRay.HEVC-GMA")]
         public void should_parse_remux2160p_quality(string title)
         {
             ParseAndVerifyQuality(title, Source.BLURAY, false, Resolution.R2160p, Modifier.REMUX);

--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -349,6 +349,16 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie Name.1993..BD25.ISO")]
         [TestCase("Movie.Title.2012.Bluray.1080p.3D.AVC.DTS-HD.MA.5.1.iso")]
         [TestCase("Movie.Title.1996.Bluray.ISO")]
+        [TestCase("Movie Title 2005 1080p USA Blu-ray AVC DTS-HD MA 5.1-PTP")]
+        [TestCase("Movie Title 2014 1080p Blu-ray AVC DTS-HD MA 5.1-PTP")]
+        [TestCase("Movie Title 1976 2160p UHD Blu-ray DTS-HD MA 5.1 DV HDR HEVC-UNTOUCHED")]
+        [TestCase("Movie Title 2004 1080p FRA Blu-ray VC-1 TrueHD 5.1-HDBEE")]
+        [TestCase("BD25.Movie.Title.1994.1080p.DTS-HD")]
+        [TestCase("Movie.Title.1997.1080p.NL.BD-50")]
+        [TestCase("Movie Title 2009 3D BD 2009 UNTOUCHED")]
+        [TestCase("Movie.Title.1982.1080p.HD.DVD.VC-1.DD+.5.1")]
+        [TestCase("Movie.Title.2007.1080p.HD.DVD.DD+.AVC")]
+        [TestCase("Movie.Title.2008.1080i.XXX.Blu-ray.MPEG-2.LPCM2.0.ISO Passworded Rar Archive")]
         public void should_parse_brdisk_1080p_quality(string title)
         {
             ParseAndVerifyQuality(title, Source.BLURAY, false, Resolution.R1080p, Modifier.BRDISK);

--- a/src/NzbDrone.Core/Parser/Augmenters/AugmentWithReleaseInfo.cs
+++ b/src/NzbDrone.Core/Parser/Augmenters/AugmentWithReleaseInfo.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Languages;
@@ -41,7 +42,9 @@ namespace NzbDrone.Core.Parser.Augmenters
                 var languageTitle = movieInfo.SimpleReleaseTitle;
                 if (movieInfo.PrimaryMovieTitle.IsNotNullOrWhiteSpace())
                 {
-                    if (languageTitle.ToLower().Contains("multi") && indexerSettings?.MultiLanguages?.Any() == true)
+                    if ((languageTitle.ToLower().Contains("multi") ||
+                         (languageTitle.ToLower().Contains("german") && new Regex(@"\bDL\b").IsMatch(languageTitle))) &&
+                        indexerSettings?.MultiLanguages?.Any() == true)
                     {
                         foreach (var i in indexerSettings.MultiLanguages)
                         {

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -34,8 +34,9 @@ namespace NzbDrone.Core.Parser
             // Anime [Subgroup] no year, info in parentheses or brackets, hash
             new Regex(@"^(?:\[(?<subgroup>.+?)\][-_. ]?)(?<title>(?![(\[]).+)(?:[\[(][^])]).*?(?<hash>\[\w{8}\])(?:$|\.)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-            // Some german or french tracker formats (missing year, ...) (Only applies to german and TrueFrench releases) - see ParserFixture for examples and tests - french removed as it broke all movies w/ french titles
-            new Regex(@"^(?<title>(?![(\[]).+?)((\W|_))(" + EditionRegex + @".{1,3})?(?:(?<!(19|20)\d{2}.*?)(German|TrueFrench))(.+?)(?=((19|20)\d{2}|$))(?<year>(19|20)\d{2}(?!p|i|\d+|\]|\W\d+))?(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            // Some german or french tracker formats (language tag before year or before common scene word, missing year) (Only applies to german, french and TrueFrench releases) - needs to be very strict to avoid false positives - see ParserFixture for examples and tests
+            new Regex(@"^(?<title>(?![(\[]).+?)((\W|_))(" + EditionRegex +
+                      @".{1,3})?(?:(?<!(19|20)\d{2}.*?|((The([-_. ]Good)?)|La|Aleksei)[-_. ])(German|French|TrueFrench))(?!.*?(German|French|TrueFrench|[-_. ].+?(19|20)\d{2}))[-_. ](?=((19|20)\d{2}|$|(DL|BluRay|WEB|WebHD|WebRip|720p|1080p|2160p|E?AC3D?|Subbed|DTS(-HD)?|COMPLETE|DVDR|HDTV|HDTVRip|PAL|DVD9|ML|MULTi|READNFO|UHD|BDRIP|DOKU|DD|SUBBED|DUBBED|DV|INTERNAL|iNT|BDRiP|HEVC|AVC|3D|DVD|S?VCD|DVDRiP|TS|LD|CAM|" + EditionRegex + @")))(?<year>(19|20)\d{2})?(.*?)(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
             // Special, Despecialized, etc. Edition Movies, e.g: Mission.Impossible.3.Special.Edition.2011
             new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*" + EditionRegex + @".{1,3}(?<year>(1(8|9)|20)\d{2}(?!p|i|\d+|\]|\W\d+)))+(\W+|_|$)(?!\\)",

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -111,7 +111,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex ReportImdbId = new Regex(@"(?<imdbid>tt\d{7,8})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex ReportTmdbId = new Regex(@"tmdb(id)?-(?<tmdbid>\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly RegexReplace SimpleTitleRegex = new RegexReplace(@"(?:(480|540|576|720|1080|2160)[ip]|[xh][\W_]?26[45]|DD\W?5\W1|[<>?*]|848x480|1280x720|1920x1080|3840x2160|4096x2160|(8|10)b(it)?|10-bit)\s*?(?![a-b0-9])",
+        private static readonly RegexReplace SimpleTitleRegex = new RegexReplace(@"[-_.\s](?:(480|540|576|720|1080|2160)[ip]|[xh][\W_]?26[45]|DD\W?5\W1|[<>?*]|848x480|1280x720|1920x1080|3840x2160|4096x2160|(8|10)b(it)?|10-bit)[-_.\s]*?(?![a-b0-9])",
                                                                 string.Empty,
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex MPEG2Regex = new Regex(@"\b(?<mpeg2>MPEG[-_. ]?2)\b");
 
-        private static readonly Regex BRDISKRegex = new Regex(@"\b(COMPLETE|ISO|BDISO|BD25|BD50|BR.?DISK)\b",
+        private static readonly Regex BRDISKRegex = new Regex(@"^(?!.*((?<!HD[._ -]|HD)DVD|BDRip|720p|MKV|XviD|WMV|REMUX|[xh][-_. ]?26[45]|\b(German|videomann|ger[. ]dub)\b))(((?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)\b)(?=.*\b(ISO|AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\b))|^((?=.*\b(^((?=.*COMPLETE)(?=.*Blu[-_. ]?ray|HD[-_. ]?DVD))|3D[-_. ]?BD|BR[-_. ]?DISK|BDISO|^((?=.*((BD|UHD)[-_. ]?(25|50|66)))(?=.*ISO)?)))))",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex ProperRegex = new Regex(@"\b(?<proper>proper)\b",

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -74,6 +74,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex HighDefPdtvRegex = new Regex(@"hr[-_. ]ws", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex RemuxRegex = new Regex(@"(?:[_. \[]|\d{4}p-)(?<remux>(?:(BD|UHD)[-_. ]?)?Remux)\b|(?<remux>(?:(BD|UHD)[-_. ]?)?Remux[_. ]\d{4}p)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex GermanRemuxRegex = new Regex(@"^(?=.*\b(German|videomann|ger[. ]dub)\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)\b)(?=.*\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2))", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex HardcodedSubsRegex = new Regex(@"\b((?<hcsub>(\w+(?<!SOFT|HORRIBLE)SUBS?))|(?<hc>(HC|SUBBED)))\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
@@ -128,7 +129,7 @@ namespace NzbDrone.Core.Parser
             var sourceMatch = sourceMatches.OfType<Match>().LastOrDefault();
             var resolution = ParseResolution(normalizedName);
             var codecRegex = CodecRegex.Match(normalizedName);
-            var remuxMatch = RemuxRegex.IsMatch(normalizedName);
+            var remuxMatch = RemuxRegex.IsMatch(normalizedName) || GermanRemuxRegex.IsMatch(normalizedName);
             var brDiskMatch = BRDISKRegex.IsMatch(normalizedName);
 
             if (RawHDRegex.IsMatch(normalizedName) && !brDiskMatch)


### PR DESCRIPTION
#### Database Migration
NO

#### Description

- Parse [UHD2BD](https://www.xrel.to/p2p/releases.html?search_results=5enI4xfOXR114028624&query=UHD2BD&maxed_out=0) as BluRay instead of HDTV
- Parsing of German Scene REMUX releases. This would be important for Germans, they have other [scene rules](https://scenerules.org/t.html?id=2016_DE_AVC.nfo). Without this, it's a lot of testing and searching for custom formats to make this work correctly, and newbies don't have enough knowledge to tell the difference between the releases, when they are all listed as BluRay-1080p. Radarr should correctly parse them out of the box.
#6307
I took the regex from the issue, but adjusted it to parse also German Remuxes without DL in the release title.

- Fixes remaining periods (or multiple spaces) when filtering SimpleReleaseTitle.
The SimpleReleaseTitle is used when parsing the title, year, episodes, ...
If there are 2 or more points in the title, this may cause unexpected results and makes it harder to debug.
Before the fix: The.Move.Title.Extended.German..BluRay.-RlsGrp
After the fix: The.Move.Title.Extended.German.BluRay-RlsGrp

- Correctly parse SCENE and P2P BluRay DISKS releases
#6307
Again, I took the regex from the issue and adjusted it to pass the tests that were already there.
It should work now and already have been tested with custom formats, but please have a look at it again.

- At last, I improved parsing of the release when the word "german", "french" or "truefrench" is in the title. It should further avoid false positives to close #6474
Whats new: when there is no year, it now only matches the word german when it is before a common scene word (BluRay, DL, HDTV, ...). It is also not matched, when the title starts with "German" or "German" is in the middle of the title.
The Only problematic titles left are the ones that end in "German", but I got all titles from themoviedb when you search for german, and there were only 3 titles with german at the end:
`The.German`
`Herman.the.German`
`Aleksei.German`
I manually excluded them in the regex, so we don't parse the language as German.
.
I just had to exclude the following tests, because they are not strict enough and could cause false positives for the english releases:
`Valana la Movie TRUEFRENCH BluRay 720p 2016 kjhlj`
`Der.Movie.James.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998`
I haven't found any releases in the format of the TRUEFRENCH one on my trackers/indexers and on predb. I hope we can exclude this test, otherwise it may become difficult or quite impossible. If someone of you has a better idea, please let me know.
For sure we can exclude the German Pso one, I [can't find any release in that format](https://www.xrel.to/group-PsO-release-list.html). It just makes things complicated, even if there are no releases in that format.

@Qstick, please have a look at it :)


#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #6307
* Fixes #6474