### PR TITLE
style: Prevent wrapping on indexer column

### DIFF
--- a/frontend/src/Activity/History/HistoryRow.css
+++ b/frontend/src/Activity/History/HistoryRow.css
@@ -8,6 +8,7 @@
   composes: cell from '~Components/Table/Cells/TableRowCell.css';
 
   width: 80px;
+  white-space: nowrap;
 }
 
 .customFormatScore {

--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.css
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.css
@@ -17,6 +17,12 @@
   width: 85px;
 }
 
+@media only screen and (min-width: calc($breakpointExtraLarge + 150px)) {
+  .indexer {
+    white-space: nowrap;
+  }
+}
+
 .quality,
 .languages {
   composes: cell from '~Components/Table/Cells/TableRowCell.css';


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Prevents wrapping in the history panel without increasing width of the column.
Also prevents wrapping in the interactive search indexer column.
Not sure whether to add this as a breakpoint value to `dimensions.js`, there's only one other reference to `1600px` in `Modal.css` called `.extraExtraLarge`. 
I noticed 1 reference also using `calc($breakpoint + )` so I went ahead and used that as an example. In any case the indexer column now starts wrapping at the same time as the title.

#### Screenshot (if UI related)
> \> History
![pr_1_history](https://github.com/Radarr/Radarr/assets/50634910/00b7d8af-ea3e-4f55-8382-8f19de32b22e)

> \> 1600px
![pr_1_long](https://github.com/Radarr/Radarr/assets/50634910/675e2087-bc48-413a-aa33-170578e907e9)

> < 1600px
![pr_1_short](https://github.com/Radarr/Radarr/assets/50634910/531aec48-15f8-4c55-93e5-05036e387f57)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #9551: prevents wrapping in the history panel and in interactive search if the modal is greater than 1600px, the same value as .extraExtraLarge breakpoint defined in Modal.css