### PR TITLE
German DL and ML tag

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/IndexerBaseFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/IndexerBaseFixture.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Moq;
+using NLog;
+using NUnit.Framework;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.IndexerTests;
+
+[TestFixture]
+public class IndexerBaseFixture : CoreTest<IndexerBase<TestIndexerSettings>>
+{
+    private TestIndexer _indexer;
+
+    [SetUp]
+    public void Setup()
+    {
+        _indexer = new TestIndexer(new Mock<IHttpClient>().Object,
+            new Mock<IIndexerStatusService>().Object,
+            new Mock<IConfigService>().Object,
+            new Mock<IParsingService>().Object,
+            new Mock<Logger>().Object)
+        {
+            Definition = new IndexerDefinition
+            {
+                Settings = new TestIndexerSettings
+                {
+                    MultiLanguages = new List<int> { Language.German.Id, Language.English.Id }
+                }
+            }
+        };
+    }
+
+    [TestCase("The.Movie.Name.2016.Multi.DTS.720p.BluRay.x264-RlsGrp")]
+    public void should_parse_multi_language(string postTitle)
+    {
+        var result = _indexer.CleanupReleases(new ReleaseInfo[] { new () { Title = postTitle, Languages = new List<Language>() } });
+        result.Single().Languages.Count.Should().Be(2);
+        result.Single().Languages.Should().Contain(Language.German);
+        result.Single().Languages.Should().Contain(Language.English);
+    }
+}

--- a/src/NzbDrone.Core.Test/IndexerTests/TestIndexer.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TestIndexer.cs
@@ -1,8 +1,10 @@
-﻿using NLog;
+﻿using System.Collections.Generic;
+using NLog;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Test.IndexerTests
 {
@@ -30,6 +32,11 @@ namespace NzbDrone.Core.Test.IndexerTests
         public override IParseIndexerResponse GetParser()
         {
             return _parser;
+        }
+
+        public new IList<ReleaseInfo> CleanupReleases(IEnumerable<ReleaseInfo> releases)
+        {
+            return base.CleanupReleases(releases);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -429,5 +429,35 @@ namespace NzbDrone.Core.Test.ParserTests
             var result = LanguageParser.ParseSubtitleLanguage(fileName);
             result.Should().Be(Language.Unknown);
         }
+
+        [TestCase("The.Movie.Name.2016.German.DTS.DL.720p.BluRay.x264-RlsGrp")]
+        public void should_add_original_language_to_german_release_with_dl_tag(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle);
+            result.Languages.Count.Should().Be(2);
+            result.Languages.Should().Contain(Language.German);
+            result.Languages.Should().Contain(Language.Original);
+        }
+
+        [TestCase("The.Movie.Name.2016.GERMAN.WEB-DL.h264-RlsGrp")]
+        [TestCase("The.Movie.Name.2016.GERMAN.WEB.DL.h264-RlsGrp")]
+        [TestCase("The Movie Name 2016 GERMAN WEB DL h264-RlsGrp")]
+        [TestCase("The.Movie.Name.2016.GERMAN.WEBDL.h264-RlsGrp")]
+        public void should_not_add_original_language_to_german_release_when_title_contains_web_dl(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle);
+            result.Languages.Count.Should().Be(1);
+            result.Languages.Should().Contain(Language.German);
+        }
+
+        [TestCase("The.Movie.Name.2023.German.ML.EAC3.720p.NF.WEB.H264-RlsGrp")]
+        public void should_add_original_language_and_english_to_german_release_with_ml_tag(string postTitle)
+        {
+            var result = Parser.Parser.ParseMovieTitle(postTitle);
+            result.Languages.Count.Should().Be(3);
+            result.Languages.Should().Contain(Language.German);
+            result.Languages.Should().Contain(Language.Original);
+            result.Languages.Should().Contain(Language.English);
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -62,6 +62,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("G.I.Movie.Movie.2013.THEATRiCAL.COMPLETE.BLURAY-GLiMMER", "G.I. Movie Movie")]
         [TestCase("www.Torrenting.org - Movie.2008.720p.X264-DIMENSION", "Movie")]
         [TestCase("The.French.Movie.2013.720p.BluRay.x264 - ROUGH[PublicHD]", "The French Movie")]
