### PR TITLE
Fixed: Calculating custom formats with languages in queue and or release push

### DIFF
--- a/src/NzbDrone.Core.Test/Download/Aggregation/Aggregators/AggregateLanguagesFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/Aggregation/Aggregators/AggregateLanguagesFixture.cs
@@ -1,8 +1,11 @@
 using System.Collections.Generic;
 using FizzWare.NBuilder;
 using FluentAssertions;
+using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.Download.Aggregation.Aggregators;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Indexers.TorrentRss;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
@@ -107,6 +110,144 @@ namespace NzbDrone.Core.Test.Download.Aggregation.Aggregators
             _remoteMovie.ParsedMovieInfo = GetParsedMovieInfo(new List<Language> { Language.Greek }, releaseTitle, releaseTokens);
 
             Subject.Aggregate(_remoteMovie).Languages.Should().Equal(Language.Greek);
+        }
+
+        [Test]
+        public void should_return_multi_languages_when_indexer_id_has_multi_languages_configuration()
+        {
+            var releaseTitle = "My.Movies.2024.MULTi.1080p.WEB.H265-RlsGroup";
+            var indexerDefinition = new IndexerDefinition
+            {
+                Id = 1,
+                Settings = new TorrentRssIndexerSettings { MultiLanguages = new List<int> { Language.Original.Id, Language.French.Id } }
+            };
+            Mocker.GetMock<IIndexerFactory>()
+                .Setup(v => v.Get(1))
+                .Returns(indexerDefinition);
+
+            _remoteMovie.ParsedMovieInfo = GetParsedMovieInfo(new List<Language> { }, releaseTitle);
+            _remoteMovie.Release.IndexerId = 1;
+            _remoteMovie.Release.Title = releaseTitle;
+
+            Subject.Aggregate(_remoteMovie).Languages.Should().BeEquivalentTo(new List<Language> { _movie.MovieMetadata.Value.OriginalLanguage, Language.French });
+            Mocker.GetMock<IIndexerFactory>().Verify(c => c.Get(1), Times.Once());
+            Mocker.GetMock<IIndexerFactory>().VerifyNoOtherCalls();
+        }
+
+        [Test]
+        public void should_return_multi_languages_from_indexer_with_id_when_indexer_id_and_name_are_set()
+        {
+            var releaseTitle = "My.Movies.2024.MULTi.1080p.WEB.H265-RlsGroup";
+            var indexerDefinition1 = new IndexerDefinition
+            {
+                Id = 1,
+                Name = "MyIndexer1",
+                Settings = new TorrentRssIndexerSettings { MultiLanguages = new List<int> { Language.Original.Id, Language.French.Id } }
+            };
+            var indexerDefinition2 = new IndexerDefinition
+            {
+                Id = 2,
+                Name = "MyIndexer2",
+                Settings = new TorrentRssIndexerSettings { MultiLanguages = new List<int> { Language.Original.Id, Language.German.Id } }
+            };
+
+            Mocker.GetMock<IIndexerFactory>()
+                .Setup(v => v.Get(1))
+                .Returns(indexerDefinition1);
+
+            Mocker.GetMock<IIndexerFactory>()
+                .Setup(v => v.All())
+                .Returns(new List<IndexerDefinition>() { indexerDefinition1, indexerDefinition2 });
+
+            _remoteMovie.ParsedMovieInfo = GetParsedMovieInfo(new List<Language> { }, releaseTitle);
+            _remoteMovie.Release.IndexerId = 1;
+            _remoteMovie.Release.Indexer = "MyIndexer2";
+            _remoteMovie.Release.Title = releaseTitle;
+
+            Subject.Aggregate(_remoteMovie).Languages.Should().BeEquivalentTo(new List<Language> { _movie.MovieMetadata.Value.OriginalLanguage, Language.French });
+            Mocker.GetMock<IIndexerFactory>().Verify(c => c.Get(1), Times.Once());
+            Mocker.GetMock<IIndexerFactory>().VerifyNoOtherCalls();
+        }
+
+        [Test]
+        public void should_return_multi_languages_when_indexer_name_has_multi_languages_configuration()
+        {
+            var releaseTitle = "My.Movies.2024.MULTi.1080p.WEB.H265-RlsGroup";
+            var indexerDefinition = new IndexerDefinition
+            {
+                Id = 1,
+                Name = "MyIndexer (Prowlarr)",
+                Settings = new TorrentRssIndexerSettings { MultiLanguages = new List<int> { Language.Original.Id, Language.French.Id } }
+            };
+
+            Mocker.GetMock<IIndexerFactory>()
+                .Setup(v => v.FindByName("MyIndexer (Prowlarr)"))
+                .Returns(indexerDefinition);
+
+            _remoteMovie.ParsedMovieInfo = GetParsedMovieInfo(new List<Language> { }, releaseTitle);
+            _remoteMovie.Release.Indexer = "MyIndexer (Prowlarr)";
+            _remoteMovie.Release.Title = releaseTitle;
+
+            Subject.Aggregate(_remoteMovie).Languages.Should().BeEquivalentTo(new List<Language> { _movie.MovieMetadata.Value.OriginalLanguage, Language.French });
+            Mocker.GetMock<IIndexerFactory>().Verify(c => c.FindByName("MyIndexer (Prowlarr)"), Times.Once());
+            Mocker.GetMock<IIndexerFactory>().VerifyNoOtherCalls();
+        }
+
+        [Test]
+        public void should_return_multi_languages_when_release_as_unknown_as_default_language_and_indexer_has_multi_languages_configuration()
+        {
+            // aaaa
+            var releaseTitle = "My.Movies.2024.MULTi.1080p.WEB.H265-RlsGroup";
+            var indexerDefinition = new IndexerDefinition
+            {
+                Id = 1,
+                Settings = new TorrentRssIndexerSettings { MultiLanguages = new List<int> { Language.Original.Id, Language.French.Id } }
+            };
+            Mocker.GetMock<IIndexerFactory>()
+                .Setup(v => v.Get(1))
+                .Returns(indexerDefinition);
+
+            _remoteMovie.ParsedMovieInfo = GetParsedMovieInfo(new List<Language> { Language.Unknown }, releaseTitle);
+            _remoteMovie.Release.IndexerId = 1;
+            _remoteMovie.Release.Title = releaseTitle;
+
+            Subject.Aggregate(_remoteMovie).Languages.Should().BeEquivalentTo(new List<Language> { _movie.MovieMetadata.Value.OriginalLanguage, Language.French });
+            Mocker.GetMock<IIndexerFactory>().Verify(c => c.Get(1), Times.Once());
+            Mocker.GetMock<IIndexerFactory>().VerifyNoOtherCalls();
+        }
+
+        [Test]
+        public void should_return_original_when_indexer_has_no_multi_languages_configuration()
+        {
+            var releaseTitle = "My.Movies.2024.MULTi.1080p.WEB.H265-RlsGroup";
+            var indexerDefinition = new IndexerDefinition
+            {
+                Id = 1,
+                Settings = new TorrentRssIndexerSettings { }
+            };
+            Mocker.GetMock<IIndexerFactory>()
+                .Setup(v => v.Get(1))
+                .Returns(indexerDefinition);
+
+            _remoteMovie.ParsedMovieInfo = GetParsedMovieInfo(new List<Language> { }, releaseTitle);
+            _remoteMovie.Release.IndexerId = 1;
+            _remoteMovie.Release.Title = releaseTitle;
+
+            Subject.Aggregate(_remoteMovie).Languages.Should().BeEquivalentTo(new List<Language> { _movie.MovieMetadata.Value.OriginalLanguage });
+            Mocker.GetMock<IIndexerFactory>().Verify(c => c.Get(1), Times.Once());
+            Mocker.GetMock<IIndexerFactory>().VerifyNoOtherCalls();
+        }
+
+        [Test]
+        public void should_return_original_when_no_indexer_value()
+        {
+            var releaseTitle = "My.Movies.2024.MULTi.1080p.WEB.H265-RlsGroup";
+
+            _remoteMovie.ParsedMovieInfo = GetParsedMovieInfo(new List<Language> { }, releaseTitle);
+            _remoteMovie.Release.Title = releaseTitle;
+
+            Subject.Aggregate(_remoteMovie).Languages.Should().BeEquivalentTo(new List<Language> { _movie.MovieMetadata.Value.OriginalLanguage });
+            Mocker.GetMock<IIndexerFactory>().VerifyNoOtherCalls();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -7,6 +7,8 @@ using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.History;
 using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Indexers.TorrentRss;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Events;
 using NzbDrone.Core.Parser;
@@ -82,6 +84,77 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
             trackedDownload.RemoteMovie.Should().NotBeNull();
             trackedDownload.RemoteMovie.Movie.Should().NotBeNull();
             trackedDownload.RemoteMovie.Movie.Id.Should().Be(3);
+        }
+
+        [Test]
+        public void should_set_indexer()
+        {
+            var movieHistory = new MovieHistory()
+            {
+                DownloadId = "35238",
+                SourceTitle = "My Movie",
+                EventType = MovieHistoryEventType.Grabbed,
+            };
+            movieHistory.Data.Add("indexer", "MyIndexer (Prowlarr)");
+            Mocker.GetMock<IHistoryService>()
+                .Setup(s => s.FindByDownloadId(It.Is<string>(sr => sr == "35238")))
+                .Returns(new List<MovieHistory>()
+                {
+                    movieHistory
+                });
+
+            var indexerDefinition = new IndexerDefinition
+            {
+                Id = 1,
+                Name = "MyIndexer (Prowlarr)",
+                Settings = new TorrentRssIndexerSettings { MultiLanguages = new List<int> { Language.Original.Id, Language.French.Id } }
+            };
+            Mocker.GetMock<IIndexerFactory>()
+                .Setup(v => v.Get(indexerDefinition.Id))
+                .Returns(indexerDefinition);
+            Mocker.GetMock<IIndexerFactory>()
+                .Setup(v => v.All())
+                .Returns(new List<IndexerDefinition>() { indexerDefinition });
+
+            var remoteMovie = new RemoteMovie
+            {
+                Movie = new Movie() { Id = 3 },
+
+                ParsedMovieInfo = new ParsedMovieInfo()
+                {
+                    MovieTitles = { "My Movie" },
+                    Year = 1998
+                }
+            };
+
+            Mocker.GetMock<IParsingService>()
+                .Setup(s => s.Map(It.IsAny<ParsedMovieInfo>(), It.IsAny<string>(), It.IsAny<int>(), null))
+                .Returns(remoteMovie);
+
+            var client = new DownloadClientDefinition()
+            {
+                Id = 1,
+                Protocol = DownloadProtocol.Torrent
+            };
+
+            var item = new DownloadClientItem()
+            {
+                Title = "My.Movie.2024.MULTi.1080p.WEB.H265-RlsGroup",
+                DownloadId = "35238",
+                DownloadClientInfo = new DownloadClientItemClientInfo
+                {
+                    Protocol = client.Protocol,
+                    Id = client.Id,
+                    Name = client.Name
+                }
+            };
+
+            var trackedDownload = Subject.TrackDownload(client, item);
+
+            trackedDownload.Should().NotBeNull();
+            trackedDownload.RemoteMovie.Should().NotBeNull();
+            trackedDownload.RemoteMovie.Release.Should().NotBeNull();
+            trackedDownload.RemoteMovie.Release.Indexer.Should().Be("MyIndexer (Prowlarr)");
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Indexers/IndexerRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/Indexers/IndexerRepositoryFixture.cs
@@ -1,0 +1,44 @@
+﻿using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Indexers
+{
+    [TestFixture]
+    public class IndexerRepositoryFixture : DbTest<IndexerRepository, IndexerDefinition>
+    {
+        private void GivenIndexers()
+        {
+            var indexers = Builder<IndexerDefinition>.CreateListOfSize(2)
+                .All()
+                .With(c => c.Id = 0)
+                .TheFirst(1)
+                .With(x => x.Name = "MyIndexer (Prowlarr)")
+                .TheNext(1)
+                .With(x => x.Name = "My Second Indexer (Prowlarr)")
+                .BuildList();
+
+            Subject.InsertMany(indexers);
+        }
+
+        [Test]
+        public void should_finds_with_name()
+        {
+            GivenIndexers();
+            var found = Subject.FindByName("MyIndexer (Prowlarr)");
+            found.Should().NotBeNull();
+            found.Name.Should().Be("MyIndexer (Prowlarr)");
+            found.Id.Should().Be(1);
+        }
+
+        [Test]
+        public void should_not_find_with_incorrect_case_name()
+        {
+            GivenIndexers();
+            var found = Subject.FindByName("myindexer (prowlarr)");
+            found.Should().BeNull();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs
+++ b/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
@@ -10,10 +12,13 @@ namespace NzbDrone.Core.Download.Aggregation.Aggregators
 {
     public class AggregateLanguages : IAggregateRemoteMovie
     {
+        private readonly IIndexerFactory _indexerFactory;
         private readonly Logger _logger;
 
-        public AggregateLanguages(Logger logger)
+        public AggregateLanguages(IIndexerFactory indexerFactory,
+                                  Logger logger)
         {
+            _indexerFactory = indexerFactory;
             _logger = logger;
         }
 
@@ -64,6 +69,26 @@ namespace NzbDrone.Core.Download.Aggregation.Aggregators
 
                 // Remove all languages that aren't part of the updated releaseTokens
                 languages = languages.Except(languagesToRemove).ToList();
+            }
+
+            if ((languages.Count == 0 || (languages.Count == 1 && languages.First() == Language.Unknown)) && releaseInfo?.Title?.IsNotNullOrWhiteSpace() == true)
+            {
+                IndexerDefinition indexer = null;
+
+                if (releaseInfo is { IndexerId: > 0 })
+                {
+                    indexer = _indexerFactory.Get(releaseInfo.IndexerId);
+                }
+                else if (releaseInfo.Indexer?.IsNotNullOrWhiteSpace() == true)
+                {
+                    indexer = _indexerFactory.FindByName(releaseInfo.Indexer);
+                }
+
+                if (indexer?.Settings is IIndexerSettings settings && settings.MultiLanguages.Any() && Parser.Parser.HasMultipleLanguages(releaseInfo.Title))
+                {
+                    // Use indexer setting for Multi-languages
+                    languages = settings.MultiLanguages.Select(i => (Language)i).ToList();
+                }
             }
 
             // Use movie language as fallback if we couldn't parse a language

--- a/src/NzbDrone.Core/Indexers/IndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBase.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using FluentValidation.Results;
 using NLog;
@@ -19,8 +18,6 @@ namespace NzbDrone.Core.Indexers
     public abstract class IndexerBase<TSettings> : IIndexer
         where TSettings : IIndexerSettings, new()
     {
-        private static readonly Regex MultiRegex = new (@"[_. ](?<multi>multi)[_. ]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
         protected readonly IIndexerStatusService _indexerStatusService;
         protected readonly IConfigService _configService;
         protected readonly IParsingService _parsingService;
@@ -83,7 +80,7 @@ namespace NzbDrone.Core.Indexers
             result.ForEach(c =>
             {
                 // Use multi languages from setting if ReleaseInfo languages is empty
-                if (c.Languages.Empty() && MultiRegex.IsMatch(c.Title) && settings.MultiLanguages.Any())
+                if (c.Languages.Empty() && settings.MultiLanguages.Any() && Parser.Parser.HasMultipleLanguages(c.Title))
                 {
                     c.Languages = settings.MultiLanguages.Select(i => (Language)i).ToList();
                 }

--- a/src/NzbDrone.Core/Indexers/IndexerFactory.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerFactory.cs
@@ -13,10 +13,12 @@ namespace NzbDrone.Core.Indexers
         List<IIndexer> RssEnabled(bool filterBlockedIndexers = true);
         List<IIndexer> AutomaticSearchEnabled(bool filterBlockedIndexers = true);
         List<IIndexer> InteractiveSearchEnabled(bool filterBlockedIndexers = true);
+        IndexerDefinition FindByName(string name);
     }
 
     public class IndexerFactory : ProviderFactory<IIndexer, IndexerDefinition>, IIndexerFactory
     {
+        private readonly IIndexerRepository _indexerRepository;
         private readonly IIndexerStatusService _indexerStatusService;
         private readonly Logger _logger;
 
@@ -28,6 +30,7 @@ namespace NzbDrone.Core.Indexers
                               Logger logger)
             : base(providerRepository, providers, container, eventAggregator, logger)
         {
+            _indexerRepository = providerRepository;
             _indexerStatusService = indexerStatusService;
             _logger = logger;
         }
@@ -80,6 +83,11 @@ namespace NzbDrone.Core.Indexers
             }
 
             return enabledIndexers.ToList();
+        }
+
+        public IndexerDefinition FindByName(string name)
+        {
+            return _indexerRepository.FindByName(name);
         }
 
         private IEnumerable<IIndexer> FilterBlockedIndexers(IEnumerable<IIndexer> indexers)

--- a/src/NzbDrone.Core/Indexers/IndexerRepository.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerRepository.cs
@@ -1,4 +1,5 @@
-﻿using NzbDrone.Core.Datastore;
+﻿using System.Linq;
+using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.ThingiProvider;
 
@@ -6,6 +7,7 @@ namespace NzbDrone.Core.Indexers
 {
     public interface IIndexerRepository : IProviderRepository<IndexerDefinition>
     {
+        IndexerDefinition FindByName(string name);
     }
 
     public class IndexerRepository : ProviderRepository<IndexerDefinition>, IIndexerRepository
@@ -13,6 +15,11 @@ namespace NzbDrone.Core.Indexers
         public IndexerRepository(IMainDatabase database, IEventAggregator eventAggregator)
             : base(database, eventAggregator)
         {
+        }
+
+        public IndexerDefinition FindByName(string name)
+        {
+            return Query(i => i.Name == name).SingleOrDefault();
         }
     }
 }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -171,6 +171,9 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex RequestInfoRegex = new Regex(@"^(?:\[.+?\])+", RegexOptions.Compiled);
 
         private static readonly string[] Numbers = new[] { "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine" };
+
+        private static readonly Regex MultiRegex = new (@"[_. ](?<multi>multi)[_. ]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         private static Dictionary<string, string> _umlautMappings = new Dictionary<string, string>
         {
             { "ö", "oe" },
@@ -582,6 +585,11 @@ namespace NzbDrone.Core.Parser
             });
 
             return title;
+        }
+
+        public static bool HasMultipleLanguages(string title)
+        {
+            return MultiRegex.IsMatch(title);
         }
 
         private static ParsedMovieInfo ParseMovieMatchCollection(MatchCollection matchCollection)


### PR DESCRIPTION
Use the indexer default languages configuration for multi-languages when a release with MULTI is pushed using the API /release/push and for tracking downloads.

#### Database Migration
NO

#### Description
A few sentences describing the overall goals of the pull request's commits.
#### Todos
- [x] Tests