### PR TITLE
MoveService: Skip move when source and destination are the same

### DIFF
--- a/src/NzbDrone.Core/Movies/MoveMovieService.cs
+++ b/src/NzbDrone.Core/Movies/MoveMovieService.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.Movies
 
             if (sourcePath.Equals(destinationPath))
             {
-                _logger.ProgressInfo("'{0}' is already in the right location.", movie.Title, sourcePath);
+                _logger.ProgressInfo("'{0}' is already in the right location '{1}'.", movie.Title, destinationPath);
                 return;
             }
 

--- a/src/NzbDrone.Core/Movies/MoveMovieService.cs
+++ b/src/NzbDrone.Core/Movies/MoveMovieService.cs
@@ -42,6 +42,12 @@ namespace NzbDrone.Core.Movies
                 return;
             }
 
+            if (sourcePath.Equals(destinationPath))
+            {
+                _logger.ProgressInfo("'{0}' is already in the right location.", movie.Title, sourcePath);
+                return;
+            }
+
             if (index != null && total != null)
             {
                 _logger.ProgressInfo("Moving {0} from '{1}' to '{2}' ({3}/{4})", movie.Title, sourcePath, destinationPath, index + 1, total);


### PR DESCRIPTION
Check if the source path and destination path are the same; if so, skip the move.

#### Database Migration
NO

#### Description
[Some places](https://forums.sonarr.tv/t/rename-of-series-folders/24823) suggest to change the use the mass rename ability of "changing the root folder to the same value" in order to rename the movies/series folders.
This works fine, with the exception of a few errors:

```
2022-12-30 10:00:37.8|Info|MoveMovieService|Moving 39 movies to '/movies'
2022-12-30 10:00:37.8|Info|MoveMovieService|Moving Interstella 5555 from '/movies/Interstella 5555 (2003)' to '/movies/Interstella 5555 (2003)' (1/39)
2022-12-30 10:00:37.8|Error|MoveMovieService|Unable to move movie from '/movies/Interstella 5555 (2003)' to '/movies/Interstella 5555 (2003)'. Try moving files manually

[v4.2.4.6635] System.IO.IOException: Source and destination can't be the same /movies/Interstella 5555 (2003)
   at NzbDrone.Common.Disk.DiskTransferService.TransferFolder(String sourcePath, String targetPath, TransferMode mode) in D:\a\1\s\src\NzbDrone.Common\Disk\DiskTransferService.cs:line 56
   at NzbDrone.Core.Movies.MoveMovieService.MoveSingleMovie(Movie movie, String sourcePath, String destinationPath, Nullable`1 index, Nullable`1 total) in D:\a\1\s\src\NzbDrone.Core\Movies\MoveMovieService.cs:line 57
```

This pull requests changes the behaviour to skip the rename if it isn't necessary avoiding the error logs which can eventually lead to:

```
2022-12-30 10:01:18.9|Error|CommandExecutor|Error occurred while executing task BulkMoveMovie

[v4.2.4.6635] code = Busy (5), message = System.Data.SQLite.SQLiteException (0x800007AF): database is locked
database is locked
   at System.Data.SQLite.SQLite3.Step(SQLiteStatement stmt)
   at System.Data.SQLite.SQLiteDataReader.NextResult()
   at System.Data.SQLite.SQLiteDataReader..ctor(SQLiteCommand cmd, CommandBehavior behave)
   at System.Data.SQLite.SQLiteCommand.ExecuteReader(CommandBehavior behavior)
   at System.Data.SQLite.SQLiteCommand.ExecuteNonQuery(CommandBehavior behavior)
   at Dapper.SqlMapper.ExecuteCommand(IDbConnection cnn, CommandDefinition& command, Action`2 paramReader) in /_/Dapper/SqlMapper.cs:line 2858
   at Dapper.SqlMapper.ExecuteImpl(IDbConnection cnn, CommandDefinition& command) in /_/Dapper/SqlMapper.cs:line 581
   at NzbDrone.Core.Datastore.BasicRepository`1.UpdateFields(IDbConnection connection, IDbTransaction transaction, TModel model, List`1 propertiesToUpdate) in D:\a\1\s\src\NzbDrone.Core\Datastore\BasicRepository.cs:line 385
   at NzbDrone.Core.Datastore.BasicRepository`1.Update(TModel model) in D:\a\1\s\src\NzbDrone.Core\Datastore\BasicRepository.cs:line 232
   at NzbDrone.Core.Movies.MovieService.UpdateMovie(Movie movie) in D:\a\1\s\src\NzbDrone.Core\Movies\MovieService.cs:line 258
   at NzbDrone.Core.Movies.MoveMovieService.RevertPath(Int32 movieId, String path) in D:\a\1\s\src\NzbDrone.Core\Movies\MoveMovieService.cs:line 76
   at NzbDrone.Core.Movies.MoveMovieService.MoveSingleMovie(Movie movie, String sourcePath, String destinationPath, Nullable`1 index, Nullable`1 total) in D:\a\1\s\src\NzbDrone.Core\Movies\MoveMovieService.cs:line 67
   at NzbDrone.Core.Movies.MoveMovieService.Execute(BulkMoveMovieCommand message) in D:\a\1\s\src\NzbDrone.Core\Movies\MoveMovieService.cs:line 98
   at NzbDrone.Core.Messaging.Commands.CommandExecutor.ExecuteCommand[TCommand](TCommand command, CommandModel commandModel) in D:\a\1\s\src\NzbDrone.Core\Messaging\Commands\CommandExecutor.cs:line 113
   at System.Dynamic.UpdateDelegates.UpdateAndExecuteVoid3[T0,T1,T2](CallSite site, T0 arg0, T1 arg1, T2 arg2)
   at NzbDrone.Core.Messaging.Commands.CommandExecutor.ExecuteCommands() in D:\a\1\s\src\NzbDrone.Core\Messaging\Commands\CommandExecutor.cs:line 44
```

It could be improved further by checking that the actual paths are identical (rather than the strings) to avoid any oddities such as relative paths, etc.
But this is a "good enough" solution for the vast majority of the cases.

I hesitated to put the progress into the log if `index` and `total` are provided, but thought it was overkill. Happy to be told otherwise.