### PR TITLE
Fixed: Correctly Parse HDDVD Remux as DVD

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -77,6 +77,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("the_movie.9x18.sunshine_days.ac3.ws_dvdrip_xvid-fov.avi", false)]
         [TestCase("The.Third.Movie Name.2008.DVDRip.360p.H264 iPod -20-40", false)]
         [TestCase("SomeMovie.2018.DVDRip.ts", false)]
+        [TestCase("Some Movie 2005 1080p HDDVD Remux VC-1 TrueHD 5.1-Mooi1990", false)]
         public void should_parse_dvd_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Source.DVD, proper, Resolution.Unknown);

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -133,7 +133,7 @@ namespace NzbDrone.Core.Parser
             {
                 result.SourceDetectionSource = QualityDetectionSource.Name;
 
-                if (sourceMatch.Groups["bluray"].Success)
+                if (sourceMatch.Groups["bluray"].Success && !sourceMatch.Groups["dvd"].Success)
                 {
                     if (brDiskMatch)
                     {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
![image](https://github.com/Radarr/Radarr/assets/55419169/d381fbc5-a433-47b9-9829-d8c9f3e1c2e1)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* https://discord.com/channels/264387956343570434/264388019585286144/1142782529896714411
* https://discord.com/channels/264387956343570434/264388019585286144/1142777194054168576