### PR TITLE
Fixed: Loading queue with pending releases for deleted movies

### DIFF
--- a/src/NzbDrone.Core/Datastore/Extensions/BuilderExtensions.cs
+++ b/src/NzbDrone.Core/Datastore/Extensions/BuilderExtensions.cs
@@ -72,6 +72,15 @@ namespace NzbDrone.Core.Datastore
             return builder.LeftJoin($"\"{rightTable}\" ON {wb.ToString()}");
         }
 
+        public static SqlBuilder InnerJoin<TLeft, TRight>(this SqlBuilder builder, Expression<Func<TLeft, TRight, bool>> filter)
+        {
+            var wb = GetWhereBuilder(builder.DatabaseType, filter, false, builder.Sequence);
+
+            var rightTable = TableMapping.Mapper.TableNameMapping(typeof(TRight));
+
+            return builder.InnerJoin($"\"{rightTable}\" ON {wb}");
+        }
+
         public static SqlBuilder GroupBy<TModel>(this SqlBuilder builder, Expression<Func<TModel, object>> property)
         {
             var table = TableMapping.Mapper.TableNameMapping(typeof(TModel));

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseRepository.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseRepository.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Movies;
 
 namespace NzbDrone.Core.Download.Pending
 {
@@ -30,7 +31,11 @@ namespace NzbDrone.Core.Download.Pending
 
         public List<PendingRelease> WithoutFallback()
         {
-            return Query(x => x.Reason != PendingReleaseReason.Fallback);
+            var builder = new SqlBuilder(_database.DatabaseType)
+                .InnerJoin<PendingRelease, Movie>((p, m) => p.MovieId == m.Id)
+                .Where<PendingRelease>(p => p.Reason != PendingReleaseReason.Fallback);
+
+            return Query(builder);
         }
     }
 }

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
@@ -254,10 +254,7 @@ namespace NzbDrone.Core.Download.Pending
             {
                 foreach (var movie in knownRemoteMovies.Values.Select(v => v.Movie))
                 {
-                    if (!movieMap.ContainsKey(movie.Id))
-                    {
-                        movieMap[movie.Id] = movie;
-                    }
+                    movieMap.TryAdd(movie.Id, movie);
                 }
             }
 
@@ -273,7 +270,7 @@ namespace NzbDrone.Core.Download.Pending
                 // Just in case the movie was removed, but wasn't cleaned up yet (housekeeper will clean it up)
                 if (movie == null)
                 {
-                    return null;
+                    continue;
                 }
 
                 // Languages will be empty if added before upgrading to v4, reparsing the languages if they're empty will set it to Unknown or better.


### PR DESCRIPTION
#### Database Migration
NO

#### Description
While we have `CleanupOrphanedPendingReleases` and a clean up on MoviesDeletedEvent, we still get cases where we get pending releases with non-existing movie ids.

We should load only the pending releases with existing movies by using an INNER JOIN to prevent queue loading errors.

#### Issues Fixed or Closed by this PR

* Fixes #10616