### PR TITLE
New: Indexer condition Custom Format

### DIFF
--- a/src/NzbDrone.Core.Test/CustomFormats/IndexerSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/IndexerSpecificationFixture.cs
@@ -1,0 +1,61 @@
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.CustomFormats
+{
+    [TestFixture]
+    public class IndexerSpecificationFixture : CoreTest<IndexerSpecification>
+    {
+        private CustomFormatInput _movieInput;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movieInput = new CustomFormatInput
+            {
+                Movie = Builder<Movie>.CreateNew().Build()
+            };
+        }
+
+        private void GivenCustomFormatIndexer(int indexerId)
+        {
+            Subject.Value = indexerId;
+        }
+
+        private void GivenMovieReleaseIndexer(int indexerId)
+        {
+            _movieInput.IndexerId = indexerId;
+        }
+
+        [Test]
+        public void should_return_false_if_indexer_id_not_captured()
+        {
+            GivenCustomFormatIndexer(4);
+            GivenMovieReleaseIndexer(-1);
+
+            Subject.IsSatisfiedBy(_movieInput).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_return_false_if_indexer_id_does_not_match_custom_format()
+        {
+            GivenCustomFormatIndexer(4);
+            GivenMovieReleaseIndexer(3);
+
+            Subject.IsSatisfiedBy(_movieInput).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_return_true_if_indexer_id_matches_custom_format()
+        {
+            GivenCustomFormatIndexer(4);
+            GivenMovieReleaseIndexer(4);
+
+            Subject.IsSatisfiedBy(_movieInput).Should().BeTrue();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Blocklisting/Blocklist.cs
+++ b/src/NzbDrone.Core/Blocklisting/Blocklist.cs
@@ -21,6 +21,7 @@ namespace NzbDrone.Core.Blocklisting
         public DownloadProtocol Protocol { get; set; }
         public string Indexer { get; set; }
         public IndexerFlags IndexerFlags { get; set; }
+        public int IndexerId { get; set; }
         public string Message { get; set; }
         public string TorrentInfoHash { get; set; }
         public List<Language> Languages { get; set; }

--- a/src/NzbDrone.Core/Blocklisting/BlocklistService.cs
+++ b/src/NzbDrone.Core/Blocklisting/BlocklistService.cs
@@ -84,6 +84,8 @@ namespace NzbDrone.Core.Blocklisting
                                 PublishedDate = remoteMovie.Release.PublishDate,
                                 Size = remoteMovie.Release.Size,
                                 Indexer = remoteMovie.Release.Indexer,
+                                IndexerFlags = remoteMovie.Release.IndexerFlags,
+                                IndexerId = remoteMovie.Release.IndexerId,
                                 Protocol = remoteMovie.Release.DownloadProtocol,
                                 Message = message,
                                 Languages = remoteMovie.ParsedMovieInfo.Languages
@@ -192,6 +194,11 @@ namespace NzbDrone.Core.Blocklisting
             if (Enum.TryParse(message.Data.GetValueOrDefault("indexerFlags"), true, out IndexerFlags flags))
             {
                 blocklist.IndexerFlags = flags;
+            }
+
+            if (int.TryParse(message.Data.GetValueOrDefault("indexerId"), out var indexerId))
+            {
+                blocklist.IndexerId = indexerId;
             }
 
             _blocklistRepository.Insert(blocklist);

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -39,7 +39,8 @@ namespace NzbDrone.Core.CustomFormats
                 Movie = remoteMovie.Movie,
                 Size = size,
                 Languages = remoteMovie.Languages,
-                IndexerFlags = remoteMovie.Release?.IndexerFlags ?? 0
+                IndexerFlags = remoteMovie.Release?.IndexerFlags ?? 0,
+                IndexerId = remoteMovie.Release?.IndexerId ?? -1
             };
 
             return ParseCustomFormat(input);
@@ -76,6 +77,7 @@ namespace NzbDrone.Core.CustomFormats
                 Movie = movie,
                 Size = blocklist.Size ?? 0,
                 IndexerFlags = blocklist.IndexerFlags,
+                IndexerId = blocklist.IndexerId,
                 Languages = blocklist.Languages
             };
 
@@ -106,6 +108,7 @@ namespace NzbDrone.Core.CustomFormats
                 Movie = movie,
                 Size = size,
                 IndexerFlags = flags,
+                IndexerId = int.TryParse(history.Data.GetValueOrDefault("IndexerId"), out var id) ? id : -1,
                 Languages = history.Languages
             };
 
@@ -198,6 +201,7 @@ namespace NzbDrone.Core.CustomFormats
                 Movie = movie,
                 Size = movieFile.Size,
                 IndexerFlags = movieFile.IndexerFlags,
+                IndexerId = movieFile.IndexerId,
                 Languages = movieFile.Languages,
                 Filename = Path.GetFileName(movieFile.RelativePath)
             };

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -108,7 +108,7 @@ namespace NzbDrone.Core.CustomFormats
                 Movie = movie,
                 Size = size,
                 IndexerFlags = flags,
