### PR TITLE
Add merge conflict labeler workflow

### DIFF
--- a/.github/workflows/conflict_labeler.yml
+++ b/.github/workflows/conflict_labeler.yml
@@ -1,0 +1,25 @@
+name: Merge Conflict Labeler
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request_target:
+    branches:
+      - develop
+    types: [synchronize]
+
+jobs:
+  label:
+    name: Labeling
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'Radarr/Radarr' }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Apply label
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: 'merge-conflict'
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
#### Description
Added a merge conflict labeler workflow for all the PR when a merge conflict is detected so people can resolve it when commit on develop branch is made

`merge-conflict` label need to be made before merging this PR