### PR TITLE
Hardcode IMAX uppercase for Edition Tags

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/EditionTagsFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/EditionTagsFixture.cs
@@ -47,11 +47,11 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [Test]
         public void should_add_edition_tag()
         {
-            _movieFile.Edition = "Uncut";
+            _movieFile.Edition = "Uncut Imax";
             _namingConfig.StandardMovieFormat = "{Movie Title} [{Edition Tags}]";
 
             Subject.BuildFileName(_movie, _movieFile)
-                   .Should().Be("South Park [Uncut]");
+                   .Should().Be("South Park [Uncut IMAX]");
         }
 
         [TestCase("{Movie Title} {edition-{Edition Tags}}")]

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -283,13 +283,9 @@ namespace NzbDrone.Core.Organizer
 
         private void AddEditionTagsTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, MovieFile movieFile)
         {
-            if (movieFile.Edition.ToUpper() == "IMAX")
+            if (movieFile.Edition.IsNotNullOrWhiteSpace())
             {
-                tokenHandlers["{Edition Tags}"] = m => "IMAX";
-            }
-            else if (movieFile.Edition.IsNotNullOrWhiteSpace())
-            {
-                tokenHandlers["{Edition Tags}"] = m => CultureInfo.CurrentCulture.TextInfo.ToTitleCase(movieFile.Edition.ToLower());
+                tokenHandlers["{Edition Tags}"] = m => CultureInfo.CurrentCulture.TextInfo.ToTitleCase(movieFile.Edition.ToLower().Replace("imax", "IMAX"));
             }
         }
 

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -283,7 +283,11 @@ namespace NzbDrone.Core.Organizer
 
         private void AddEditionTagsTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, MovieFile movieFile)
         {
-            if (movieFile.Edition.IsNotNullOrWhiteSpace())
+            if (movieFile.Edition.ToUpper() == "IMAX")
+            {
+                tokenHandlers["{Edition Tags}"] = m => "IMAX";
+            }
+            else if (movieFile.Edition.IsNotNullOrWhiteSpace())
             {
                 tokenHandlers["{Edition Tags}"] = m => CultureInfo.CurrentCulture.TextInfo.ToTitleCase(movieFile.Edition.ToLower());
             }


### PR DESCRIPTION
#### Database Migration
 NO

#### Description
Hardcode IMAX Edition Tags to uppercase - ignore case preference.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR