### PR TITLE
Fixed: Postgres timezone issues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -577,6 +577,7 @@ stages:
           -e POSTGRES_PASSWORD=radarr \
           -e POSTGRES_USER=radarr \
           -p 5432:5432/tcp \
+          -v /usr/share/zoneinfo/America/Chicago:/etc/localtime:ro \
           postgres:14
         displayName: Start postgres
       - bash: |
@@ -722,6 +723,7 @@ stages:
             -e POSTGRES_PASSWORD=radarr \
             -e POSTGRES_USER=radarr \
             -p 5432:5432/tcp \
+            -v /usr/share/zoneinfo/America/Chicago:/etc/localtime:ro \
             postgres:14
           displayName: Start postgres
         - bash: |

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -8,5 +8,6 @@
     <add key="SQLite" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/SQLite/nuget/v3/index.json" />
     <add key="coverlet-nightly" value="https://pkgs.dev.azure.com/Servarr/coverlet/_packaging/coverlet-nightly/nuget/v3/index.json" />
     <add key="FFMpegCore" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/FFMpegCore/nuget/v3/index.json" />
+    <add key="FluentMigrator" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/FluentMigrator/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/NzbDrone.Core.Test/Datastore/DatabaseFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/DatabaseFixture.cs
@@ -28,6 +28,20 @@ namespace NzbDrone.Core.Test.Datastore
         }
 
         [Test]
