### PR TITLE
Update SkyHookProxy.cs to add OriginalTitle to AlternativeTitles

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -236,6 +236,21 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             movie.CleanOriginalTitle = resource.OriginalTitle.CleanMovieTitle();
             movie.Overview = resource.Overview;
 
+            // Modification starts here
+            // Check if OriginalTitle is different from Title and not already in AlternativeTitles
+            if (!string.IsNullOrWhiteSpace(movie.OriginalTitle) && movie.OriginalTitle != movie.Title &&
+                !resource.AlternativeTitles.Any(alt => alt.Title == movie.OriginalTitle))
+            {
+                var originalTitleAlt = new AlternativeTitle
+                {
+                    Title = movie.OriginalTitle,
+                    SourceType = SourceType.TMDB, // Assuming the source is TMDB, adjust if necessary
+                    CleanTitle = movie.OriginalTitle.CleanMovieTitle() // Clean the title if required
+                };
+                movie.AlternativeTitles.Add(originalTitleAlt);
+            }
+            // Modification ends here
+
             movie.AlternativeTitles.AddRange(resource.AlternativeTitles.Select(MapAlternativeTitle));
 
             movie.Translations.AddRange(resource.Translations.Select(MapTranslation));


### PR DESCRIPTION
The OriginalTitle property is not being exposed by Radarr, which limits the subtitle search results by Bazarr. It only exposes "Title" and "AlternativeTitles", when usually in the case of non-english movies, the OriginalTitle is the one likely to get the most search results. So with this modification, OriginalTitle will also be appended to the AlternativeTitles list.
This might also be impacting Radarr's search in indexers, not sure (it'd seem that Radarr is searching also by OriginalTitle, but it might be an illusion created by the search by imdbid). But by all means it's quite odd not to see the OriginalTitle anywhere in the UI, and this should solve it too.

#### Todos
- not tested / not sure if this is enough or other files have to be similarly modified too

