### PR TITLE
Fixed: CF score bypassing upgrades not being allowed if a revision upgrade is present

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeDiskSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeDiskSpecificationFixture.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.MediaFiles;
@@ -331,6 +332,43 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             GivenFileQuality(new QualityModel(Quality.WEBDL1080p));
             GivenNewQuality(new QualityModel(Quality.WEBDL1080p));
+
+            GivenOldCustomFormats(new List<CustomFormat>());
+            GivenNewCustomFormats(new List<CustomFormat> { customFormat });
+
+            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_return_false_if_quality_profile_does_not_allow_upgrades_but_format_cutoff_is_above_current_score_and_is_revision_upgrade()
+        {
+            var customFormat = new CustomFormat("My Format", new ResolutionSpecification { Value = (int)Resolution.R1080p }) { Id = 1 };
+
+            Mocker.GetMock<IConfigService>()
+                .SetupGet(s => s.DownloadPropersAndRepacks)
+                .Returns(ProperDownloadTypes.DoNotPrefer);
+
+            GivenProfile(new QualityProfile
+            {
+                Cutoff = Quality.SDTV.Id,
+                MinFormatScore = 0,
+                CutoffFormatScore = 10000,
+                Items = Qualities.QualityFixture.GetDefaultQualities(),
+                FormatItems = CustomFormatsTestHelpers.GetSampleFormatItems("My Format"),
+                UpgradeAllowed = false
+            });
+
+            _parseResultSingle.Movie.QualityProfile.FormatItems = new List<ProfileFormatItem>
+            {
+                new ProfileFormatItem
+                {
+                    Format = customFormat,
+                    Score = 50
+                }
+            };
+
+            GivenFileQuality(new QualityModel(Quality.WEBDL1080p, new Revision(version: 1)));
+            GivenNewQuality(new QualityModel(Quality.WEBDL1080p, new Revision(version: 2)));
 
             GivenOldCustomFormats(new List<CustomFormat>());
             GivenNewCustomFormats(new List<CustomFormat> { customFormat });

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeSpecificationFixture.cs
@@ -121,7 +121,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                        new List<CustomFormat>(),
                        new QualityModel(Quality.HDTV720p, new Revision(version: 1)),
                        new List<CustomFormat>())
-                   .Should().Be(UpgradeableRejectReason.CustomFormatScore);
+                   .Should().Be(UpgradeableRejectReason.UpgradesNotAllowed);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeSpecificationFixture.cs
@@ -108,6 +108,25 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         }
 
         [Test]
+        public void should_return_false_if_proper_and_autoDownloadPropers_is_do_not_prefer()
+        {
+            GivenAutoDownloadPropers(ProperDownloadTypes.DoNotPrefer);
+
+            var profile = new QualityProfile
+            {
+                Items = Qualities.QualityFixture.GetDefaultQualities(),
+            };
+
+            Subject.IsUpgradable(
+                       profile,
+                       new QualityModel(Quality.DVD, new Revision(version: 1)),
+                       new List<CustomFormat>(),
+                       new QualityModel(Quality.DVD, new Revision(version: 2)),
+                       new List<CustomFormat>())
+                   .Should().Be(UpgradeableRejectReason.UpgradesNotAllowed);
+        }
+
+        [Test]
         public void should_return_false_if_release_and_existing_file_are_the_same()
         {
             var profile = new QualityProfile

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/QueueSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/QueueSpecification.cs
@@ -96,17 +96,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
                     case UpgradeableRejectReason.MinCustomFormatScore:
                         return Decision.Reject("Release in queue has Custom Format score within Custom Format score increment: {0}", qualityProfile.MinUpgradeFormatScore);
-                }
 
-                _logger.Debug("Checking if profiles allow upgrading. Queued: {0}", remoteMovie.ParsedMovieInfo.Quality);
-
-                if (!_upgradableSpecification.IsUpgradeAllowed(subject.Movie.QualityProfile,
-                                                               remoteMovie.ParsedMovieInfo.Quality,
-                                                               remoteMovie.CustomFormats,
-                                                               subject.ParsedMovieInfo.Quality,
-                                                               subject.CustomFormats))
-                {
-                    return Decision.Reject("Another release is queued and the Quality profile does not allow upgrades");
+                    case UpgradeableRejectReason.UpgradesNotAllowed:
+                        return Decision.Reject("Release in queue and Quality Profile '{0}' does not allow upgrades", qualityProfile.Name);
                 }
 
                 if (_upgradableSpecification.IsRevisionUpgrade(remoteMovie.ParsedMovieInfo.Quality, subject.ParsedMovieInfo.Quality))

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
@@ -107,6 +107,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
 
                     case UpgradeableRejectReason.MinCustomFormatScore:
                         return Decision.Reject("{0} grab event in history has Custom Format score within Custom Format score increment: {1}", rejectionSubject, qualityProfile.MinUpgradeFormatScore);
+
+                    case UpgradeableRejectReason.UpgradesNotAllowed:
+                        return Decision.Reject("{0} grab event in history and Quality Profile '{1}' does not allow upgrades", rejectionSubject, qualityProfile.Name);
                 }
             }
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradableSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradableSpecification.cs
@@ -57,6 +57,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 return UpgradeableRejectReason.None;
             }
 
+            if (!qualityProfile.UpgradeAllowed)
+            {
+                _logger.Debug("Quality profile '{0}' does not allow upgrading. Skipping.", qualityProfile.Name);
+
+                return UpgradeableRejectReason.UpgradesNotAllowed;
+            }
+
             // Reject unless the user does not prefer propers/repacks and it's a revision downgrade.
             if (downloadPropersAndRepacks != ProperDownloadTypes.DoNotPrefer &&
                 qualityRevisionCompare < 0)
@@ -86,7 +93,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 return UpgradeableRejectReason.CustomFormatScore;
             }
 
-            if (qualityProfile.UpgradeAllowed && currentFormatScore >= qualityProfile.CutoffFormatScore)
+            if (currentFormatScore >= qualityProfile.CutoffFormatScore)
             {
                 _logger.Debug("Existing item meets cut-off for custom formats, skipping. Existing: [{0}] ({1}). Cutoff score: {2}",
                     currentCustomFormats.ConcatToString(),

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
@@ -83,6 +83,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
                 case UpgradeableRejectReason.MinCustomFormatScore:
                     return Decision.Reject("Existing file on disk has Custom Format score within Custom Format score increment: {0}", qualityProfile.MinUpgradeFormatScore);
+
+                case UpgradeableRejectReason.UpgradesNotAllowed:
+                    return Decision.Reject("Existing file on disk and Quality Profile '{0}' does not allow upgrades", qualityProfile.Name);
             }
 
             return Decision.Accept();

--- a/src/NzbDrone.Core/DecisionEngine/UpgradeableRejectReason.cs
+++ b/src/NzbDrone.Core/DecisionEngine/UpgradeableRejectReason.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.DecisionEngine
         QualityCutoff,
         CustomFormatScore,
         CustomFormatCutoff,
-        MinCustomFormatScore
+        MinCustomFormatScore,
+        UpgradesNotAllowed
     }
 }


### PR DESCRIPTION
#### Description
Similar to Sonarr's [issue](https://github.com/Sonarr/Sonarr/pull/7460) of `Upgrades allowed` being bypassed if there was a revision upgrade. Fixed in the same way as the Sonarr version.

- Closes #10751