### PR TITLE
New: Seperate Syslog Level from log level and add Syslog custom app name

### DIFF
--- a/frontend/src/App/App.js
+++ b/frontend/src/App/App.js
@@ -8,7 +8,7 @@ import AppRoutes from './AppRoutes';
 
 function App({ store, history }) {
   return (
-    <DocumentTitle title="Radarr">
+    <DocumentTitle title={window.Radarr.instanceName}>
       <Provider store={store}>
         <ConnectedRouter history={history}>
           <PageConnector>

--- a/frontend/src/Components/Page/PageContent.js
+++ b/frontend/src/Components/Page/PageContent.js
@@ -14,7 +14,7 @@ function PageContent(props) {
 
   return (
     <ErrorBoundary errorComponent={PageContentError}>
-      <DocumentTitle title={title ? `${title} - Radarr` : 'Radarr'}>
+      <DocumentTitle title={title ? `${title} - ${window.Radarr.instanceName}` : window.Radarr.instanceName}>
         <div className={className}>
           {children}
         </div>

--- a/frontend/src/Settings/General/HostSettings.js
+++ b/frontend/src/Settings/General/HostSettings.js
@@ -20,6 +20,7 @@ function HostSettings(props) {
     bindAddress,
     port,
     urlBase,
+    instanceName,
     enableSsl,
     sslPort,
     sslCertPath,
@@ -70,6 +71,22 @@ function HostSettings(props) {
           helpTextWarning={translate('RestartRequiredHelpTextWarning')}
           onChange={onInputChange}
           {...urlBase}
+        />
+      </FormGroup>
+
+      <FormGroup
+        advancedSettings={advancedSettings}
+        isAdvanced={true}
+      >
+        <FormLabel>{translate('InstanceName')}</FormLabel>
+
+        <FormInputGroup
+          type={inputTypes.TEXT}
+          name="instanceName"
+          helpText={translate('InstanceNameHelpText')}
+          helpTextWarning={translate('RestartRequiredHelpTextWarning')}
+          onChange={onInputChange}
+          {...instanceName}
         />
       </FormGroup>
 

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -237,7 +237,7 @@ namespace NzbDrone.Core.Configuration
 
         public int SyslogPort => GetValueInt("SyslogPort", 514, persist: false);
 
-        public string SyslogLevel => GetValue("SyslogLevel", LogLevel).ToLowerInvariant();
+        public string SyslogLevel => GetValue("SyslogLevel", LogLevel, false).ToLowerInvariant();
 
         public int GetValueInt(string key, int defaultValue, bool persist = true)
         {

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -45,11 +45,13 @@ namespace NzbDrone.Core.Configuration
         string SslCertPassword { get; }
         string UrlBase { get; }
         string UiFolder { get; }
+        string InstanceName { get; }
         bool UpdateAutomatically { get; }
         UpdateMechanism UpdateMechanism { get; }
         string UpdateScriptPath { get; }
         string SyslogServer { get; }
         int SyslogPort { get; }
+        string SyslogLevel { get; }
         string PostgresHost { get; }
         int PostgresPort { get; }
         string PostgresUser { get; }
@@ -223,6 +225,7 @@ namespace NzbDrone.Core.Configuration
         }
 
         public string UiFolder => BuildInfo.IsDebug ? Path.Combine("..", "UI") : "UI";
+        public string InstanceName => GetValue("InstanceName", BuildInfo.AppName);
 
         public bool UpdateAutomatically => GetValueBoolean("UpdateAutomatically", false, false);
 
@@ -231,7 +234,10 @@ namespace NzbDrone.Core.Configuration
         public string UpdateScriptPath => GetValue("UpdateScriptPath", "", false);
 
         public string SyslogServer => GetValue("SyslogServer", "", persist: false);
+
         public int SyslogPort => GetValueInt("SyslogPort", 514, persist: false);
+
+        public string SyslogLevel => GetValue("SyslogLevel", LogLevel).ToLowerInvariant();
 
         public int GetValueInt(string key, int defaultValue, bool persist = true)
         {

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
@@ -44,7 +44,8 @@ namespace NzbDrone.Core.Instrumentation
 
             if (_configFileProvider.SyslogServer.IsNotNullOrWhiteSpace())
             {
-                SetSyslogParameters(_configFileProvider.SyslogServer, _configFileProvider.SyslogPort, minimumLogLevel);
+                var syslogLevel = LogLevel.FromString(_configFileProvider.SyslogLevel);
+                SetSyslogParameters(_configFileProvider.SyslogServer, _configFileProvider.SyslogPort, syslogLevel);
             }
 
             var rules = LogManager.Configuration.LoggingRules;
@@ -118,7 +119,7 @@ namespace NzbDrone.Core.Instrumentation
             syslogTarget.MessageSend.Udp.Server = syslogServer;
             syslogTarget.MessageSend.Udp.ReconnectInterval = 500;
             syslogTarget.MessageCreation.Rfc = RfcNumber.Rfc5424;
-            syslogTarget.MessageCreation.Rfc5424.AppName = BuildInfo.AppName;
+            syslogTarget.MessageCreation.Rfc5424.AppName = _configFileProvider.InstanceName;
 
             var loggingRule = new LoggingRule("*", minimumLogLevel, syslogTarget);
 

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -441,6 +441,8 @@
     "IndexerTagHelpText": "Only use this indexer for movies with at least one matching tag. Leave blank to use with all movies.",
     "Info": "Info",
     "InstallLatest": "Install Latest",
+    "InstanceName": "Instance Name",
+    "InstanceNameHelpText": "Instance name in tab and for Syslog app name",
     "InteractiveImport": "Interactive Import",
     "InteractiveImportErrLanguage": "Language must be chosen for each selected file",
     "InteractiveImportErrMovie": "Movie must be chosen for each selected file",

--- a/src/NzbDrone.Core/Validation/RuleBuilderExtensions.cs
+++ b/src/NzbDrone.Core/Validation/RuleBuilderExtensions.cs
@@ -61,5 +61,11 @@ namespace NzbDrone.Core.Validation
         {
             return ruleBuilder.WithState(v => NzbDroneValidationState.Warning);
         }
+
+        public static IRuleBuilderOptions<T, string> ContainsRadarr<T>(this IRuleBuilder<T, string> ruleBuilder)
+        {
+            ruleBuilder.SetValidator(new NotEmptyValidator(null));
+            return ruleBuilder.SetValidator(new RegularExpressionValidator("radarr", RegexOptions.IgnoreCase)).WithMessage("Must contain Radarr");
+        }
     }
 }

--- a/src/Radarr.Api.V3/Config/HostConfigController.cs
+++ b/src/Radarr.Api.V3/Config/HostConfigController.cs
@@ -40,6 +40,7 @@ namespace Radarr.Api.V3.Config
             SharedValidator.RuleFor(c => c.Port).ValidPort();
 
             SharedValidator.RuleFor(c => c.UrlBase).ValidUrlBase();
+            SharedValidator.RuleFor(c => c.InstanceName).ContainsRadarr().When(c => c.InstanceName.IsNotNullOrWhiteSpace());
 
             SharedValidator.RuleFor(c => c.Username).NotEmpty().When(c => c.AuthenticationMethod != AuthenticationType.None);
             SharedValidator.RuleFor(c => c.Password).NotEmpty().When(c => c.AuthenticationMethod != AuthenticationType.None);

--- a/src/Radarr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Radarr.Api.V3/Config/HostConfigResource.cs
@@ -25,6 +25,7 @@ namespace Radarr.Api.V3.Config
         public string SslCertPath { get; set; }
         public string SslCertPassword { get; set; }
         public string UrlBase { get; set; }
+        public string InstanceName { get; set; }
         public bool UpdateAutomatically { get; set; }
         public UpdateMechanism UpdateMechanism { get; set; }
         public string UpdateScriptPath { get; set; }
@@ -66,6 +67,7 @@ namespace Radarr.Api.V3.Config
                 SslCertPath = model.SslCertPath,
                 SslCertPassword = model.SslCertPassword,
                 UrlBase = model.UrlBase,
+                InstanceName = model.InstanceName,
                 UpdateAutomatically = model.UpdateAutomatically,
                 UpdateMechanism = model.UpdateMechanism,
                 UpdateScriptPath = model.UpdateScriptPath,

--- a/src/Radarr.Api.V3/System/SystemController.cs
+++ b/src/Radarr.Api.V3/System/SystemController.cs
@@ -59,6 +59,7 @@ namespace Radarr.Api.V3.System
             return new
             {
                 AppName = BuildInfo.AppName,
+                InstanceName = _configFileProvider.InstanceName,
                 Version = BuildInfo.Version.ToString(),
                 BuildTime = BuildInfo.BuildDateTime,
                 IsDebug = BuildInfo.IsDebug,

--- a/src/Radarr.Http/Frontend/InitializeJsController.cs
+++ b/src/Radarr.Http/Frontend/InitializeJsController.cs
@@ -48,6 +48,7 @@ namespace Radarr.Http.Frontend
             builder.AppendLine($"  apiKey: '{_apiKey}',");
             builder.AppendLine($"  release: '{BuildInfo.Release}',");
             builder.AppendLine($"  version: '{BuildInfo.Version.ToString()}',");
+            builder.AppendLine($"  instanceName: '{_configFileProvider.InstanceName.ToString()}',");
             builder.AppendLine($"  branch: '{_configFileProvider.Branch.ToLower()}',");
             builder.AppendLine($"  analytics: {_analyticsService.IsEnabled.ToString().ToLowerInvariant()},");
             builder.AppendLine($"  userHash: '{HashUtil.AnonymousToken()}',");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Seperates the syslog level from the file log level
Adds an option to have a custom application name for syslog to enable knowing what logs are for what instance when logging multiple instances

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)