### PR TITLE
Fixed: Parse TELESYNCH as TELESYNC

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -36,6 +36,7 @@ namespace NzbDrone.Core.Test.ParserTests
         };
 
         [TestCase("Movie.Title.3.2017.720p.TSRip.x264.AAC-Ozlem", false)]
+        [TestCase("Movie: Title (2024) TeleSynch 2160p | HEVC-FILVOVAN", false)]
         public void should_parse_ts(string title, bool proper)
         {
             ParseAndVerifyQuality(title, QualitySource.TELESYNC, proper, Resolution.R720p);

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Parser
                                                             (?<dsr>WS[-_. ]DSR|DSR)|
                                                             (?<regional>R[0-9]{1}|REGIONAL)|
                                                             (?<scr>SCR|SCREENER|DVDSCR|DVDSCREENER)|
-                                                            (?<ts>TS[-_. ]|TELESYNC|HD-TS|HDTS|PDVD|TSRip|HDTSRip)|
+                                                            (?<ts>TS[-_. ]|TELESYNCH?|HD-TS|HDTS|PDVD|TSRip|HDTSRip)|
                                                             (?<tc>TC|TELECINE|HD-TC|HDTC)|
                                                             (?<cam>CAMRIP|(?:NEW)?CAM|HD-?CAM(?:Rip)?|HQCAM)|
                                                             (?<wp>WORKPRINT|WP)|


### PR DESCRIPTION
Fixes #10414
