### PR TITLE
chore(git): Ignore `.idea/` completely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,27 +166,8 @@ packages.config.md5sum
 
 # Common IntelliJ Platform excludes
 
-# User specific
-**/.idea/**/workspace.xml
-**/.idea/**/tasks.xml
-**/.idea/shelf/*
-**/.idea/dictionaries
-**/.idea/.idea.Radarr.Posix
-**/.idea/.idea.Radarr.Windows
-
-# Sensitive or high-churn files
-**/.idea/**/dataSources/
-**/.idea/**/dataSources.ids
-**/.idea/**/dataSources.xml
-**/.idea/**/dataSources.local.xml
-**/.idea/**/sqlDataSources.xml
-**/.idea/**/dynamic.xml
-
-# Rider
-# Rider auto-generates .iml files, and contentModel.xml
-**/.idea/**/*.iml
-**/.idea/**/contentModel.xml
-**/.idea/**/modules.xml
+# Ignore Rider projects completely for now
+.idea/
 
 # ignore node_modules symlink
 node_modules


### PR DESCRIPTION
Unless the repository owners wish to have these files in their repo, they should be ignored so that contributors are not stepping around these files.
