### PR TITLE
Fixed: User Triggered Auto Searches now ignores monitored status

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/MoviesSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/MoviesSearchService.cs
@@ -42,14 +42,15 @@ namespace NzbDrone.Core.IndexerSearch
             foreach (var movieId in message.MovieIds)
             {
                 var movie = _movieService.GetMovie(movieId);
+                var userInvokedSearch = message.Trigger == CommandTrigger.Manual;
 
-                if (!movie.Monitored && message.Trigger != CommandTrigger.Manual)
+                if (!movie.Monitored && !userInvokedSearch)
                 {
                     _logger.Debug("Movie {0} is not monitored, skipping search", movie.Title);
                     continue;
                 }
 
-                var decisions = _releaseSearchService.MovieSearch(movieId, false, false);
+                var decisions = _releaseSearchService.MovieSearch(movieId, userInvokedSearch, false);
                 downloadedCount += _processDownloadDecisions.ProcessDecisions(decisions).Grabbed.Count;
             }
 


### PR DESCRIPTION
… download/processing of unmonitored movies

#### Database Migration
| NO

#### Description
Set userInvoked to true for manually triggered searches, to allow for download/processing of unmonitored movies. Per discord discussion

