### PR TITLE
Fix: Trace logging postgres cleanse for large json files.

### DIFF
--- a/src/NzbDrone.Common.Test/InstrumentationTests/CleanseLogMessageFixture.cs
+++ b/src/NzbDrone.Common.Test/InstrumentationTests/CleanseLogMessageFixture.cs
@@ -64,6 +64,7 @@ namespace NzbDrone.Common.Test.InstrumentationTests
         [TestCase("https://notifiarr.com/notifier.php: api=1234530f-422f-4aac-b6b3-01233210aaaa&radarr_health_issue_message=Download")]
         [TestCase("/readarr/signalr/messages/negotiate?access_token=1234530f422f4aacb6b301233210aaaa&negotiateVersion=1")]
         [TestCase(@"[Info] MigrationController: *** Migrating Database=radarr-main;Host=postgres14;Username=mySecret;Password=mySecret;Port=5432;Enlist=False ***")]
+        [TestCase(@"[Info] MigrationController: *** Migrating Database=radarr-main;Host=postgres14;Username=mySecret;Password=mySecret;Port=5432;token=mySecret;Enlist=False&username=mySecret;mypassword=mySecret;mypass=shouldkeep1;test_token=mySecret;password=123%@%_@!#^#@;use_password=mySecret;get_token=shouldkeep2;usetoken=shouldkeep3;passwrd=mySecret;")]
 
         // Announce URLs (passkeys) Magnet & Tracker
         [TestCase(@"magnet_uri"":""magnet:?xt=urn:btih:9pr04sgkillroyimaveql2tyu8xyui&dn=&tr=https%3a%2f%2fxxx.yyy%2f9pr04sg601233210imaveql2tyu8xyui%2fannounce""}")]
@@ -84,7 +85,22 @@ namespace NzbDrone.Common.Test.InstrumentationTests
             var cleansedMessage = CleanseLogMessage.Cleanse(message);
 
             cleansedMessage.Should().NotContain("mySecret");
+            cleansedMessage.Should().NotContain("123%@%_@!#^#@");
             cleansedMessage.Should().NotContain("01233210");
+        }
+
+        [TestCase(@"[Info] MigrationController: *** Migrating Database=radarr-main;Host=postgres14;Username=mySecret;Password=mySecret;Port=5432;token=mySecret;Enlist=False&username=mySecret;mypassword=mySecret;mypass=shouldkeep1;test_token=mySecret;password=123%@%_@!#^#@;use_password=mySecret;get_token=shouldkeep2;usetoken=shouldkeep3;passwrd=mySecret;")]
+        public void should_keep_message(string message)
+        {
+            var cleansedMessage = CleanseLogMessage.Cleanse(message);
+
+            cleansedMessage.Should().NotContain("mySecret");
+            cleansedMessage.Should().NotContain("123%@%_@!#^#@");
+            cleansedMessage.Should().NotContain("01233210");
+
+            cleansedMessage.Should().Contain("shouldkeep1");
+            cleansedMessage.Should().Contain("shouldkeep2");
+            cleansedMessage.Should().Contain("shouldkeep3");
         }
 
         [TestCase(@"Some message (from 32.2.3.5 user agent)")]

--- a/src/NzbDrone.Common/Instrumentation/CleanseLogMessage.cs
+++ b/src/NzbDrone.Common/Instrumentation/CleanseLogMessage.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Common.Instrumentation
                 new Regex(@"iptorrents\.com/[/a-z0-9?&;]*?(?:[?&;](u|tp)=(?<secret>[^&=;]+?))+(?= |;|&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
                 new Regex(@"/fetch/[a-z0-9]{32}/(?<secret>[a-z0-9]{32})", RegexOptions.Compiled),
                 new Regex(@"getnzb.*?(?<=\?|&)(r)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-                new Regex(@"\b[^;=]*?(_?(?<!use|get_)token|username|passwo?rd)=(?<secret>[^&=]+?)(?= |&|$|;)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                new Regex(@"\b(\w*)?(_?(?<!use|get_)token|username|passwo?rd)=(?<secret>[^&=]+?)(?= |&|$|;)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
                 // Trackers Announce Keys; Designed for Qbit Json; should work for all in theory
                 new Regex(@"announce(\.php)?(/|%2f|%3fpasskey%3d)(?<secret>[a-z0-9]{16,})|(?<secret>[a-z0-9]{16,})(/|%2f)announce"),


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Log cleanse when tracing is enabled is extremely slow for large json files.

This fixes the log clense regex and adds additional tests.

#### Todos
- [X] Tests

#### Issues Fixed or Closed by this PR

* Fixes #7578