### PR TITLE
Fixed: Parsing custom formats for releases titles containing colon

### DIFF
--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -118,7 +118,7 @@ namespace NzbDrone.Core.Parser
                                                                 string.Empty,
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex SimpleReleaseTitleRegex = new Regex(@"\s*(?:[<>?*:|])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex SimpleReleaseTitleRegex = new Regex(@"\s*(?:[<>?*|])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         // Valid TLDs http://data.iana.org/TLD/tlds-alpha-by-domain.txt
         private static readonly RegexReplace WebsitePrefixRegex = new RegexReplace(@"^(?:\[\s*)?(?:www\.)?[-a-z0-9-]{1,256}\.(?:[a-z]{2,6}\.[a-z]{2,6}|xn--[a-z0-9-]{4,}|[a-z]{2,})\b(?:\s*\]|[ -]{2,})[ -]*",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
SimplifyReleaseTitle replaces these titles
`Bakering Borking Forever 2022 BluRay 1080p DD 5 1 x264-RlsGroup` -> `A Movie 2022 BluRay 1080p DD 5 1 x264-RlsGroup`
`Bakering: Borking Forever 2022 BluRay 1080p DD5.1 x264-RlsGroup`-> `A Movie2022 BluRay 1080p DD 5 1 x264-RlsGroup`

This breaks custom formats  for year with a word boundary, eg. `\b20\d{2}\b`.