### PR TITLE
When querying TagRepository.GetTags, if the given tag set is null, skip it.

### DIFF
--- a/src/NzbDrone.Core/Tags/TagRepository.cs
+++ b/src/NzbDrone.Core/Tags/TagRepository.cs
@@ -39,6 +39,11 @@ namespace NzbDrone.Core.Tags
 
         public List<Tag> GetTags(HashSet<int> tagIds)
         {
+            if (tagIds == null)
+            {
+                return new List<Tag>();
+            }
+
             return Query(t => tagIds.Contains(t.Id));
         }
     }


### PR DESCRIPTION
When querying TagRepository.GetTags, if the given tag set is null, skip it.

This may occur if a Movie is added or otherwise being handled with a missing "tags" field, i.e. instead of an empty set, its Tags property is null.

#### Database Migration
NO

#### Description
This addresses #10067 

#### Todos
- [ ] Tests *I'm unsure of a suitable place for NzbDrone.Core test cases, please recommend if you know where!*
- [n/a] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [n/a] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #10067 