### PR TITLE
WIP: Add IPv6 override for http client

### DIFF
--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -41,6 +41,7 @@ namespace NzbDrone.Core.Configuration
         bool LogSql { get; }
         int LogRotate { get; }
         bool FilterSentryEvents { get; }
+        bool ForceIPv6 { get; }
         string Branch { get; }
         string ApiKey { get; }
         string SslCertPath { get; }
@@ -211,6 +212,7 @@ namespace NzbDrone.Core.Configuration
         public bool LogSql => GetValueBoolean("LogSql", false, persist: false);
         public int LogRotate => GetValueInt("LogRotate", 50, persist: false);
         public bool FilterSentryEvents => GetValueBoolean("FilterSentryEvents", true, persist: false);
+        public bool ForceIPv6 => GetValueBoolean("ForceIPv6", false, persist: false);
         public string SslCertPath => GetValue("SslCertPath", "");
         public string SslCertPassword => GetValue("SslCertPassword", "");
 


### PR DESCRIPTION
#### Database Migration
 NO

#### Description
It's goal is to allow an override for unstable IPv6 only environments like k8s.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #7637