### PR TITLE
Use branded message title for Telegram notifications

### DIFF
--- a/src/NzbDrone.Core/Notifications/NotificationBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationBase.cs
@@ -24,6 +24,7 @@ namespace NzbDrone.Core.Notifications
         protected const string MOVIE_GRABBED_TITLE_BRANDED = "Radarr - " + MOVIE_GRABBED_TITLE;
         protected const string MOVIE_ADDED_TITLE_BRANDED = "Radarr - " + MOVIE_ADDED_TITLE;
         protected const string MOVIE_DOWNLOADED_TITLE_BRANDED = "Radarr - " + MOVIE_DOWNLOADED_TITLE;
+        protected const string MOVIE_UPGRADED_TITLE_BRANDED = "Radarr - " + MOVIE_UPGRADED_TITLE;
         protected const string MOVIE_DELETED_TITLE_BRANDED = "Radarr - " + MOVIE_DELETED_TITLE;
         protected const string MOVIE_FILE_DELETED_TITLE_BRANDED = "Radarr - " + MOVIE_FILE_DELETED_TITLE;
         protected const string HEALTH_ISSUE_TITLE_BRANDED = "Radarr - " + HEALTH_ISSUE_TITLE;

--- a/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
@@ -20,54 +20,54 @@ namespace NzbDrone.Core.Notifications.Telegram
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            _proxy.SendNotification(MOVIE_GRABBED_TITLE, grabMessage.Message, Settings);
+            _proxy.SendNotification(MOVIE_GRABBED_TITLE_BRANDED, grabMessage.Message, Settings);
         }
 
         public override void OnDownload(DownloadMessage message)
         {
             if (message.OldMovieFiles.Any())
             {
-                _proxy.SendNotification(MOVIE_UPGRADED_TITLE, message.Message, Settings);
+                _proxy.SendNotification(MOVIE_UPGRADED_TITLE_BRANDED, message.Message, Settings);
             }
             else
             {
-                _proxy.SendNotification(MOVIE_DOWNLOADED_TITLE, message.Message, Settings);
+                _proxy.SendNotification(MOVIE_DOWNLOADED_TITLE_BRANDED, message.Message, Settings);
             }
         }
 
         public override void OnMovieAdded(Movie movie)
         {
-            _proxy.SendNotification(MOVIE_ADDED_TITLE, $"{movie.Title} added to library", Settings);
+            _proxy.SendNotification(MOVIE_ADDED_TITLE_BRANDED, $"{movie.Title} added to library", Settings);
         }
 
         public override void OnMovieFileDelete(MovieFileDeleteMessage deleteMessage)
         {
-            _proxy.SendNotification(MOVIE_FILE_DELETED_TITLE, deleteMessage.Message, Settings);
+            _proxy.SendNotification(MOVIE_FILE_DELETED_TITLE_BRANDED, deleteMessage.Message, Settings);
         }
 
         public override void OnMovieDelete(MovieDeleteMessage deleteMessage)
         {
-            _proxy.SendNotification(MOVIE_DELETED_TITLE, deleteMessage.Message, Settings);
+            _proxy.SendNotification(MOVIE_DELETED_TITLE_BRANDED, deleteMessage.Message, Settings);
         }
 
         public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)
         {
-            _proxy.SendNotification(HEALTH_ISSUE_TITLE, healthCheck.Message, Settings);
+            _proxy.SendNotification(HEALTH_ISSUE_TITLE_BRANDED, healthCheck.Message, Settings);
         }
 
         public override void OnHealthRestored(HealthCheck.HealthCheck previousCheck)
         {
-            _proxy.SendNotification(HEALTH_RESTORED_TITLE, $"The following issue is now resolved: {previousCheck.Message}", Settings);
+            _proxy.SendNotification(HEALTH_RESTORED_TITLE_BRANDED, $"The following issue is now resolved: {previousCheck.Message}", Settings);
         }
 
         public override void OnApplicationUpdate(ApplicationUpdateMessage updateMessage)
         {
-            _proxy.SendNotification(APPLICATION_UPDATE_TITLE, updateMessage.Message, Settings);
+            _proxy.SendNotification(APPLICATION_UPDATE_TITLE_BRANDED, updateMessage.Message, Settings);
         }
 
         public override void OnManualInteractionRequired(ManualInteractionRequiredMessage message)
         {
-            _proxy.SendNotification(MANUAL_INTERACTION_REQUIRED_TITLE, message.Message, Settings);
+            _proxy.SendNotification(MANUAL_INTERACTION_REQUIRED_TITLE_BRANDED, message.Message, Settings);
         }
 
         public override ValidationResult Test()


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Using branded title for Telegram nitification messages for more convenient determination of notification source in case of using multiple notificators in one Telegram channel or group.
#### Screenshot (if UI related)

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* Fixes #9845