### PR TITLE
Fixed: Release Year mandatory to generate valid file formats

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -41,7 +41,9 @@ namespace NzbDrone.Core.Organizer
         private static readonly Regex TitleRegex = new Regex(@"(?<tag>\{(?:imdb-|edition-))?\{(?<prefix>[- ._\[(]*)(?<token>(?:[a-z0-9]+)(?:(?<separator>[- ._]+)(?:[a-z0-9]+))?)(?::(?<customFormat>[ ,a-z0-9|+-]+(?<![- ])))?(?<suffix>[-} ._)\]]*)\}",
                                                              RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
-        public static readonly Regex MovieTitleRegex = new Regex(@"(?<token>\{(?:(?:Movie)(?<separator>[- ._])(?:Clean)?(?:OriginalTitle|Title(?:The)?)(?::(?<customFormat>[a-z0-9|-]+))?|Original[- ._](?:Title|Filename))\})",
+        public static readonly Regex ReleaseYearRegex = new Regex(@"\{Release[- ._]Year\}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public static readonly Regex MovieTitleRegex = new Regex(@"(?<token>\{(?:Movie)(?<separator>[- ._])(?:Clean)?(?:OriginalTitle|Title(?:The)?)(?::(?<customFormat>[a-z0-9|-]+))?\})",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex FileNameCleanupRegex = new Regex(@"([- ._])(\1)+", RegexOptions.Compiled);

--- a/src/NzbDrone.Core/Organizer/FileNameValidation.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameValidation.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
@@ -8,20 +9,56 @@ namespace NzbDrone.Core.Organizer
 {
     public static class FileNameValidation
     {
-        public static IRuleBuilderOptions<T, string> ValidMovieFolderFormat<T>(this IRuleBuilder<T, string> ruleBuilder)
-        {
-            ruleBuilder.SetValidator(new NotEmptyValidator(null));
-            ruleBuilder.SetValidator(new IllegalCharactersValidator());
-
-            return ruleBuilder.SetValidator(new RegularExpressionValidator(FileNameBuilder.MovieTitleRegex)).WithMessage("Must contain movie title");
-        }
+        internal static readonly Regex OriginalTokenRegex = new (@"(\{Original[- ._](?:Title|Filename)\})",
+                                                                            RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static IRuleBuilderOptions<T, string> ValidMovieFormat<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
             ruleBuilder.SetValidator(new NotEmptyValidator(null));
             ruleBuilder.SetValidator(new IllegalCharactersValidator());
 
-            return ruleBuilder.SetValidator(new RegularExpressionValidator(FileNameBuilder.MovieTitleRegex)).WithMessage("Must contain movie title");
+            return ruleBuilder.SetValidator(new ValidMovieFormatValidator());
+        }
+
+        public static IRuleBuilderOptions<T, string> ValidMovieFolderFormat<T>(this IRuleBuilder<T, string> ruleBuilder)
+        {
+            ruleBuilder.SetValidator(new NotEmptyValidator(null));
+            ruleBuilder.SetValidator(new IllegalCharactersValidator());
+
+            return ruleBuilder.SetValidator(new ValidMovieFolderFormatValidator());
+        }
+    }
+
+    public class ValidMovieFormatValidator : PropertyValidator
+    {
+        protected override string GetDefaultMessageTemplate() => "Must contain movie title and release year OR Original Title";
+
+        protected override bool IsValid(PropertyValidatorContext context)
+        {
+            if (context.PropertyValue is not string value)
+            {
+                return false;
+            }
+
+            return (FileNameBuilder.MovieTitleRegex.IsMatch(value) && FileNameBuilder.ReleaseYearRegex.IsMatch(value)) ||
+                   FileNameValidation.OriginalTokenRegex.IsMatch(value);
+        }
+    }
+
+    public class ValidMovieFolderFormatValidator : PropertyValidator
+    {
+        protected override string GetDefaultMessageTemplate() => "Must contain movie title";
+
+        protected override bool IsValid(PropertyValidatorContext context)
+        {
+            if (context.PropertyValue is not string value)
+            {
+                return false;
+            }
+
+            // TODO: Deprecate OriginalTokenRegex use for Movie Folder Format
+            return FileNameBuilder.MovieTitleRegex.IsMatch(value) ||
+                   FileNameValidation.OriginalTokenRegex.IsMatch(value);
         }
     }
 

--- a/src/NzbDrone.Core/Organizer/FileNameValidationService.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameValidationService.cs
@@ -13,7 +13,7 @@ namespace NzbDrone.Core.Organizer
 
         public ValidationFailure ValidateMovieFilename(SampleResult sampleResult)
         {
-            var validationFailure = new ValidationFailure("MovieFormat", ERROR_MESSAGE);
+            var validationFailure = new ValidationFailure("StandardMovieFormat", ERROR_MESSAGE);
             var parsedMovieInfo = Parser.Parser.ParseMovieTitle(sampleResult.FileName);
 
             if (parsedMovieInfo == null)

--- a/src/NzbDrone.Integration.Test/ApiTests/NamingConfigFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/NamingConfigFixture.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Integration.Test.ApiTests
         {
             var config = NamingConfig.GetSingle();
             config.RenameMovies = false;
-            config.StandardMovieFormat = "{Movie Title}";
+            config.StandardMovieFormat = "{Movie Title} {Release Year}";
 
             var result = NamingConfig.Put(config);
             result.RenameMovies.Should().BeFalse();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Since 1d286df85d3741c4047e5f23a20508edfcc6e64f we're no longer allowing unable to parse file names, even with the typo in FileNameValidationService preventing the error from being displayed in the UI. 

To mitigate this, `{Release Year}` token is now mandatory for Movie Format to prevent this.

#### Issues Fixed or Closed by this PR

* Fixes #10560