### PR TITLE
Fixed: Log Premier Year for reject reasons

### DIFF
--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -314,17 +314,18 @@ namespace NzbDrone.Core.Parser
                     case MappingResultType.Success:
                         return $"Successfully mapped release name {ReleaseName} to movie {Movie}";
                     case MappingResultType.NotParsable:
-                        return $"Failed to find movie title in release name {ReleaseName}";
+                        return $"Failed to find movie title in release name {ReleaseName}. Possibly due to missing year in search string.";
                     case MappingResultType.TitleNotFound:
                         return $"Could not find {RemoteMovie.ParsedMovieInfo.PrimaryMovieTitle}";
                     case MappingResultType.WrongYear:
-                        return $"Failed to map movie, expected year {RemoteMovie.Movie.MovieMetadata.Value.Year}, but found {RemoteMovie.ParsedMovieInfo.Year}";
+                        var commay = RemoteMovie.Movie.MovieMetadata.Value.SecondaryYear == 0 ? "" : ", ";
+                        return $"Failed to map movie, expected years {RemoteMovie.Movie.MovieMetadata.Value.Year}{commay}{RemoteMovie.Movie.MovieMetadata.Value.SecondaryYear}, but found {RemoteMovie.ParsedMovieInfo.Year}";
                     case MappingResultType.WrongTitle:
                         var comma = RemoteMovie.Movie.MovieMetadata.Value.AlternativeTitles.Count > 0 ? ", " : "";
                         return
                             $"Failed to map movie, found title(s) {string.Join(", ", RemoteMovie.ParsedMovieInfo.MovieTitles)}, expected one of: {RemoteMovie.Movie.MovieMetadata.Value.Title}{comma}{string.Join(", ", RemoteMovie.Movie.MovieMetadata.Value.AlternativeTitles)}";
                     default:
-                        return $"Failed to map movie for unknown reasons";
+                        return $"Failed to map movie for unknown reasons. Possibly due to missing year in search string.";
                 }
             }
         }

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -314,7 +314,7 @@ namespace NzbDrone.Core.Parser
                     case MappingResultType.Success:
                         return $"Successfully mapped release name {ReleaseName} to movie {Movie}";
                     case MappingResultType.NotParsable:
-                        return $"Failed to find movie title in release name {ReleaseName}. Possibly due to missing year in search string.";
+                        return $"Failed to find movie title in release name {ReleaseName}. Possibly due to missing year in release name.";
                     case MappingResultType.TitleNotFound:
                         return $"Could not find {RemoteMovie.ParsedMovieInfo.PrimaryMovieTitle}";
                     case MappingResultType.WrongYear:

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -325,7 +325,7 @@ namespace NzbDrone.Core.Parser
                         return
                             $"Failed to map movie, found title(s) {string.Join(", ", RemoteMovie.ParsedMovieInfo.MovieTitles)}, expected one of: {RemoteMovie.Movie.MovieMetadata.Value.Title}{comma}{string.Join(", ", RemoteMovie.Movie.MovieMetadata.Value.AlternativeTitles)}";
                     default:
-                        return $"Failed to map movie for unknown reasons. Possibly due to missing year in search string.";
+                        return $"Failed to map movie for unknown reasons. Possibly due to missing year in title/name to be parsed.";
                 }
             }
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- improve reject reasons to users to clarify 1) year is required and 2) also note the premier year that was looked for (if any)
- reduce support requests given reject will now state both premier and release years rather than only release years thus users thinking radarr ONLY uses release year

#### Screenshot (if UI related)

#### Todos
- Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX