### PR TITLE
New: Save release sort key, order, and filter

### DIFF
--- a/frontend/src/Store/Actions/releaseActions.js
+++ b/frontend/src/Store/Actions/releaseActions.js
@@ -213,7 +213,9 @@ export const defaultState = {
 
 export const persistState = [
   'releases.customFilters',
-  'releases.selectedFilterKey'
+  'releases.selectedFilterKey',
+  'releases.sortKey',
+  'releases.sortDirection'
 ];
 
 //
@@ -301,7 +303,16 @@ export const actionHandlers = handleThunks({
 export const reducers = createHandleActions({
 
   [CLEAR_RELEASES]: (state) => {
-    return Object.assign({}, state, defaultState);
+    return Object.assign(
+      {},
+      state,
+      defaultState,
+      {
+        sortDirection: state.sortDirection,
+        sortKey: state.sortKey,
+        selectedFilterKey: state.selectedFilterKey
+      }
+    );
   },
 
   [UPDATE_RELEASE]: (state, { payload }) => {


### PR DESCRIPTION
#### Database Migration
No

#### Description
Remembering the user's sort column, sort order, and sort filter selections when searching releases.

#### Screenshot (if UI related)
No visible changes.  The column will just be remembered.

#### Todos
- [N/A] Tests (ran tests)
- [N/A] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)  (no additional language)
- [N/A] [Wiki Updates](https://wiki.servarr.com) (no documentation changes required)

#### Issues Fixed or Closed by this PR

* Addresses https://github.com/Radarr/Radarr/issues/4935 