### PR TITLE
Fixed: Parse "Català" and "Catalán" as Catalan

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -416,6 +416,10 @@ namespace NzbDrone.Core.Test.ParserTests
         }
 
         [TestCase("Movie.Title.1994.Catalan.1080p.XviD-LOL")]
+        [TestCase("Movie.Title.2024.Catalán.1080p.XviD-LOL")]
+        [TestCase("Movie.Title.(2024).(Catala.Spanish.Subs).WEBRip.1080p.x264-EAC3")]
+        [TestCase("Movie.Title.(2024).(Spanish.Catala.English.Subs).BDRip.1080p.x264-EAC3")]
+        [TestCase("Movie Title [2024] [BDrip 1080p-x264-AC3 5.1 català-español-english+sub]")]
         public void should_parse_language_catalan(string postTitle)
         {
             var result = Parser.Parser.ParseMovieTitle(postTitle, true);

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -31,6 +31,7 @@ namespace NzbDrone.Core.Parser
                                                                             (?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)|
                                                                             (?<ukrainian>(?:(?:\dx)?UKR))|
                                                                             (?<spanish>\b(?:español|castellano)\b)|
+                                                                            (?<catalan>\b(?:catalan?|catalán|català)\b)|
                                                                             (?<latvian>\b(?:lat|lav|lv)\b)|
                                                                             (?<telugu>\btel\b)|
                                                                             (?<vietnamese>\bVIE\b)",
@@ -208,11 +209,6 @@ namespace NzbDrone.Core.Parser
                 languages.Add(Language.SpanishLatino);
             }
 
-            if (lowerTitle.Contains("catalan"))
-            {
-                languages.Add(Language.Catalan);
-            }
-
             if (lowerTitle.Contains("tamil"))
             {
                 languages.Add(Language.Tamil);
@@ -346,6 +342,11 @@ namespace NzbDrone.Core.Parser
                 if (match.Groups["spanish"].Success)
                 {
                     languages.Add(Language.Spanish);
+                }
+
+                if (match.Groups["catalan"].Success)
+                {
+                    languages.Add(Language.Catalan);
                 }
 
                 if (match.Groups["ukrainian"].Success)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adding support for `Catalán`, `Català` and `Catala` as Catalan language.

#### Issues Fixed or Closed by this PR

* Fixes #10584