### PR TITLE
Fix: add better support for czech/slovak movie language and czech/slo…

### DIFF
--- a/frontend/src/Settings/UI/UISettings.js
+++ b/frontend/src/Settings/UI/UISettings.js
@@ -21,7 +21,9 @@ export const weekColumnOptions = [
   { key: 'ddd M/D', value: 'Tue 3/25' },
   { key: 'ddd MM/DD', value: 'Tue 03/25' },
   { key: 'ddd D/M', value: 'Tue 25/3' },
-  { key: 'ddd DD/MM', value: 'Tue 25/03' }
+  { key: 'ddd DD/MM', value: 'Tue 25/03' },
+  { key: 'ddd D.M.', value: 'Tue 25.3.' },
+  { key: 'ddd DD.MM.', value: 'Tue 25.03.' }
 ];
 
 const shortDateFormatOptions = [
@@ -30,12 +32,15 @@ const shortDateFormatOptions = [
   { key: 'MM/D/YYYY', value: '03/25/2014' },
   { key: 'MM/DD/YYYY', value: '03/25/2014' },
   { key: 'DD/MM/YYYY', value: '25/03/2014' },
-  { key: 'YYYY-MM-DD', value: '2014-03-25' }
+  { key: 'YYYY-MM-DD', value: '2014-03-25' },
+  { key: 'DD.M.YYYY', value: '25.3.2014' },
+  { key: 'DD.MM.YYYY', value: '25.03.2014' }
 ];
 
 const longDateFormatOptions = [
   { key: 'dddd, MMMM D YYYY', value: 'Tuesday, March 25, 2014' },
-  { key: 'dddd, D MMMM YYYY', value: 'Tuesday, 25 March, 2014' }
+  { key: 'dddd, D MMMM YYYY', value: 'Tuesday, 25 March, 2014' },
+  { key: 'dddd, DD.MMMM YYYY', value: 'Tuesday, 25.March 2014' }
 ];
 
 export const timeFormatOptions = [

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,4 +1,5 @@
 import { createBrowserHistory } from 'history';
+import moment from 'moment';
 import React from 'react';
 import { render } from 'react-dom';
 import createAppStore from 'Store/createAppStore';
@@ -11,6 +12,8 @@ import './index.css';
 
 const history = createBrowserHistory();
 const store = createAppStore(history);
+
+moment.locale('cs');
 
 render(
   <App

--- a/src/NzbDrone.Core.Test/Languages/LanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/Languages/LanguageFixture.cs
@@ -47,6 +47,7 @@ namespace NzbDrone.Core.Test.Languages
                 new object[] { 32, Language.Ukrainian },
                 new object[] { 33, Language.Persian },
                 new object[] { 34, Language.Bengali },
+                new object[] { 36, Language.Slovak },
             };
 
         public static object[] ToIntCases =
@@ -88,6 +89,7 @@ namespace NzbDrone.Core.Test.Languages
                 new object[] { Language.Ukrainian, 32 },
                 new object[] { Language.Persian, 33 },
                 new object[] { Language.Bengali, 34 },
+                new object[] { Language.Slovak, 36 }
             };
 
         [Test]

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -294,11 +294,23 @@ namespace NzbDrone.Core.Test.ParserTests
         }
 
         [TestCase("Movie.Title.1994.CZ.1080p.XviD-LOL")]
+        [TestCase("Movie.Title.1994.1080p.XviD-LOL.czech")]
+        [TestCase("Movie.Title.1994.1080p.XviD-LOL[CS]")]
         public void should_parse_language_czech(string postTitle)
         {
             var result = Parser.Parser.ParseMovieTitle(postTitle, true);
 
             result.Languages.Should().BeEquivalentTo(Language.Czech);
+        }
+
+        [TestCase("Movie.Title.1994.SK.1080p.XviD-LOL")]
+        [TestCase("Movie.Title.1994.1080p.XviD-LOL.slovak")]
+        [TestCase("Movie.Title.1994.1080p.XviD-LOL[SK]")]
+        public void should_parse_language_slovak(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle, true);
+
+            result.Languages.Should().BeEquivalentTo(Language.Slovak);
         }
 
         [TestCase("Movie.Title.2019.ARABIC.WEBRip.x264-VXT")]

--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -105,6 +105,7 @@ namespace NzbDrone.Core.Languages
         public static Language Ukrainian => new Language(32, "Ukrainian");
         public static Language Persian => new Language(33, "Persian");
         public static Language Bengali => new Language(34, "Bengali");
+        public static Language Slovak => new Language(36, "Slovak");
         public static Language Any => new Language(-1, "Any");
         public static Language Original => new Language(-2, "Original");
 
@@ -149,6 +150,7 @@ namespace NzbDrone.Core.Languages
                     Ukrainian,
                     Persian,
                     Bengali,
+                    Slovak,
                     Any,
                     Original
                 };

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -380,6 +380,18 @@ namespace NzbDrone.Core.Organizer
             {
                 mediaInfoAudioLanguages = $"[{mediaInfoAudioLanguages}]";
             }
