### PR TITLE
New: Added env var support for config.xml options

### DIFF
--- a/src/NzbDrone.Common.Test/ConfigFileProviderTest.cs
+++ b/src/NzbDrone.Common.Test/ConfigFileProviderTest.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Options;
 using NzbDrone.Core.Authentication;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Test.Common;
@@ -43,6 +45,26 @@ namespace NzbDrone.Common.Test
             Mocker.GetMock<IDiskProvider>()
                 .Setup(v => v.WriteAllText(configFile, It.IsAny<string>()))
                 .Callback<string, string>((p, t) => _configFileContents = t);
+
+            Mocker.GetMock<IOptions<AuthOptions>>()
+                .Setup(v => v.Value)
+                .Returns(new AuthOptions());
+
+            Mocker.GetMock<IOptions<AppOptions>>()
+                .Setup(v => v.Value)
+                .Returns(new AppOptions());
+
+            Mocker.GetMock<IOptions<ServerOptions>>()
+                .Setup(v => v.Value)
+                .Returns(new ServerOptions());
+
+            Mocker.GetMock<IOptions<LogOptions>>()
+                .Setup(v => v.Value)
+                .Returns(new LogOptions());
+
+            Mocker.GetMock<IOptions<UpdateOptions>>()
+                .Setup(v => v.Value)
+                .Returns(new UpdateOptions());
         }
 
         [Test]

--- a/src/NzbDrone.Common.Test/ServiceFactoryFixture.cs
+++ b/src/NzbDrone.Common.Test/ServiceFactoryFixture.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using NzbDrone.Common.Composition.Extensions;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Instrumentation.Extensions;
+using NzbDrone.Common.Options;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Datastore.Extensions;
 using NzbDrone.Core.Lifecycle;
@@ -33,6 +34,11 @@ namespace NzbDrone.Common.Test
 
             container.RegisterInstance(new Mock<IHostLifetime>().Object);
             container.RegisterInstance(new Mock<IOptions<PostgresOptions>>().Object);
+            container.RegisterInstance(new Mock<IOptions<AppOptions>>().Object);
+            container.RegisterInstance(new Mock<IOptions<AuthOptions>>().Object);
+            container.RegisterInstance(new Mock<IOptions<ServerOptions>>().Object);
+            container.RegisterInstance(new Mock<IOptions<LogOptions>>().Object);
+            container.RegisterInstance(new Mock<IOptions<UpdateOptions>>().Object);
 
             var serviceProvider = container.GetServiceProvider();
 

--- a/src/NzbDrone.Common/Options/AppOptions.cs
+++ b/src/NzbDrone.Common/Options/AppOptions.cs
@@ -1,0 +1,8 @@
+namespace NzbDrone.Common.Options;
+
+public class AppOptions
+{
+    public string InstanceName { get; set; }
+    public string Theme { get; set; }
+    public bool? LaunchBrowser { get; set; }
+}

--- a/src/NzbDrone.Common/Options/AuthOptions.cs
+++ b/src/NzbDrone.Common/Options/AuthOptions.cs
@@ -1,0 +1,9 @@
+namespace NzbDrone.Common.Options;
+
+public class AuthOptions
+{
+    public string ApiKey { get; set; }
+    public bool? Enabled { get; set; }
+    public string Method { get; set; }
+    public string Required { get; set; }
+}

--- a/src/NzbDrone.Common/Options/LogOptions.cs
+++ b/src/NzbDrone.Common/Options/LogOptions.cs
@@ -1,0 +1,14 @@
+namespace NzbDrone.Common.Options;
+
+public class LogOptions
+{
+    public string Level { get; set; }
+    public bool? FilterSentryEvents { get; set; }
+    public int? Rotate { get; set; }
+    public bool? Sql { get; set; }
+    public string ConsoleLevel { get; set; }
+    public bool? AnalyticsEnabled { get; set; }
+    public string SyslogServer { get; set; }
+    public int? SyslogPort { get; set; }
+    public string SyslogLevel { get; set; }
+}

--- a/src/NzbDrone.Common/Options/ServerOptions.cs
+++ b/src/NzbDrone.Common/Options/ServerOptions.cs
@@ -1,0 +1,12 @@
+namespace NzbDrone.Common.Options;
+
+public class ServerOptions
+{
+    public string UrlBase { get; set; }
+    public string BindAddress { get; set; }
+    public int? Port { get; set; }
+    public bool? EnableSsl { get; set; }
+    public int? SslPort { get; set; }
+    public string SslCertPath { get; set; }
+    public string SslCertPassword { get; set; }
+}

