### PR TITLE
chore: Chain exceptions when trying to get rss's item size

### DIFF
--- a/src/NzbDrone.Core/Indexers/RssParser.cs
+++ b/src/NzbDrone.Core/Indexers/RssParser.cs
@@ -165,9 +165,9 @@ namespace NzbDrone.Core.Indexers
             {
                 releaseInfo.Size = GetSize(item);
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                throw new SizeParsingException("Unable to parse size from: {0}", releaseInfo.Title);
+                throw new SizeParsingException("Unable to parse size from: {0}", e, releaseInfo.Title);
             }
 
             return releaseInfo;


### PR DESCRIPTION
This is only meant to be more helpful when reading the exceptions log.
While implementing a rss service, this kept throwing and it does not show the original exception so I can fix what's being returned.