### PR TITLE
Fixed: Avoid Sqlite Error when all profiles have lowest quality cutoff

### DIFF
--- a/src/NzbDrone.Core/Movies/MovieCutoffService.cs
+++ b/src/NzbDrone.Core/Movies/MovieCutoffService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Qualities;
@@ -39,6 +40,13 @@ namespace NzbDrone.Core.Movies
                 {
                     qualitiesBelowCutoff.Add(new QualitiesBelowCutoff(profile.Id, belowCutoff.SelectMany(i => i.GetQualities().Select(q => q.Id))));
                 }
+            }
+
+            if (qualitiesBelowCutoff.Empty())
+            {
+                pagingSpec.Records = new List<Movie>();
+
+                return pagingSpec;
             }
 
             return _movieRepository.MoviesWhereCutoffUnmet(pagingSpec, qualitiesBelowCutoff);


### PR DESCRIPTION
(cherry picked from commit  f05e109b50cca496e7b42e2833eff161a43e12f4)

Sonarr Pull

#### Issues Fixed or Closed by this PR

* Fixes #8017