### PR TITLE
Fixed: Allow to bulk edit movies without a valid quality profile

### DIFF
--- a/src/Radarr.Api.V3/MovieFiles/MovieFileResource.cs
+++ b/src/Radarr.Api.V3/MovieFiles/MovieFileResource.cs
@@ -84,7 +84,7 @@ namespace Radarr.Api.V3.MovieFiles
                 Edition = model.Edition,
                 ReleaseGroup = model.ReleaseGroup,
                 MediaInfo = model.MediaInfo.ToResource(model.SceneName),
-                QualityCutoffNotMet = upgradableSpecification?.QualityCutoffNotMet(movie.QualityProfile, model.Quality) ?? false,
+                QualityCutoffNotMet = movie.QualityProfile != null && (upgradableSpecification?.QualityCutoffNotMet(movie.QualityProfile, model.Quality) ?? false),
                 OriginalFilePath = model.OriginalFilePath,
                 IndexerFlags = (int)model.IndexerFlags
             };


### PR DESCRIPTION
#### Description
Would behave like upstream allowing bulk editing movies to have a new and valid quality profile, while failing to load the movie details page.

#### Issues Fixed or Closed by this PR

* Fixes #XXXX