### PR TITLE
New: add support for .rrignore file to ignore movie folder in library import

### DIFF
--- a/src/NzbDrone.Core/RootFolders/RootFolderService.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolderService.cs
@@ -162,7 +162,7 @@ namespace NzbDrone.Core.RootFolders
             var setToRemove = SpecialFolders;
             results.RemoveAll(x => setToRemove.Contains(new DirectoryInfo(x.Path.ToLowerInvariant()).Name));
 
-            results.RemoveAll(x => Directory.GetFiles(x.Path, IgnoreFolderFile).Length > 0);
+            results.RemoveAll(x => Directory.Exists(x.Path) && Directory.GetFiles(x.Path, IgnoreFolderFile).Length > 0);
 
             _logger.Debug("{0} unmapped folders detected.", results.Count);
             return results.OrderBy(u => u.Name, StringComparer.InvariantCultureIgnoreCase).ToList();

--- a/src/NzbDrone.Core/RootFolders/RootFolderService.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolderService.cs
@@ -30,6 +30,8 @@ namespace NzbDrone.Core.RootFolders
         private readonly IConfigService _configService;
         private readonly Logger _logger;
 
+        private static readonly string IgnoreFolderFile = ".rrignore";
+
         private static readonly HashSet<string> SpecialFolders = new HashSet<string>
                                                                  {
                                                                      "$recycle.bin",
@@ -159,6 +161,8 @@ namespace NzbDrone.Core.RootFolders
 
             var setToRemove = SpecialFolders;
             results.RemoveAll(x => setToRemove.Contains(new DirectoryInfo(x.Path.ToLowerInvariant()).Name));
+
+            results.RemoveAll(x => Directory.GetFiles(x.Path, IgnoreFolderFile).Length > 0);
 
             _logger.Debug("{0} unmapped folders detected.", results.Count);
             return results.OrderBy(u => u.Name, StringComparer.InvariantCultureIgnoreCase).ToList();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
add support for .rrignore file to ignore movie folder in library import
In case themoviedb does not contain a certain movie, or in case of multiple versions of a movie (extended, directors cut, normal) (or just a general need to ignore a movie in radarr) it is not possible to import a movie into radarr but it is still displayed on import. For these cases it would be good to have the option to ignore these movies on import. Just create a `.rrignore` file and the given movie/directory will be ignored.

#### Screenshot (if UI related)

#### Todos

#### Issues Fixed or Closed by this PR
