### PR TITLE
Added Original Title to Movie Details and to Add Movie Search Result

### DIFF
--- a/frontend/src/AddMovie/AddNewMovie/AddNewMovieSearchResult.css
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewMovieSearchResult.css
@@ -85,6 +85,7 @@
   margin-top: 20px;
 }
 
+.originalTitle,
 .originalLanguage,
 .studio,
 .genres {

--- a/frontend/src/AddMovie/AddNewMovie/AddNewMovieSearchResult.css.d.ts
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewMovieSearchResult.css.d.ts
@@ -9,6 +9,7 @@ interface CssExports {
   'icons': string;
   'links': string;
   'originalLanguage': string;
+  'originalTitle': string;
   'overlay': string;
   'overview': string;
   'poster': string;

--- a/frontend/src/AddMovie/AddNewMovie/AddNewMovieSearchResult.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewMovieSearchResult.js
@@ -12,6 +12,7 @@ import MovieStatusLabel from 'Movie/Details/MovieStatusLabel';
 import MovieIndexProgressBar from 'Movie/Index/ProgressBar/MovieIndexProgressBar';
 import MoviePoster from 'Movie/MoviePoster';
 import formatRuntime from 'Utilities/Date/formatRuntime';
+import equalsIgnoringCase from 'Utilities/String/equalsIgnoringCase';
 import translate from 'Utilities/String/translate';
 import AddNewMovieModal from './AddNewMovieModal';
 import styles from './AddNewMovieSearchResult.css';
@@ -63,6 +64,7 @@ class AddNewMovieSearchResult extends Component {
       year,
       studio,
       originalLanguage,
+      originalTitle,
       genres,
       status,
       overview,
@@ -229,6 +231,20 @@ class AddNewMovieSearchResult extends Component {
               }
 
               {
+                originalTitle && !equalsIgnoringCase(title, originalTitle) ?
+                  <Label size={sizes.LARGE}>
+                    <Icon
+                      name={icons.FILM}
+                      size={13}
+                    />
+                    <span className={styles.originalTitle}>
+                      {originalTitle}
+                    </span>
+                  </Label> :
+                  null
+              }
+
+              {
                 studio ?
                   <Label size={sizes.LARGE}>
                     <Icon
@@ -328,6 +344,7 @@ AddNewMovieSearchResult.propTypes = {
   year: PropTypes.number.isRequired,
   studio: PropTypes.string,
   originalLanguage: PropTypes.object,
+  originalTitle: PropTypes.string,
   genres: PropTypes.arrayOf(PropTypes.string),
   status: PropTypes.string.isRequired,
   overview: PropTypes.string,

--- a/frontend/src/Movie/Details/MovieDetails.js
+++ b/frontend/src/Movie/Details/MovieDetails.js
@@ -38,6 +38,7 @@ import fonts from 'Styles/Variables/fonts';
 import * as keyCodes from 'Utilities/Constants/keyCodes';
 import formatRuntime from 'Utilities/Date/formatRuntime';
 import formatBytes from 'Utilities/Number/formatBytes';
+import equalsIgnoringCase from 'Utilities/String/equalsIgnoringCase';
 import translate from 'Utilities/String/translate';
 import MovieCastPosters from './Credits/Cast/MovieCastPosters';
 import MovieCrewPosters from './Credits/Crew/MovieCrewPosters';
@@ -620,6 +621,20 @@ class MovieDetails extends Component {
                       >
                         <span className={styles.originalLanguage}>
                           {originalLanguage.name}
+                        </span>
+                      </InfoLabel> :
+                      null
+                  }
+
+                  {
+                    originalTitle && !isSmallScreen && !equalsIgnoringCase(title, originalTitle) ?
+                      <InfoLabel
+                        className={styles.detailsInfoLabel}
+                        name={translate('OriginalTitle')}
+                        size={sizes.LARGE}
+                      >
+                        <span className={styles.originalLanguage}>
+                          {originalTitle}
                         </span>
                       </InfoLabel> :
                       null

--- a/frontend/src/Utilities/String/equalsIgnoringCase.ts
+++ b/frontend/src/Utilities/String/equalsIgnoringCase.ts
@@ -1,0 +1,5 @@
+function equalsIgnoringCase(a: string, b: string): boolean {
+  return a.localeCompare(b, undefined, { sensitivity: 'accent' }) === 0;
+}
+
+export default equalsIgnoringCase;


### PR DESCRIPTION
Added original title to Movie details and movie search result where it differs from the language chosen for Radarr.
Example: If Radarr is in English, and movie is called "Dogs" and the original is in Spanish called "Amores de Perros" (just as example), it would show both.

**Movie Details:**
<img width="794" alt="image" src="https://github.com/user-attachments/assets/85d05d81-5e84-47d0-bba3-643e73ec36cd">

**Add Movie Search Result:**
<img width="807" alt="image" src="https://github.com/user-attachments/assets/d99aebb1-b5d3-4db9-8f8d-e0877a6b0498">


