### PR TITLE
Fixed: Remote path mapping UI being partially hidden on smaller screens

### DIFF
--- a/frontend/src/Settings/DownloadClients/RemotePathMappings/RemotePathMapping.css
+++ b/frontend/src/Settings/DownloadClients/RemotePathMappings/RemotePathMapping.css
@@ -8,11 +8,15 @@
 }
 
 .host {
-  flex: 0 0 300px;
+  @add-mixin truncate;
+
+  flex: 0 1 300px;
 }
 
 .path {
-  flex: 0 0 400px;
+  @add-mixin truncate;
+
+  flex: 0 1 400px;
 }
 
 .actions {

--- a/frontend/src/Settings/DownloadClients/RemotePathMappings/RemotePathMappings.css
+++ b/frontend/src/Settings/DownloadClients/RemotePathMappings/RemotePathMappings.css
@@ -1,15 +1,20 @@
 .remotePathMappingsHeader {
   display: flex;
   margin-bottom: 10px;
+  padding-right: 24px;
   font-weight: bold;
 }
 
 .host {
-  flex: 0 0 300px;
+  @add-mixin truncate;
+
+  flex: 0 1 300px;
 }
 
 .path {
-  flex: 0 0 400px;
+  @add-mixin truncate;
+
+  flex: 0 1 400px;
 }
 
 .addRemotePathMapping {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes the remote path mapping UI being pushed off-screen at lower resolutions/widths and making the edit button inaccessible. The changes mostly mirror the relevant changes in Sonarr/Sonarr@979ea44, but also aligns headers and paths at lower resolutions.


#### Screenshot (if UI related)
**Before:**
![Skjermbilde 2023-02-21 kl  10 06 42](https://user-images.githubusercontent.com/773150/220299192-48f1b5c5-2f5c-4983-b300-e4b327f14032.png)


**After:**
![Skjermbilde 2023-02-21 kl  10 06 24](https://user-images.githubusercontent.com/773150/220299229-9e9d1177-7c5f-42bb-8dbb-aa952fbd8599.png)


#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* Fixes #6686 