### PR TITLE
New: Improve Edition Naming for Ordinals and Certain Keywords

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/EditionTagsFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/EditionTagsFixture.cs
@@ -24,10 +24,10 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         {
             _movie = Builder<Movie>
                 .CreateNew()
-                .With(s => s.Title = "South Park")
+                .With(m => m.Title = "Movie Title")
                 .Build();
 
-            _movieFile = new MovieFile { Quality = new QualityModel(), ReleaseGroup = "SonarrTest" };
+            _movieFile = new MovieFile { Quality = new QualityModel(), ReleaseGroup = "RadarrTest" };
 
             _namingConfig = NamingConfig.Default;
             _namingConfig.RenameMovies = true;
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _namingConfig.StandardMovieFormat = "{Movie Title} [{Edition Tags}]";
 
             Subject.BuildFileName(_movie, _movieFile)
-                   .Should().Be("South Park [Uncut]");
+                   .Should().Be("Movie Title [Uncut]");
         }
 
         [TestCase("{Movie Title} {edition-{Edition Tags}}")]
@@ -61,7 +61,99 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _namingConfig.StandardMovieFormat = movieFormat;
 
             Subject.BuildFileName(_movie, _movieFile)
-                   .Should().Be("South Park");
+                   .Should().Be("Movie Title");
+        }
+
+        [TestCase("1st anniversary edition", "{Movie Title} [{Edition Tags}]", "Movie Title [1st Anniversary Edition]")]
+        [TestCase("2nd Anniversary edition", "{Movie Title} [{Edition Tags}]", "Movie Title [2nd Anniversary Edition]")]
+        [TestCase("3rd anniversary Edition", "{Movie Title} [{Edition Tags}]", "Movie Title [3rd Anniversary Edition]")]
+        [TestCase("4th anNiverSary eDitIOn", "{Movie Title} [{Edition Tags}]", "Movie Title [4th Anniversary Edition]")]
+        [TestCase("5th anniversary edition", "{Movie Title} [{Edition Tags}]", "Movie Title [5th Anniversary Edition]")]
+        [TestCase("6th anNiverSary EDITION", "{Movie Title} [{Edition Tags}]", "Movie Title [6th Anniversary Edition]")]
+        [TestCase("7TH anniversary edition", "{Movie Title} [{Edition Tags}]", "Movie Title [7th Anniversary Edition]")]
+        [TestCase("8Th anniversary edition", "{Movie Title} [{Edition Tags}]", "Movie Title [8th Anniversary Edition]")]
+        [TestCase("9tH anniversary edition", "{Movie Title} [{Edition Tags}]", "Movie Title [9th Anniversary Edition]")]
+        [TestCase("10th anniversary edition", "{Movie Title} [{edition tags}]", "Movie Title [10th anniversary edition]")]
+        [TestCase("10TH anniversary edition", "{Movie Title} [{edition tags}]", "Movie Title [10th anniversary edition]")]
+        [TestCase("10Th anniversary edition", "{Movie Title} [{edition tags}]", "Movie Title [10th anniversary edition]")]
+        [TestCase("10th anniversary edition", "{Movie Title} [{Edition Tags}]", "Movie Title [10th Anniversary Edition]")]
+        [TestCase("10TH anniversary edition", "{Movie Title} [{Edition Tags}]", "Movie Title [10th Anniversary Edition]")]
+        [TestCase("10Th anniversary edition", "{Movie Title} [{Edition Tags}]", "Movie Title [10th Anniversary Edition]")]
+        [TestCase("10th anniversary edition", "{Movie Title} [{EDITION TAGS}]", "Movie Title [10TH ANNIVERSARY EDITION]")]
+        [TestCase("10TH anniversary edition", "{Movie Title} [{EDITION TAGS}]", "Movie Title [10TH ANNIVERSARY EDITION]")]
+        [TestCase("10Th anniversary edition", "{Movie Title} [{EDITION TAGS}]", "Movie Title [10TH ANNIVERSARY EDITION]")]
+        public void should_always_lowercase_ordinals(string edition, string movieFormat, string expected)
+        {
+            _movieFile.Edition = edition;
+            _namingConfig.StandardMovieFormat = movieFormat;
+
+            Subject.BuildFileName(_movie, _movieFile)
+                   .Should().Be(expected);
+        }
+
+        [TestCase("imax", "{Movie Title} [{edition tags}]", "Movie Title [imax]")]
+        [TestCase("IMAX", "{Movie Title} [{edition tags}]", "Movie Title [imax]")]
+        [TestCase("Imax", "{Movie Title} [{edition tags}]", "Movie Title [imax]")]
+        [TestCase("imax", "{Movie Title} [{Edition Tags}]", "Movie Title [IMAX]")]
+        [TestCase("IMAX", "{Movie Title} [{Edition Tags}]", "Movie Title [IMAX]")]
+        [TestCase("Imax", "{Movie Title} [{Edition Tags}]", "Movie Title [IMAX]")]
+        [TestCase("imax", "{Movie Title} [{EDITION TAGS}]", "Movie Title [IMAX]")]
+        [TestCase("IMAX", "{Movie Title} [{EDITION TAGS}]", "Movie Title [IMAX]")]
+        [TestCase("Imax", "{Movie Title} [{EDITION TAGS}]", "Movie Title [IMAX]")]
+        [TestCase("imax edition", "{Movie Title} [{edition tags}]", "Movie Title [imax edition]")]
+        [TestCase("imax edition", "{Movie Title} [{Edition Tags}]", "Movie Title [IMAX Edition]")]
+        [TestCase("Imax edition", "{Movie Title} [{EDITION TAGS}]", "Movie Title [IMAX EDITION]")]
+        [TestCase("imax version", "{Movie Title} [{Edition Tags}]", "Movie Title [IMAX Version]")]
+        [TestCase("IMAX-edition", "{Movie Title} [{Edition Tags}]", "Movie Title [IMAX-Edition]")]
+        [TestCase("IMAX_edition", "{Movie Title} [{Edition Tags}]", "Movie Title [IMAX_Edition]")]
+        [TestCase("IMAX.eDiTioN", "{Movie Title} [{Edition Tags}]", "Movie Title [IMAX.Edition]")]
+        [TestCase("IMAX ed.", "{Movie Title} [{edition tags}]", "Movie Title [imax ed.]")]
+        [TestCase("IMAX ed.", "{Movie Title} [{Edition Tags}]", "Movie Title [IMAX Ed.]")]
+        [TestCase("Imax-ed.", "{Movie Title} [{Edition Tags}]", "Movie Title [IMAX-Ed.]")]
+        [TestCase("imax.Ed", "{Movie Title} [{Edition Tags}]", "Movie Title [IMAX.Ed]")]
+        [TestCase("Imax_ed", "{Movie Title} [{Edition Tags}]", "Movie Title [IMAX_Ed]")]
+        [TestCase("3d", "{Movie Title} [{edition tags}]", "Movie Title [3d]")]
+        [TestCase("3D", "{Movie Title} [{edition tags}]", "Movie Title [3d]")]
+        [TestCase("3d", "{Movie Title} [{Edition Tags}]", "Movie Title [3D]")]
+        [TestCase("3D", "{Movie Title} [{Edition Tags}]", "Movie Title [3D]")]
+        [TestCase("3d", "{Movie Title} [{EDITION TAGS}]", "Movie Title [3D]")]
+        [TestCase("3D", "{Movie Title} [{EDITION TAGS}]", "Movie Title [3D]")]
+        [TestCase("hdr", "{Movie Title} [{edition tags}]", "Movie Title [hdr]")]
+        [TestCase("HDR", "{Movie Title} [{edition tags}]", "Movie Title [hdr]")]
+        [TestCase("Hdr", "{Movie Title} [{edition tags}]", "Movie Title [hdr]")]
+        [TestCase("hdr", "{Movie Title} [{Edition Tags}]", "Movie Title [HDR]")]
+        [TestCase("HDR", "{Movie Title} [{Edition Tags}]", "Movie Title [HDR]")]
+        [TestCase("Hdr", "{Movie Title} [{Edition Tags}]", "Movie Title [HDR]")]
+        [TestCase("hdr", "{Movie Title} [{EDITION TAGS}]", "Movie Title [HDR]")]
+        [TestCase("HDR", "{Movie Title} [{EDITION TAGS}]", "Movie Title [HDR]")]
+        [TestCase("Hdr", "{Movie Title} [{EDITION TAGS}]", "Movie Title [HDR]")]
+        [TestCase("dv", "{Movie Title} [{edition tags}]", "Movie Title [dv]")]
+        [TestCase("DV", "{Movie Title} [{edition tags}]", "Movie Title [dv]")]
+        [TestCase("Dv", "{Movie Title} [{edition tags}]", "Movie Title [dv]")]
+        [TestCase("dv", "{Movie Title} [{Edition Tags}]", "Movie Title [DV]")]
+        [TestCase("DV", "{Movie Title} [{Edition Tags}]", "Movie Title [DV]")]
+        [TestCase("Dv", "{Movie Title} [{Edition Tags}]", "Movie Title [DV]")]
+        [TestCase("dv", "{Movie Title} [{EDITION TAGS}]", "Movie Title [DV]")]
+        [TestCase("DV", "{Movie Title} [{EDITION TAGS}]", "Movie Title [DV]")]
+        [TestCase("Dv", "{Movie Title} [{EDITION TAGS}]", "Movie Title [DV]")]
+        [TestCase("sdr", "{Movie Title} [{edition tags}]", "Movie Title [sdr]")]
+        [TestCase("SDR", "{Movie Title} [{edition tags}]", "Movie Title [sdr]")]
+        [TestCase("Sdr", "{Movie Title} [{edition tags}]", "Movie Title [sdr]")]
+        [TestCase("sdr", "{Movie Title} [{Edition Tags}]", "Movie Title [SDR]")]
+        [TestCase("SDR", "{Movie Title} [{Edition Tags}]", "Movie Title [SDR]")]
+        [TestCase("Sdr", "{Movie Title} [{Edition Tags}]", "Movie Title [SDR]")]
+        [TestCase("sdr", "{Movie Title} [{EDITION TAGS}]", "Movie Title [SDR]")]
+        [TestCase("SDR", "{Movie Title} [{EDITION TAGS}]", "Movie Title [SDR]")]
+        [TestCase("Sdr", "{Movie Title} [{EDITION TAGS}]", "Movie Title [SDR]")]
+        [TestCase("THEATRICAL", "{Movie Title} [{Edition Tags}]", "Movie Title [Theatrical]")]
+        [TestCase("director's CUt", "{Movie Title} [{Edition Tags}]", "Movie Title [Director's Cut]")]
+        public void should_always_uppercase_special_strings(string edition, string movieFormat, string expected)
+        {
+            _movieFile.Edition = edition;
+            _namingConfig.StandardMovieFormat = movieFormat;
+
+            Subject.BuildFileName(_movie, _movieFile)
+                   .Should().Be(expected);
         }
     }
 }

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -317,7 +317,7 @@ namespace NzbDrone.Core.Organizer
         {
             if (movieFile.Edition.IsNotNullOrWhiteSpace())
             {
-                tokenHandlers["{Edition Tags}"] = m => Truncate(CultureInfo.CurrentCulture.TextInfo.ToTitleCase(movieFile.Edition.ToLower()), m.CustomFormat);
+                tokenHandlers["{Edition Tags}"] = m => Truncate(GetEditionToken(movieFile), m.CustomFormat);
             }
         }
 
