### PR TITLE
Fixed: Toolbar Button labels overlap

### DIFF
--- a/frontend/src/Components/Page/Toolbar/PageToolbarButton.css
+++ b/frontend/src/Components/Page/Toolbar/PageToolbarButton.css
@@ -2,7 +2,8 @@
   composes: link from '~Components/Link/Link.css';
 
   padding-top: 4px;
-  width: $toolbarButtonWidth;
+  min-width: $toolbarButtonWidth;
+  width: min-content;
   text-align: center;
 
   &:hover {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Prevents PageToolbarButton overlap when labels are too long by increasing the width of the button to `min-content`

#### Screenshot (if UI related)
Current behavior:
![imagen](https://user-images.githubusercontent.com/6920322/185760826-34bd518b-b254-4182-a6b0-c571c64cf23e.png)
Behavior after PR:
![imagen](https://user-images.githubusercontent.com/6920322/185760852-69c7b58a-7970-4a2c-857f-34f6fa117407.png)

#### Todos

#### Issues Fixed or Closed by this PR
* Fixes #7553 