### PR TITLE
New Feature: Add Download Protocol to Custom Formats and Movie Files

### DIFF
--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -6,6 +6,7 @@ using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.History;
+using NzbDrone.Core.Indexers;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser;
@@ -42,7 +43,8 @@ namespace NzbDrone.Core.CustomFormats
                 Movie = remoteMovie.Movie,
                 Size = size,
                 Languages = remoteMovie.Languages,
-                IndexerFlags = remoteMovie.Release?.IndexerFlags ?? 0
+                IndexerFlags = remoteMovie.Release?.IndexerFlags ?? 0,
+                DownloadProtocol = remoteMovie.Release?.DownloadProtocol ?? 0
             };
 
             return ParseCustomFormat(input);
@@ -79,7 +81,8 @@ namespace NzbDrone.Core.CustomFormats
                 Movie = movie,
                 Size = blocklist.Size ?? 0,
                 Languages = blocklist.Languages,
-                IndexerFlags = blocklist.IndexerFlags
+                IndexerFlags = blocklist.IndexerFlags,
+                DownloadProtocol = blocklist.Protocol
             };
 
             return ParseCustomFormat(input);
@@ -91,6 +94,7 @@ namespace NzbDrone.Core.CustomFormats
 
             long.TryParse(history.Data.GetValueOrDefault("size"), out var size);
             Enum.TryParse(history.Data.GetValueOrDefault("indexerFlags"), true, out IndexerFlags indexerFlags);
+            Enum.TryParse(history.Data.GetValueOrDefault("protocol"), true, out DownloadProtocol downloadProtocol);
 
             var movieInfo = new ParsedMovieInfo
             {
@@ -109,7 +113,8 @@ namespace NzbDrone.Core.CustomFormats
                 Movie = movie,
                 Size = size,
                 Languages = history.Languages,
-                IndexerFlags = indexerFlags
+                IndexerFlags = indexerFlags,
+                DownloadProtocol = downloadProtocol
             };
 
             return ParseCustomFormat(input);
@@ -135,7 +140,8 @@ namespace NzbDrone.Core.CustomFormats
                 Size = localMovie.Size,
                 Languages = localMovie.Languages,
                 IndexerFlags = localMovie.IndexerFlags,
-                Filename = Path.GetFileName(localMovie.Path)
+                Filename = Path.GetFileName(localMovie.Path),
+                DownloadProtocol = localMovie.DownloadItem?.DownloadClientInfo?.Protocol ?? 0
             };
 
             return ParseCustomFormat(input);
@@ -206,7 +212,8 @@ namespace NzbDrone.Core.CustomFormats
                 Size = movieFile.Size,
                 Languages = movieFile.Languages,
                 IndexerFlags = movieFile.IndexerFlags,
-                Filename = Path.GetFileName(movieFile.RelativePath)
+                Filename = Path.GetFileName(movieFile.RelativePath),
+                DownloadProtocol = movieFile.DownloadProtocol
             };
 
             return ParseCustomFormat(input, allCustomFormats);

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatInput.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatInput.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
@@ -13,6 +14,7 @@ namespace NzbDrone.Core.CustomFormats
         public IndexerFlags IndexerFlags { get; set; }
         public List<Language> Languages { get; set; }
         public string Filename { get; set; }
+        public DownloadProtocol DownloadProtocol { get; set; }
 
         public CustomFormatInput()
         {

--- a/src/NzbDrone.Core/CustomFormats/Specifications/DownloadProtocolSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/DownloadProtocolSpecification.cs
@@ -1,0 +1,36 @@
+using FluentValidation;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.CustomFormats
+{
+    public class DownloadProtocolSpecificationValidator : AbstractValidator<DownloadProtocolSpecification>
+    {
+        public DownloadProtocolSpecificationValidator()
+        {
+            RuleFor(c => c.Value).NotEmpty();
+        }
+    }
+
+    public class DownloadProtocolSpecification : CustomFormatSpecificationBase
+    {
+        private static readonly DownloadProtocolSpecificationValidator Validator = new DownloadProtocolSpecificationValidator();
+
+        public override int Order => 11;
+        public override string ImplementationName => "Download Protocol";
+
+        [FieldDefinition(1, Label = "CustomFormatsSpecificationDownloadProtocol", Type = FieldType.Select, SelectOptions = typeof(DownloadProtocol))]
+        public int Value { get; set; }
+
+        protected override bool IsSatisfiedByWithoutNegate(CustomFormatInput input)
+        {
+            return input.DownloadProtocol == (DownloadProtocol)Value;
+        }
+
+        public override NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate(this));
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/242_add_download_protocol_to_moviefiles.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/242_add_download_protocol_to_moviefiles.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(242)]
+    public class add_download_protocol_to_moviefiles : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("MovieFiles").AddColumn("DownloadProtocol").AsInt32().WithDefaultValue(0);
+        }
+    }
+}