+        public void postgres_should_not_contain_timestamp_without_timezone_columns()
+        {
+            if (Db.DatabaseType != DatabaseType.PostgreSQL)
+            {
+                return;
+            }
+
+            Mocker.Resolve<IDatabase>()
+                .OpenConnection().Query("SELECT table_name, column_name, data_type FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = 'public' AND data_type = 'timestamp without time zone'")
+                .Should()
+                .BeNullOrEmpty();
+        }
+
+        [Test]
         public void get_version()
         {
             Mocker.Resolve<IDatabase>().Version.Should().BeGreaterThan(new Version("3.0.0"));

--- a/src/NzbDrone.Core/Datastore/Migration/212_postgres_update_timestamp_columns_to_with_timezone.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/212_postgres_update_timestamp_columns_to_with_timezone.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(212)]
+    public class postgres_update_timestamp_columns_to_with_timezone : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Blocklist").AlterColumn("Date").AsDateTimeOffset().NotNullable();
+            Alter.Table("Blocklist").AlterColumn("PublishedDate").AsDateTimeOffset().Nullable();
+            Alter.Table("Collections").AlterColumn("Added").AsDateTimeOffset().Nullable();
+            Alter.Table("Collections").AlterColumn("LastInfoSync").AsDateTimeOffset().Nullable();
+            Alter.Table("Commands").AlterColumn("QueuedAt").AsDateTimeOffset().NotNullable();
+            Alter.Table("Commands").AlterColumn("StartedAt").AsDateTimeOffset().Nullable();
+            Alter.Table("Commands").AlterColumn("EndedAt").AsDateTimeOffset().Nullable();
+            Alter.Table("DownloadClientStatus").AlterColumn("InitialFailure").AsDateTimeOffset().Nullable();
+            Alter.Table("DownloadClientStatus").AlterColumn("MostRecentFailure").AsDateTimeOffset().Nullable();
+            Alter.Table("DownloadClientStatus").AlterColumn("DisabledTill").AsDateTimeOffset().Nullable();
+            Alter.Table("DownloadHistory").AlterColumn("Date").AsDateTimeOffset().NotNullable();
+            Alter.Table("ExtraFiles").AlterColumn("Added").AsDateTimeOffset().NotNullable();
+            Alter.Table("ExtraFiles").AlterColumn("LastUpdated").AsDateTimeOffset().NotNullable();
+            Alter.Table("History").AlterColumn("Date").AsDateTimeOffset().NotNullable();
+            Alter.Table("ImportListStatus").AlterColumn("InitialFailure").AsDateTimeOffset().Nullable();
+            Alter.Table("ImportListStatus").AlterColumn("MostRecentFailure").AsDateTimeOffset().Nullable();
+            Alter.Table("ImportListStatus").AlterColumn("DisabledTill").AsDateTimeOffset().Nullable();
+            Alter.Table("IndexerStatus").AlterColumn("InitialFailure").AsDateTimeOffset().Nullable();
+            Alter.Table("IndexerStatus").AlterColumn("MostRecentFailure").AsDateTimeOffset().Nullable();
+            Alter.Table("IndexerStatus").AlterColumn("DisabledTill").AsDateTimeOffset().Nullable();
+            Alter.Table("IndexerStatus").AlterColumn("CookiesExpirationDate").AsDateTimeOffset().Nullable();
+            Alter.Table("MetadataFiles").AlterColumn("LastUpdated").AsDateTimeOffset().NotNullable();
+            Alter.Table("MetadataFiles").AlterColumn("Added").AsDateTimeOffset().Nullable();
+            Alter.Table("MovieFiles").AlterColumn("DateAdded").AsDateTimeOffset().NotNullable();
+            Alter.Table("MovieMetadata").AlterColumn("DigitalRelease").AsDateTimeOffset().Nullable();
+            Alter.Table("MovieMetadata").AlterColumn("InCinemas").AsDateTimeOffset().Nullable();
+            Alter.Table("MovieMetadata").AlterColumn("LastInfoSync").AsDateTimeOffset().Nullable();
+            Alter.Table("MovieMetadata").AlterColumn("PhysicalRelease").AsDateTimeOffset().Nullable();
+            Alter.Table("Movies").AlterColumn("Added").AsDateTimeOffset().Nullable();
+            Alter.Table("PendingReleases").AlterColumn("Added").AsDateTimeOffset().NotNullable();
+            Alter.Table("ScheduledTasks").AlterColumn("LastExecution").AsDateTimeOffset().NotNullable();
+            Alter.Table("ScheduledTasks").AlterColumn("LastStartTime").AsDateTimeOffset().Nullable();
+            Alter.Table("SubtitleFiles").AlterColumn("Added").AsDateTimeOffset().NotNullable();
+            Alter.Table("SubtitleFiles").AlterColumn("LastUpdated").AsDateTimeOffset().NotNullable();
+            Alter.Table("VersionInfo").AlterColumn("AppliedOn").AsDateTimeOffset().Nullable();
+        }
+
+        protected override void LogDbUpgrade()
+        {
+            Alter.Table("Logs").AlterColumn("Time").AsDateTimeOffset().NotNullable();
+            Alter.Table("UpdateHistory").AlterColumn("Date").AsDateTimeOffset().NotNullable();
+            Alter.Table("VersionInfo").AlterColumn("AppliedOn").AsDateTimeOffset().Nullable();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Radarr.Core.csproj
+++ b/src/NzbDrone.Core/Radarr.Core.csproj
@@ -5,7 +5,6 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Equ" Version="2.3.0" />
-    <PackageReference Include="FluentMigrator.Runner.Postgres" Version="3.3.2" />
     <PackageReference Include="MailKit" Version="2.15.0" />
     <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="Servarr.FFMpegCore" Version="4.7.0-26" />
@@ -14,8 +13,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="FluentMigrator.Runner" Version="3.3.2" />
-    <PackageReference Include="FluentMigrator.Runner.SQLite" Version="3.3.2" />
+    <PackageReference Include="Servarr.FluentMigrator.Runner" Version="3.3.2.9" />
+    <PackageReference Include="Servarr.FluentMigrator.Runner.SQLite" Version="3.3.2.9" />
+    <PackageReference Include="Servarr.FluentMigrator.Runner.Postgres" Version="3.3.2.9" />
     <PackageReference Include="FluentValidation" Version="8.6.2" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
#### Database Migration
Yes - 212

#### Description
Fluent Migrator creates Timestamp without time zone columns by default, when combined with a non UTC timezone this causes issues with dates. 

Sets each column to DataType Timestamp with time zone.

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)