### PR TITLE
Fixed: Optional square and round brackets for "{Release Year}"

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Organizer
         private static readonly Regex TitleRegex = new Regex(@"(?<tag>\{(?:imdb-|edition-))?\{(?<prefix>[- ._\[(]*)(?<token>(?:[a-z0-9]+)(?:(?<separator>[- ._]+)(?:[a-z0-9]+))?)(?::(?<customFormat>[ ,a-z0-9|+-]+(?<![- ])))?(?<suffix>[-} ._)\]]*)\}",
                                                              RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
-        public static readonly Regex ReleaseYearRegex = new Regex(@"\{Release[- ._]Year\}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        public static readonly Regex ReleaseYearRegex = new Regex(@"\{[\[\(]?Release[- ._]Year[\]\)]?\}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static readonly Regex MovieTitleRegex = new Regex(@"(?<token>\{(?:Movie)(?<separator>[- ._])(?:Clean)?(?:OriginalTitle|Title(?:The)?)(?::(?<customFormat>[a-z0-9|-]+))?\})",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);

--- a/src/NzbDrone.Integration.Test/ApiTests/NamingConfigFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/NamingConfigFixture.cs
@@ -20,12 +20,14 @@ namespace NzbDrone.Integration.Test.ApiTests
             NamingConfig.Get(config.Id).Id.Should().Be(config.Id);
         }
 
-        [Test]
-        public void should_be_able_to_update()
+        [TestCase("{Movie Title} {Release Year}")]
+        [TestCase("{Movie Title} {(Release Year)}")]
+        [TestCase("{Movie Title} {[Release Year]}")]
+        public void should_be_able_to_update(string standardMovieFormat)
         {
             var config = NamingConfig.GetSingle();
             config.RenameMovies = false;
-            config.StandardMovieFormat = "{Movie Title} {Release Year}";
+            config.StandardMovieFormat = standardMovieFormat;
 
             var result = NamingConfig.Put(config);
             result.RenameMovies.Should().BeFalse();


### PR DESCRIPTION
#### Database Migration
#### Description
Allowing `{Movie Title} {(Release Year)}` and `{Movie Title} {[Release Year]}` as it was before being mandatory.