+        [TestCase("The.Good.German.2006.720p.BluRay.x264-RlsGrp", "The Good German", Description = "Hardcoded to exclude from German regex")]
         public void should_parse_movie_title(string postTitle, string title)
         {
             Parser.Parser.ParseMovieTitle(postTitle).PrimaryMovieTitle.Should().Be(title);
@@ -124,6 +125,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Die.fantastische.Reise.des.Dr.Dolittle.2020.German.DL.LD.1080p.WEBRip.x264-PRD", "Die fantastische Reise des Dr. Dolittle", "", 2020, Description = "dot after dr")]
         [TestCase("Der.Film.deines.Lebens.German.2011.PAL.DVDR-ETM", "Der Film deines Lebens", "", 2011, Description = "year at wrong position")]
         [TestCase("Kick.Ass.2.2013.German.DTS.DL.720p.BluRay.x264-Pate_", "Kick Ass 2", "", 2013, Description = "underscore at the end")]
+        [TestCase("The.Good.German.2006.GERMAN.720p.HDTV.x264-RLsGrp", "The Good German", "", 2006, Description = "German in the title")]
         public void should_parse_german_movie(string postTitle, string title, string edition, int year)
         {
             var movie = Parser.Parser.ParseMovieTitle(postTitle);
@@ -238,6 +240,10 @@ namespace NzbDrone.Core.Test.ParserTests
 
         [TestCase("The.Italian.Movie.2025.720p.BluRay.X264-AMIABLE")]
         [TestCase("The.French.Movie.2013.720p.BluRay.x264 - ROUGH[PublicHD]")]
+        [TestCase("The.German.Doctor.2013.LIMITED.DVDRip.x264-RedBlade", Description = "When German is not followed by a year or a SCENE word it is not matched")]
+        [TestCase("The.Good.German.2006.720p.HDTV.x264-TVP", Description = "The Good German is hardcoded not to match")]
+        [TestCase("German.Lancers.2019.720p.BluRay.x264-UNiVERSUM", Description = "German at the beginning is never matched")]
+        [TestCase("The.German.2019.720p.BluRay.x264-UNiVERSUM", Description = "The German is hardcoded not to match")]
         public void should_not_parse_wrong_language_in_title(string postTitle)
         {
             var parsed = Parser.Parser.ParseMovieTitle(postTitle, true);

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -245,22 +245,6 @@ namespace NzbDrone.Core.Test.ParserTests
             parsed.Languages.First().Should().Be(Language.Unknown);
         }
 
-        [TestCase("The.Movie.Name.2016.German.DTS.DL.720p.BluRay.x264-MULTiPLEX")]
-        public void should_not_parse_multi_language_in_releasegroup(string postTitle)
-        {
-            var parsed = Parser.Parser.ParseMovieTitle(postTitle, true);
-            parsed.Languages.Count.Should().Be(1);
-            parsed.Languages.First().Should().Be(Language.German);
-        }
-
-        [TestCase("The.Movie.Name.2016.German.Multi.DTS.DL.720p.BluRay.x264-MULTiPLEX")]
-        public void should_parse_multi_language(string postTitle)
-        {
-            var parsed = Parser.Parser.ParseMovieTitle(postTitle, true);
-            parsed.Languages.Count.Should().Be(1);
-            parsed.Languages.Should().Contain(Language.German);
-        }
-
         [TestCase("Movie.Title.2016.1080p.KORSUB.WEBRip.x264.AAC2.0-RADARR", "KORSUB")]
         [TestCase("Movie.Title.2016.1080p.KORSUBS.WEBRip.x264.AAC2.0-RADARR", "KORSUBS")]
         [TestCase("Movie Title 2017 HC 720p HDRiP DD5 1 x264-LEGi0N", "Generic Hardcoded Subs")]

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Parser
             new Regex(@"^(?:\[(?<subgroup>.+?)\][-_. ]?)(?<title>(?![(\[]).+)(?:[\[(][^])]).*?(?<hash>\[\w{8}\])(?:$|\.)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
             // Some german or french tracker formats (missing year, ...) (Only applies to german and TrueFrench releases) - see ParserFixture for examples and tests - french removed as it broke all movies w/ french titles
-            new Regex(@"^(?<title>(?![(\[]).+?)((\W|_))(" + EditionRegex + @".{1,3})?(?:(?<!(19|20)\d{2}.*?)(German|TrueFrench))(.+?)(?=((19|20)\d{2}|$))(?<year>(19|20)\d{2}(?!p|i|\d+|\]|\W\d+))?(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<title>(?![(\[]).+?)((\W|_))(" + EditionRegex + @".{1,3})?(?:(?<!(19|20)\d{2}.*?)(?<!(?:Good|The)[_ .-])(German|TrueFrench))(.+?)(?=((19|20)\d{2}|$))(?<year>(19|20)\d{2}(?!p|i|\d+|\]|\W\d+))?(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
             // Special, Despecialized, etc. Edition Movies, e.g: Mission.Impossible.3.Special.Edition.2011
             new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*" + EditionRegex + @".{1,3}(?<year>(1(8|9)|20)\d{2}(?!p|i|\d+|\]|\W\d+)))+(\W+|_|$)(?!\\)",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR consists of 3 parts (split by commit):

1. Added tests related to the `Multi` tag in releases
2. Correctly parses German DL and ML tags
The `DL` tag (Dual Language) is quite like the `Multi` tag, but for the German Scene, it specifies that the release contains the German and the original language.
The `ML` tag (Multi Language) contains the following languages: `German`, `Original`, `English` or more ([examples on xrel.to](https://www.xrel.to/p2p/releases.html?search_results=MRUJJIw4j3167540907&page=4))
3. It fixes #6474 by hardcoding some specific known movie titles that contain the word "German" so that the regex excludes these releases.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #6474 