+            else
+            {
+                var lang = LanguageParser.ParseLanguages(movieFile.RelativePath).FirstOrDefault();
+                if (lang != null)
+                {
+                    var isoLang = IsoLanguages.Get(lang);
+                    if (isoLang != null)
+                    {
+                        mediaInfoAudioLanguages = $"[{isoLang.TwoLetterCode.ToUpper()}]";
+                    }
+                }
+            }
 
             var mediaInfoAudioLanguagesAll = mediaInfoAudioLanguages;
             if (mediaInfoAudioLanguages == "[EN]")

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -42,7 +42,8 @@ namespace NzbDrone.Core.Parser
                                                                new IsoLanguage("uk", "", "ukr", "Ukrainian", Language.Ukrainian),
                                                                new IsoLanguage("fa", "", "fas", "Persian", Language.Persian),
                                                                new IsoLanguage("be", "", "ben", "Bengali", Language.Bengali),
-                                                               new IsoLanguage("lt", "", "lit", "Lithuanian", Language.Lithuanian)
+                                                               new IsoLanguage("lt", "", "lit", "Lithuanian", Language.Lithuanian),
+                                                               new IsoLanguage("sk", "", "slk", "Slovak", Language.Slovak)
                                                            };
 
         public static IsoLanguage Find(string isoCode)

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -26,11 +26,14 @@ namespace NzbDrone.Core.Parser
                                                                             (?<hebrew>\bHebDub\b)|
                                                                             (?<polish>\b(?:PL\W?DUB|DUB\W?PL|LEK\W?PL|PL\W?LEK)\b)|
                                                                             (?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)|
-                                                                            (?<ukrainian>(?:(?:\dx)?UKR))",
+                                                                            (?<ukrainian>(?:(?:\dx)?UKR))|
+                                                                            (?<czech>\b(?:CS|CZ)\b)|
+                                                                            (?<slovak>\b(?:SK)\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
         private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?:(?i)(?<!SUB[\W|_|^]))(?:(?<lithuanian>\bLT\b)|
-                                                                                                          (?<czech>\bCZ\b)|
+                                                                                                          (?<czech>\b(?:CS|CZ)\b)|
+                                                                                                          (?<slovak>\bSK\b)|
                                                                                                           (?<polish>\bPL\b)|
                                                                                                           (?<bulgarian>\bBG\b))(?:(?i)(?![\W|_|^]SUB))",
                                                                 RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
@@ -41,6 +44,16 @@ namespace NzbDrone.Core.Parser
         {
             var lowerTitle = title.ToLower();
             var languages = new List<Language>();
+
+            if (lowerTitle.Contains("czech"))
+            {
+                languages.Add(Language.Czech);
+            }
+
+            if (lowerTitle.Contains("slovak"))
+            {
+                languages.Add(Language.Slovak);
+            }
 
             if (lowerTitle.Contains("english"))
             {
@@ -195,6 +208,11 @@ namespace NzbDrone.Core.Parser
                 languages.Add(Language.Czech);
             }
 
+            if (caseSensitiveMatch.Groups["slovak"].Captures.Cast<Capture>().Any())
+            {
+                languages.Add(Language.Slovak);
+            }
+
             if (caseSensitiveMatch.Groups["polish"].Captures.Cast<Capture>().Any())
             {
                 languages.Add(Language.Polish);
@@ -227,6 +245,16 @@ namespace NzbDrone.Core.Parser
                 if (match.Groups["greek"].Captures.Cast<Capture>().Any())
                 {
                     languages.Add(Language.Greek);
+                }
+
+                if (match.Groups["czech"].Success)
+                {
+                    languages.Add(Language.Czech);
+                }
+
+                if (match.Groups["slovak"].Success)
+                {
+                    languages.Add(Language.Slovak);
                 }
 
                 if (match.Groups["french"].Success)


### PR DESCRIPTION
#### Description
(corrected version of wrong PR Fix: Add better czech slovak support for audio and datetime in UI #7353)

Fix: add better support for czech/slovak movie language and czech/slovak date/time in UI
- if movie cointains **unknown** audio, you can set audio language by filename (Moonfall (2022) - [tmdb-406759][Bluray-1080p].czech.mkv or Moonfall (2022) - [tmdb-406759][Bluray-1080p][CS].mkv). this works for all supported languages, not only czech/slovak. this modification applied only when radarr cannot detect language (mostly due to a mislabeled (UND) language of audio track in the mkv)
- you can have two language versions of one movie in one directory, and renaming is correct (like bluray EN version, and TV rip with CZECH language, with different time length and cant be merged) 


#### Screenshot (if UI related)
this tv show have CZECH language but in mkv audio tract is set as UND(efined) and radarr cannot detect language and set it to ENGLISH. this is wrong, because radarr trying find another czech release and bazarr trying find czech subtitles.
someone didnot set LANGUAGE for track. its "normal" for very old releases or "home made rips"
![image](https://user-images.githubusercontent.com/11536984/173208735-509dbc10-b0ba-47b2-9191-4f65432b7a89.png)

you can have two language versions of one movie in one directory, and renaming is correct (like bluray EN version, and TV rip with CZECH language, with different time length and cant be merged
![image](https://user-images.githubusercontent.com/11536984/173206879-3a414cd7-0818-45ca-8652-affb333a4bdd.png)

![image](https://user-images.githubusercontent.com/11536984/173206572-1457e513-b432-47c2-a628-008eb0c3e968.png)
![image](https://user-images.githubusercontent.com/11536984/173206582-3d5a9ec1-fc3d-4d1f-a192-250ab7491f21.png)
![image](https://user-images.githubusercontent.com/11536984/173206590-85aa4453-adc1-4d7d-9e60-c008c0d14b19.png)
