### PR TITLE
Fixed: Validate root folder existence when adding movie

### DIFF
--- a/src/NzbDrone.Core/Validation/Paths/RootFolderExistsValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/RootFolderExistsValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation.Validators;
+using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.RootFolders;
 
@@ -19,7 +20,7 @@ namespace NzbDrone.Core.Validation.Paths
         {
             context.MessageFormatter.AppendArgument("path", context.PropertyValue?.ToString());
 
-            return context.PropertyValue == null || _rootFolderService.All().Exists(r => r.Path.PathEquals(context.PropertyValue.ToString()));
+            return context.PropertyValue == null || _rootFolderService.All().Exists(r => r.Path.IsPathValid(PathValidationType.CurrentOs) && r.Path.PathEquals(context.PropertyValue.ToString()));
         }
     }
 }

--- a/src/Radarr.Api.V3/Movies/MovieController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieController.cs
@@ -70,6 +70,7 @@ namespace Radarr.Api.V3.Movies
                            RecycleBinValidator recycleBinValidator,
                            SystemFolderValidator systemFolderValidator,
                            QualityProfileExistsValidator qualityProfileExistsValidator,
+                           RootFolderExistsValidator rootFolderExistsValidator,
                            MovieFolderAsRootFolderValidator movieFolderAsRootFolderValidator,
                            Logger logger)
             : base(signalRBroadcaster)
@@ -103,6 +104,7 @@ namespace Radarr.Api.V3.Movies
             PostValidator.RuleFor(s => s.Path).IsValidPath().When(s => s.RootFolderPath.IsNullOrWhiteSpace());
             PostValidator.RuleFor(s => s.RootFolderPath)
                          .IsValidPath()
+                         .SetValidator(rootFolderExistsValidator)
                          .SetValidator(movieFolderAsRootFolderValidator)
                          .When(s => s.Path.IsNullOrWhiteSpace());
             PostValidator.RuleFor(s => s.Title).NotEmpty().When(s => s.TmdbId <= 0);
@@ -240,6 +242,7 @@ namespace Radarr.Api.V3.Movies
 
         [RestPostById]
         [Consumes("application/json")]
+        [Produces("application/json")]
         public ActionResult<MovieResource> AddMovie([FromBody] MovieResource moviesResource)
         {
             var movie = _addMovieService.AddMovie(moviesResource.ToModel());
@@ -249,6 +252,7 @@ namespace Radarr.Api.V3.Movies
 
         [RestPutById]
         [Consumes("application/json")]
+        [Produces("application/json")]
         public ActionResult<MovieResource> UpdateMovie([FromBody] MovieResource moviesResource, [FromQuery] bool moveFiles = false)
         {
             var movie = _moviesService.GetMovie(moviesResource.Id);


### PR DESCRIPTION
#### Description
Directed to overseer/jellyseer users that forget to update the root folders in their instances after making changes in Sonarr/Radarr, resulting in broken items in queue due to the paths not existing.