### PR TITLE
Match 'HQCAM' as CAM source

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -41,6 +41,14 @@ namespace NzbDrone.Core.Test.ParserTests
             ParseAndVerifyQuality(title, Source.TELESYNC, proper, Resolution.R720p);
         }
 
+        [TestCase("Movie Name 2018 NEW PROPER 720p HD-CAM X264 HQ-CPG", true)]
+        [TestCase("Movie Name (2022) 1080p HQCAM ENG x264 AAC - QRips", false)]
+        [TestCase("Movie Name (2018) 720p Hindi HQ CAMrip x264 AAC 1.4GB", false)]
+        public void should_parse_cam(string title, bool proper)
+        {
+            ParseAndVerifyQuality(title, Source.CAM, proper, Resolution.Unknown);
+        }
+
         [TestCase("S07E23 .avi ", false)]
         [TestCase("Movie Name S02E01 HDTV XviD 2HD", false)]
         [TestCase("Movie Name S05E11 PROPER HDTV XviD 2HD", true)]

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Parser
                                                                 (?<scr>SCR|SCREENER|DVDSCR|DVDSCREENER)|
                                                                 (?<ts>TS[-_. ]|TELESYNC|HD-TS|HDTS|PDVD|TSRip|HDTSRip)|
                                                                 (?<tc>TC|TELECINE|HD-TC|HDTC)|
-                                                                (?<cam>CAMRIP|CAM|HDCAM|HD-CAM)|
+                                                                (?<cam>CAMRIP|CAM|HDCAM|HQCAM|HD-CAM)|
                                                                 (?<wp>WORKPRINT|WP)|
                                                                 (?<pdtv>PDTV)|
                                                                 (?<sdtv>SDTV)|


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add 'HQCAM' token to cam source regex to fix cam sources not being matched correctly.

Ex. "Thor : Love and Thunder (2022) 1080p HQCAM ENG x264 AAC - QRips" is not matched as CAM

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)