-                IndexerId = int.TryParse(history.Data.GetValueOrDefault("IndexerId"), out var id) ? id : -1,
+                IndexerId = int.TryParse(history.Data.GetValueOrDefault("indexerId"), out var indexerId) ? indexerId : -1,
                 Languages = history.Languages
             };
 

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatInput.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatInput.cs
@@ -11,6 +11,7 @@ namespace NzbDrone.Core.CustomFormats
         public Movie Movie { get; set; }
         public long Size { get; set; }
         public IndexerFlags IndexerFlags { get; set; }
+        public int? IndexerId { get; set; }
         public List<Language> Languages { get; set; }
         public string Filename { get; set; }
 

--- a/src/NzbDrone.Core/CustomFormats/Specifications/IndexerSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/IndexerSpecification.cs
@@ -1,0 +1,35 @@
+using FluentValidation;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.CustomFormats
+{
+    public class IndexerSpecificationValidator : AbstractValidator<IndexerSpecification>
+    {
+        public IndexerSpecificationValidator()
+        {
+            RuleFor(c => c.Value).GreaterThan(0);
+        }
+    }
+
+    public class IndexerSpecification : CustomFormatSpecificationBase
+    {
+        private static readonly IndexerSpecificationValidator Validator = new IndexerSpecificationValidator();
+
+        public override int Order => 4;
+        public override string ImplementationName => "Indexer";
+
+        [FieldDefinition(1, Label = "Indexer", Type = FieldType.Select, SelectOptionsProviderAction = "indexers")]
+        public int Value { get; set; }
+
+        protected override bool IsSatisfiedByWithoutNegate(CustomFormatInput input)
+        {
+            return input.IndexerId == Value;
+        }
+
+        public override NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate(this));
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/234_add_indexer_id_columns.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/234_add_indexer_id_columns.cs
@@ -1,0 +1,15 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(234)]
+    public class add_indexer_id_columns : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Blocklist").AddColumn("IndexerId").AsInt32().WithDefaultValue(-1);
+            Alter.Table("MovieFiles").AddColumn("IndexerId").AsInt32().WithDefaultValue(-1);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -161,6 +161,13 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                         trackedDownload.RemoteMovie.Release ??= new ReleaseInfo();
                         trackedDownload.RemoteMovie.Release.IndexerFlags = flags;
                     }
+
+                    if (trackedDownload.RemoteMovie != null &&
+                        int.TryParse(grabbedEvent?.Data?.GetValueOrDefault("indexerId"), out var indexerId))
+                    {
+                        trackedDownload.RemoteMovie.Release ??= new ReleaseInfo();
+                        trackedDownload.RemoteMovie.Release.IndexerId = indexerId;
+                    }
                 }
 
                 // Calculate custom formats

--- a/src/NzbDrone.Core/History/HistoryService.cs
+++ b/src/NzbDrone.Core/History/HistoryService.cs
@@ -204,6 +204,7 @@ namespace NzbDrone.Core.History
             history.Data.Add("ReleaseGroup", message.MovieInfo.ReleaseGroup);
             history.Data.Add("CustomFormatScore", message.MovieInfo.CustomFormatScore.ToString());
             history.Data.Add("IndexerFlags", message.ImportedMovie.IndexerFlags.ToString());
+            history.Data.Add("IndexerId", message.ImportedMovie.IndexerId.ToString());
 
             _historyRepository.Insert(history);
         }
@@ -229,6 +230,7 @@ namespace NzbDrone.Core.History
             history.Data.Add("Reason", message.Reason.ToString());
             history.Data.Add("ReleaseGroup", message.MovieFile.ReleaseGroup);
             history.Data.Add("IndexerFlags", message.MovieFile.IndexerFlags.ToString());
+            history.Data.Add("IndexerId", message.MovieFile.IndexerId.ToString());
 
             _historyRepository.Insert(history);
         }
@@ -256,6 +258,7 @@ namespace NzbDrone.Core.History
             history.Data.Add("RelativePath", relativePath);
             history.Data.Add("ReleaseGroup", message.MovieFile.ReleaseGroup);
             history.Data.Add("IndexerFlags", message.MovieFile.IndexerFlags.ToString());
+            history.Data.Add("IndexerId", message.MovieFile.IndexerId.ToString());
 
             _historyRepository.Insert(history);
         }

--- a/src/NzbDrone.Core/MediaFiles/MovieFile.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieFile.cs
@@ -21,6 +21,7 @@ namespace NzbDrone.Core.MediaFiles
         public string SceneName { get; set; }
         public string ReleaseGroup { get; set; }
         public IndexerFlags IndexerFlags { get; set; }
