### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/azuresync.yml
+++ b/.github/workflows/azuresync.yml
@@ -7,8 +7,12 @@ on:
 
 concurrency: azuresync-${{ github.event.issue.number }}
 
+permissions: {}
 jobs:
   alert:
+    permissions:
+      issues: write # to update issue body
+
     runs-on: ubuntu-latest
     steps:
       - uses: danhellem/github-actions-issue-to-work-item@master

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -5,8 +5,13 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions: {}
 jobs:
   lock:
+    permissions:
+      issues: write # to lock issues (dessant/lock-threads)
+      pull-requests: write # to lock PRs (dessant/lock-threads)
+
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v2

--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -4,8 +4,12 @@ on:
   issues:
     types: [labeled, unlabeled, reopened]
 
+permissions: {}
 jobs:
   support:
+    permissions:
+      issues: write # to modify issues
+
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/support-requests@v2


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.