### PR TITLE
New: Cleanup orphaned movies with no moviemetadata entry

### DIFF
--- a/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupOrphanedMovies.cs
+++ b/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupOrphanedMovies.cs
@@ -1,0 +1,26 @@
+using Dapper;
+using NzbDrone.Core.Datastore;
+
+namespace NzbDrone.Core.Housekeeping.Housekeepers
+{
+    public class CleanupOrphanedMovies : IHousekeepingTask
+    {
+        private readonly IMainDatabase _database;
+
+        public CleanupOrphanedMovies(IMainDatabase database)
+        {
+            _database = database;
+        }
+
+        public void Clean()
+        {
+            using var mapper = _database.OpenConnection();
+            mapper.Execute(@"DELETE FROM ""Movies""
+                             WHERE ""Id"" IN (
+                             SELECT ""Movies"".""Id"" FROM ""Movies""
+                             LEFT OUTER JOIN ""MovieMetadata""
+                             ON ""Movies"".""MovieMetadataId"" = ""MovieMetadata"".""Id""
+                             WHERE ""MovieMetadata"".""Id"" IS NULL)");
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
If a metadata entry somehow gets purged or the movie gets added incorrectly, clean the db during housekeeping to bring Radarr back to a usable state instead of being perm broken. 

#### Todos
- [ ] Tests