### PR TITLE
Logger fix for a successful move

### DIFF
--- a/src/NzbDrone.Core/Movies/MoveMovieService.cs
+++ b/src/NzbDrone.Core/Movies/MoveMovieService.cs
@@ -56,7 +56,7 @@ namespace NzbDrone.Core.Movies
                 _diskProvider.CreateFolder(new DirectoryInfo(destinationPath).Parent.FullName);
                 _diskTransferService.TransferFolder(sourcePath, destinationPath, TransferMode.Move);
 
-                _logger.ProgressInfo("{0} moved successfully to {1}", movie.Title, movie.Path);
+                _logger.ProgressInfo("{0} moved successfully to {1}", movie.Title, destinationPath);
 
                 _eventAggregator.PublishEvent(new MovieMovedEvent(movie, sourcePath, destinationPath));
             }


### PR DESCRIPTION
In the success print by the logger, a message is being printed that indicates the movie was successfully moved to the source folder, not the destination folder.
I updated the logger statement to print that the movie was moved successfully to the destination folder.

#### Database Migration
NO

#### Description
This pull request fixes a logger print statement. Fairly simple fix that should have limited impact.

#### Screenshot (if UI related)

#### Todos
- No todos

#### Issues Fixed or Closed by this PR

[Issue# 7440](https://github.com/Radarr/Radarr/issues/7440)