### PR TITLE
Bump macOS runner version to 13

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ variables:
   innoVersion: '6.2.2'
   windowsImage: 'windows-2022'
   linuxImage: 'ubuntu-20.04'
-  macImage: 'macOS-12'
+  macImage: 'macOS-13'
 
 trigger:
   branches:


### PR DESCRIPTION
#### Database Migration
NO

#### Description
`macOS-12` is deprecated and being removed on 12/3/24.