--- a/src/NzbDrone.Core/History/HistoryService.cs
+++ b/src/NzbDrone.Core/History/HistoryService.cs
@@ -203,6 +203,7 @@ namespace NzbDrone.Core.History
             history.Data.Add("DownloadClient", message.DownloadClientInfo?.Type);
             history.Data.Add("DownloadClientName", message.DownloadClientInfo?.Name);
             history.Data.Add("ReleaseGroup", message.MovieInfo.ReleaseGroup);
+            history.Data.Add("Protocol", ((int)message.MovieInfo.DownloadItem?.DownloadClientInfo?.Protocol).ToString());
             history.Data.Add("CustomFormatScore", message.MovieInfo.CustomFormatScore.ToString());
             history.Data.Add("Size", message.MovieInfo.Size.ToString());
             history.Data.Add("IndexerFlags", message.ImportedMovie.IndexerFlags.ToString());

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -276,6 +276,7 @@
   "CustomFormatsSettings": "Custom Formats Settings",
   "CustomFormatsSettingsSummary": "Custom Formats and Settings",
   "CustomFormatsSettingsTriggerInfo": "A Custom Format will be applied to a release or file when it matches at least one of each of the different condition types chosen.",
+  "CustomFormatsSpecificationDownloadProtocol": "Download Protocol",
   "CustomFormatsSpecificationExceptLanguage": "Except Language",
   "CustomFormatsSpecificationExceptLanguageHelpText": "Matches if any language other than the selected language is present",
   "CustomFormatsSpecificationFlag": "Flag",

--- a/src/NzbDrone.Core/MediaFiles/MovieFile.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieFile.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Movies;
@@ -26,6 +27,7 @@ namespace NzbDrone.Core.MediaFiles
         public string Edition { get; set; }
         public Movie Movie { get; set; }
         public List<Language> Languages { get; set; }
+        public DownloadProtocol DownloadProtocol { get; set; }
 
         public override string ToString()
         {

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportApprovedMovie.cs
@@ -96,6 +96,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
                     movieFile.Movie = localMovie.Movie;
                     movieFile.ReleaseGroup = localMovie.ReleaseGroup;
                     movieFile.Edition = localMovie.Edition;
+                    movieFile.DownloadProtocol = localMovie.DownloadItem?.DownloadClientInfo?.Protocol ?? 0;
 
                     if (downloadClientItem?.DownloadId.IsNotNullOrWhiteSpace() == true)
                     {


### PR DESCRIPTION
- Added DownloadProtocol to CustomFormatInput
- Created DownloadProtocolSpecification for Custom Formats
- Added DownloadProtocol column to MovieFiles via migration
- Updated HistoryService to track download protocol
- Added localization for download protocol specification

#### Database Migration
YES - 242

#### Description
This pull request adds a new custom format option for download protocol. This is NOT an indexer priority feature. It just checks if the download protocol is usenet or torrent. This can be useful in many scenarios but I needed it for 2 specific reasons.

1. I wanted to prioritize usenet due to disk space constrains. Then freeleech torrent and then torrent. Normally, you would prioritize your indexers in your indexer manager etc. However, this only works if the releases all have the same custom format score and prioritizing freeleech is not possible without adding the freeleech indexer flag custom format. Adding that custom format changes the release's score making it more preferable than usenet. Lets say we have a release from 3 different indexers: 1 usenet and 2 torrent. They all have the same score. If we add +10 for freeleech relases, it would prevent usenet from being prefered. But if we don't, non-freeleech options could be preferred based on the indexer priority if there is no usenet option. With this custom format option, users can give usenet like +20 and freeleech +10 etc. This way, if identical releases have all the options, usenet is prefered. If not, freeleech would be preferred. If that is not available as well, download would be decided based on indexer priority like always. 

2. Sometimes a torrent has just a little bit higher score than usenet (like DD vs DD+, my setup only differs 10 points for those) and I would still prefer usenet instead of needing to keep the file for a long time over that tiny improvement. With this feature, users can bump usenet releases a little bit, according to their custom format scoring.

This change doesn't affect anybody if they don't want to use it but it would make a lot of people happy. 

#### Screenshot (if UI related)
![Screenshot from 2025-02-16 19-46-42](https://github.com/user-attachments/assets/88ef4e64-a71b-41c3-9623-87baa88dd682)

![Screenshot from 2025-02-16 19-46-48](https://github.com/user-attachments/assets/f567cca2-1424-4c97-8de7-ea6a8af444ea)

#### Todos
- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #4279