### PR TITLE
Ensure that a Movie created from MovieResource has a non-null Tags set.

### DIFF
--- a/src/Radarr.Api.V3/Movies/MovieResource.cs
+++ b/src/Radarr.Api.V3/Movies/MovieResource.cs
@@ -198,7 +198,7 @@ namespace Radarr.Api.V3.Movies
 
                 RootFolderPath = resource.RootFolderPath,
 
-                Tags = resource.Tags,
+                Tags = resource.Tags ?? new HashSet<int>(),
                 Added = resource.Added,
                 AddOptions = resource.AddOptions
             };


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This addresses #10067 (where handling a MovieAdded event may encounter failures if Tags is `null`).

#### Todos
- [?] Tests *Tested manually, please call out if there are existing Radarr.Api model tests which this can add to*
- [n/a] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [n/a] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #10067