### PR TITLE
Fix watch state not preserved on metadata rewrite

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -305,6 +305,8 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 
                     details.Add(new XElement("trailer", "plugin://plugin.video.youtube/play/?video_id=" + movie.MovieMetadata.Value.YouTubeTrailerId));
 
+                    details.Add(new XElement("watched", watched));
+
                     if (movieFile.MediaInfo != null)
                     {
                         var sceneName = movieFile.GetSceneOrFileName();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds the missing `watched` element in metadata writes. Everything else was already in place, reading the original state, etc. It's just the element that wasn't being written to the new *.nfo* file. This behavior is now 1:1 with Sonarr.

#### Issues Fixed or Closed by this PR

* Fixes [#7435](https://github.com/Radarr/Radarr/issues/7435)