### PR TITLE
Fixed: Parse year in title from square brackets

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -215,6 +215,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie Name FRENCH BluRay 720p 2016 kjhlj", 2016)]
         [TestCase("Der.Movie.German.Bluray.FuckYou.Pso.Why.cant.you.follow.scene.rules.1998", 1998)]
         [TestCase("Movie Name (1897) [DVD].mp4", 1897)]
+        [TestCase("World Movie Z Movie [2023]", 2023)]
         public void should_parse_movie_year(string postTitle, int year)
         {
             Parser.Parser.ParseMovieTitle(postTitle).Year.Should().Be(year);

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -144,7 +144,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex AnimeReleaseGroupRegex = new Regex(@"^(?:\[(?<subgroup>(?!\s).+?(?<!\s))\](?:_|-|\s|\.)?)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex YearInTitleRegex = new Regex(@"^(?<title>.+?)(?:\W|_)?(?<year>\d{4})",
+        private static readonly Regex YearInTitleRegex = new Regex(@"^(?<title>.+?)(?:\W|_.)?[\(\[]?(?<year>\d{4})[\]\)]?",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         // Handle Exception Release Groups that don't follow -RlsGrp; Manual List


### PR DESCRIPTION
(cherry picked from commit 99e60196a4e513d6340a090de4a5517f205e7a29)

* Fixes #7777