### PR TITLE
PWA missing name

### DIFF
--- a/frontend/src/Content/Images/Icons/manifest.json
+++ b/frontend/src/Content/Images/Icons/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "",
+    "name": "Radarr",
     "icons": [
         {
             "src": "/Content/Images/Icons/android-chrome-192x192.png",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When you install Radarr as a PWA (i.e. using "Add to Home Screen" in Firefox for Android), it has the correct icon but the generic name "Website" since the manifest name field is null. [The name field is mandatory](https://developer.mozilla.org/en-US/docs/Web/Manifest/name).

#### Screenshot (if UI related)

See how Nzbget has the correct name, but Sonarr and Radarr do not.
![Screenshot_20220215-142250](https://user-images.githubusercontent.com/1984514/154159902-097b8cb1-0976-4580-935a-f45f53a579ad.png)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX