### PR TITLE
fix(Newznab): if the parser has a movie search, then use this search type

### DIFF
--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -165,9 +165,14 @@ namespace NzbDrone.Core.Indexers.Newznab
                         searchQuery = string.Format("{0} {1}", searchQuery, searchCriteria.Movie.Year);
                     }
 
+                    var capabilities = _capabilitiesProvider.GetCapabilities(Settings);
+                    var searchType = capabilities.SupportedMovieSearchParameters.Contains("q")
+                        ? "movie"
+                        : "search";
+
                     chain.Add(GetPagedRequests(MaxPages,
                         Settings.Categories,
-                        "search",
+                        searchType,
                         string.Format("&q={0}", NewsnabifyTitle(searchQuery))));
                 }
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
if the indexer has a movie search, then use search type as `movie` instead of `search`. This will allow Prowlarr to use search type-specific rules: `{{ if eq .Query.Type "movie" }}...{{ else }}...{{ end }}`