### PR TITLE
Show name of mount points that fail in DiskProvider

### DIFF
--- a/src/NzbDrone.Mono/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Mono/Disk/DiskProvider.cs
@@ -182,10 +182,18 @@ namespace NzbDrone.Mono.Disk
             try
             {
                 mounts.AddRange(GetDriveInfoMounts()
-                        .Select(d => new DriveInfoMount(d, FindDriveType.Find(d.DriveFormat)))
-                        .Where(d => d.DriveType == DriveType.Fixed ||
-                                d.DriveType == DriveType.Network ||
-                                d.DriveType == DriveType.Removable));
+                    .Select(d =>
+                    {
+                        try
+                        {
+                            return new DriveInfoMount(d, FindDriveType.Find(d.DriveFormat));
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new Exception($"Failed to fetch drive info for mount point: {d.Name}", ex);
+                        }
+                    })
+                    .Where(d => d.DriveType is DriveType.Fixed or DriveType.Network or DriveType.Removable));
             }
             catch (Exception e)
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
A workaround in showing the mount point(s) that fail in errors like:
```
2023-05-16 17:05:35.9|Warn|DiskProvider|Unable to get drive mounts: Access to the path is denied.

[v4.5.1.7282] System.UnauthorizedAccessException: Access to the path is denied.
 ---> System.IO.IOException: Operation not permitted
   --- End of inner exception stack trace ---
   at System.IO.DriveInfo.CheckStatfsResultAndThrowIfNecessary(Int32 result)
   at System.IO.DriveInfo.get_DriveFormat()
   at NzbDrone.Mono.Disk.DiskProvider.<>c.<GetAllMounts>b__16_0(DriveInfo d) in D:\a\1\s\src\NzbDrone.Mono\Disk\DiskProvider.cs:line 185
   at System.Linq.Enumerable.SelectListIterator`2.MoveNext()
   at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
   at System.Collections.Generic.List`1.InsertRange(Int32 index, IEnumerable`1 collection)
   at NzbDrone.Mono.Disk.DiskProvider.GetAllMounts() in D:\a\1\s\src\NzbDrone.Mono\Disk\DiskProvider.cs:line 195
```