### PR TITLE
Added: Apprise provider for notifications

### DIFF
--- a/src/NzbDrone.Core/Notifications/Apprise/Apprise.cs
+++ b/src/NzbDrone.Core/Notifications/Apprise/Apprise.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+
+using FluentValidation.Results;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Movies;
+
+namespace NzbDrone.Core.Notifications.Apprise
+{
+    public class Apprise : NotificationBase<AppriseSettings>
+    {
+        private readonly IAppriseProxy _proxy;
+
+        public Apprise(IAppriseProxy proxy)
+        {
+            _proxy = proxy;
+        }
+
+        public override string Name => "Apprise API";
+
+        public override string Link => "https://github.com/caronc/apprise";
+
+        public override void OnGrab(GrabMessage grabMessage)
+        {
+            _proxy.SendNotification(MOVIE_GRABBED_TITLE_BRANDED, grabMessage.Message, Settings);
+        }
+
+        public override void OnDownload(DownloadMessage message)
+        {
+            _proxy.SendNotification(MOVIE_DOWNLOADED_TITLE_BRANDED, message.Message, Settings);
+        }
+
+        public override void OnMovieAdded(Movie movie)
+        {
+            _proxy.SendNotification(MOVIE_ADDED_TITLE_BRANDED, $"{movie.Title} added to library", Settings);
+        }
+
+        public override void OnMovieFileDelete(MovieFileDeleteMessage deleteMessage)
+        {
+            _proxy.SendNotification(MOVIE_FILE_DELETED_TITLE, deleteMessage.Message, Settings);
+        }
+
+        public override void OnMovieDelete(MovieDeleteMessage deleteMessage)
+        {
+            _proxy.SendNotification(MOVIE_DELETED_TITLE, deleteMessage.Message, Settings);
+        }
+
+        public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)
+        {
+            _proxy.SendNotification(HEALTH_ISSUE_TITLE_BRANDED, healthCheck.Message, Settings);
+        }
+
+        public override void OnApplicationUpdate(ApplicationUpdateMessage updateMessage)
+        {
+            _proxy.SendNotification(APPLICATION_UPDATE_TITLE_BRANDED, updateMessage.Message, Settings);
+        }
+
+        public override ValidationResult Test()
+        {
+            var failures = new List<ValidationFailure>();
+
+            failures.AddIfNotNull(_proxy.Test(Settings));
+
+            return new ValidationResult(failures);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Apprise/AppriseException.cs
+++ b/src/NzbDrone.Core/Notifications/Apprise/AppriseException.cs
@@ -1,0 +1,18 @@
+using System;
+using NzbDrone.Common.Exceptions;
+
+namespace NzbDrone.Core.Notifications.Apprise
+{
+    public class AppriseException : NzbDroneException
+    {
+        public AppriseException(string message)
+            : base(message)
+        {
+        }
+
+        public AppriseException(string message, Exception innerException, params object[] args)
+            : base(message, innerException, args)
+        {
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Apprise/ApprisePayload.cs
+++ b/src/NzbDrone.Core/Notifications/Apprise/ApprisePayload.cs
@@ -1,0 +1,17 @@
+using System;
+using Newtonsoft.Json;
+
+namespace NzbDrone.Core.Notifications.Apprise
+{
+    public class ApprisePayload
+    {
+        public string Title { get; set; }
+
+        public string Body { get; set; }
+
+        [JsonProperty("type")]
+        public ApprisePriority NotificationType { get; set; }
+
+        public string Tag { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Apprise/ApprisePriority.cs
+++ b/src/NzbDrone.Core/Notifications/Apprise/ApprisePriority.cs
@@ -1,0 +1,19 @@
+using System.Runtime.Serialization;
+
+namespace NzbDrone.Core.Notifications.Apprise
+{
+    public enum ApprisePriority
+    {
+        [EnumMember(Value = "info")]
+        Info = 0,
+
+        [EnumMember(Value = "success")]
+        Success,
+
+        [EnumMember(Value = "warning")]
+        Warning,
+
+        [EnumMember(Value = "failure")]
+        Failure,
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Apprise/AppriseProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Apprise/AppriseProxy.cs
@@ -1,0 +1,130 @@
+using System;
+
+using FluentValidation.Results;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Common.Serializer;
+
+namespace NzbDrone.Core.Notifications.Apprise
+{
+    public interface IAppriseProxy
+    {
+        void SendNotification(string title, string message, AppriseSettings settings);
+
+        ValidationFailure Test(AppriseSettings settings);
+    }
+
+    public class AppriseProxy : IAppriseProxy
+    {
+        private const string DEFAULT_PUSH_URL = "http://localhost:8000/notify/apprise";
+
+        private readonly IHttpClient _httpClient;
+
+        private readonly Logger _logger;
+
+        public AppriseProxy(IHttpClient httpClient, Logger logger)
+        {
+            _httpClient = httpClient;
+            _logger = logger;
+        }
+
+        public void SendNotification(string title, string message, AppriseSettings settings)
+        {
+            var error = false;
+
+            var serverUrl = settings.ServerUrl.IsNullOrWhiteSpace() ? AppriseProxy.DEFAULT_PUSH_URL : settings.ServerUrl;
+
+            var request = BuildTopicRequest(serverUrl, settings);
+            var payload = CreatePayload(title, message, settings);
+
+            try
+            {
+                SendNotification(payload, request);
+            }
+            catch (AppriseException ex)
+            {
+                _logger.Error(ex, "Unable to send test message to server: {0}", serverUrl);
+                error = true;
+            }
+
+            if (error)
+            {
+                throw new AppriseException("Unable to send apprise notifications");
+            }
+        }
+
+        private HttpRequestBuilder BuildTopicRequest(string serverUrl, AppriseSettings settings)
+        {
+            var trimServerUrl = serverUrl.TrimEnd('/');
+
+            var requestBuilder = new HttpRequestBuilder($"{trimServerUrl}").Post();
+            requestBuilder.Accept(HttpAccept.Json);
+
+            requestBuilder.Headers.Add("Content-Type", "application/json");
+
+            if (settings.Tag.IsNotNullOrWhiteSpace())
+            {
+                requestBuilder.AddQueryParam("tag", settings.Tag);
+            }
+
+            return requestBuilder;
+        }
+
+        public ValidationFailure Test(AppriseSettings settings)
+        {
+            try
+            {
+                const string title = "Radarr - Test Notification";
+
+                const string body = "This is a test message from Radarr";
+
+                SendNotification(title, body, settings);
+            }
+            catch (HttpException ex)
+            {
+                _logger.Error(ex, "Unable to send test message");
+                return new ValidationFailure("ServerUrl", "Unable to send test message");
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unable to send test message");
+                return new ValidationFailure("", "Unable to send test message");
+            }
+
+            return null;
+        }
+
+        private void SendNotification(ApprisePayload payload, HttpRequestBuilder requestBuilder)
+        {
+            try
+            {
+                var request = requestBuilder.Build();
+                request.SetContent(payload.ToJson());
+
+                _httpClient.Execute(request);
+            }
+            catch (HttpException ex)
+            {
+                throw new AppriseException("Unable to send text message: {0}. HttpStatus: {1}", ex, ex.Response.StatusCode, ex.Message);
+            }
+        }
+
+        private static ApprisePayload CreatePayload(string title, string message, AppriseSettings settings)
+        {
+            var payload = new ApprisePayload
+            {
+                Title = title,
+                Body = message,
+                NotificationType = (ApprisePriority)settings.NotificationType
+            };
+
+            if (settings.Tag.IsNotNullOrWhiteSpace())
+            {
+                payload.Tag = settings.Tag;
+            }
+
+            return payload;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Apprise/AppriseSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Apprise/AppriseSettings.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using FluentValidation;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.Notifications.Apprise
+{
+    public class AppriseSettingsValidator : AbstractValidator<AppriseSettings>
+    {
+        public AppriseSettingsValidator()
+        {
+            RuleFor(c => c.NotificationType).InclusiveBetween(0, 3);
+            RuleFor(c => c.ServerUrl).IsValidUrl().When(c => !c.ServerUrl.IsNullOrWhiteSpace());
+        }
+    }
+
+    public class AppriseSettings : IProviderConfig
+    {
+        private static readonly AppriseSettingsValidator Validator = new AppriseSettingsValidator();
+
+        public AppriseSettings()
+        {
+            NotificationType = 0;
+            Tag = null;
+        }
+
+        [FieldDefinition(0, Label = "Server Url", Type = FieldType.Url, HelpLink = "https://github.com/caronc/apprise-api#api-details", HelpText = "Use http or https scheme", Placeholder = "http://localhost:8000/notify/apprise")]
+        public string ServerUrl { get; set; }
+
+        [FieldDefinition(3, Label = "Notification Type", Type = FieldType.Select, SelectOptions = typeof(ApprisePriority))]
+        public int NotificationType { get; set; }
+
+        [FieldDefinition(5, Label = "Apprise Tag", Type = FieldType.Tag, HelpText = "Optional tag to send", Placeholder = "all", HelpLink = "https://github.com/caronc/apprise/wiki/config")]
+        public string Tag { get; set; }
+
+        public NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate(this));
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds [Apprise API](https://github.com/caronc/apprise-api#api-details) as a notification provider. Only supports simple http/https connection since no official c# wrapper (no special URI schemes). Simple config, (e.g. http://localhost:8000/notify/apprise).

Heavily follows recent [ntfy.sh PR](https://github.com/Radarr/Radarr/pull/7455).

#### Issues Fixed or Closed by this PR

* None, but can open feature request if desired