+        public int IndexerId { get; set; } = -1;
         public QualityModel Quality { get; set; }
         public List<Language> Languages { get; set; }
         public MediaInfoModel MediaInfo { get; set; }

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
@@ -104,6 +104,11 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
                         {
                             movieFile.IndexerFlags = flags;
                         }
+
+                        if (int.TryParse(grabHistory?.Data.GetValueOrDefault("indexerId"), out var indexerId))
+                        {
+                            movieFile.IndexerId = indexerId;
+                        }
                     }
 
                     bool copyOnly;

--- a/src/Radarr.Api.V3/MovieFiles/MovieFileController.cs
+++ b/src/Radarr.Api.V3/MovieFiles/MovieFileController.cs
@@ -94,6 +94,7 @@ namespace Radarr.Api.V3.MovieFiles
         {
             var movieFile = _mediaFileService.GetMovie(movieFileResource.Id);
             movieFile.IndexerFlags = (IndexerFlags)movieFileResource.IndexerFlags;
+            movieFile.IndexerId = movieFileResource.IndexerId;
             movieFile.Quality = movieFileResource.Quality;
             movieFile.Languages = movieFileResource.Languages;
             movieFile.Edition = movieFileResource.Edition;
@@ -133,6 +134,11 @@ namespace Radarr.Api.V3.MovieFiles
                 if (resource.IndexerFlags != null)
                 {
                     movieFile.IndexerFlags = (IndexerFlags)resource.IndexerFlags.Value;
+                }
+
+                if (resource.IndexerId != null)
+                {
+                    movieFile.IndexerId = resource.IndexerId.Value;
                 }
 
                 if (resource.Edition != null)

--- a/src/Radarr.Api.V3/MovieFiles/MovieFileListResource.cs
+++ b/src/Radarr.Api.V3/MovieFiles/MovieFileListResource.cs
@@ -13,5 +13,6 @@ namespace Radarr.Api.V3.MovieFiles
         public string ReleaseGroup { get; set; }
         public string SceneName { get; set; }
         public int? IndexerFlags { get; set; }
+        public int? IndexerId { get; set; }
     }
 }

--- a/src/Radarr.Api.V3/MovieFiles/MovieFileResource.cs
+++ b/src/Radarr.Api.V3/MovieFiles/MovieFileResource.cs
@@ -20,6 +20,7 @@ namespace Radarr.Api.V3.MovieFiles
         public DateTime DateAdded { get; set; }
         public string SceneName { get; set; }
         public int IndexerFlags { get; set; }
+        public int IndexerId { get; set; }
         public QualityModel Quality { get; set; }
         public List<CustomFormatResource> CustomFormats { get; set; }
         public int CustomFormatScore { get; set; }
@@ -52,6 +53,7 @@ namespace Radarr.Api.V3.MovieFiles
                 DateAdded = model.DateAdded,
                 SceneName = model.SceneName,
                 IndexerFlags = (int)model.IndexerFlags,
+                IndexerId = model.IndexerId,
                 Quality = model.Quality,
                 Languages = model.Languages,
                 ReleaseGroup = model.ReleaseGroup,
@@ -79,6 +81,7 @@ namespace Radarr.Api.V3.MovieFiles
                 DateAdded = model.DateAdded,
                 SceneName = model.SceneName,
                 IndexerFlags = (int)model.IndexerFlags,
+                IndexerId = model.IndexerId,
                 Quality = model.Quality,
                 Languages = model.Languages,
                 Edition = model.Edition,

--- a/src/Radarr.Api.V3/Specifications/SpecificationsController.cs
+++ b/src/Radarr.Api.V3/Specifications/SpecificationsController.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Indexers;
+using Radarr.Http;
+
+namespace Radarr.Api.V3.Specifications
+{
+    [V3ApiController]
+    public class SpecificationsController : Controller
+    {
+        private readonly IIndexerFactory _indexerFactory;
+
+        public SpecificationsController(IIndexerFactory indexerFactory)
+        {
+            _indexerFactory = indexerFactory;
+        }
+
+        [HttpPost("action/indexers")]
+        public object GetIndexers()
+        {
+            return new
+            {
+                options = _indexerFactory.All().Select(o => new FieldSelectOption { Value = o.Id, Name = o.Name }).ToList()
+            };
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
YES - Migration 234 - Adds a "IndexerId" column to the "Blocklist" and "MovieFiles" tables to support evaluating this new indexer Custom Format based on the saved value

#### Description
Implement a new Custom Format condition based on the indexer used to grab the specific content. This allows for more granular priority setting based on indexers, and also now facilitates defining custom conditions (using the other Custom Format conditions) that are specific to a or multiple indexers.

Note: It took a bit of time to familiarize myself with the structure of the project, and understand how it all works. Therefore, the way I implemented the dropdown for selecting the Indexer (or any other part of my changes for that matter), may not be optimal/ideal; alternative suggestions are welcome.

#### Issues Fixed or Closed by this PR

* Fixes #6697 