### PR TITLE
Add Albanian language.

### DIFF
--- a/src/NzbDrone.Core.Test/Languages/LanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/Languages/LanguageFixture.cs
@@ -61,7 +61,8 @@ namespace NzbDrone.Core.Test.Languages
                 new object[] { 46, Language.Macedonian },
                 new object[] { 47, Language.Slovenian },
                 new object[] { 48, Language.Malayalam },
-                new object[] { 49, Language.Kannada }
+                new object[] { 49, Language.Kannada },
+                new object[] { 50, Language.Albanian }
             };
 
         public static object[] ToIntCases =
@@ -117,7 +118,8 @@ namespace NzbDrone.Core.Test.Languages
                 new object[] { Language.Macedonian, 46 },
                 new object[] { Language.Slovenian, 47 },
                 new object[] { Language.Malayalam, 48 },
-                new object[] { Language.Kannada, 49 }
+                new object[] { Language.Kannada, 49 },
+                new object[] { Language.Albanian, 50 }
             };
 
         [Test]

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -444,6 +444,14 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Should().Contain(Language.Kannada);
         }
 
+        [TestCase("Movie Title (2024) Albanian 1080p HD AVC MP4 x264 .9.8GB TEAMTR")]
+        [TestCase("Movie.Title.2024.Albanian.1080p.AMZN.WEB-DL.DD+2.0.x264-Telly")]
+        public void should_parse_language_albanian(string postTitle)
+        {
+            var result = LanguageParser.ParseLanguages(postTitle);
+            result.Should().Contain(Language.Albanian);
+        }
+
         [TestCase("Movie.Title.en.sub")]
         [TestCase("Movie Title.eng.sub")]
         [TestCase("Movie.Title.eng.forced.sub")]

--- a/src/NzbDrone.Core/ImportLists/TMDb/TMDbLanguageCodes.cs
+++ b/src/NzbDrone.Core/ImportLists/TMDb/TMDbLanguageCodes.cs
@@ -61,6 +61,8 @@ namespace NzbDrone.Core.ImportLists.TMDb
         [FieldOption(Hint = "Malayalam")]
         ml,
         [FieldOption(Hint = "Kannada")]
-        kn
+        kn,
+        [FieldOption(Hint = "Albanian")]
+        sq
     }
 }

--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -120,6 +120,7 @@ namespace NzbDrone.Core.Languages
         public static Language Slovenian => new Language(47, "Slovenian");
         public static Language Malayalam => new Language(48, "Malayalam");
         public static Language Kannada => new Language(49, "Kannada");
+        public static Language Albanian => new Language(50, "Albanian");
         public static Language Any => new Language(-1, "Any");
         public static Language Original => new Language(-2, "Original");
 
@@ -179,6 +180,7 @@ namespace NzbDrone.Core.Languages
                     Slovenian,
                     Malayalam,
                     Kannada,
+                    Albanian,
                     Any,
                     Original
                 };

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -59,6 +59,7 @@ namespace NzbDrone.Core.Parser
                                                                new IsoLanguage("sl", "", "slv", "Slovenian", Language.Slovenian),
                                                                new IsoLanguage("ml", "", "mal", "Malayalam", Language.Malayalam),
                                                                new IsoLanguage("kn", "", "kan", "Kannada", Language.Kannada),
+                                                               new IsoLanguage("sq", "", "sqi", "Albanian", Language.Albanian),
                                                            };
 
         private static readonly Dictionary<string, Language> AlternateIsoCodeMappings = new ()

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -229,6 +229,11 @@ namespace NzbDrone.Core.Parser
                 languages.Add(Language.Kannada);
             }
 
+            if (lowerTitle.Contains("albanian"))
+            {
+                languages.Add(Language.Albanian);
+            }
+
             // Case sensitive
             var caseSensitiveMatches = CaseSensitiveLanguageRegex.Matches(title);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Hive (2021) is currently showing Original Language of English even though it is listed as Albanian on the The Movie Database.
This is because the Albanian language is not currently supported.

Added the Albanian language ~~and also defaulted to Unknown instead of English when a language is not found, to avoid confusion going forward~~.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

*