### PR TITLE
Fixed: Releases from PTP showing skewed publish date

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/PTPTests/PTPFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/PTPTests/PTPFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Net.Http;
 using FluentAssertions;
@@ -55,7 +56,7 @@ namespace NzbDrone.Core.Test.IndexerTests.PTPTests
             first.DownloadUrl.Should().Be("https://passthepopcorn.me/torrents.php?action=download&id=452135&authkey=00000000000000000000000000000000&torrent_pass=00000000000000000000000000000000");
             first.InfoUrl.Should().Be("https://passthepopcorn.me/torrents.php?id=148131&torrentid=452135");
 
-            // first.PublishDate.Should().Be(DateTime.Parse("2017-04-17T12:13:42+0000").ToUniversalTime()); stupid timezones
+            first.PublishDate.Should().Be(DateTime.Parse("2016-10-18T23:40:59+0000").ToUniversalTime());
             first.Size.Should().Be(2466170624L);
             first.InfoHash.Should().BeNullOrEmpty();
             first.MagnetUrl.Should().BeNullOrEmpty();

--- a/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornParser.cs
+++ b/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornParser.cs
@@ -97,7 +97,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
                             InfoUrl = GetInfoUrl(result.GroupId, id),
                             Seeders = int.Parse(torrent.Seeders),
                             Peers = int.Parse(torrent.Leechers) + int.Parse(torrent.Seeders),
-                            PublishDate = torrent.UploadTime.ToUniversalTime(),
+                            PublishDate = TimeZoneInfo.ConvertTimeToUtc(torrent.UploadTime, TimeZoneInfo.Utc), // PTP returns UTC timestamps, without a timezone specifier.
                             Golden = torrent.GoldenPopcorn,
                             Scene = torrent.Scene,
                             Approved = torrent.Checked,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
PTP returns UTC timestamps, without a timezone specifier. Previously, users would see skewed publish dates, as the UTC timestamps were being parsed as if they were in the system's timezone. To fix this, we just assume the publish date is in UTC.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #8050