### PR TITLE
New: Allowed sort keys for paginated resources

### DIFF
--- a/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusions.tsx
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusions.tsx
@@ -42,7 +42,7 @@ import styles from './ImportListExclusions.css';
 
 const COLUMNS: Column[] = [
   {
-    name: 'tmdbid',
+    name: 'tmdbId',
     label: () => translate('TMDBId'),
     isVisible: true,
     isSortable: true,

--- a/frontend/src/Store/Actions/systemActions.js
+++ b/frontend/src/Store/Actions/systemActions.js
@@ -110,7 +110,6 @@ export const defaultState = {
       {
         name: 'actions',
         columnLabel: () => translate('Actions'),
-        isSortable: true,
         isVisible: true,
         isModifiable: false
       }

--- a/src/Radarr.Api.V3/Blocklist/BlocklistController.cs
+++ b/src/Radarr.Api.V3/Blocklist/BlocklistController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
@@ -29,7 +30,18 @@ namespace Radarr.Api.V3.Blocklist
         public PagingResource<BlocklistResource> GetBlocklist([FromQuery] PagingRequestResource paging, [FromQuery] int[] movieIds = null, [FromQuery] DownloadProtocol[] protocols = null)
         {
             var pagingResource = new PagingResource<BlocklistResource>(paging);
-            var pagingSpec = pagingResource.MapToPagingSpec<BlocklistResource, NzbDrone.Core.Blocklisting.Blocklist>("date", SortDirection.Descending);
+            var pagingSpec = pagingResource.MapToPagingSpec<BlocklistResource, NzbDrone.Core.Blocklisting.Blocklist>(
+                "date",
+                SortDirection.Descending,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "movieMetadata.sortTitle",
+                    "sourceTitle",
+                    "languages",
+                    "quality",
+                    "date",
+                    "indexer"
+                });
 
             if (movieIds?.Any() == true)
             {

--- a/src/Radarr.Api.V3/History/HistoryController.cs
+++ b/src/Radarr.Api.V3/History/HistoryController.cs
@@ -64,7 +64,16 @@ namespace Radarr.Api.V3.History
         public PagingResource<HistoryResource> GetHistory([FromQuery] PagingRequestResource paging, bool includeMovie, [FromQuery(Name = "eventType")] int[] eventTypes, string downloadId, [FromQuery] int[] movieIds = null, [FromQuery] int[] languages = null, [FromQuery] int[] quality = null)
         {
             var pagingResource = new PagingResource<HistoryResource>(paging);
-            var pagingSpec = pagingResource.MapToPagingSpec<HistoryResource, MovieHistory>("date", SortDirection.Descending);
+            var pagingSpec = pagingResource.MapToPagingSpec<HistoryResource, MovieHistory>(
+                "date",
+                SortDirection.Descending,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "movieMetadata.sortTitle",
+                    "languages",
+                    "quality",
+                    "date"
+                });
 
             if (eventTypes != null && eventTypes.Any())
             {

--- a/src/Radarr.Api.V3/ImportLists/ImportListExclusionController.cs
+++ b/src/Radarr.Api.V3/ImportLists/ImportListExclusionController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Core.Datastore;
 using NzbDrone.Core.ImportLists.ImportExclusions;
 using Radarr.Http;
 using Radarr.Http.Extensions;
@@ -47,7 +48,16 @@ namespace Radarr.Api.V3.ImportLists
         public PagingResource<ImportListExclusionResource> GetImportListExclusionsPaged([FromQuery] PagingRequestResource paging)
         {
             var pagingResource = new PagingResource<ImportListExclusionResource>(paging);
-            var pageSpec = pagingResource.MapToPagingSpec<ImportListExclusionResource, ImportListExclusion>();
+            var pageSpec = pagingResource.MapToPagingSpec<ImportListExclusionResource, ImportListExclusion>(
+                "id",
+                SortDirection.Descending,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "id",
+                    "tmdbId",
+                    "movieTitle",
+                    "movieYear"
+                });
 
             return pageSpec.ApplyToPage(_importListExclusionService.Paged, ImportListExclusionResourceMapper.ToResource);
         }

--- a/src/Radarr.Api.V3/Wanted/CutoffController.cs
+++ b/src/Radarr.Api.V3/Wanted/CutoffController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.CustomFormats;
@@ -45,13 +46,18 @@ namespace Radarr.Api.V3.Wanted
         public PagingResource<MovieResource> GetCutoffUnmetMovies([FromQuery] PagingRequestResource paging, bool monitored = true)
         {
             var pagingResource = new PagingResource<MovieResource>(paging);
-            var pagingSpec = new PagingSpec<Movie>
-            {
-                Page = pagingResource.Page,
-                PageSize = pagingResource.PageSize,
-                SortKey = pagingResource.SortKey,
-                SortDirection = pagingResource.SortDirection
-            };
+            var pagingSpec = pagingResource.MapToPagingSpec<MovieResource, Movie>(
+                "movieMetadata.sortTitle",
+                SortDirection.Ascending,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "movieMetadata.sortTitle",
+                    "movieMetadata.year",
+                    "movieMetadata.inCinemas",
+                    "movieMetadata.digitalRelease",
+                    "movieMetadata.physicalRelease",
+                    "movies.lastSearchTime"
+                });
 
             pagingSpec.FilterExpressions.Add(v => v.Monitored == monitored);
 

--- a/src/Radarr.Api.V3/Wanted/MissingController.cs
+++ b/src/Radarr.Api.V3/Wanted/MissingController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.CustomFormats;
@@ -41,13 +42,18 @@ namespace Radarr.Api.V3.Wanted
         public PagingResource<MovieResource> GetMissingMovies([FromQuery] PagingRequestResource paging, bool monitored = true)
         {
             var pagingResource = new PagingResource<MovieResource>(paging);
-            var pagingSpec = new PagingSpec<Movie>
-            {
-                Page = pagingResource.Page,
-                PageSize = pagingResource.PageSize,
-                SortKey = pagingResource.SortKey,
-                SortDirection = pagingResource.SortDirection
-            };
+            var pagingSpec = pagingResource.MapToPagingSpec<MovieResource, Movie>(
+                "movieMetadata.sortTitle",
+                SortDirection.Ascending,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "movieMetadata.sortTitle",
+                    "movieMetadata.year",
+                    "movieMetadata.inCinemas",
+                    "movieMetadata.digitalRelease",
+                    "movieMetadata.physicalRelease",
+                    "movies.lastSearchTime"
+                });
 
             pagingSpec.FilterExpressions.Add(v => v.Monitored == monitored);
 

--- a/src/Radarr.Http/PagingResource.cs
+++ b/src/Radarr.Http/PagingResource.cs
@@ -38,7 +38,11 @@ namespace Radarr.Http
 
     public static class PagingResourceMapper
     {
-        public static PagingSpec<TModel> MapToPagingSpec<TResource, TModel>(this PagingResource<TResource> pagingResource, string defaultSortKey = "Id", SortDirection defaultSortDirection = SortDirection.Ascending)
+        public static PagingSpec<TModel> MapToPagingSpec<TResource, TModel>(
+            this PagingResource<TResource> pagingResource,
+            string defaultSortKey = "Id",
+            SortDirection defaultSortDirection = SortDirection.Ascending,
+            HashSet<string> allowedSortKeys = null)
         {
             var pagingSpec = new PagingSpec<TModel>
             {
@@ -55,6 +59,13 @@ namespace Radarr.Http
                 {
                     pagingSpec.SortDirection = defaultSortDirection;
                 }
+            }
+
+            if (pagingResource.SortKey != null &&
+                allowedSortKeys is { Count: > 0 } &&
+                !allowedSortKeys.Contains(pagingResource.SortKey))
+            {
+                pagingSpec.SortKey = defaultSortKey;
             }
 
             return pagingSpec;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Prevent fatal exceptions due to bad sorting keys that require locale storage resetting to fix the issue.