### PR TITLE
Fixed: Multilanguages release when the release name as MULTI and a language in it

### DIFF
--- a/src/NzbDrone.Core.Test/Download/Aggregation/Aggregators/AggregateLanguagesFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/Aggregation/Aggregators/AggregateLanguagesFixture.cs
@@ -168,6 +168,50 @@ namespace NzbDrone.Core.Test.Download.Aggregation.Aggregators
         }
 
         [Test]
+        public void should_return_multi_languages_when_release_as_specified_language_and_indexer_has_multi_languages_configuration()
+        {
+            var releaseTitle = "Some.Movie.2024.MULTi.VFF.VFQ.1080p.BluRay.DTS.HDMA.x264-RlsGroup";
+            var indexerDefinition = new IndexerDefinition
+            {
+                Id = 1,
+                Settings = new TorrentRssIndexerSettings { MultiLanguages = new List<int> { Language.Original.Id, Language.French.Id } }
+            };
+            Mocker.GetMock<IIndexerFactory>()
+                .Setup(v => v.Find(1))
+                .Returns(indexerDefinition);
+
+            _remoteMovie.ParsedMovieInfo = GetParsedMovieInfo(new List<Language> { Language.French }, releaseTitle);
+            _remoteMovie.Release.IndexerId = 1;
+            _remoteMovie.Release.Title = releaseTitle;
+
+            Subject.Aggregate(_remoteMovie).Languages.Should().BeEquivalentTo(new List<Language> { _movie.MovieMetadata.Value.OriginalLanguage, Language.French });
+            Mocker.GetMock<IIndexerFactory>().Verify(c => c.Find(1), Times.Once());
+            Mocker.GetMock<IIndexerFactory>().VerifyNoOtherCalls();
+        }
+
+        [Test]
+        public void should_return_multi_languages_when_release_as_other_language_and_indexer_has_multi_languages_configuration()
+        {
+            var releaseTitle = "Some.Movie.2024.MULTi.GERMAN.1080p.BluRay.DTS.HDMA.x264-RlsGroup";
+            var indexerDefinition = new IndexerDefinition
+            {
+                Id = 1,
+                Settings = new TorrentRssIndexerSettings { MultiLanguages = new List<int> { Language.Original.Id, Language.French.Id } }
+            };
+            Mocker.GetMock<IIndexerFactory>()
+                .Setup(v => v.Find(1))
+                .Returns(indexerDefinition);
+
+            _remoteMovie.ParsedMovieInfo = GetParsedMovieInfo(new List<Language> { Language.German }, releaseTitle);
+            _remoteMovie.Release.IndexerId = 1;
+            _remoteMovie.Release.Title = releaseTitle;
+
+            Subject.Aggregate(_remoteMovie).Languages.Should().BeEquivalentTo(new List<Language> { _movie.MovieMetadata.Value.OriginalLanguage, Language.French, Language.German });
+            Mocker.GetMock<IIndexerFactory>().Verify(c => c.Find(1), Times.Once());
+            Mocker.GetMock<IIndexerFactory>().VerifyNoOtherCalls();
+        }
+
+        [Test]
         public void should_return_original_when_indexer_has_no_multi_languages_configuration()
         {
             var releaseTitle = "Series.Title.S01E01.MULTi.1080p.WEB.H265-RlsGroup";

--- a/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs
+++ b/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs
@@ -88,7 +88,7 @@ namespace NzbDrone.Core.Download.Aggregation.Aggregators
                 if (indexer?.Settings is IIndexerSettings settings && settings.MultiLanguages.Any() && Parser.Parser.HasMultipleLanguages(releaseInfo.Title))
                 {
                     // Use indexer setting for Multi-languages
-                    if (languages.Count == 0 || languages.First() == Language.Unknown)
+                    if (languages.Count == 0 || (languages.Count == 1 && languages.First() == Language.Unknown))
                     {
                         languages = settings.MultiLanguages.Select(i => (Language)i).ToList();
                     }

--- a/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs
+++ b/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.Download.Aggregation.Aggregators
                 languages = languages.Except(languagesToRemove).ToList();
             }
 
-            if (releaseInfo?.Title?.IsNotNullOrWhiteSpace() == true && Parser.Parser.HasMultipleLanguages(releaseInfo.Title))
+            if (releaseInfo?.Title?.IsNotNullOrWhiteSpace() == true)
             {
                 IndexerDefinition indexer = null;
 
@@ -85,7 +85,7 @@ namespace NzbDrone.Core.Download.Aggregation.Aggregators
                     indexer = _indexerFactory.FindByName(releaseInfo.Indexer);
                 }
 
-                if (indexer?.Settings is IIndexerSettings settings && settings.MultiLanguages.Any())
+                if (indexer?.Settings is IIndexerSettings settings && settings.MultiLanguages.Any() && Parser.Parser.HasMultipleLanguages(releaseInfo.Title))
                 {
                     // Use indexer setting for Multi-languages
                     if (languages.Count == 0 || languages.First() == Language.Unknown)


### PR DESCRIPTION
Use the indexer languages configuration for multi-languages when a release with `MULTI` AND a specified language is pushed using the API /release/push and for tracking downloads.

#### Database Migration
NO

#### Description
Using the release/push API, if you send a release like "Some.Movies.2024.MULTI.FRENCH.WEB-RlsGroup" since "FRENCH" was detected in the title, the app won't append the others languages from the "MULTI" configuration of the indexer.
So if you configure in the Profile : "Language: Original", the release will be rejected because only FRENCH was detected and not "Original".

Since "Multi-languages" releases can be quite "tricky", I've made the it will append all the languages.
For exemple (Some.Movies.2024.MULTI.GERMAN.WEB-RlsGroup) if the release is detected as "GERMAN" and the multi configuration is "Original + French", it will set `languages` as : German + Original + French. So if the original language for the release was "German" referring to : https://github.com/Radarr/Radarr/blob/develop/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs#L104 `languages` is going to be German + French.
If the original language for the movie was English, `languages` is going to be German + English + French.