### PR TITLE
New: extract "additional" parameters from the release title, in order to be able to apply custom formats to them

### DIFF
--- a/src/NzbDrone.Core/CustomFormats/Specifications/ReleaseTitleSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/ReleaseTitleSpecification.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.CustomFormats
 
         protected override bool IsSatisfiedByWithoutNegate(CustomFormatInput input)
         {
-            return MatchString(input.MovieInfo?.SimpleReleaseTitle) || MatchString(input.Filename) || MatchString(input.MovieInfo?.TitleExtraParameters);
+            return MatchString(input.MovieInfo?.SimpleReleaseTitle) || MatchString(input.Filename) || MatchString(input.MovieInfo?.PostTitleParameters);
         }
     }
 }

--- a/src/NzbDrone.Core/CustomFormats/Specifications/ReleaseTitleSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/ReleaseTitleSpecification.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.CustomFormats
 
         protected override bool IsSatisfiedByWithoutNegate(CustomFormatInput input)
         {
-            return MatchString(input.MovieInfo?.SimpleReleaseTitle) || MatchString(input.Filename);
+            return MatchString(input.MovieInfo?.SimpleReleaseTitle) || MatchString(input.Filename) || MatchString(input.MovieInfo?.TitleExtraParameters);
         }
     }
 }

--- a/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Parser.Model
         public string OriginalTitle { get; set; }
         public string ReleaseTitle { get; set; }
         public string SimpleReleaseTitle { get; set; }
-        public string TitleExtraParameters { get; set; }
+        public string PostTitleParameters { get; set; }
         public QualityModel Quality { get; set; }
         public List<Language> Languages { get; set; }
         public string ReleaseGroup { get; set; }

--- a/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
@@ -16,6 +16,7 @@ namespace NzbDrone.Core.Parser.Model
         public string OriginalTitle { get; set; }
         public string ReleaseTitle { get; set; }
         public string SimpleReleaseTitle { get; set; }
+        public string TitleExtraParameters { get; set; }
         public QualityModel Quality { get; set; }
         public List<Language> Languages { get; set; }
         public string ReleaseGroup { get; set; }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly RegexReplace[] PreSubstitutionRegex = Array.Empty<RegexReplace>();
 
-        private static readonly Regex ExtraParametersRegex = new Regex(@"(?<extra>.+)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
+        private static readonly Regex PostTitleParametersRegex = new Regex(@"(?<additional>.+)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         private static readonly Regex[] ReportMovieTitleRegex = new[]
         {
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Parser
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),*/
 
             // Normal movie format, e.g: Mission.Impossible.3.2011
-            new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|(1(8|9)|20)\d{2}|\]|\W(1(8|9)|20)\d{2})))+(\W+|_|$)(?!\\)" + ExtraParametersRegex, RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|(1(8|9)|20)\d{2}|\]|\W(1(8|9)|20)\d{2})))+(\W+|_|$)(?!\\)" + PostTitleParametersRegex, RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
             // PassThePopcorn Torrent names: Star.Wars[PassThePopcorn]
             new Regex(@"^(?<title>.+?)?(?:(?:[-_\W](?<![()\[!]))*(?<year>(\[\w *\])))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
@@ -669,9 +669,9 @@ namespace NzbDrone.Core.Parser
                 result.Edition = matchCollection[0].Groups["edition"].Value.Replace(".", " ");
             }
 
-            if (matchCollection[0].Groups["extra"].Success)
+            if (matchCollection[0].Groups["additional"].Success)
             {
-                result.TitleExtraParameters = matchCollection[0].Groups["extra"].Value.Replace(".", " ");
+                result.PostTitleParameters = matchCollection[0].Groups["additional"].Value.Replace(".", " ");
             }
 
             var movieTitles = new List<string>();

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -224,10 +224,8 @@ namespace NzbDrone.Core.Parser
                     Logger.Debug("Reversed name detected. Converted to '{0}'", title);
                 }
 
-                var releaseTitle = RemoveFileExtension(title);
-
                 // Trim dashes from end
-                releaseTitle = releaseTitle.Trim('-', '_');
+                var releaseTitle = title.Trim('-', '_');
 
                 releaseTitle = releaseTitle.Replace("【", "[").Replace("】", "]");
 
@@ -283,6 +281,8 @@ namespace NzbDrone.Core.Parser
                         {
                             continue;
                         }
+
+                        releaseTitle = RemoveFileExtension(releaseTitle);
 
                         // TODO: Add tests for this!
                         var simpleReleaseTitle = SimpleReleaseTitleRegex.Replace(releaseTitle, string.Empty);

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -23,6 +23,8 @@ namespace NzbDrone.Core.Parser
 
         private static readonly RegexReplace[] PreSubstitutionRegex = Array.Empty<RegexReplace>();
 
+        private static readonly Regex ExtraParametersRegex = new Regex(@"(?<extra>.+)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
+
         private static readonly Regex[] ReportMovieTitleRegex = new[]
         {
             // Anime [Subgroup] and Year
@@ -49,7 +51,7 @@ namespace NzbDrone.Core.Parser
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),*/
 
             // Normal movie format, e.g: Mission.Impossible.3.2011
-            new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|(1(8|9)|20)\d{2}|\]|\W(1(8|9)|20)\d{2})))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|(1(8|9)|20)\d{2}|\]|\W(1(8|9)|20)\d{2})))+(\W+|_|$)(?!\\)" + ExtraParametersRegex, RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
             // PassThePopcorn Torrent names: Star.Wars[PassThePopcorn]
             new Regex(@"^(?<title>.+?)?(?:(?:[-_\W](?<![()\[!]))*(?<year>(\[\w *\])))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
@@ -665,6 +667,11 @@ namespace NzbDrone.Core.Parser
             if (matchCollection[0].Groups["edition"].Success)
             {
                 result.Edition = matchCollection[0].Groups["edition"].Value.Replace(".", " ");
+            }
+
+            if (matchCollection[0].Groups["extra"].Success)
+            {
+                result.TitleExtraParameters = matchCollection[0].Groups["extra"].Value.Replace(".", " ");
             }
 
             var movieTitles = new List<string>();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The goal is to include potential file extensions in the calculation of the custom formats score. This bypasses the issue where .xvid is treated as an extension and thus excluded from the release title, resulting in different custom format scores in cases that look similar. Managed this way also makes it possible in the future to completely separate the custom format application only to the extra parameters, without applying them to the release title. I would think that this would also solve some extreme cases where a custom format is matched to the movie title.

#### To take into consideration

I have added the extra parameters regex only to the normal movie format regex. It might be needed to add it to other movie formats.

#### Issues Fixed or Closed by this PR

* Fixes #6824