### PR TITLE
Fix: Re-enable Filter Search Indicator

### DIFF
--- a/frontend/src/Components/Menu/FilterMenu.js
+++ b/frontend/src/Components/Menu/FilterMenu.js
@@ -4,7 +4,7 @@ import { icons } from 'Helpers/Props';
 import translate from 'Utilities/String/translate';
 import FilterMenuContent from './FilterMenuContent';
 import Menu from './Menu';
-import ToolbarMenuButton from './ToolbarMenuButton';
+import PageMenuButton from './PageMenuButton';
 import styles from './FilterMenu.css';
 
 class FilterMenu extends Component {
@@ -60,7 +60,7 @@ class FilterMenu extends Component {
             iconName={icons.FILTER}
             text={translate('Filter')}
             isDisabled={isDisabled}
-            indicator={selectedFilterKey !== 'all'}
+            showIndicator={selectedFilterKey !== 'all'}
           />
 
           <FilterMenuContent
@@ -106,7 +106,7 @@ FilterMenu.propTypes = {
 FilterMenu.defaultProps = {
   className: styles.filterMenu,
   isDisabled: false,
-  buttonComponent: ToolbarMenuButton
+  buttonComponent: PageMenuButton
 };
 
 export default FilterMenu;

--- a/frontend/src/Components/Menu/PageMenuButton.css
+++ b/frontend/src/Components/Menu/PageMenuButton.css
@@ -1,9 +1,17 @@
 .menuButton {
   composes: menuButton from '~./MenuButton.css';
 
+  position: relative;
+
   &:hover {
     color: #666;
   }
+}
+
+.indicatorContainer {
+  position: absolute;
+  top: 10px;
+  left: 10px;
 }
 
 .label {

--- a/frontend/src/Components/Menu/PageMenuButton.js
+++ b/frontend/src/Components/Menu/PageMenuButton.js
@@ -1,13 +1,15 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Icon from 'Components/Icon';
 import MenuButton from 'Components/Menu/MenuButton';
+import { icons } from 'Helpers/Props';
 import styles from './PageMenuButton.css';
 
 function PageMenuButton(props) {
   const {
     iconName,
-    indicator,
+    showIndicator,
     text,
     ...otherProps
   } = props;
@@ -22,6 +24,22 @@ function PageMenuButton(props) {
         size={18}
       />
 
+      {
+        showIndicator ?
+          <span
+            className={classNames(
+              styles.indicatorContainer,
+              'fa-layers fa-fw'
+            )}
+          >
+            <Icon
+              name={icons.CIRCLE}
+              size={9}
+            />
+          </span> :
+          null
+      }
+
       <div className={styles.label}>
         {text}
       </div>
@@ -32,11 +50,11 @@ function PageMenuButton(props) {
 PageMenuButton.propTypes = {
   iconName: PropTypes.object.isRequired,
   text: PropTypes.string,
-  indicator: PropTypes.bool.isRequired
+  showIndicator: PropTypes.bool.isRequired
 };
 
 PageMenuButton.defaultProps = {
-  indicator: false
+  showIndicator: false
 };
 
 export default PageMenuButton;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixing the filter indicator display in Search Panel.  Pulling in a Sonarr change that fixes the position and using the ToolbarMenuButton as the indicator logic was moved there in a previous change. 

#### Screenshot (if UI related)
Filter enabled: 
![image](https://user-images.githubusercontent.com/55123373/204167857-9218a265-aa2e-48f8-be33-a03e4bb9d0e8.png)

No filter enabled (all results shown):
![image](https://user-images.githubusercontent.com/55123373/204167868-cb8d6df9-605f-4b3d-a8dc-77b0dea011c7.png)

#### Todos
- [N/A] Tests
- [N/A] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ N/A] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #7082
