### PR TITLE
Fixed: Changing movies to another root folder without moving files

### DIFF
--- a/src/NzbDrone.Common.Test/PathExtensionFixture.cs
+++ b/src/NzbDrone.Common.Test/PathExtensionFixture.cs
@@ -413,5 +413,25 @@ namespace NzbDrone.Common.Test
         {
             path.GetCleanPath().Should().Be(cleanPath);
         }
+
+        [TestCase(@"C:\Test\", @"C:\Test\Series Title", "Series Title")]
+        [TestCase(@"C:\Test\", @"C:\Test\Collection\Series Title", @"Collection\Series Title")]
+        [TestCase(@"C:\Test\mydir\", @"C:\Test\mydir\Collection\Series Title", @"Collection\Series Title")]
+        [TestCase(@"\\server\share", @"\\server\share\Series Title", "Series Title")]
+        [TestCase(@"\\server\share\mydir\", @"\\server\share\mydir\/Collection\Series Title", @"Collection\Series Title")]
+        public void windows_path_should_return_relative_path(string parentPath, string childPath, string relativePath)
+        {
+            parentPath.GetRelativePath(childPath).Should().Be(relativePath);
+        }
+
+        [TestCase(@"/test", "/test/Series Title", "Series Title")]
+        [TestCase(@"/test/", "/test/Collection/Series Title", "Collection/Series Title")]
+        [TestCase(@"/test/mydir", "/test/mydir/Series Title", "Series Title")]
+        [TestCase(@"/test/mydir/", "/test/mydir/Collection/Series Title", "Collection/Series Title")]
+        [TestCase(@"/test/mydir/", @"/test/mydir/\Collection/Series Title", "Collection/Series Title")]
+        public void unix_path_should_return_relative_path(string parentPath, string childPath, string relativePath)
+        {
+            parentPath.GetRelativePath(childPath).Should().Be(relativePath);
+        }
     }
 }

--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -86,7 +86,7 @@ namespace NzbDrone.Common.Extensions
                 throw new NotParentException("{0} is not a child of {1}", childPath, parentPath);
             }
 
-            return childPath.Substring(parentPath.Length).Trim(Path.DirectorySeparatorChar);
+            return childPath.Substring(parentPath.Length).Trim('\\', '/');
         }
 
         public static string GetParentPath(this string childPath)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When migrating from Windows to Linux, changing the root folder for a series from `E:\Media\Movies` to `/mnt/media/movies` without moving the files would use the relative path but due to difference between path separators would result into an invalid path `/mnt/media/movies/\Movie Title`.

#### Issues Fixed or Closed by this PR

* Fixes #10578
* Closes #10598