### PR TITLE
Fixed: Cleaning the French preposition 'à' from titles

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/NormalizeTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/NormalizeTitleFixture.cs
@@ -26,6 +26,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("24", "24")]
         [TestCase("I'm a cyborg, but that's OK", "imcyborgbutthatsok")]
         [TestCase("Im a cyborg, but thats ok", "imcyborgbutthatsok")]
+        [TestCase("Test: Something à Deux", "testsomethingdeux")]
+        [TestCase("Parler à", "parlera")]
         public void should_remove_special_characters_and_casing(string dirty, string clean)
         {
             var result = dirty.CleanMovieTitle();

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex NormalizeAlternativeTitleRegex = new Regex(@"[ ]+(?:A\.K\.A\.)[ ]+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex NormalizeRegex = new Regex(@"((?:\b|_)(?<!^|[^a-zA-Z0-9_']\w[^a-zA-Z0-9_'])(a(?!$|[^a-zA-Z0-9_']\w[^a-zA-Z0-9_'])|an|the|and|or|of)(?!$)(?:\b|_))|\W|_",
+        private static readonly Regex NormalizeRegex = new Regex(@"((?:\b|_)(?<!^|[^a-zA-Z0-9_']\w[^a-zA-Z0-9_'])([aà](?!$|[^a-zA-Z0-9_']\w[^a-zA-Z0-9_'])|an|the|and|or|of)(?!$)(?:\b|_))|\W|_",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex FileExtensionRegex = new Regex(@"\.[a-z0-9]{2,4}$",
@@ -471,7 +471,7 @@ namespace NzbDrone.Core.Parser
                 return title;
             }
 
-            return ReplaceGermanUmlauts(NormalizeRegex.Replace(title, string.Empty).ToLower()).RemoveAccent();
+            return ReplaceGermanUmlauts(NormalizeRegex.Replace(title, string.Empty).ToLowerInvariant()).RemoveAccent();
         }
 
         public static string NormalizeEpisodeTitle(this string title)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Properly normalize the French preposition `à` in order for `Something a Deux` and `Something à Deux` to generate the same clean title.