### PR TITLE
Add support multiLanguageTitle in ParsingService.cs

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
@@ -29,7 +29,9 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
         private ParsedMovieInfo _umlautAltInfo;
         private ParsedMovieInfo _multiLanguageInfo;
         private ParsedMovieInfo _multiLanguageWithOriginalInfo;
+        private ParsedMovieInfo _multiLanguageTitle;
         private MovieSearchCriteria _movieSearchCriteria;
+        private MovieSearchCriteria _movieSearchCriteriaFirstPart;
 
         [SetUp]
         public void Setup()
@@ -114,6 +116,25 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             _movieSearchCriteria = new MovieSearchCriteria
             {
                 Movie = _movie
+            };
+
+            _multiLanguageTitle = new ParsedMovieInfo
+            {
+                MovieTitles = new List<string> { "Fack Ju Göthe 2 / Фак ю Готе 2" },
+                Languages = new List<Language> { Language.English },
+                Year = _movie.Year
+            };
+
+            _movieSearchCriteriaFirstPart = new MovieSearchCriteria
+            {
+                Movie = Builder<Movie>.CreateNew()
+                    .With(m => m.Title = "Fack Ju Göthe")
+                    .With(m => m.MovieMetadata.Value.CleanTitle = "fackjugoethe")
+                    .With(m => m.Year = 2010)
+                    .With(m => m.MovieMetadata.Value.AlternativeTitles = new List<AlternativeTitle> { new AlternativeTitle("Fack Ju Göthe: First") })
+                    .With(m => m.MovieMetadata.Value.Translations = new List<MovieTranslation> { new MovieTranslation { Title = "Translated Title", CleanTitle = "translatedtitle" } })
+                    .With(m => m.MovieMetadata.Value.OriginalLanguage = Language.English)
+                    .Build()
             };
         }
 
@@ -208,6 +229,18 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             Subject.Map(_multiLanguageWithOriginalInfo, "", _movieSearchCriteria).RemoteMovie.ParsedMovieInfo.Languages.Should().Contain(Language.English);
             Subject.Map(_multiLanguageWithOriginalInfo, "", _movieSearchCriteria).RemoteMovie.ParsedMovieInfo.Languages.Should().Contain(Language.French);
             Subject.Map(_multiLanguageWithOriginalInfo, "", _movieSearchCriteria).RemoteMovie.ParsedMovieInfo.Languages.Should().NotContain(Language.Original);
+        }
+
+        [Test]
+        public void should_match_multilanguage_multiLanguageTitle()
+        {
+            Subject.Map(_multiLanguageTitle, "", _movieSearchCriteria).MappingResultType.Should().Be(MappingResultType.Success);
+        }
+
+        [Test]
+        public void should_not_match_multilanguage_multiLanguageTitle()
+        {
+            Subject.Map(_multiLanguageTitle, "", _movieSearchCriteriaFirstPart).MappingResultType.Should().Be(MappingResultType.WrongTitle);
         }
     }
 }

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -260,9 +260,15 @@ namespace NzbDrone.Core.Parser
 
             var cleanTitle = parsedMovieInfo.PrimaryMovieTitle.CleanMovieTitle();
 
+            var multilangsTitle = new List<string>();
+            if (parsedMovieInfo.PrimaryMovieTitle.Contains('/'))
+            {
+                multilangsTitle = parsedMovieInfo.PrimaryMovieTitle.Split('/').ToList().ConvertAll<string>(t => t.CleanMovieTitle());
+            }
+
             foreach (var title in possibleTitles)
             {
-                if (title == cleanTitle)
+                if (title == cleanTitle || multilangsTitle.Contains(title))
                 {
                     possibleMovie = searchCriteria.Movie;
                 }
@@ -273,12 +279,12 @@ namespace NzbDrone.Core.Parser
                     var romanNumeral = numeralMapping.RomanNumeralLowerCase;
 
                     // _logger.Debug(cleanTitle);
-                    if (title.Replace(arabicNumeral, romanNumeral) == cleanTitle)
+                    if (title.Replace(arabicNumeral, romanNumeral) == cleanTitle || multilangsTitle.Contains(title.Replace(arabicNumeral, romanNumeral)))
                     {
                         possibleMovie = searchCriteria.Movie;
                     }
 
-                    if (title == cleanTitle.Replace(arabicNumeral, romanNumeral))
+                    if (title == cleanTitle.Replace(arabicNumeral, romanNumeral) || multilangsTitle.Select(t => t.Replace(arabicNumeral, romanNumeral)).Contains(title))
                     {
                         possibleMovie = searchCriteria.Movie;
                     }


### PR DESCRIPTION
**Describe the bug**
**Failed to map movie**  if the torrent has several movie titles in the title (Translated / English) (for example: Енола Голмс / Enola Holmes (2020) UHD WEB-DL 2160p 4K HDR H.265 Ukr/Eng | Sub Ukr/Eng)

#### Database Migration
NO

#### Description
Add support multiLanguageTitle in ParsingService.cs
Add Tests for this problem

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
Fixes this problem

#### Comment
I don't know C# well and maybe my solution is not perfect, please check and edit my code