--- a/src/NzbDrone.Common/Options/UpdateOptions.cs
+++ b/src/NzbDrone.Common/Options/UpdateOptions.cs
@@ -1,0 +1,9 @@
+namespace NzbDrone.Common.Options;
+
+public class UpdateOptions
+{
+    public string Mechanism { get; set; }
+    public bool? Automatically { get; set; }
+    public string ScriptPath { get; set; }
+    public string Branch { get; set; }
+}

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -10,6 +10,7 @@ using NzbDrone.Common.Cache;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Options;
 using NzbDrone.Core.Authentication;
 using NzbDrone.Core.Configuration.Events;
 using NzbDrone.Core.Datastore;
@@ -71,6 +72,11 @@ namespace NzbDrone.Core.Configuration
         private readonly IDiskProvider _diskProvider;
         private readonly ICached<string> _cache;
         private readonly PostgresOptions _postgresOptions;
+        private readonly AuthOptions _authOptions;
+        private readonly AppOptions _appOptions;
+        private readonly ServerOptions _serverOptions;
+        private readonly UpdateOptions _updateOptions;
+        private readonly LogOptions _logOptions;
 
         private readonly string _configFile;
         private static readonly Regex HiddenCharacterRegex = new Regex("[^a-z0-9]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -81,13 +87,23 @@ namespace NzbDrone.Core.Configuration
                                   ICacheManager cacheManager,
                                   IEventAggregator eventAggregator,
                                   IDiskProvider diskProvider,
-                                  IOptions<PostgresOptions> postgresOptions)
+                                  IOptions<PostgresOptions> postgresOptions,
+                                  IOptions<AuthOptions> authOptions,
+                                  IOptions<AppOptions> appOptions,
+                                  IOptions<ServerOptions> serverOptions,
+                                  IOptions<UpdateOptions> updateOptions,
+                                  IOptions<LogOptions> logOptions)
         {
             _cache = cacheManager.GetCache<string>(GetType());
             _eventAggregator = eventAggregator;
             _diskProvider = diskProvider;
             _configFile = appFolderInfo.GetConfigPath();
             _postgresOptions = postgresOptions.Value;
+            _authOptions = authOptions.Value;
+            _appOptions = appOptions.Value;
+            _serverOptions = serverOptions.Value;
+            _updateOptions = updateOptions.Value;
+            _logOptions = logOptions.Value;
         }
 
         public Dictionary<string, object> GetConfigDictionary()
@@ -143,7 +159,7 @@ namespace NzbDrone.Core.Configuration
             {
                 const string defaultValue = "*";
 
-                var bindAddress = GetValue("BindAddress", defaultValue);
+                var bindAddress = _serverOptions.BindAddress ?? GetValue("BindAddress", defaultValue);
                 if (string.IsNullOrWhiteSpace(bindAddress))
                 {
                     return defaultValue;
@@ -153,19 +169,19 @@ namespace NzbDrone.Core.Configuration
             }
         }
 
-        public int Port => GetValueInt("Port", 7878);
+        public int Port => _serverOptions.Port ?? GetValueInt("Port", 7878);
 
-        public int SslPort => GetValueInt("SslPort", 9898);
+        public int SslPort => _serverOptions.SslPort ?? GetValueInt("SslPort", 9898);
 
-        public bool EnableSsl => GetValueBoolean("EnableSsl", false);
+        public bool EnableSsl => _serverOptions.EnableSsl ?? GetValueBoolean("EnableSsl", false);
 
