### PR TITLE
fix(parser): parsing for Russian/Cyrillic titles

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -285,5 +285,18 @@ namespace NzbDrone.Core.Test.ParserTests
         {
             Parser.Parser.NormalizeImdbId(imdbid).Should().BeEquivalentTo(normalized);
         }
+
+        [TestCase(@"Аватар / Avatar (Джеймс Кэмерон / James Cameron) [2009, США, фантастика] [Special Edition Re-release Cut]", "Avatar", 2009)]
+        [TestCase(@"Кот в сапогах 2: Последнее желание / Puss in Boots: The Last Wish / 2022 / ПМ, СТ / WEB-DLRip", "Puss in Boots: The Last Wish", 2022)]
+        [TestCase(@"Аферисты / Sharper (2023) WEB-DLRip от MegaPeer | D", "Sharper", 2023)]
+        public void should_parse_cyrillic_titles(string postTitle, string title, int year)
+        {
+            var movieInfo = Parser.Parser.ParseMovieTitle(postTitle);
+            using (new AssertionScope())
+            {
+                movieInfo.PrimaryMovieTitle.Should().Be(title);
+                movieInfo.Year.Should().Be(year);
+            }
+        }
     }
 }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -40,6 +40,9 @@ namespace NzbDrone.Core.Parser
             // Some german or french tracker formats (missing year, ...) (Only applies to german and TrueFrench releases) - see ParserFixture for examples and tests - french removed as it broke all movies w/ french titles
             new Regex(@"^(?<title>(?![(\[]).+?)((\W|_))(" + EditionRegex + @".{1,3})?(?:(?<!(19|20)\d{2}.*?)(German|TrueFrench))(.+?)(?=((19|20)\d{2}|$))(?<year>(19|20)\d{2}(?!p|i|\d+|\]|\W\d+))?(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
+            // most releases in russian have the format "Cyrillic title / Latin title (Cyrillic director / Latin director)[2000, some info]" or "Cyrillic title / Latin title/ 2000" or "Cyrillic title / Latin title (2000)"
+            new Regex(@"^[\p{IsCyrillic}][^\/]+\/\s?(?<title>[^\(\[\(\/]+)\s?(\(\p{IsCyrillic}[^\)\/]+\/[^\)]+\))?\s?[\[\/\(]\s?(?<year>(19|20)\d{2})", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
             // Special, Despecialized, etc. Edition Movies, e.g: Mission.Impossible.3.Special.Edition.2011
             new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*" + EditionRegex + @".{1,3}(?<year>(1(8|9)|20)\d{2}(?!p|i|\d+|\]|\W\d+)))+(\W+|_|$)(?!\\)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),


### PR DESCRIPTION
#### Database Migration
NO

#### Description
fix for parsing titles written in Russian/Cyrillic. This fix will not affect other parsers, because the regular expression checks for Cyrillic at the beginning of the title

#### examples (added to tests)

##### 1.
release: `Аватар / Avatar (Джеймс Кэмерон / James Cameron) [2009, США, фантастика] [Special Edition Re-release Cut]`
title: `Avatar`
year: `2009`


##### 2.
release: `Кот в сапогах 2: Последнее желание / Puss in Boots: The Last Wish / 2022 / ПМ, СТ / WEB-DLRip`
title: `Puss in Boots: The Last Wish`
year: `2022`

##### 3.
release: `Аферисты / Sharper (2023) WEB-DLRip от MegaPeer | D`
title: `Sharper`
year: `2023`