### PR TITLE
Fixed: Updater showing version being updated from on non-windows platforms

### DIFF
--- a/src/NzbDrone.Update/UpdateEngine/DetectExistingVersion.cs
+++ b/src/NzbDrone.Update/UpdateEngine/DetectExistingVersion.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using NLog;
+using NzbDrone.Common.EnvironmentInfo;
+using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Update.UpdateEngine
 {
@@ -22,7 +24,7 @@ namespace NzbDrone.Update.UpdateEngine
         {
             try
             {
-                var targetExecutable = Path.Combine(targetFolder, "Radarr.exe");
+                var targetExecutable = Path.Combine(targetFolder, BuildInfo.AppName.ProcessNameToExe());
 
                 if (File.Exists(targetExecutable))
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes the "unknown" version on non-windows platform - this is caused by the migration to .NET and not using mono on non-windows platforms

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #7098 