### PR TITLE
Fix: Use relative paths instead of absolute paths for webmanifest

### DIFF
--- a/frontend/src/Content/Images/Icons/manifest.json
+++ b/frontend/src/Content/Images/Icons/manifest.json
@@ -2,16 +2,17 @@
     "name": "Radarr",
     "icons": [
         {
-            "src": "/Content/Images/Icons/android-chrome-192x192.png",
+            "src": "android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/Content/Images/Icons/android-chrome-512x512.png",
+            "src": "android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }
     ],
+    "start_url": "../../../../",
     "theme_color": "#3a3f51",
     "background_color": "#3a3f51",
     "display": "standalone"


### PR DESCRIPTION
#### Database Migration
NO

#### Description
https://github.com/Sonarr/Sonarr/pull/5689 for Radarr. Use relative paths in the manifest instead of absolute paths.

#### Issues Fixed or Closed by this PR

* Fixes #8608