### PR TITLE
New: Parsing POL as Polish and EN as English

### DIFF
--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?:(?i)(?<!SUB[\W|_|^]))(?:(?<lithuanian>\bLT\b)|
                                                                                                           (?<czech>\b(?:CZ|CZE|Cze)\b)|
-                                                                                                          (?<german>\b(?:DE|DEU|GER|Deu|Ger|)\b)|
+                                                                                                          (?<german>\b(?:DE|DEU|GER|Deu|Ger)\b)|
                                                                                                           (?<spain>\b(?:ES|SPA|Spa)\b)|
                                                                                                           (?<polish>\b(?:PL|POL|Pol)\b)|
                                                                                                           (?<bulgarian>\bBG\b))(?:(?i)(?![\W|_|^]SUB))|

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?:(?i)(?<!SUB[\W|_|^]))(?:(?<lithuanian>\bLT\b)|
                                                                                                           (?<czech>\bCZ\b)|
-                                                                                                          (?<polish>\b(?:(PL|POL)\b)|
+                                                                                                          (?<polish>\b(?:PL|POL)\b)|
                                                                                                           (?<bulgarian>\bBG\b))(?:(?i)(?![\W|_|^]SUB))|
                                                                                                           (?<slovak>\bSK\b)",
                                                                 RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Parser
                                                                             (?<polish>\b(?:PL\W?DUB|DUB\W?PL|LEK\W?PL|PL\W?LEK)\b)|
                                                                             (?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)|
                                                                             (?<ukrainian>(?:(?:\dx)?UKR))|
-                                                                            (?<spanish>\b(?:español|castellano\b)|
+                                                                            (?<spanish>\b(?:español|castellano)\b)|
                                                                             (?<latvian>\b(?:lat|lav|lv)\b)|
                                                                             (?<telugu>\btel\b)|
                                                                             (?<vietnamese>\bVIE\b)",

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Parser
                                                                             (?<greek>greek)|
                                                                             (?<french>\b(?:FR|VO|VF|VFF|VFQ|VFI|VF2|TRUEFRENCH|FRENCH|FRE|FRA)\b)|
                                                                             (?<russian>\b(?:rus|ru)\b)|
-                                                                            (?<english>\beng\b)|
+                                                                            (?<english>\b(?:eng|en)\b)|
                                                                             (?<hungarian>\b(?:HUNDUB|HUN)\b)|
                                                                             (?<hebrew>\b(?:HebDub|HebDubbed)\b)|
                                                                             (?<polish>\b(?:PL\W?DUB|DUB\W?PL|LEK\W?PL|PL\W?LEK)\b)|
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?:(?i)(?<!SUB[\W|_|^]))(?:(?<lithuanian>\bLT\b)|
                                                                                                           (?<czech>\bCZ\b)|
-                                                                                                          (?<polish>\bPL\b)|
+                                                                                                          (?<polish>\b(?:(PL|POL)\b)|
                                                                                                           (?<bulgarian>\bBG\b))(?:(?i)(?![\W|_|^]SUB))|
                                                                                                           (?<slovak>\bSK\b)",
                                                                 RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -30,16 +30,19 @@ namespace NzbDrone.Core.Parser
                                                                             (?<polish>\b(?:PL\W?DUB|DUB\W?PL|LEK\W?PL|PL\W?LEK)\b)|
                                                                             (?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)|
                                                                             (?<ukrainian>(?:(?:\dx)?UKR))|
-                                                                            (?<spanish>\b(?:español|castellano)\b)|
+                                                                            (?<spanish>\b(?:español|castellano\b)|
                                                                             (?<latvian>\b(?:lat|lav|lv)\b)|
                                                                             (?<telugu>\btel\b)|
                                                                             (?<vietnamese>\bVIE\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
         private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?:(?i)(?<!SUB[\W|_|^]))(?:(?<lithuanian>\bLT\b)|
-                                                                                                          (?<czech>\bCZ\b)|
-                                                                                                          (?<polish>\b(?:PL|POL)\b)|
+                                                                                                          (?<czech>\b(?:CZ|CZE|Cze)\b)|
+                                                                                                          (?<german>\b(?:DE|DEU|GER|Deu|Ger|)\b)|
+                                                                                                          (?<spain>\b(?:ES|SPA|Spa)\b)|
+                                                                                                          (?<polish>\b(?:PL|POL|Pol)\b)|
                                                                                                           (?<bulgarian>\bBG\b))(?:(?i)(?![\W|_|^]SUB))|
+                                                                                                          (?<turkish>\b(?:TR|TUR|Tur)\b)|
                                                                                                           (?<slovak>\bSK\b)",
                                                                 RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 


### PR DESCRIPTION
Adding the phrase "POL" to indicate the Polish language and the phrase "en" to indicate English.

#### Database Migration
NO

#### Description
Adding the phrase "POL" to indicate the Polish language and the phrase "en" to indicate English. This is intended to identify files marked with both "PL" and "POL" for Polish, as well as "en" and "eng" for English.


An example release where it does not detect all languages ​​is: "Godzilla King of the Monsters 2019 Eng Fre Ger Ita Spa Cze Hun Pol Rus Hin Tam Tel Tha Tur 2160p BluRay Remux DV HDR HEVC Atmos-SGF". Languages ​​have been marked here by ISO codes 639-2/B.

Of course it still does not recognize all languages, but I focused on European languages.
