### PR TITLE
Search for new movie rather than select first suggestion on key press

### DIFF
--- a/frontend/src/Components/Page/Header/MovieSearchInput.js
+++ b/frontend/src/Components/Page/Header/MovieSearchInput.js
@@ -161,13 +161,12 @@ class MovieSearchInput extends Component {
       return;
     }
 
-    // If an suggestion is not selected go to the first movie,
-    // otherwise go to the selected movie.
-
-    if (highlightedSuggestionIndex == null) {
-      this.goToMovie(suggestions[0]);
-    } else {
+    // If a suggestion is highlighted, go to that movie
+    // otherwise search for a new movie
+    if (highlightedSuggestionIndex) {
       this.goToMovie(suggestions[highlightedSuggestionIndex]);
+    } else {
+      this.props.onGoToAddNewMovie(value);
     }
 
     this._autosuggest.input.blur();

--- a/frontend/src/Components/Page/Header/MovieSearchInput.js
+++ b/frontend/src/Components/Page/Header/MovieSearchInput.js
@@ -161,12 +161,12 @@ class MovieSearchInput extends Component {
       return;
     }
 
-    // If a suggestion is highlighted, go to that movie
-    // otherwise search for a new movie
-    if (highlightedSuggestionIndex) {
-      this.goToMovie(suggestions[highlightedSuggestionIndex]);
-    } else {
+    // If no suggestion is highlighted, search for a new movie
+    // otherwise go to the suggested movie
+    if (highlightedSuggestionIndex == null) {
       this.props.onGoToAddNewMovie(value);
+    } else {
+      this.goToMovie(suggestions[highlightedSuggestionIndex]);
     }
 
     this._autosuggest.input.blur();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Most search engines do not select the first suggestion upon pressing enter, they perform a search for your term. Radarr will currently do this when there are no existing movies that match the search term, but it will go to the first matching existing movie if one exists.

Update the Radarr search to look for a new movie upon pressing `Tab` or `Enter` instead of selecting the first existing film if there is one. The behaviour for no matching existing films remains the same. It will navigate to the highlighted selection if selected.

#### Screenshot (if UI related)
Behavioural change rather than visual change.

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
N/A

#### Other info
[Corresponding PR for Sonarr](https://github.com/Sonarr/Sonarr/pull/6522)