### PR TITLE
fix: swap trailing determiners at the end of titles

### DIFF
--- a/src/NzbDrone.Common/Extensions/StringExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/StringExtensions.cs
@@ -12,6 +12,7 @@ namespace NzbDrone.Common.Extensions
     public static class StringExtensions
     {
         private static readonly Regex CamelCaseRegex = new Regex("(?<!^)[A-Z]", RegexOptions.Compiled);
+        private static readonly Regex TrailingDeterminerRegex = new Regex("(, The)$|(, A)$", RegexOptions.Compiled);
 
         public static string NullSafe(this string target)
         {
@@ -227,6 +228,19 @@ namespace NzbDrone.Common.Extensions
             Array.Reverse(array);
 
             return new string(array);
+        }
+
+        // Some files have their determiner (The, A) at the end of the title to help sorting, flip them back to prevent searching errors.
+        public static string SwapTrailingDeterminers(this string input)
+        {
+            var match = TrailingDeterminerRegex.Match(input);
+            if (match.Success)
+            {
+                input = TrailingDeterminerRegex.Replace(input, string.Empty);
+                input = match.Value.Replace(", ", string.Empty) + " " + input;
+            }
+
+            return input;
         }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/NormalizeTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/NormalizeTitleFixture.cs
@@ -186,5 +186,17 @@ namespace NzbDrone.Core.Test.ParserTests
         {
             "Tokyo Ghoul A".CleanMovieTitle().Should().Be("tokyoghoula");
         }
+
+        [TestCase("Prestige, The", "theprestige")]
+        [TestCase("Prestige, A", "aprestige")]
+        [TestCase("Crow, The", "thecrow")]
+        [TestCase("Crow, A", "acrow")]
+        [TestCase("Beautiful Romance, The", "thebeautifulromance")]
+        [TestCase("Beautiful Romance, A", "abeautifulromance")]
+        public void should_swap_determiner(string parsedSeriesName, string seriesName)
+        {
+            var result = parsedSeriesName.CleanMovieTitle();
+            result.Should().Be(seriesName);
+        }
     }
 }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -466,7 +466,7 @@ namespace NzbDrone.Core.Parser
                 return title;
             }
 
-            return ReplaceGermanUmlauts(NormalizeRegex.Replace(title, string.Empty).ToLower()).RemoveAccent();
+            return ReplaceGermanUmlauts(NormalizeRegex.Replace(title.SwapTrailingDeterminers(), string.Empty).ToLower()).RemoveAccent();
         }
 
         public static string NormalizeEpisodeTitle(this string title)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Some files have their `, A` or `, The` at the end of the file to prevent alphabetical sorting clustering these titles together. This stops working when searching for files inside Radarr as a cleaned title will have 'prestigethe' instead of 'theprestige'.

Seeing as `the` and `a` in the middle of a title are already filtered out and covered in a different test case I didn't write a negative test case.

This is just covering English, I assume to support more languages the regex will need to be expanded.

#### Screenshot (if UI related)

#### Todos
- [X] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #9815 