### PR TITLE
Fixed: Radarr import list not finding any matches when filtering by Root Folders

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Radarr/RadarrAPIResource.cs
+++ b/src/NzbDrone.Core/ImportLists/Radarr/RadarrAPIResource.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.ImportLists.Radarr
         public int Year { get; set; }
         public string TitleSlug { get; set; }
         public int QualityProfileId { get; set; }
-        public string RootFolderPath { get; set; }
+        public string Path { get; set; }
         public HashSet<int> Tags { get; set; }
     }
 

--- a/src/NzbDrone.Core/ImportLists/Radarr/RadarrImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Radarr/RadarrImport.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.ImportLists.Radarr
                         continue;
                     }
 
-                    if (Settings.RootFolderPaths.Any() && !Settings.RootFolderPaths.Any(rootFolderPath => remoteMovie.RootFolderPath.ContainsIgnoreCase(rootFolderPath)))
+                    if (Settings.RootFolderPaths.Any() && !Settings.RootFolderPaths.Any(rootFolderPath => remoteMovie.Path.ContainsIgnoreCase(rootFolderPath)))
                     {
                         continue;
                     }

--- a/src/NzbDrone.Core/ImportLists/Radarr/RadarrImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Radarr/RadarrImport.cs
@@ -129,8 +129,8 @@ namespace NzbDrone.Core.ImportLists.Radarr
                     options = remoteRootfolders.OrderBy(d => d.Path, StringComparer.InvariantCultureIgnoreCase)
                         .Select(d => new
                         {
-                            value = d.Path,
-                            name = d.Path
+                            Value = d.Path,
+                            Name = d.Path
                         })
                 };
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When syncing two Radarr instances, if one or more root folders had been selected as a filter, the sync would always find 0 matches. This was caused by the import list looking for a `rootFolderPath` property in the `/movie` API request, which exists in Sonarr's API but not Radarr's. This makes the import process look for and compare a `path` property instead. 

#### Todos
None