### PR TITLE
Correctly parse SCENE and P2P BluRay DISKS releases

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -275,7 +275,6 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie.Name.2011.1080p.UHD.BluRay.DD5.1.HDR.x265-CtrlHD.mkv", false)]
         [TestCase("Movie.Name.2016.German.DTS.DL.1080p.UHDBD.x265-TDO.mkv", false)]
         [TestCase("Movie.Name.2021.1080p.BDLight.x265-AVCDVD", false)]
-        [TestCase("Random.Title.2010.1080p.HD.DVD.AVC.DDP.5.1-GRouP", false)]
         [TestCase("Movie.Title.2012.German.DL.1080p.UHD2BD.x264-QfG", false)]
         public void should_parse_bluray1080p_quality(string title, bool proper)
         {
@@ -344,6 +343,22 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie Name.1993..BD25.ISO")]
         [TestCase("Movie.Title.2012.Bluray.1080p.3D.AVC.DTS-HD.MA.5.1.iso")]
         [TestCase("Movie.Title.1996.Bluray.ISO")]
+        [TestCase("Random.Title.2010.1080p.HD.DVD.AVC.DDP.5.1-GRouP", false)]
+        [TestCase("Movie Title 2005 1080p USA Blu-ray AVC DTS-HD MA 5.1-PTP")]
+        [TestCase("Movie Title 2014 1080p Blu-ray AVC DTS-HD MA 5.1-PTP")]
+        [TestCase("Movie Title 1976 2160p UHD Blu-ray DTS-HD MA 5.1 DV HDR HEVC-UNTOUCHED")]
+        [TestCase("Movie Title 2004 1080p FRA Blu-ray VC-1 TrueHD 5.1-HDBEE")]
+        [TestCase("BD25.Movie.Title.1994.1080p.DTS-HD")]
+        [TestCase("Movie.Title.1997.1080p.NL.BD-50")]
+        [TestCase("Movie Title 2009 3D BD 2009 UNTOUCHED")]
+        [TestCase("Movie.Title.1982.1080p.HD.DVD.VC-1.DD+.5.1")]
+        [TestCase("Movie.Title.2007.1080p.HD.DVD.DD+.AVC")]
+        [TestCase("Movie.Title.2008.1080i.XXX.Blu-ray.MPEG-2.LPCM2.0.ISO")]
+        [TestCase("Movie.Title.2008.BONUS.GERMAN.SUBBED.COMPLETE.BLURAY")]
+        [TestCase("The German 2021 Bluray AVC")]
+        [TestCase("German.Only.Movie.2021.French.1080p.BluRay.AVC-UNTAVC")]
+        [TestCase("Movie.Title.2008.US.Directors.Cut.UHD.BD66.Blu-ray")]
+        [TestCase("Movie Title 2010 720p Blu-ray AVC DTS-HD MA 5.1")]
         public void should_parse_brdisk_1080p_quality(string title)
         {
             ParseAndVerifyQuality(title, Source.BLURAY, false, Resolution.R1080p, Modifier.BRDISK);

--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -358,7 +358,6 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("The German 2021 Bluray AVC")]
         [TestCase("German.Only.Movie.2021.French.1080p.BluRay.AVC-UNTAVC")]
         [TestCase("Movie.Title.2008.US.Directors.Cut.UHD.BD66.Blu-ray")]
-        [TestCase("Movie Title 2010 720p Blu-ray AVC DTS-HD MA 5.1")]
         public void should_parse_brdisk_1080p_quality(string title)
         {
             ParseAndVerifyQuality(title, Source.BLURAY, false, Resolution.R1080p, Modifier.BRDISK);

--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -343,7 +343,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie Name.1993..BD25.ISO")]
         [TestCase("Movie.Title.2012.Bluray.1080p.3D.AVC.DTS-HD.MA.5.1.iso")]
         [TestCase("Movie.Title.1996.Bluray.ISO")]
-        [TestCase("Random.Title.2010.1080p.HD.DVD.AVC.DDP.5.1-GRouP", false)]
+        [TestCase("Random.Title.2010.1080p.HD.DVD.AVC.DDP.5.1-GRouP")]
         [TestCase("Movie Title 2005 1080p USA Blu-ray AVC DTS-HD MA 5.1-PTP")]
         [TestCase("Movie Title 2014 1080p Blu-ray AVC DTS-HD MA 5.1-PTP")]
         [TestCase("Movie Title 1976 2160p UHD Blu-ray DTS-HD MA 5.1 DV HDR HEVC-UNTOUCHED")]

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex MPEG2Regex = new (@"\b(?<mpeg2>MPEG[-_. ]?2)\b");
 
-        private static readonly Regex BRDISKRegex = new (@"\b(COMPLETE|ISO|BDISO|BD25|BD50|BR.?DISK)\b",
+        private static readonly Regex BRDISKRegex = new (@"^(?!.*\b((?<!HD[._ -]|HD)DVD|BDRip|720p|MKV|XviD|WMV|d3g|(BD)?REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*DL|((?<=\d{4}).*German.*(DL)?)(?=.*\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\b))\b)(((?=.*(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\b)(?=.*\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\b))|^((?=.*\b(^((?=.*\b((.*_)?COMPLETE.*|Dis[ck])\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*",
                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex ProperRegex = new (@"\b(?<proper>proper)\b",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Correctly parses P2P Blu-ray disks as well as Scene releases as BR-DISK

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes
* https://github.com/Radarr/Radarr/issues/6307
* https://github.com/Radarr/Radarr/issues/3223