### PR TITLE
Add _temp* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ src/UI/.idea/*
 node_modules/
 _output*
 _artifacts
+_temp*
 _rawPackage/
 _dotTrace*
 _tests/


### PR DESCRIPTION
_temp folder is created automatically when running radarr locally and should not be pushed to git
