### PR TITLE
Fixed: RootFolderPath not set for Movies from API

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Test.MediaFiles.DiskScanServiceTests
                   .Returns((string path) => Directory.GetParent(path).FullName);
 
             Mocker.GetMock<IRootFolderService>()
-                  .Setup(s => s.GetBestRootFolderPath(It.IsAny<string>()))
+                  .Setup(s => s.GetBestRootFolderPath(It.IsAny<string>(), null))
                   .Returns(_rootFolder);
 
             Mocker.GetMock<IMediaFileService>()

--- a/src/NzbDrone.Core.Test/MediaFiles/MovieFileMovingServiceTests/MoveMovieFileFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MovieFileMovingServiceTests/MoveMovieFileFixture.cs
@@ -57,7 +57,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieFileMovingServiceTests
                   .Returns(true);
 
             Mocker.GetMock<IRootFolderService>()
-                  .Setup(s => s.GetBestRootFolderPath(It.IsAny<string>()))
+                  .Setup(s => s.GetBestRootFolderPath(It.IsAny<string>(), null))
                   .Returns(rootFolder);
         }
 

--- a/src/NzbDrone.Core.Test/MovieTests/MovieFolderPathBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieFolderPathBuilderFixture.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.Test.MovieTests
         public void GivenExistingRootFolder(string rootFolder)
         {
             Mocker.GetMock<IRootFolderService>()
-                  .Setup(s => s.GetBestRootFolderPath(It.IsAny<string>()))
+                  .Setup(s => s.GetBestRootFolderPath(It.IsAny<string>(), null))
                   .Returns(rootFolder);
         }
 

--- a/src/NzbDrone.Core.Test/MovieTests/RefreshMovieServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/RefreshMovieServiceFixture.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Test.MovieTests
                   .Callback<int>((i) => { throw new MovieNotFoundException(i); });
 
             Mocker.GetMock<IRootFolderService>()
-                  .Setup(s => s.GetBestRootFolderPath(It.IsAny<string>()))
+                  .Setup(s => s.GetBestRootFolderPath(It.IsAny<string>(), null))
                   .Returns(string.Empty);
         }
 

--- a/src/NzbDrone.Core/RootFolders/RootFolderService.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolderService.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.RootFolders
         RootFolder Add(RootFolder rootDir);
         void Remove(int id);
         RootFolder Get(int id, bool timeout);
-        string GetBestRootFolderPath(string path);
+        string GetBestRootFolderPath(string path, List<RootFolder> rootFolders = null);
     }
 
     public class RootFolderService : IRootFolderService
@@ -180,9 +180,11 @@ namespace NzbDrone.Core.RootFolders
             return rootFolder;
         }
 
-        public string GetBestRootFolderPath(string path)
+        public string GetBestRootFolderPath(string path, List<RootFolder> rootFolders = null)
         {
-            var possibleRootFolder = All().Where(r => r.Path.IsParentPath(path)).MaxBy(r => r.Path.Length);
+            var allRootFoldersToConsider = rootFolders ?? All();
+
+            var possibleRootFolder = allRootFoldersToConsider.Where(r => r.Path.IsParentPath(path)).MaxBy(r => r.Path.Length);
 
             if (possibleRootFolder == null)
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Set the root folder path for movies without destroying the db

#### Screenshot (if UI related)

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* Closes #8456 