### PR TITLE
Fix tags for existing subtitle files getting lost in renaming 

### DIFF
--- a/src/NzbDrone.Core/Extras/Subtitles/ExistingSubtitleImporter.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/ExistingSubtitleImporter.cs
@@ -54,6 +54,7 @@ namespace NzbDrone.Core.Extras.Subtitles
                         MovieFileId = movie.MovieFileId,
                         RelativePath = movie.Path.GetRelativePath(possibleSubtitleFile),
                         Language = LanguageParser.ParseSubtitleLanguage(possibleSubtitleFile),
+                        LanguageTags = LanguageParser.ParseLanguageTags(possibleSubtitleFile).ToList<string>(),
                         Extension = extension
                     };
 

--- a/src/NzbDrone.Core/Extras/Subtitles/ExistingSubtitleImporter.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/ExistingSubtitleImporter.cs
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.Extras.Subtitles
                         MovieFileId = movie.MovieFileId,
                         RelativePath = movie.Path.GetRelativePath(possibleSubtitleFile),
                         Language = LanguageParser.ParseSubtitleLanguage(possibleSubtitleFile),
-                        LanguageTags = LanguageParser.ParseLanguageTags(possibleSubtitleFile).ToList<string>(),
+                        LanguageTags = LanguageParser.ParseLanguageTags(possibleSubtitleFile),
                         Extension = extension
                     };
 

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -185,9 +185,9 @@ namespace NzbDrone.Core.Extras.Subtitles
                 var subFile = new SubtitleFile
                 {
                     Language = language,
-                    Extension = extension
+                    Extension = extension,
+                    LanguageTags = languageTags
                 };
-                subFile.LanguageTags = languageTags.ToList();
                 subFile.RelativePath = PathExtensions.GetRelativePath(sourceFolder, file);
                 subtitleFiles.Add(subFile);
             }

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -346,7 +346,7 @@ namespace NzbDrone.Core.Parser
             return languages.DistinctBy(l => (int)l).ToList();
         }
 
-        public static IEnumerable<string> ParseLanguageTags(string fileName)
+        public static List<string> ParseLanguageTags(string fileName)
         {
             try
             {
@@ -355,14 +355,14 @@ namespace NzbDrone.Core.Parser
                 var languageTags = match.Groups["tags"].Captures.Cast<Capture>()
                     .Where(tag => !tag.Value.Empty())
                     .Select(tag => tag.Value.ToLower());
-                return languageTags;
+                return languageTags.ToList();
             }
             catch (Exception ex)
             {
                 Logger.Debug(ex, "Failed parsing language tags from subtitle file: {0}", fileName);
             }
 
-            return Enumerable.Empty<string>();
+            return new List<string>();
         }
 
         public static Language ParseSubtitleLanguage(string fileName)


### PR DESCRIPTION
#### Description

When renaming movies with associated subtitle files that weren't directly imported by Radarr, subtitle tags like SDH, Forced, HI, would be lost. This affected setups like Bazarr or other ways of manually putting subtitle files in the movies' folder. Files imported alongside video files in automatic or manual imports weren't affected.

Tags were already getting parsed, but weren't getting passed along to the records.

#### Issues Fixed or Closed by this PR

* Fixes #7710
* Fixes #8275 
* Fixes #8392