### PR TITLE
Added term "brazilian" to Brazilian Portuguese regex

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -163,6 +163,7 @@ namespace NzbDrone.Core.Test.ParserTests
 
         [TestCase("Movie.Title.1994.Dublado.1080p.XviD-LOL")]
         [TestCase("Movie.Title.2.2019.1080p.Bluray.Dublado.WWW.TPF.GRATIS")]
+        [TestCase("Movie.Title.2014.1080p.Bluray.Brazilian.WWW.TPF.GRATIS")]
         public void should_parse_language_brazilian_portuguese(string postTitle)
         {
             var result = Parser.Parser.ParseMovieTitle(postTitle, true);

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Parser
                                                                             (?<german>german\b|videomann|ger[. ]dub)|
                                                                             (?<flemish>flemish)|
                                                                             (?<bulgarian>bgaudio)|
-                                                                            (?<brazilian>dublado|brazilian)|
+                                                                            (?<brazilian>dublado)|
                                                                             (?<greek>greek)|
                                                                             (?<french>\b(?:FR|VO|VFF|VFQ|VFI|VF2|TRUEFRENCH|FRE|FRA)\b)|
                                                                             (?<russian>\brus\b)|
@@ -151,6 +151,11 @@ namespace NzbDrone.Core.Parser
             if (lowerTitle.Contains("portuguese"))
             {
                 languages.Add(Language.Portuguese);
+            }
+
+            if (lowerTitle.Contains("brazilian"))
+            {
+                languages.Add(Language.PortugueseBR);
             }
 
             if (lowerTitle.Contains("hungarian"))

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Parser
                                                                             (?<german>german\b|videomann|ger[. ]dub)|
                                                                             (?<flemish>flemish)|
                                                                             (?<bulgarian>bgaudio)|
-                                                                            (?<brazilian>dublado)|
+                                                                            (?<brazilian>dublado|brazilian)|
                                                                             (?<greek>greek)|
                                                                             (?<french>\b(?:FR|VO|VFF|VFQ|VFI|VF2|TRUEFRENCH|FRE|FRA)\b)|
                                                                             (?<russian>\brus\b)|


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added term "brazilian" to Brazilian Portuguese regex

#### Screenshot (if UI related)

#### Todos
- [ X ] Tests
- [ X ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ X ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX