### PR TITLE
Fixed: Latvian and Russian language parsing

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -140,6 +140,8 @@ namespace NzbDrone.Core.Test.ParserTests
         }
 
         [TestCase("Movie.Title.1994.Russian.1080p.XviD-LOL")]
+        [TestCase("Movie.Title.2020.WEB-DLRip.AVC.AC3.EN.RU.ENSub.RUSub-LOL")]
+        [TestCase("Movie Title (2020) WEB-DL (720p) Rus-Eng")]
         public void should_parse_language_russian(string postTitle)
         {
             var result = Parser.Parser.ParseMovieTitle(postTitle, true);
@@ -388,6 +390,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie.Title.2022.lv.WEBRip.XviD-LOL")]
         [TestCase("Movie.Title.2022.LATVIAN.WEBRip.XviD-LOL")]
         [TestCase("Movie.Title.2022.Latvian.WEBRip.XviD-LOL")]
+        [TestCase("Movie.Title.2022.1080p.WEB-DL.DDP5.1.Atmos.H.264.Lat.Eng")]
+        [TestCase("Movie.Title.2022.1080p.WEB-DL.LAV.RUS-NPPK")]
         public void should_parse_language_latvian(string postTitle)
         {
             var result = Parser.Parser.ParseMovieTitle(postTitle);

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Parser
                                                                             (?<brazilian>dublado)|
                                                                             (?<greek>greek)|
                                                                             (?<french>\b(?:FR|VO|VF|VFF|VFQ|VFI|VF2|TRUEFRENCH|FRE|FRA)\b)|
-                                                                            (?<russian>\brus\b)|
+                                                                            (?<russian>\b(?:rus|ru)\b)|
                                                                             (?<english>\beng\b)|
                                                                             (?<hungarian>\b(?:HUNDUB|HUN)\b)|
                                                                             (?<hebrew>\b(?:HebDub|HebDubbed)\b)|
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Parser
                                                                             (?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)|
                                                                             (?<ukrainian>(?:(?:\dx)?UKR))|
                                                                             (?<spanish>\b(?:español|castellano)\b)|
-                                                                            (?<latvian>\bLV\b)|
+                                                                            (?<latvian>\b(?:lat|lav|lv)\b)|
                                                                             (?<telugu>\btel\b)|
                                                                             (?<vietnamese>\bVIE\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Improved support for Latvian with test cases I have encountered in the wild and fixed a case where Russian is not recognized (RU instead of RUS).

#### Todos
- [x] Tests
- N/A Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- N/A [Wiki Updates](https://wiki.servarr.com)