### PR TITLE
Fixed: Remove pre-DB from frontend storage

### DIFF
--- a/frontend/src/Store/Migrators/migrate.js
+++ b/frontend/src/Store/Migrators/migrate.js
@@ -1,5 +1,7 @@
 import migrateBlacklistToBlocklist from './migrateBlacklistToBlocklist';
+import migratePreDbToReleased from './migratePreDbToReleased';
 
 export default function migrate(persistedState) {
   migrateBlacklistToBlocklist(persistedState);
+  migratePreDbToReleased(persistedState);
 }

--- a/frontend/src/Store/Migrators/migratePreDbToReleased.js
+++ b/frontend/src/Store/Migrators/migratePreDbToReleased.js
@@ -1,0 +1,18 @@
+import get from 'lodash';
+
+export default function migratePreDbToReleased(persistedState) {
+  const addMovie = get(persistedState, 'addMovie.defaults.minimumAvailability');
+  const discoverMovie = get(persistedState, 'discoverMovie.defaults.minimumAvailability');
+
+  if (!addMovie && !discoverMovie) {
+    return;
+  }
+
+  if (addMovie === 'preDB') {
+    persistedState.addMovie.defaults.minimumAvailability = 'released';
+  }
+
+  if (discoverMovie === 'preDB') {
+    persistedState.discoverMovie.defaults.minimumAvailability = 'released';
+  }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Expands on https://github.com/Radarr/Radarr/commit/4d2a311e40d84ba6bf55130bfb6552a797912616 to remove the pre-DB option from cached settings in the frontend