### PR TITLE
New: Parse IMDB and TMDB URLs as search terms

### DIFF
--- a/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxySearchFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxySearchFixture.cs
@@ -23,6 +23,8 @@ namespace NzbDrone.Core.Test.MetadataSource.SkyHook
         // [TestCase("The Man from U.N.C.L.E.", "The Man from U.N.C.L.E.")]
         [TestCase("imdb:tt2527336", "Star Wars: The Last Jedi")]
         [TestCase("imdb:tt2798920", "Annihilation")]
+        [TestCase("https://www.imdb.com/title/tt0033467/", "Citizen Kane")]
+        [TestCase("https://www.themoviedb.org/movie/775-le-voyage-dans-la-lune", "A Trip to the Moon")]
         public void successful_search(string title, string expected)
         {
             var result = Subject.SearchForNewMovie(title);
@@ -41,6 +43,8 @@ namespace NzbDrone.Core.Test.MetadataSource.SkyHook
         [TestCase("tmdbid:1")]
         [TestCase("adjalkwdjkalwdjklawjdlKAJD;EF")]
         [TestCase("imdb: tt9805708")]
+        [TestCase("https://www.UNKNOWN-DOMAIN.com/title/tt0033467/")]
+        [TestCase("https://www.themoviedb.org/MALFORMED/775-le-voyage-dans-la-lune")]
         public void no_search_result(string term)
         {
             var result = Subject.SearchForNewMovie(term);

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using NLog;
 using NzbDrone.Common.Cloud;
@@ -405,6 +406,20 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
         {
             try
             {
+                var match = new Regex("^https://www.imdb.com/title/(tt[0-9]+).*?$").Match(title);
+                if (match.Success)
+                {
+                    title = "imdb:" + match.Groups[1].Value;
+                }
+                else
+                {
+                    match = new Regex("^https://www.themoviedb.org/movie/([0-9]+).*$").Match(title);
+                    if (match.Success)
+                    {
+                        title = "tmdb:" + match.Groups[1].Value;
+                    }
+                }
+
                 var lowerTitle = title.ToLower();
 
                 lowerTitle = lowerTitle.Replace(".", "");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The aim of this pull request is to add the ability to use IMDB and TMDB movie page URLs as valid search terms on the Add New Movie page.

#### Screenshot (if UI related)
N/A

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #10511