### PR TITLE
Fixed: Don't Clean if no lists synced

### DIFF
--- a/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedImportListMoviesFixture.cs
+++ b/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupOrphanedImportListMoviesFixture.cs
@@ -1,0 +1,55 @@
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Housekeeping.Housekeepers;
+using NzbDrone.Core.ImportLists;
+using NzbDrone.Core.ImportLists.ImportListMovies;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
+{
+    [TestFixture]
+    public class CleanupOrphanedImportListMoviesFixture : DbTest<CleanupOrphanedImportListMovies, ImportListMovie>
+    {
+        private ImportListDefinition _importList;
+
+        [SetUp]
+        public void Setup()
+        {
+            _importList = Builder<ImportListDefinition>.CreateNew()
+                                                       .BuildNew();
+        }
+
+        private void GivenImportList()
+        {
+            Db.Insert(_importList);
+        }
+
+        [Test]
+        public void should_delete_orphaned_importlistmovies()
+        {
+            var status = Builder<ImportListMovie>.CreateNew()
+                                                 .With(h => h.ListId = _importList.Id)
+                                                 .BuildNew();
+            Db.Insert(status);
+
+            Subject.Clean();
+            AllStoredModels.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_not_delete_unorphaned_importlistmovies()
+        {
+            GivenImportList();
+
+            var status = Builder<ImportListMovie>.CreateNew()
+                                                 .With(h => h.ListId = _importList.Id)
+                                                 .BuildNew();
+            Db.Insert(status);
+
+            Subject.Clean();
+            AllStoredModels.Should().HaveCount(1);
+            AllStoredModels.Should().Contain(h => h.ListId == _importList.Id);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupOrphanedImportListMovies.cs
+++ b/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupOrphanedImportListMovies.cs
@@ -1,0 +1,27 @@
+using Dapper;
+using NzbDrone.Core.Datastore;
+
+namespace NzbDrone.Core.Housekeeping.Housekeepers
+{
+    public class CleanupOrphanedImportListMovies : IHousekeepingTask
+    {
+        private readonly IMainDatabase _database;
+
+        public CleanupOrphanedImportListMovies(IMainDatabase database)
+        {
+            _database = database;
+        }
+
+        public void Clean()
+        {
+            using var mapper = _database.OpenConnection();
+
+            mapper.Execute(@"DELETE FROM ""ImportListMovies""
+                                     WHERE ""Id"" IN (
+                                     SELECT ""ImportListMovies"".""Id"" FROM ""ImportListMovies""
+                                     LEFT OUTER JOIN ""ImportLists""
+                                     ON ""ImportListMovies"".""ListId"" = ""ImportLists"".""Id""
+                                     WHERE ""ImportLists"".""Id"" IS NULL)");
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
+++ b/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
@@ -113,6 +113,7 @@ namespace NzbDrone.Core.ImportLists
                             }
 
                             result.AnyFailure |= importListReports.AnyFailure;
+                            result.SyncedLists++;
 
                             _importListStatusService.UpdateListSyncStatus(importList.Definition.Id);
                         }
@@ -130,7 +131,7 @@ namespace NzbDrone.Core.ImportLists
 
             result.Movies = result.Movies.DistinctBy(r => new { r.TmdbId, r.ImdbId, r.Title }).ToList();
 
-            _logger.Debug("Found {0} total reports from {1} lists", result.Movies.Count, importLists.Count);
+            _logger.Debug("Found {0} total reports from {1} lists", result.Movies.Count, result.SyncedLists);
 
             return result;
         }

--- a/src/NzbDrone.Core/ImportLists/ImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListBase.cs
@@ -19,6 +19,7 @@ namespace NzbDrone.Core.ImportLists
 
         public List<ImportListMovie> Movies { get; set; }
         public bool AnyFailure { get; set; }
+        public int SyncedLists { get; set; }
     }
 
     public abstract class ImportListBase<TSettings> : IImportList

--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -60,6 +60,11 @@ namespace NzbDrone.Core.ImportLists
                 return;
             }
 
+            if (result.SyncedLists == 0)
+            {
+                return;
+            }
+
             if (!result.AnyFailure)
             {
                 CleanLibrary();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Don't clean or process results if we didn't do anything during the list sync. Also adds housekeeper for ListMovies when lists are gone (incase the event driven delete event gets missed due to restart or other app failure)

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes #9011