### PR TITLE
Update MediaInfoResource.cs

### DIFF
--- a/src/Radarr.Api.V3/MovieFiles/MediaInfoResource.cs
+++ b/src/Radarr.Api.V3/MovieFiles/MediaInfoResource.cs
@@ -57,7 +57,8 @@ namespace Radarr.Api.V3.MovieFiles
         {
             if (runTime.Hours > 0)
             {
-                return $"{runTime.Hours}:{runTime.Minutes:00}:{runTime.Seconds:00}";
+                var totalHours = (runTime.Days * 24) + runTime.Hours;
+                return $"{totalHours}:{runTime.Minutes:00}:{runTime.Seconds:00}";
             }
 
             return $"{runTime.Minutes}:{runTime.Seconds:00}";


### PR DESCRIPTION
Fixed runtime value for movies longer than 24 hours

#### Database Migration
NO

#### Description
Currently, for movies with a runtime longer than 24 hours, the MediaInfo runtime hour value is the number of hours of the file mod 24. The updated code now correctly converts days and hours into hours (e.g., a file with a runTime is 27:10:23 will show as 27:10:23 instead of 3:10:23).

This is my first time doing something like this so I hope I did everything right.

#### Screenshot (if UI related)
N / A

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
* Fixes #10256