### PR TITLE
fix(lang): `deu` is german language

### DIFF
--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(LanguageParser));
 
         private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_|^)(?<italian>\b(?:ita|italian)\b)|
-                                                                            (?<german>german\b|videomann|ger[. ]dub)|
+                                                                            (?<german>german\b|\bdeu\b|videomann|ger[. ]dub)|
                                                                             (?<flemish>flemish)|
                                                                             (?<bulgarian>bgaudio)|
                                                                             (?<brazilian>dublado)|


### PR DESCRIPTION
#### Database Migration
NO

#### Description
fix regex
`deu` is ISO code for German
see: [ISO 639](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)

#### Example
`Уроки фарси (AKA Persian Lessons)(2020)[Россия, Германия, Беларусь, драма, военный, BDRip-AVC] Dub (Кириллица) + [multi(Rus,Deu)][Original(Deu)][Subs(Rus, Eng)]`