### PR TITLE
Include movie title and year when logging report

### DIFF
--- a/src/NzbDrone.Core/Download/DownloadService.cs
+++ b/src/NzbDrone.Core/Download/DownloadService.cs
@@ -109,7 +109,7 @@ namespace NzbDrone.Core.Download
                 movieGrabbedEvent.DownloadId = downloadClientId;
             }
 
-            _logger.ProgressInfo("Report sent to {0} from indexer {1}. {2}", downloadClient.Definition.Name, remoteMovie.Release.Indexer, downloadTitle);
+            _logger.ProgressInfo("{0} ({1}) report sent to {2} from indexer {3}. {4}", remoteMovie.Movie.Title, remoteMovie.Movie.Year, downloadClient.Definition.Name, remoteMovie.Release.Indexer, downloadTitle);
             _eventAggregator.PublishEvent(movieGrabbedEvent);
         }
     }

--- a/src/NzbDrone.Core/Download/DownloadService.cs
+++ b/src/NzbDrone.Core/Download/DownloadService.cs
@@ -109,7 +109,7 @@ namespace NzbDrone.Core.Download
                 movieGrabbedEvent.DownloadId = downloadClientId;
             }
 
-            _logger.ProgressInfo("{0} ({1}) report sent to {2} from indexer {3}. {4}", remoteMovie.Movie.Title, remoteMovie.Movie.Year, downloadClient.Definition.Name, remoteMovie.Release.Indexer, downloadTitle);
+            _logger.ProgressInfo("Report for {0} ({1}) sent to {2} from indexer {3}. {4}", remoteMovie.Movie.Title, remoteMovie.Movie.Year, downloadClient.Definition.Name, remoteMovie.Release.Indexer, downloadTitle);
             _eventAggregator.PublishEvent(movieGrabbedEvent);
         }
     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description

If an unknown release is grabbed, it's very difficult to determine from the logs which movie it was grabbed from. For example, previously in logs it would display

```
DownloadService: Report sent to SABnzbd. The.Ultimate.Oppa.2022.1080p.AMZN.WEB-DL.DDP5.1.x264-HDMAX
```

This PR adds extra debugging info in logs to allow us to trace back much easier

```
DownloadService: Expensive Candy (2022) report sent to SABnzbd. The.Ultimate.Oppa.2022.1080p.AMZN.WEB-DL.DDP5.1.x264-HDMAX
```

#### Screenshot (if UI related)
None
#### Todos
None

#### Issues Fixed or Closed by this PR

None