### PR TITLE
Fixed: Replace diacritics in Clean Title naming tokens

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleFixture.cs
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         }
 
         [TestCase("Florence + the Machine", "Florence + the Machine")]
-        [TestCase("Beyoncé X10", "Beyoncé X10")]
+        [TestCase("Beyoncé X10", "Beyonce X10")]
         [TestCase("Girlfriends' Guide to Divorce", "Girlfriends Guide to Divorce")]
         [TestCase("Rule #23: Never Lie to the Kids", "Rule #23 Never Lie to the Kids")]
         [TestCase("Anne Hathaway/Florence + The Machine", "Anne Hathaway Florence + The Machine")]
@@ -70,8 +70,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [TestCase("Won`t Get Fooled Again", "Wont Get Fooled Again")]
         [TestCase("Don’t Blink", "Dont Blink")]
         [TestCase("The ` Legend of Kings", "The Legend of Kings")]
-
-        // [TestCase("", "")]
+        [TestCase("Joker: Folie à deux", "Joker Folie a deux")]
         public void should_get_expected_title_back(string title, string expected)
         {
             _series.Title = title;

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -220,7 +220,7 @@ namespace NzbDrone.Core.Organizer
             title = ScenifyReplaceChars.Replace(title, " ");
             title = ScenifyRemoveChars.Replace(title, string.Empty);
 
-            return title;
+            return title.RemoveDiacritics();
         }
 
         public static string TitleThe(string title)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Replacing diacritics for clean title naming tokens to provide cleaner paths.

#### Issues Fixed or Closed by this PR

* Fixes #10911