### PR TITLE
Improve handling of releases without video files

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/DownloadedMoviesImportServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DownloadedMoviesImportServiceFixture.cs
@@ -445,6 +445,58 @@ namespace NzbDrone.Core.Test.MediaFiles
                   .Verify(v => v.DeleteFolder(It.IsAny<string>(), true), Times.Never());
         }
 
+        [Test]
+        public void should_return_rejection_if_nothing_imported_and_contains_rar_file()
+        {
+            GivenValidMovie();
+
+            var path = @"C:\media\ba09030e-1234-1234-1234-123456789abc\[HorribleSubs] American Psycho (2000) [720p]\[HorribleSubs] American Psycho (2000) [720p].mkv".AsOsAgnostic();
+            var imported = new List<ImportDecision>();
+
+            Mocker.GetMock<IMakeImportDecision>()
+                .Setup(s => s.GetImportDecisions(It.IsAny<List<string>>(), It.IsAny<Movie>(), It.IsAny<DownloadClientItem>(), null, true, true))
+                .Returns(imported);
+
+            Mocker.GetMock<IImportApprovedMovie>()
+                .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), true, null, ImportMode.Auto))
+                .Returns(imported.Select(i => new ImportResult(i)).ToList());
+
+            Mocker.GetMock<IDiskProvider>()
+                .Setup(s => s.GetFiles(It.IsAny<string>(), SearchOption.AllDirectories))
+                .Returns(new[] { _videoFiles.First().Replace(".ext", ".rar") });
+
+            var result = Subject.ProcessPath(path);
+
+            result.Count.Should().Be(1);
+            result.First().Result.Should().Be(ImportResultType.Rejected);
+        }
+
+        [Test]
+        public void should_return_rejection_if_nothing_imported_and_contains_executable_file()
+        {
+            GivenValidMovie();
+
+            var path = @"C:\media\ba09030e-1234-1234-1234-123456789abc\[HorribleSubs] American Psycho (2000) [720p]\[HorribleSubs] American Psycho (2000) [720p].mkv".AsOsAgnostic();
+            var imported = new List<ImportDecision>();
+
+            Mocker.GetMock<IMakeImportDecision>()
+                .Setup(s => s.GetImportDecisions(It.IsAny<List<string>>(), It.IsAny<Movie>(), It.IsAny<DownloadClientItem>(), null, true, true))
+                .Returns(imported);
+
+            Mocker.GetMock<IImportApprovedMovie>()
+                .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), true, null, ImportMode.Auto))
+                .Returns(imported.Select(i => new ImportResult(i)).ToList());
+
+            Mocker.GetMock<IDiskProvider>()
+                .Setup(s => s.GetFiles(It.IsAny<string>(), SearchOption.AllDirectories))
+                .Returns(new[] { _videoFiles.First().Replace(".ext", ".exe") });
+
+            var result = Subject.ProcessPath(path);
+
+            result.Count.Should().Be(1);
+            result.First().Result.Should().Be(ImportResultType.Rejected);
+        }
+
         private void VerifyNoImport()
         {
             Mocker.GetMock<IImportApprovedMovie>().Verify(c => c.Import(It.IsAny<List<ImportDecision>>(), true, null, ImportMode.Auto),

--- a/src/NzbDrone.Core/MediaFiles/FileExtensions.cs
+++ b/src/NzbDrone.Core/MediaFiles/FileExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace NzbDrone.Core.MediaFiles
+{
+    internal static class FileExtensions
+    {
+        private static List<string> _archiveExtensions = new List<string>
+        {
+            ".rar",
+            ".r00",
+            ".zip",
+            ".tar",
+            ".gz",
+            ".tar.gz"
+        };
+
+        private static List<string> _executableExtensions = new List<string>
+        {
+            ".exe",
+            ".bat",
+            ".cmd",
+            ".sh"
+        };
+
+        public static HashSet<string> ArchiveExtensions => new HashSet<string>(_archiveExtensions, StringComparer.OrdinalIgnoreCase);
+        public static HashSet<string> ExecutableExtensions => new HashSet<string>(_executableExtensions, StringComparer.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
New: Show warning in queue if download contains executable or archive file and no video file was detected

(cherry picked from commit b15b6a079846b21cac8476820fce9cde81732291)

Fixes: #7908 