### PR TITLE
Fixed: Detect 3D in some video files

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -70,7 +70,8 @@ const mediaInfoTokens = [
   { token: '{MediaInfo VideoCodec}', example: 'x264' },
   { token: '{MediaInfo VideoBitDepth}', example: '10' },
   { token: '{MediaInfo VideoDynamicRange}', example: 'HDR' },
-  { token: '{MediaInfo VideoDynamicRangeType}', example: 'DV HDR10' }
+  { token: '{MediaInfo VideoDynamicRangeType}', example: 'DV HDR10' },
+  { token: '{MediaInfo 3D}', example: '3D' }
 ];
 
 const releaseGroupTokens = [

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -425,7 +425,6 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
                    .Should().Be("South.Park.H264.DTS.[EN+ES+IT]");
         }
 
-        [Ignore("not currently supported")]
         [Test]
         public void should_format_mediainfo_3d_properly()
         {

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -75,7 +75,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 mediaInfoModel.VideoCodecID = analysis.PrimaryVideoStream?.CodecTagString;
                 mediaInfoModel.VideoProfile = analysis.PrimaryVideoStream?.Profile;
                 mediaInfoModel.VideoBitrate = analysis.PrimaryVideoStream?.BitRate ?? 0;
-                mediaInfoModel.VideoMultiViewCount = 1;
+                mediaInfoModel.VideoMultiViewCount = analysis.PrimaryVideoStream?.Tags.ContainsKey("stereo_mode") ?? false ? 2 : 1;
                 mediaInfoModel.VideoBitDepth = GetPixelFormat(analysis.PrimaryVideoStream?.PixelFormat)?.Components.Min(x => x.BitDepth) ?? 8;
                 mediaInfoModel.VideoColourPrimaries = analysis.PrimaryVideoStream?.ColorPrimaries;
                 mediaInfoModel.VideoTransferCharacteristics = analysis.PrimaryVideoStream?.ColorTransfer;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Uses `stero_mode` to detect 3D from ffprobe for video files with correct metadata

#### Screenshot (if UI related)

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes #7695 