### PR TITLE
Fixed: Loading movies with duplicated translations

### DIFF
--- a/src/NzbDrone.Common/Extensions/IEnumerableExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/IEnumerableExtensions.cs
@@ -54,10 +54,8 @@ namespace NzbDrone.Common.Extensions
             foreach (var item in src)
             {
                 var key = keySelector(item);
-                if (!result.ContainsKey(key))
-                {
-                    result[key] = item;
-                }
+
+                result.TryAdd(key, item);
             }
 
             return result;
@@ -69,10 +67,9 @@ namespace NzbDrone.Common.Extensions
             foreach (var item in src)
             {
                 var key = keySelector(item);
-                if (!result.ContainsKey(key))
-                {
-                    result[key] = valueSelector(item);
-                }
+                var value = valueSelector(item);
+
+                result.TryAdd(key, value);
             }
 
             return result;

--- a/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupDuplicateMovieTranslations.cs
+++ b/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupDuplicateMovieTranslations.cs
@@ -1,0 +1,27 @@
+using Dapper;
+using NzbDrone.Core.Datastore;
+
+namespace NzbDrone.Core.Housekeeping.Housekeepers
+{
+    public class CleanupDuplicateMovieTranslations : IHousekeepingTask
+    {
+        private readonly IMainDatabase _database;
+
+        public CleanupDuplicateMovieTranslations(IMainDatabase database)
+        {
+            _database = database;
+        }
+
+        public void Clean()
+        {
+            using var mapper = _database.OpenConnection();
+
+            mapper.Execute(@"DELETE FROM ""MovieTranslations""
+            WHERE ""Id"" IN (
+                SELECT MAX(""Id"") FROM ""MovieTranslations""
+                GROUP BY ""MovieMetadataId"", ""Language""
+                HAVING COUNT(""Id"") > 1
+            )");
+        }
+    }
+}

--- a/src/Radarr.Api.V3/Collections/CollectionController.cs
+++ b/src/Radarr.Api.V3/Collections/CollectionController.cs
@@ -165,7 +165,7 @@ namespace Radarr.Api.V3.Collections
                 .ToDictionary(x => x.Key, x => (IEnumerable<MovieMetadata>)x);
 
             var translations = _movieTranslationService.GetAllTranslationsForLanguage(configLanguage);
-            var tdict = translations.ToDictionary(x => x.MovieMetadataId);
+            var tdict = translations.ToDictionaryIgnoreDuplicates(x => x.MovieMetadataId);
 
             foreach (var collection in collections)
             {

--- a/src/Radarr.Api.V3/Movies/MovieController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieController.cs
@@ -150,7 +150,7 @@ namespace Radarr.Api.V3.Movies
                 var translations = _movieTranslationService
                     .GetAllTranslationsForLanguage(translationLanguage);
 
-                var tdict = translations.ToDictionary(x => x.MovieMetadataId);
+                var tdict = translations.ToDictionaryIgnoreDuplicates(x => x.MovieMetadataId);
                 var sdict = movieStats.ToDictionary(x => x.MovieId);
 
                 if (!excludeLocalCovers)

--- a/src/Radarr.Api.V3/Movies/MovieEditorController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieEditorController.cs
@@ -116,7 +116,7 @@ namespace Radarr.Api.V3.Movies
             var availabilityDelay = _configService.AvailabilityDelay;
 
             var translations = _movieTranslationService.GetAllTranslationsForLanguage(configLanguage);
-            var tdict = translations.ToDictionary(x => x.MovieMetadataId);
+            var tdict = translations.ToDictionaryIgnoreDuplicates(x => x.MovieMetadataId);
 
             var updatedMovies = _movieService.UpdateMovie(moviesToUpdate, !resource.MoveFiles);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
In same cases a MovieMetadata manages to have duplicated rows with the same Language id leading to a `An item with the same key has already been added. Key: 123` error. 

I suspect this happens mainly due to `MovieTranslationService.UpdateTranslations` not handling same language duplicates.

#### Issues Fixed or Closed by this PR

* Fixes #6340