### PR TITLE
Fixed: Import now handles filename enclosed in square brackets

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
@@ -455,5 +455,23 @@ namespace NzbDrone.Core.Test.MediaFiles.DiskScanServiceTests
 
             files.Should().HaveCount(2);
         }
+
+        [Test]
+        public void should_detect_obfuscated_and_normal_movie_files()
+        {
+            GivenMovieFolder();
+
+            GivenFiles(new List<string>
+                       {
+                           Path.Combine(_movie.Path, "This is a Movie.mp4").AsOsAgnostic(),
+                           Path.Combine(_movie.Path, "[private]-[group]-[This is a Movie.mp4]-[1_12]").AsOsAgnostic(),
+                           Path.Combine(_movie.Path, "[private]-[group]-[This is a Movie.nfo]-[2_12]").AsOsAgnostic(),
+                           Path.Combine(_movie.Path, "[private]-[group]-[This is a Movie.txt]-[3_12]").AsOsAgnostic()
+                       });
+
+            var files = Subject.GetVideoFiles(_movie.Path);
+
+            files.Should().HaveCount(2);
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -20,7 +20,6 @@ using NzbDrone.Core.Test.Framework;
 
 namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 {
-    [Platform(Exclude = "Win")]
     [TestFixture]
 
     public class FileNameBuilderFixture : CoreTest<FileNameBuilder>
@@ -749,6 +748,30 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             Subject.BuildFileName(_movie, _movieFile);
 
             Mocker.GetMock<IUpdateMediaInfo>().Verify(v => v.Update(_movieFile, _movie), Times.Never());
+        }
+
+        [TestCase("Movie.mp4", "Movie.mp4")]
+        [TestCase("Movie.mkv", "Movie.mkv")]
+        [TestCase("Movie.mp4]-[1_2]", "Movie.mp4")]
+        [TestCase("Movie.mkv]-[1_2]", "Movie.mkv")]
+        public void should_rename_invalid_extensions(string filePath, string expectedName)
+        {
+            _namingConfig.StandardMovieFormat =
+                "{Movie.Title}";
+
+            var movie = Builder<Movie>
+                .CreateNew()
+                .With(s => s.Title = "Movie")
+                .With(s => s.Path = "")
+                .Build();
+
+            var movieFile = Builder<MovieFile>
+                .CreateNew()
+                .With(s => s.RelativePath = filePath)
+                .Build();
+
+            var newFileName = Subject.BuildFileName(movie, movieFile);
+            Subject.BuildFilePath(movie, newFileName,  Path.GetExtension(filePath)).Should().Be(expectedName);
         }
 
         private void GivenMediaInfoModel(string videoCodec = "h264",

--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -200,7 +200,7 @@ namespace NzbDrone.Core.MediaFiles
                                            .ToList();
 
             // Find corrupted extensions in the format of: "[FileName.mkv]-[1_2]"
-            var mediaFilesListIncorrectExtension = filesOnDisk.Where(file => MediaFileExtensions.Extensions.Contains(Path.GetExtension(file).Split(']').First())).ToList();
+            var mediaFilesListIncorrectExtension = filesOnDisk.Except(mediaFileList).Where(file => MediaFileExtensions.Extensions.Contains(Path.GetExtension(file).Split(']').First())).ToList();
 
             mediaFileList.AddRange(mediaFilesListIncorrectExtension);
 
@@ -227,7 +227,7 @@ namespace NzbDrone.Core.MediaFiles
                                            .ToList();
 
             // Find corrupted extensions in the format of: "[FileName.mkv]-[1_2]"
-            var mediaFilesListIncorrectExtension = filesOnDisk.Where(file => MediaFileExtensions.Extensions.Contains(Path.GetExtension(file).Split(']').First())).ToList();
+            var mediaFilesListIncorrectExtension = filesOnDisk.Except(mediaFileList).Where(file => MediaFileExtensions.Extensions.Contains(Path.GetExtension(file).Split(']').First())).ToList();
 
             mediaFileList.AddRange(mediaFilesListIncorrectExtension);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Certain usenet providers name files in ways which require manual renaming of files and re-import. This change allows automatic recovery in some instances.

eg.

> [PRiVATE]-[WtFnZb]-[This.Is.a.Movie.mkv]-[2_13]

The way this works is detects if a movie has a valid extension with a square bracket following eg. ```\*.mkv]\*``` and then treats it as a valid movie file. This uses the existing extension list.

On import, it will rename the corrupted extension back to the correct base extension.

#### Todos
- [ X ] Tests
