### PR TITLE
Fixed: Close database connection in housekeeping tasks

### DIFF
--- a/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupOrphanedDownloadClientStatus.cs
+++ b/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupOrphanedDownloadClientStatus.cs
@@ -14,14 +14,15 @@ namespace NzbDrone.Core.Housekeeping.Housekeepers
 
         public void Clean()
         {
-            var mapper = _database.OpenConnection();
-
-            mapper.Execute(@"DELETE FROM ""DownloadClientStatus""
-                                     WHERE ""Id"" IN (
-                                     SELECT ""DownloadClientStatus"".""Id"" FROM ""DownloadClientStatus""
-                                     LEFT OUTER JOIN ""DownloadClients""
-                                     ON ""DownloadClientStatus"".""ProviderId"" = ""DownloadClients"".""Id""
-                                     WHERE ""DownloadClients"".""Id"" IS NULL)");
+            using (var mapper = _database.OpenConnection())
+            {
+                mapper.Execute(@"DELETE FROM ""DownloadClientStatus""
+                                         WHERE ""Id"" IN (
+                                         SELECT ""DownloadClientStatus"".""Id"" FROM ""DownloadClientStatus""
+                                         LEFT OUTER JOIN ""DownloadClients""
+                                         ON ""DownloadClientStatus"".""ProviderId"" = ""DownloadClients"".""Id""
+                                         WHERE ""DownloadClients"".""Id"" IS NULL)");
+            }
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently, when the housekeeping tasks run, three database connections are left open, which will eventually result in the database no longer accepting connections. 
