### PR TITLE
Bump MonoTorrent to 2.0.7

### DIFF
--- a/src/NzbDrone.Core/Radarr.Core.csproj
+++ b/src/NzbDrone.Core/Radarr.Core.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NLog" Version="5.0.1" />
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />
-    <PackageReference Include="MonoTorrent" Version="2.0.5" />
+    <PackageReference Include="MonoTorrent" Version="2.0.7" />
     <PackageReference Include="System.Text.Json" Version="6.0.5" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Includes https://github.com/alanmcgovern/monotorrent/pull/584, which fixes an issue that causes Radarr to fail to download some torrents.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX