### PR TITLE
New: Added new API endpoints to get missing and wanted movies

### DIFF
--- a/src/NzbDrone.Core/Movies/MovieRepository.cs
+++ b/src/NzbDrone.Core/Movies/MovieRepository.cs
@@ -31,6 +31,7 @@ namespace NzbDrone.Core.Movies
         List<int> GetRecommendations();
         bool ExistsByMetadataId(int metadataId);
         HashSet<int> AllMovieWithCollectionsTmdbIds();
+        List<Movie> FindMissing();
     }
 
     public class MovieRepository : BasicRepository<Movie>, IMovieRepository
@@ -377,6 +378,11 @@ namespace NzbDrone.Core.Movies
             {
                 return conn.Query<int>("SELECT \"TmdbId\" FROM \"MovieMetadata\" JOIN \"Movies\" ON (\"Movies\".\"MovieMetadataId\" = \"MovieMetadata\".\"Id\") WHERE \"CollectionTmdbId\" > 0").ToHashSet();
             }
+        }
+
+        public List<Movie> FindMissing()
+        {
+            return Query(x => x.Monitored == true && x.MovieFileId == 0);
         }
     }
 }

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -47,6 +47,8 @@ namespace NzbDrone.Core.Movies
         void RemoveAddOptions(Movie movie);
         bool ExistsByMetadataId(int metadataId);
         HashSet<int> AllMovieWithCollectionsTmdbIds();
+        List<Movie> GetMissingMovies();
+        List<Movie> GetWantedMovies();
     }
 
     public class MovieService : IMovieService, IHandle<MovieFileAddedEvent>,
@@ -411,6 +413,16 @@ namespace NzbDrone.Core.Movies
 
                 UpdateMovie(movie);
             }
+        }
+
+        public List<Movie> GetMissingMovies()
+        {
+            return _movieRepository.FindMissing();
+        }
+
+        public List<Movie> GetWantedMovies()
+        {
+            return _movieRepository.FindMissing().Where(m => m.IsAvailable() == true).ToList();
         }
     }
 }

--- a/src/Radarr.Api.V3/Movies/MissingController.cs
+++ b/src/Radarr.Api.V3/Movies/MissingController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Core.Movies;
+using Radarr.Http;
+
+namespace Radarr.Api.V3.Movies
+{
+    [V3ApiController("missing")]
+    public class MissingController : Controller
+    {
+        private readonly IMovieService _movieService;
+
+        public MissingController(IMovieService movieService)
+        {
+            _movieService = movieService;
+        }
+
+        [HttpGet]
+        public MissingWantedResource GetMissing()
+        {
+            return _movieService.GetMissingMovies().ToResource();
+        }
+    }
+}

--- a/src/Radarr.Api.V3/Movies/MissingWantedResource.cs
+++ b/src/Radarr.Api.V3/Movies/MissingWantedResource.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using NzbDrone.Core.Movies;
+using Radarr.Http.REST;
+
+namespace Radarr.Api.V3.Movies
+{
+    public class MissingWantedResource : RestResource
+    {
+        public int Total {  get; set; }
+        public List<MovieResource> Movies { get; set; }
+    }
+
+    public static class MissingResourceMapper
+    {
+        public static MissingWantedResource ToResource(this List<Movie> model)
+        {
+            if (model == null)
+            {
+                return null;
+            }
+
+            return new MissingWantedResource
+            {
+                Total = model.Count,
+                Movies = model.ToResource(0)
+            };
+        }
+    }
+}

--- a/src/Radarr.Api.V3/Movies/WantedController.cs
+++ b/src/Radarr.Api.V3/Movies/WantedController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Core.Movies;
+using Radarr.Http;
+
+namespace Radarr.Api.V3.Movies
+{
+    [V3ApiController("wanted")]
+    public class WantedController : Controller
+    {
+        private readonly IMovieService _movieService;
+
+        public WantedController(IMovieService movieService)
+        {
+            _movieService = movieService;
+        }
+
+        [HttpGet]
+        public MissingWantedResource GetWanted()
+        {
+            return _movieService.GetWantedMovies().ToResource();
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added new APIs so third party apps can easier get info regarding wanted and missing movies without using the /api/v3/movie API, as it can be quite slow for large libraries.
Been a while since I worked with .Net so there will probably some comments on changes.
I made 2 Controller's as I was not sure what was best practice here.

#### Todos
- [ ] Tests - Didnt find any existing examples, but did test locally
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com) - As its API changes I assume this is autogenerated in the openapi.json file?

#### Issues Fixed or Closed by this PR
* Fixes #7704