### PR TITLE
New: Add config file setting for CGNAT authentication bypass

### DIFF
--- a/src/NzbDrone.Common.Test/ExtensionTests/IPAddressExtensionsFixture.cs
+++ b/src/NzbDrone.Common.Test/ExtensionTests/IPAddressExtensionsFixture.cs
@@ -21,9 +21,28 @@ namespace NzbDrone.Common.Test.ExtensionTests
         [TestCase("1.2.3.4")]
         [TestCase("172.55.0.1")]
         [TestCase("192.55.0.1")]
+        [TestCase("100.64.0.1")]
+        [TestCase("100.127.255.254")]
         public void should_return_false_for_public_ip_address(string ipAddress)
         {
             IPAddress.Parse(ipAddress).IsLocalAddress().Should().BeFalse();
+        }
+
+        [TestCase("100.64.0.1")]
+        [TestCase("100.127.255.254")]
+        [TestCase("100.100.100.100")]
+        public void should_return_true_for_cgnat_ip_address(string ipAddress)
+        {
+            IPAddress.Parse(ipAddress).IsCgnatIpAddress().Should().BeTrue();
+        }
+
+        [TestCase("1.2.3.4")]
+        [TestCase("192.168.5.1")]
+        [TestCase("100.63.255.255")]
+        [TestCase("100.128.0.0")]
+        public void should_return_false_for_non_cgnat_ip_address(string ipAddress)
+        {
+            IPAddress.Parse(ipAddress).IsCgnatIpAddress().Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Common/Extensions/IpAddressExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/IpAddressExtensions.cs
@@ -52,5 +52,11 @@ namespace NzbDrone.Common.Extensions
 
             return isLinkLocal || isClassA || isClassC || isClassB;
         }
+
+        public static bool IsCgnatIpAddress(this IPAddress ipAddress)
+        {
+            var bytes = ipAddress.GetAddressBytes();
+            return bytes.Length == 4 && bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127;
+        }
     }
 }

--- a/src/NzbDrone.Common/Options/AuthOptions.cs
+++ b/src/NzbDrone.Common/Options/AuthOptions.cs
@@ -6,4 +6,5 @@ public class AuthOptions
     public bool? Enabled { get; set; }
     public string Method { get; set; }
     public string Required { get; set; }
+    public bool? TrustCgnatIpAddresses { get; set; }
 }

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -66,6 +66,7 @@ namespace NzbDrone.Core.Configuration
         string PostgresMainDb { get; }
         string PostgresLogDb { get; }
         string Theme { get; }
+        bool TrustCgnatIpAddresses { get; }
     }
 
     public class ConfigFileProvider : IConfigFileProvider
@@ -461,5 +462,7 @@ namespace NzbDrone.Core.Configuration
         {
             SetValue("ApiKey", GenerateApiKey());
         }
+
+        public bool TrustCgnatIpAddresses => _authOptions.TrustCgnatIpAddresses ?? GetValueBoolean("TrustCgnatIpAddresses", false, persist: false);
     }
 }

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -444,6 +444,12 @@ namespace NzbDrone.Core.Configuration
 
         public string ApplicationUrl => GetValue("ApplicationUrl", string.Empty);
 
+        public bool TrustCgnatIpAddresses
+        {
+            get { return GetValueBoolean("TrustCgnatIpAddresses", false); }
+            set { SetValue("TrustCgnatIpAddresses", value); }
+        }
+
         private string GetValue(string key)
         {
             return GetValue(key, string.Empty);

--- a/src/Radarr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Radarr.Api.V3/Config/HostConfigResource.cs
@@ -45,6 +45,7 @@ namespace Radarr.Api.V3.Config
         public string BackupFolder { get; set; }
         public int BackupInterval { get; set; }
         public int BackupRetention { get; set; }
+        public bool TrustCgnatIpAddresses { get; set; }
     }
 
     public static class HostConfigResourceMapper

--- a/src/Radarr.Http/Authentication/UiAuthorizationHandler.cs
+++ b/src/Radarr.Http/Authentication/UiAuthorizationHandler.cs
@@ -27,10 +27,13 @@ namespace NzbDrone.Http.Authentication
             if (_authenticationRequired == AuthenticationRequiredType.DisabledForLocalAddresses)
             {
                 if (context.Resource is HttpContext httpContext &&
-                    IPAddress.TryParse(httpContext.GetRemoteIP(), out var ipAddress) &&
-                    ipAddress.IsLocalAddress())
+                    IPAddress.TryParse(httpContext.GetRemoteIP(), out var ipAddress))
                 {
-                    context.Succeed(requirement);
+                    if (ipAddress.IsLocalAddress() ||
+                        (_configService.TrustCgnatIpAddresses && ipAddress.IsCgnatIpAddress()))
+                    {
+                        context.Succeed(requirement);
+                    }
                 }
             }
 


### PR DESCRIPTION
(cherry picked from commit [4c41a4f368046f73f82306bbd73bec992392938b](https://github.com/Sonarr/Sonarr/commit/4c41a4f368046f73f82306bbd73bec992392938b))

#### Database Migration
NO

#### Description
Added support for CGNAT IP ranges (100.64.0.0/10) to be optionally recognized as trusted addresses, allowing authentication bypass when accessing Radarr through CGNAT networks (like Tailscale), consistent with other local network behavior.

Configurable via config or RADARR__AUTH__TRUSTCGNATIPADDRESSES environment variable

#### Issues Fixed or Closed by this PR

* Closes #10734