### PR TITLE
fix: when normalizing a movie title, do not replace the letter `й`

### DIFF
--- a/src/NzbDrone.Common/Extensions/StringExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/StringExtensions.cs
@@ -65,6 +65,10 @@ namespace NzbDrone.Common.Extensions
         public static string RemoveAccent(this string text)
         {
             var normalizedString = text.Normalize(NormalizationForm.FormD);
+
+            // use the Cyrillic letter "й" instead of the combined unicode characters
+            normalizedString = Regex.Replace(normalizedString, "и\u0306", "й", RegexOptions.IgnoreCase);
+
             var stringBuilder = new StringBuilder();
 
             foreach (var c in normalizedString)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
when normalizing a movie title, do not replace the Cyrillic letter `й`

Radarr uses normalization to search and compare movie titles: all diacritical letters are replaced with normal letters. But for the Cyrillic letter "й", the replacement for "и" is incorrect, because it turns out different words, and most trackers in Cyrillic do not understand such a replacement.

### Example

film `Гуляй, Вася!` (2017)
https://www.themoviedb.org/movie/430263

search string after normalization:
`Гуляи Вася 2017`
movie not found:
[rutracker.org](https://rutracker.org/forum/tracker.php?nm=%D0%93%D1%83%D0%BB%D1%8F%D0%B8%20%D0%92%D0%B0%D1%81%D1%8F%202017)
[0day.kiev.ua](https://0day.kiev.ua/modules.php?name=News&file=search&query=%C3%F3%EB%FF%E8+%C2%E0%F1%FF+2017&topic=&author=&days=0&type=1)

but finds with the letter `й`:
[rutracker.org](https://rutracker.org/forum/tracker.php?nm=%D0%93%D1%83%D0%BB%D1%8F%D0%B9%20%D0%92%D0%B0%D1%81%D1%8F%202017)
[0day.kiev.ua](https://0day.kiev.ua/modules.php?name=News&file=search&query=%C3%F3%EB%FF%E9+%C2%E0%F1%FF&topic=&author=&days=0&type=1)

it is necessary to leave the letter `й` because the combination letter + combinable unicode diacritic also does not find the movie, an example for `Гуляй Вася 2017`, where `й = и + \u0306`:
[rutracker.org](https://rutracker.org/forum/tracker.php?nm=%D0%93%D1%83%D0%BB%D1%8F%D0%B8%CC%86%20%D0%92%D0%B0%D1%81%D1%8F%202017)
[0day.kiev.ua](https://0day.kiev.ua/modules.php?name=News&file=search&query=%C3%F3%EB%FF%E8%26%23774%3B+%C2%E0%F1%FF+2017&topic=&author=&days=0&type=1)