### PR TITLE
Fixed: Add only movies with release dates from monitored collections

### DIFF
--- a/src/NzbDrone.Core/Movies/RefreshCollectionService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshCollectionService.cs
@@ -125,10 +125,14 @@ namespace NzbDrone.Core.Movies
         {
             if (collection.Monitored)
             {
+                var collectionMovies = _movieMetadataService
+                    .GetMoviesByCollectionTmdbId(collection.TmdbId)
+                    .Where(m => m.Status is MovieStatusType.InCinemas or MovieStatusType.Released)
+                    .ToList();
+
                 var existingMovies = _movieService.AllMovieTmdbIds();
-                var collectionMovies = _movieMetadataService.GetMoviesByCollectionTmdbId(collection.TmdbId);
                 var excludedMovies = _importListExclusionService.All().Select(e => e.TmdbId);
-                var moviesToAdd = collectionMovies.Where(m => !existingMovies.Contains(m.TmdbId)).Where(m => !excludedMovies.Contains(m.TmdbId));
+                var moviesToAdd = collectionMovies.Where(m => !existingMovies.Contains(m.TmdbId)).Where(m => !excludedMovies.Contains(m.TmdbId)).ToList();
 
                 if (moviesToAdd.Any())
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Due to issues caused by untitled movies that were only announced, @thezoggy is getting a lot of movies added with bad paths. 

This change would prevent announced movies from being added to library until they have a release date.