### PR TITLE
Fixed: Format bitrate for primary streams in media info

### DIFF
--- a/frontend/src/MovieFile/Editor/MediaInfo.tsx
+++ b/frontend/src/MovieFile/Editor/MediaInfo.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import DescriptionList from 'Components/DescriptionList/DescriptionList';
 import DescriptionListItem from 'Components/DescriptionList/DescriptionListItem';
 import MediaInfoProps from 'typings/MediaInfo';
+import formatBitrate from 'Utilities/Number/formatBitrate';
 import getEntries from 'Utilities/Object/getEntries';
 
 function MediaInfo(props: MediaInfoProps) {
@@ -16,9 +17,19 @@ function MediaInfo(props: MediaInfoProps) {
           return null;
         }
 
-        return (
-          <DescriptionListItem key={key} title={title} data={props[key]} />
-        );
+        if (key === 'audioBitrate' || key === 'videoBitrate') {
+          return (
+            <DescriptionListItem
+              key={key}
+              title={title}
+              data={
+                <span title={value.toString()}>{formatBitrate(value)}</span>
+              }
+            />
+          );
+        }
+
+        return <DescriptionListItem key={key} title={title} data={value} />;
       })}
     </DescriptionList>
   );

--- a/frontend/src/Utilities/Number/formatBitrate.ts
+++ b/frontend/src/Utilities/Number/formatBitrate.ts
@@ -1,0 +1,19 @@
+import { filesize } from 'filesize';
+
+function formatBitrate(input: string | number) {
+  const size = Number(input);
+
+  if (isNaN(size)) {
+    return '';
+  }
+
+  const { value, symbol } = filesize(size, {
+    base: 10,
+    round: 1,
+    output: 'object',
+  });
+
+  return `${value} ${symbol}/s`;
+}
+
+export default formatBitrate;

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -21,8 +21,8 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         private readonly Logger _logger;
         private readonly List<FFProbePixelFormat> _pixelFormats;
 
-        public const int MINIMUM_MEDIA_INFO_SCHEMA_REVISION = 8;
-        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 13;
+        public const int MINIMUM_MEDIA_INFO_SCHEMA_REVISION = 14;
+        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 14;
 
         private static readonly string[] ValidHdrColourPrimaries = { "bt2020" };
         private static readonly string[] HlgTransferFunctions = { "arib-std-b67" };
@@ -80,7 +80,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 mediaInfoModel.VideoFormat = primaryVideoStream?.CodecName;
                 mediaInfoModel.VideoCodecID = primaryVideoStream?.CodecTagString;
                 mediaInfoModel.VideoProfile = primaryVideoStream?.Profile;
-                mediaInfoModel.VideoBitrate = primaryVideoStream?.BitRate ?? 0;
+                mediaInfoModel.VideoBitrate = GetBitrate(primaryVideoStream);
                 mediaInfoModel.VideoMultiViewCount = primaryVideoStream?.Tags?.ContainsKey("stereo_mode") ?? false ? 2 : 1;
                 mediaInfoModel.VideoBitDepth = GetPixelFormat(primaryVideoStream?.PixelFormat)?.Components.Min(x => x.BitDepth) ?? 8;
                 mediaInfoModel.VideoColourPrimaries = primaryVideoStream?.ColorPrimaries;
@@ -91,7 +91,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 mediaInfoModel.AudioFormat = analysis.PrimaryAudioStream?.CodecName;
                 mediaInfoModel.AudioCodecID = analysis.PrimaryAudioStream?.CodecTagString;
                 mediaInfoModel.AudioProfile = analysis.PrimaryAudioStream?.Profile;
-                mediaInfoModel.AudioBitrate = analysis.PrimaryAudioStream?.BitRate ?? 0;
+                mediaInfoModel.AudioBitrate = GetBitrate(analysis.PrimaryAudioStream);
                 mediaInfoModel.RunTime = GetBestRuntime(analysis.PrimaryAudioStream?.Duration, primaryVideoStream?.Duration, analysis.Format.Duration);
                 mediaInfoModel.AudioStreamCount = analysis.AudioStreams.Count;
                 mediaInfoModel.AudioChannels = analysis.PrimaryAudioStream?.Channels ?? 0;
@@ -159,6 +159,21 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             }
 
             return video.Value;
+        }
+
+        private static long GetBitrate(MediaStream mediaStream)
+        {
+            if (mediaStream?.BitRate is > 0)
+            {
+                return mediaStream.BitRate;
+            }
+
+            if ((mediaStream?.Tags?.TryGetValue("BPS", out var bitratePerSecond) ?? false) && bitratePerSecond.IsNotNullOrWhiteSpace())
+            {
+                return Convert.ToInt64(bitratePerSecond);
+            }
+
+            return 0;
         }
 
         private VideoStream GetPrimaryVideoStream(IMediaAnalysis mediaAnalysis)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixing the value for video bitrate by using the tag `BPS`, and using filesize in base 10 to properly format both bitrates in a human readable output.