-        public bool LaunchBrowser => GetValueBoolean("LaunchBrowser", true);
+        public bool LaunchBrowser => _appOptions.LaunchBrowser ?? GetValueBoolean("LaunchBrowser", true);
 
         public string ApiKey
         {
             get
             {
-                var apiKey = GetValue("ApiKey", GenerateApiKey());
+                var apiKey = _authOptions.ApiKey ?? GetValue("ApiKey", GenerateApiKey());
 
                 if (apiKey.IsNullOrWhiteSpace())
                 {
@@ -181,7 +197,7 @@ namespace NzbDrone.Core.Configuration
         {
             get
             {
-                var enabled = GetValueBoolean("AuthenticationEnabled", false, false);
+                var enabled = _authOptions.Enabled ?? GetValueBoolean("AuthenticationEnabled", false, false);
 
                 if (enabled)
                 {
@@ -189,36 +205,41 @@ namespace NzbDrone.Core.Configuration
                     return AuthenticationType.Basic;
                 }
 
-                return GetValueEnum("AuthenticationMethod", AuthenticationType.None);
+                return Enum.TryParse<AuthenticationType>(_authOptions.Method, out var enumValue)
+                    ? enumValue
+                    : GetValueEnum("AuthenticationMethod", AuthenticationType.None);
             }
         }
 
-        public AuthenticationRequiredType AuthenticationRequired => GetValueEnum("AuthenticationRequired", AuthenticationRequiredType.Enabled);
+        public AuthenticationRequiredType AuthenticationRequired =>
+            Enum.TryParse<AuthenticationRequiredType>(_authOptions.Required, out var enumValue)
+                ? enumValue
+                : GetValueEnum("AuthenticationRequired", AuthenticationRequiredType.Enabled);
 
-        public bool AnalyticsEnabled => GetValueBoolean("AnalyticsEnabled", true, persist: false);
+        public bool AnalyticsEnabled => _logOptions.AnalyticsEnabled ?? GetValueBoolean("AnalyticsEnabled", true, persist: false);
 
-        public string Branch => GetValue("Branch", "master").ToLowerInvariant();
+        public string Branch => _updateOptions.Branch ?? GetValue("Branch", "master").ToLowerInvariant();
 
-        public string LogLevel => GetValue("LogLevel", "info").ToLowerInvariant();
-        public string ConsoleLogLevel => GetValue("ConsoleLogLevel", string.Empty, persist: false);
-        public string Theme => GetValue("Theme", "auto", persist: false);
+        public string LogLevel => _logOptions.Level ?? GetValue("LogLevel", "info").ToLowerInvariant();
+        public string ConsoleLogLevel => _logOptions.ConsoleLevel ?? GetValue("ConsoleLogLevel", string.Empty, persist: false);
+        public string Theme => _appOptions.Theme ?? GetValue("Theme", "auto", persist: false);
         public string PostgresHost => _postgresOptions?.Host ?? GetValue("PostgresHost", string.Empty, persist: false);
         public string PostgresUser => _postgresOptions?.User ?? GetValue("PostgresUser", string.Empty, persist: false);
         public string PostgresPassword => _postgresOptions?.Password ?? GetValue("PostgresPassword", string.Empty, persist: false);
         public string PostgresMainDb => _postgresOptions?.MainDb ?? GetValue("PostgresMainDb", "radarr-main", persist: false);
         public string PostgresLogDb => _postgresOptions?.LogDb ?? GetValue("PostgresLogDb", "radarr-log", persist: false);
         public int PostgresPort => (_postgresOptions?.Port ?? 0) != 0 ? _postgresOptions.Port : GetValueInt("PostgresPort", 5432, persist: false);
-        public bool LogSql => GetValueBoolean("LogSql", false, persist: false);
-        public int LogRotate => GetValueInt("LogRotate", 50, persist: false);
-        public bool FilterSentryEvents => GetValueBoolean("FilterSentryEvents", true, persist: false);
-        public string SslCertPath => GetValue("SslCertPath", "");
-        public string SslCertPassword => GetValue("SslCertPassword", "");
+        public bool LogSql => _logOptions.Sql ?? GetValueBoolean("LogSql", false, persist: false);
+        public int LogRotate => _logOptions.Rotate ?? GetValueInt("LogRotate", 50, persist: false);
+        public bool FilterSentryEvents => _logOptions.FilterSentryEvents ?? GetValueBoolean("FilterSentryEvents", true, persist: false);
+        public string SslCertPath => _serverOptions.SslCertPath ?? GetValue("SslCertPath", "");
+        public string SslCertPassword => _serverOptions.SslCertPassword ?? GetValue("SslCertPassword", "");
 
         public string UrlBase
         {
             get
             {
-                var urlBase = GetValue("UrlBase", "").Trim('/');
+                var urlBase = _serverOptions.UrlBase ?? GetValue("UrlBase", "").Trim('/');
 
                 if (urlBase.IsNullOrWhiteSpace())
                 {
@@ -230,19 +251,22 @@ namespace NzbDrone.Core.Configuration
         }
 
         public string UiFolder => BuildInfo.IsDebug ? Path.Combine("..", "UI") : "UI";
-        public string InstanceName => GetValue("InstanceName", BuildInfo.AppName);
+        public string InstanceName => _appOptions.InstanceName ?? GetValue("InstanceName", BuildInfo.AppName);
 
-        public bool UpdateAutomatically => GetValueBoolean("UpdateAutomatically", false, false);
+        public bool UpdateAutomatically => _updateOptions.Automatically ?? GetValueBoolean("UpdateAutomatically", false, false);
 
-        public UpdateMechanism UpdateMechanism => GetValueEnum("UpdateMechanism", UpdateMechanism.BuiltIn, false);
+        public UpdateMechanism UpdateMechanism =>
+            Enum.TryParse<UpdateMechanism>(_updateOptions.Mechanism, out var enumValue)
+                ? enumValue
+                : GetValueEnum("UpdateMechanism", UpdateMechanism.BuiltIn, false);
 
-        public string UpdateScriptPath => GetValue("UpdateScriptPath", "", false);
+        public string UpdateScriptPath => _updateOptions.ScriptPath ?? GetValue("UpdateScriptPath", "", false);
 
-        public string SyslogServer => GetValue("SyslogServer", "", persist: false);
+        public string SyslogServer => _logOptions.SyslogServer ?? GetValue("SyslogServer", "", persist: false);
 
-        public int SyslogPort => GetValueInt("SyslogPort", 514, persist: false);
+        public int SyslogPort => _logOptions.SyslogPort ?? GetValueInt("SyslogPort", 514, persist: false);
 
-        public string SyslogLevel => GetValue("SyslogLevel", LogLevel, false).ToLowerInvariant();
+        public string SyslogLevel => _logOptions.SyslogLevel ?? GetValue("SyslogLevel", LogLevel, persist: false).ToLowerInvariant();
 
         public int GetValueInt(string key, int defaultValue, bool persist = true)
         {

--- a/src/NzbDrone.Host.Test/ContainerFixture.cs
+++ b/src/NzbDrone.Host.Test/ContainerFixture.cs
@@ -12,6 +12,7 @@ using NzbDrone.Common;
 using NzbDrone.Common.Composition.Extensions;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Instrumentation.Extensions;
+using NzbDrone.Common.Options;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Datastore.Extensions;
 using NzbDrone.Core.Download;
@@ -47,6 +48,11 @@ namespace NzbDrone.App.Test
             container.RegisterInstance<IHostLifetime>(new Mock<IHostLifetime>().Object);
             container.RegisterInstance<IBroadcastSignalRMessage>(new Mock<IBroadcastSignalRMessage>().Object);
             container.RegisterInstance<IOptions<PostgresOptions>>(new Mock<IOptions<PostgresOptions>>().Object);
+            container.RegisterInstance<IOptions<AuthOptions>>(new Mock<IOptions<AuthOptions>>().Object);
+            container.RegisterInstance<IOptions<AppOptions>>(new Mock<IOptions<AppOptions>>().Object);
+            container.RegisterInstance<IOptions<ServerOptions>>(new Mock<IOptions<ServerOptions>>().Object);
+            container.RegisterInstance<IOptions<UpdateOptions>>(new Mock<IOptions<UpdateOptions>>().Object);
+            container.RegisterInstance<IOptions<LogOptions>>(new Mock<IOptions<LogOptions>>().Object);
 
             _container = container.GetServiceProvider();
         }

--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -21,6 +21,7 @@ using NzbDrone.Common.Exceptions;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation;
 using NzbDrone.Common.Instrumentation.Extensions;
+using NzbDrone.Common.Options;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Datastore.Extensions;
 using PostgresOptions = NzbDrone.Core.Datastore.PostgresOptions;
@@ -96,6 +97,11 @@ namespace NzbDrone.Host
                             .ConfigureServices(services =>
                             {
                                 services.Configure<PostgresOptions>(config.GetSection("Radarr:Postgres"));
+                                services.Configure<AppOptions>(config.GetSection("Radarr:App"));
+                                services.Configure<AuthOptions>(config.GetSection("Radarr:Auth"));
+                                services.Configure<ServerOptions>(config.GetSection("Radarr:Server"));
+                                services.Configure<LogOptions>(config.GetSection("Radarr:Log"));
+                                services.Configure<UpdateOptions>(config.GetSection("Radarr:Update"));
                             }).Build();
 
                         break;
@@ -123,12 +129,12 @@ namespace NzbDrone.Host
         {
             var config = GetConfiguration(context);
 
-            var bindAddress = config.GetValue(nameof(ConfigFileProvider.BindAddress), "*");
-            var port = config.GetValue(nameof(ConfigFileProvider.Port), 7878);
-            var sslPort = config.GetValue(nameof(ConfigFileProvider.SslPort), 8787);
-            var enableSsl = config.GetValue(nameof(ConfigFileProvider.EnableSsl), false);
-            var sslCertPath = config.GetValue<string>(nameof(ConfigFileProvider.SslCertPath));
-            var sslCertPassword = config.GetValue<string>(nameof(ConfigFileProvider.SslCertPassword));
+            var bindAddress = config.GetValue<string>($"Radarr:Server:{nameof(ServerOptions.BindAddress)}") ?? config.GetValue(nameof(ConfigFileProvider.BindAddress), "*");
+            var port = config.GetValue<int?>($"Radarr:Server:{nameof(ServerOptions.Port)}") ?? config.GetValue(nameof(ConfigFileProvider.Port), 7878);
+            var sslPort = config.GetValue<int?>($"Radarr:Server:{nameof(ServerOptions.SslPort)}") ?? config.GetValue(nameof(ConfigFileProvider.SslPort), 8787);
+            var enableSsl = config.GetValue<bool?>($"Radarr:Server:{nameof(ServerOptions.EnableSsl)}") ?? config.GetValue(nameof(ConfigFileProvider.EnableSsl), false);
+            var sslCertPath = config.GetValue<string>($"Radarr:Server:{nameof(ServerOptions.SslCertPath)}") ?? config.GetValue<string>(nameof(ConfigFileProvider.SslCertPath));
+            var sslCertPassword = config.GetValue<string>($"Radarr:Server:{nameof(ServerOptions.SslCertPassword)}") ?? config.GetValue<string>(nameof(ConfigFileProvider.SslCertPassword));
 
             var urls = new List<string> { BuildUrl("http", bindAddress, port) };
 
@@ -150,6 +156,12 @@ namespace NzbDrone.Host
                 .ConfigureServices(services =>
                 {
                     services.Configure<PostgresOptions>(config.GetSection("Radarr:Postgres"));
+                    services.Configure<PostgresOptions>(config.GetSection("Radarr:Postgres"));
+                    services.Configure<AppOptions>(config.GetSection("Radarr:App"));
+                    services.Configure<AuthOptions>(config.GetSection("Radarr:Auth"));
+                    services.Configure<ServerOptions>(config.GetSection("Radarr:Server"));
+                    services.Configure<LogOptions>(config.GetSection("Radarr:Log"));
+                    services.Configure<UpdateOptions>(config.GetSection("Radarr:Update"));
                 })
                 .ConfigureWebHost(builder =>
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
A few sentences describing the overall goals of the pull request's commits.

Adds environment variable support for all options in config.xml. Using the IOptions pattern this will allow users to override config with the following environment variables

The environment variables will take precedence over config.xml for populated values. This change is not breaking and will still default to config.xml for anything not set as an environment variable.

<details>
<summary>New environment variables</summary>

RADARR__APP__INSTANCENAME
RADARR__APP__THEME
RADARR__APP__LAUNCHBROWSER

RADARR__AUTH__APIKEY
RADARR__AUTH__ENABLED
RADARR__AUTH__METHOD
RADARR__AUTH__REQUIRED

RADARR__SERVER__URLBASE
RADARR__SERVER__BINDADDRESS
RADARR__SERVER__PORT
RADARR__SERVER__ENABLESSL
RADARR__SERVER__SSLPORT
RADARR__SERVER__SSLCERTPATH
RADARR__SERVER__SSLCERTPASSWORD

RADARR__LOG__LEVEL
RADARR__LOG__FILTERSENTRYEVENTS
RADARR__LOG__ROTATE
RADARR__LOG__SQL
RADARR__LOG__CONSOLELEVEL
RADARR__LOG__ANALYTICSENABLED
RADARR__LOG__SYSLOGSERVER
RADARR__LOG__SYSLOGPORT
RADARR__LOG__SYSLOGLEVEL

RADARR__UPDATE__MECHANISM
RADARR__UPDATE__AUTOMATICALLY
RADARR__UPDATE__SCRIPTPATH
RADARR__UPDATE__BRANCH
</details>


Pulled from upstream https://github.com/Sonarr/Sonarr/commit/d051dac12c8b797761a0d1f3b4aa84cff47ed13d


#### Issues Fixed or Closed by this PR

* Fixes #[9959](https://github.com/Radarr/Radarr/issues/9959)