@@ -531,6 +531,16 @@ namespace NzbDrone.Core.Organizer
             {
                 return response;
             }
+        }
+
+        private string GetEditionToken(MovieFile movieFile)
+        {
+            var edition = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(movieFile.Edition.ToLowerInvariant());
+
+            edition = Regex.Replace(edition, @"((?:\b|_)\d{1,3}(?:st|th|rd|nd)(?:\b|_))", match => match.Groups[1].Value.ToLowerInvariant(), RegexOptions.IgnoreCase);
+            edition = Regex.Replace(edition, @"((?:\b|_)(?:IMAX|3D|SDR|HDR|DV)(?:\b|_))", match => match.Groups[1].Value.ToUpperInvariant(), RegexOptions.IgnoreCase);
+
+            return edition;
         }
 
         private void UpdateMediaInfoIfNeeded(string pattern, MovieFile movieFile, Movie movie)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Addresses #7649 
(Original goal was "Make IMAX Uppercase in Edition Tags", this now handles both lowercase (ordinals) and uppercase, as covered in the tests:

Always lowercases ordinals, except when using `[EDITION TAGS]`:
- 1st, 2nd, 3rd, 4th, 5th, 6th, 7th, 8th, 9th, 10th, ... 20th, ... 30th... etc.

Always uppercases special words, except when using `[edition tags]`:
- Imax → IMAX
- Hdr → HDR
- Sdr → SDR
- 3d → 3D

(And all mixed-case variants of these, e.g. imax, Imax, IMAX iMaX))

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [ ] ~Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)~
- [ ] [Wiki Updates](https://wiki.servarr.com) (Unsure if needed?)

#### Issues Fixed or Closed by this PR

* Fixes #7649