### PR TITLE
Fixed: FFprobe failing on MacOS and AV1 streams

### DIFF
--- a/src/NzbDrone.Core/Radarr.Core.csproj
+++ b/src/NzbDrone.Core/Radarr.Core.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="MailKit" Version="2.15.0" />
     <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="Servarr.FFMpegCore" Version="4.7.0-26" />
-    <PackageReference Include="Servarr.FFprobe" Version="5.0.0.64" />
+    <PackageReference Include="Servarr.FFprobe" Version="5.0.0.86" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Update ffprobe:
 - Remove dependency on libX11 on MacOS
 - Add support for AV1 streams

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX