### PR TITLE
New: Auto theme option to match OS theme

### DIFF
--- a/frontend/src/Styles/Themes/index.js
+++ b/frontend/src/Styles/Themes/index.js
@@ -1,7 +1,11 @@
 import * as dark from './dark';
 import * as light from './light';
 
+const defaultDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const auto = defaultDark ? { ...dark } : { ...light };
+
 export default {
+  auto,
   light,
   dark
 };

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -198,7 +198,7 @@ namespace NzbDrone.Core.Configuration
 
         public string LogLevel => GetValue("LogLevel", "info").ToLowerInvariant();
         public string ConsoleLogLevel => GetValue("ConsoleLogLevel", string.Empty, persist: false);
-        public string Theme => GetValue("Theme", "light", persist: false);
+        public string Theme => GetValue("Theme", "auto", persist: false);
         public string PostgresHost => _postgresOptions?.Host ?? GetValue("PostgresHost", string.Empty, persist: false);
         public string PostgresUser => _postgresOptions?.User ?? GetValue("PostgresUser", string.Empty, persist: false);
         public string PostgresPassword => _postgresOptions?.Password ?? GetValue("PostgresPassword", string.Empty, persist: false);

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -928,7 +928,7 @@
   "SettingsShowRelativeDates": "Show Relative Dates",
   "SettingsShowRelativeDatesHelpText": "Show relative (Today/Yesterday/etc) or absolute dates",
   "SettingsTheme": "Theme",
-  "SettingsThemeHelpText": "Change Application UI Theme, Inspired by Theme.Park",
+  "SettingsThemeHelpText": "Change Application UI Theme, 'Auto' Theme will use your OS Theme to set Light or Dark mode. Inspired by Theme.Park",
   "SettingsTimeFormat": "Time Format",
   "SettingsWeekColumnHeader": "Week Column Header",
   "SettingsWeekColumnHeaderHelpText": "Shown above each column when week is the active view",


### PR DESCRIPTION
Co-authored-by: Qstick <qstick@gmail.com>
(cherry picked from commit 4ca5a213fa0fc29ed93e7e31b080728d6fa7f1f3)

#### Database Migration
NO

#### Description
Adds support for `prefers-color-scheme` to use the OS preferred theme (light or dark) and also makes it default with the option for the user to force the theme that they want in UI Settings

#### Todos
- N/A

#### Issues Fixed or Closed by this PR

* Fixes #7845