### PR TITLE
FIx OriginalFilePath

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
@@ -240,7 +240,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
                 return grandparentPath.GetRelativePath(path);
             }
 
-            return Path.Combine(Path.GetFileName(parentPath), Path.GetFileName(path));
+            return Path.GetFileName(path);
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Well this is a fun one. It seems that a good while ago 63197d38cedbc5958c1c66126dd9ad868c718b29 added the functionality to store the OriginalFilePath. So far ~nothing relied upon it, meaning that it seems like it went unnoticed that Sonarr/Sonarr@e3a9f753d2 was later added to fix up Sonarr's version of this functionality from Sonarr/Sonarr@ff4a550cbbea4f3201895862076680a0ee5ae0dd. This replicates that fix.

I noticed this while actually trying to use the functionality from #10195, which when doing an import via a script with extras fails in `AggregateSubtitleInfo.cs`, because it seems to be fed the OriginalFilePath as null.

#### Screenshot (if UI related)

#### Todos

#### Issues Fixed or Closed by this PR