### PR TITLE
feat: Use ChangeTracker for MovieMetadata update

### DIFF
--- a/src/NzbDrone.Core.Test/MovieTests/AlternativeTitleServiceTests/AlternativeTitleServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/AlternativeTitleServiceTests/AlternativeTitleServiceFixture.cs
@@ -43,8 +43,12 @@ namespace NzbDrone.Core.Test.MovieTests.AlternativeTitleServiceTests
         [Test]
         public void should_update_insert_remove_titles()
         {
-            var titles = new List<AlternativeTitle> { _title2, _title3 };
-            var updates = new List<AlternativeTitle> { _title2 };
+            // Deep copy of _title2, but change Title
+            // to ensure it gets into the update list
+            var updatedTitle2 = _title2.JsonClone();
+            updatedTitle2.Title = updatedTitle2.Title + "TEST";
+            var titles = new List<AlternativeTitle> { updatedTitle2, _title3 };
+            var updates = new List<AlternativeTitle> { updatedTitle2 };
             var deletes = new List<AlternativeTitle> { _title1 };
             var inserts = new List<AlternativeTitle> { _title3 };
             GivenExistingTitles(_title1, _title2);
@@ -98,11 +102,22 @@ namespace NzbDrone.Core.Test.MovieTests.AlternativeTitleServiceTests
             var existingTitle = Builder<AlternativeTitle>.CreateNew().With(t => t.Id = 2).Build();
             GivenExistingTitles(existingTitle);
             var updateTitle = existingTitle.JsonClone();
+            updateTitle.Title = updateTitle.Title + "TEST";
             updateTitle.Id = 0;
 
             Subject.UpdateTitles(new List<AlternativeTitle> { updateTitle }, _movie);
 
             Mocker.GetMock<IAlternativeTitleRepository>().Verify(r => r.UpdateMany(It.Is<IList<AlternativeTitle>>(list => list.First().Id == existingTitle.Id)), Times.Once());
+        }
+
+        [Test]
+        public void should_not_update_same_translations()
+        {
+            GivenExistingTitles(_title1);
+
+            Subject.UpdateTitles(new List<AlternativeTitle> { _title1 }, _movie);
+
+            Mocker.GetMock<IAlternativeTitleRepository>().Verify(r => r.UpdateMany(new List<AlternativeTitle>()), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MovieTests/CreditTests/CreditServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/CreditTests/CreditServiceFixture.cs
@@ -101,6 +101,20 @@ namespace NzbDrone.Core.Test.MovieTests.AlternativeTitleServiceTests
         }
 
         [Test]
+        public void should_remove_existing_duplicates()
+        {
+            var duplicated = _credit1.JsonClone();
+            duplicated.Id = 2;
+            GivenExistingCredits(_credit1, duplicated);
+            var translations = new List<Credit> { _credit1 };
+            var deleted = new List<Credit> { duplicated };
+
+            Subject.UpdateCredits(translations, _movie);
+
+            Mocker.GetMock<ICreditRepository>().Verify(r => r.DeleteMany(deleted), Times.Once());
+        }
+
+        [Test]
         public void should_not_update_same_credits()
         {
             GivenExistingCredits(_credit1);

--- a/src/NzbDrone.Core.Test/MovieTests/CreditTests/CreditServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/CreditTests/CreditServiceFixture.cs
@@ -43,8 +43,11 @@ namespace NzbDrone.Core.Test.MovieTests.AlternativeTitleServiceTests
         [Test]
         public void should_update_insert_remove_titles()
         {
-            var titles = new List<Credit> { _credit2, _credit3 };
-            var updates = new List<Credit> { _credit2 };
+            var updatedCredit2 = _credit2.JsonClone();
+            updatedCredit2.Character = updatedCredit2.Character + "TEST";
+
+            var titles = new List<Credit> { updatedCredit2, _credit3 };
+            var updates = new List<Credit> { updatedCredit2 };
             var deletes = new List<Credit> { _credit1 };
             var inserts = new List<Credit> { _credit3 };
 
@@ -89,11 +92,22 @@ namespace NzbDrone.Core.Test.MovieTests.AlternativeTitleServiceTests
             GivenExistingCredits(existingCredit);
 
             var updateCredit = existingCredit.JsonClone();
+            updateCredit.Character = updateCredit.Character + "TEST";
             updateCredit.Id = 0;
 
             Subject.UpdateCredits(new List<Credit> { updateCredit }, _movie);
 
             Mocker.GetMock<ICreditRepository>().Verify(r => r.UpdateMany(It.Is<IList<Credit>>(list => list.First().Id == existingCredit.Id)), Times.Once());
+        }
+
+        [Test]
+        public void should_not_update_same_credits()
+        {
+            GivenExistingCredits(_credit1);
+
+            Subject.UpdateCredits(new List<Credit> { _credit1 }, _movie);
+
+            Mocker.GetMock<ICreditRepository>().Verify(r => r.UpdateMany(new List<Credit>()), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MovieTests/Translations/TranslationServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/Translations/TranslationServiceFixture.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Translations;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.MovieTests.TranslationServiceTests
+{
+    [TestFixture]
+    public class TranslationServiceFixture : CoreTest<MovieTranslationService>
+    {
+        private MovieTranslation _translation1;
+        private MovieTranslation _translation2;
+        private MovieTranslation _translation3;
+
+        private MovieMetadata _movie;
+
+        [SetUp]
+        public void Setup()
+        {
+            var generated = 3;
+            var langs = Pick<Language>.UniqueRandomList(generated).From(Language.All);
+            var translations = Builder<MovieTranslation>.CreateListOfSize(generated).All()
+                .With(t => t.MovieMetadataId = 0)
+                .With((t, idx) => t.Language = langs[idx]).Build();
+            _translation1 = translations[0];
+            _translation2 = translations[1];
+            _translation3 = translations[2];
+
+            _movie = Builder<MovieMetadata>.CreateNew()
+                .With(m => m.CleanTitle = "myothertitle")
+                .With(m => m.Id = 1)
+                .Build();
+        }
+
+        private void GivenExistingTranslations(params MovieTranslation[] titles)
+        {
+            Mocker.GetMock<IMovieTranslationRepository>().Setup(r => r.FindByMovieMetadataId(_movie.Id))
+                .Returns(titles.ToList());
+        }
+
+        [Test]
+        public void should_update_insert_remove_titles()
+        {
+            // Deep copy of _title2, but change Title
+            // to ensure it gets into the update list
+            var updatedTranslation2 = _translation2.JsonClone();
+            updatedTranslation2.Title = updatedTranslation2.Title + "TEST";
+            var translations = new List<MovieTranslation> { updatedTranslation2, _translation3 };
+            var updates = new List<MovieTranslation> { updatedTranslation2 };
+            var deletes = new List<MovieTranslation> { _translation1 };
+            var inserts = new List<MovieTranslation> { _translation3 };
+            GivenExistingTranslations(_translation1, _translation2);
+
+            Subject.UpdateTranslations(translations, _movie);
+
+            Mocker.GetMock<IMovieTranslationRepository>().Verify(r => r.InsertMany(inserts), Times.Once());
+            Mocker.GetMock<IMovieTranslationRepository>().Verify(r => r.UpdateMany(updates), Times.Once());
+            Mocker.GetMock<IMovieTranslationRepository>().Verify(r => r.DeleteMany(deletes), Times.Once());
+        }
+
+        [Test]
+        public void should_not_insert_duplicates()
+        {
+            GivenExistingTranslations();
+            var translations = new List<MovieTranslation> { _translation1, _translation1 };
+            var inserts = new List<MovieTranslation> { _translation1 };
+
+            Subject.UpdateTranslations(translations, _movie);
+
+            Mocker.GetMock<IMovieTranslationRepository>().Verify(r => r.InsertMany(inserts), Times.Once());
+        }
+
+        [Test]
+        public void should_update_movie_id()
+        {
+            GivenExistingTranslations();
+            var translations = new List<MovieTranslation> { _translation1, _translation2 };
+
+            Subject.UpdateTranslations(translations, _movie);
+
+            _translation1.MovieMetadataId.Should().Be(_movie.Id);
+            _translation2.MovieMetadataId.Should().Be(_movie.Id);
+        }
+
+        [Test]
+        public void should_update_with_correct_id()
+        {
+            var existingTranslations = Builder<MovieTranslation>.CreateNew()
+                .With(t => t.Id = 2)
+                .With(t => t.Language = Language.French).Build();
+            GivenExistingTranslations(existingTranslations);
+            var updateTranslations = existingTranslations.JsonClone();
+            updateTranslations.Overview = "Overview";
+            updateTranslations.Id = 0;
+
+            Subject.UpdateTranslations(new List<MovieTranslation> { updateTranslations }, _movie);
+
+            Mocker.GetMock<IMovieTranslationRepository>().Verify(r => r.UpdateMany(It.Is<IList<MovieTranslation>>(list => list.First().Id == existingTranslations.Id)), Times.Once());
+        }
+
+        [Test]
+        public void should_not_update_same_translations()
+        {
+            GivenExistingTranslations(_translation1);
+
+            Subject.UpdateTranslations(new List<MovieTranslation> { _translation1 }, _movie);
+
+            Mocker.GetMock<IMovieTranslationRepository>().Verify(r => r.UpdateMany(new List<MovieTranslation>()), Times.Once());
+        }
+    }
+}

--- a/src/NzbDrone.Core/ChangeDetector/ChangeDetector.cs
+++ b/src/NzbDrone.Core/ChangeDetector/ChangeDetector.cs
@@ -2,12 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Equ;
-using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Movies;
 
 namespace NzbDrone.Core.ChangeDetector
 {
     internal static class ChangeDetector<TSource>
-        where TSource : ModelBase
+        where TSource : Entity<TSource>
     {
         private static MemberwiseEqualityComparer<TSource> _comparer;
 
@@ -37,6 +37,7 @@ namespace NzbDrone.Core.ChangeDetector
             insert = new List<TSource>();
             update = new List<TSource>();
             var existingClean = existing.ToList();
+
             foreach (var src in source)
             {
                 // Try to find from current DB stored entities if one match
@@ -56,12 +57,11 @@ namespace NzbDrone.Core.ChangeDetector
                     // Remove to only keep MovieTranslation that should be removed
                     existingClean.Remove(foundDb);
 
+                    src.UseDbFieldsFrom(foundDb);
+
                     // Exists, deep comparison to check if a property change
                     if (!_comparer.Equals(src, foundDb))
                     {
-                        // At least one property changed, update
-                        // Set the Id to the entity to update
-                        src.Id = foundDb.Id;
                         update.Add(src);
                     }
                 }

--- a/src/NzbDrone.Core/ChangeDetector/ChangeDetector.cs
+++ b/src/NzbDrone.Core/ChangeDetector/ChangeDetector.cs
@@ -4,9 +4,9 @@ using System.Linq;
 using Equ;
 using NzbDrone.Core.Datastore;
 
-namespace NzbDrone.Core.ChangeTracker
+namespace NzbDrone.Core.ChangeDetector
 {
-    internal static class ChangeTracker<TSource>
+    internal static class ChangeDetector<TSource>
         where TSource : ModelBase
     {
         private static MemberwiseEqualityComparer<TSource> _comparer;

--- a/src/NzbDrone.Core/ChangeTracker/ChangeTracker.cs
+++ b/src/NzbDrone.Core/ChangeTracker/ChangeTracker.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Equ;
+using NzbDrone.Core.Datastore;
+
+namespace NzbDrone.Core.ChangeTracker
+{
+    internal static class ChangeTracker<TSource>
+        where TSource : ModelBase
+    {
+        private static MemberwiseEqualityComparer<TSource> _comparer;
+
+        internal static void DetectChanges<TKey>(
+            IEnumerable<TSource> source,
+            IEnumerable<TSource> existing,
+            Func<TSource, TKey> keySelector,
+            out List<TSource> insert,
+            out List<TSource> update,
+            out List<TSource> delete)
+            where TKey : class =>
+        DetectChanges(source, existing, keySelector, null, out insert, out update, out delete);
+
+        internal static void DetectChanges<TKey>(
+            IEnumerable<TSource> source,
+            IEnumerable<TSource> existing,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer,
+            out List<TSource> insert,
+            out List<TSource> update,
+            out List<TSource> delete)
+            where TKey : class
+        {
+            keyComparer ??= EqualityComparer<TKey>.Default;
+            _comparer ??= MemberwiseEqualityComparer<TSource>.ByProperties;
+
+            insert = new List<TSource>();
+            update = new List<TSource>();
+            var existingClean = existing.ToList();
+            foreach (var src in source)
+            {
+                // Try to find from current DB stored entities if one match
+                var foundDb = existing.FirstOrDefault(t =>
+
+                    // Optimization: Use HashCode first, and then Equality comparer
+                    keyComparer.GetHashCode(keySelector(src)) == keyComparer.GetHashCode(keySelector(t)) &&
+                    keyComparer.Equals(keySelector(src), keySelector(t)));
+
+                // Does not exist, to insert
+                if (foundDb == null)
+                {
+                    insert.Add(src);
+                }
+                else
+                {
+                    // Remove to only keep MovieTranslation that should be removed
+                    existingClean.Remove(foundDb);
+
+                    // Exists, deep comparison to check if a property change
+                    if (!_comparer.Equals(src, foundDb))
+                    {
+                        // At least one property changed, update
+                        // Set the Id to the entity to update
+                        src.Id = foundDb.Id;
+                        update.Add(src);
+                    }
+                }
+            }
+
+            // The only elements that remains in current DB stored entities
+            // are the one not matching any of the new entities
+            // They should be removed
+            delete = existingClean;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/ModelBase.cs
+++ b/src/NzbDrone.Core/Datastore/ModelBase.cs
@@ -1,10 +1,12 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
+using Equ;
 
 namespace NzbDrone.Core.Datastore
 {
     [DebuggerDisplay("{GetType()} ID = {Id}")]
     public abstract class ModelBase
     {
+        [MemberwiseEqualityIgnore]
         public int Id { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Datastore/ModelBase.cs
+++ b/src/NzbDrone.Core/Datastore/ModelBase.cs
@@ -1,12 +1,10 @@
 using System.Diagnostics;
-using Equ;
 
 namespace NzbDrone.Core.Datastore
 {
     [DebuggerDisplay("{GetType()} ID = {Id}")]
     public abstract class ModelBase
     {
-        [MemberwiseEqualityIgnore]
         public int Id { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitle.cs
+++ b/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitle.cs
@@ -1,9 +1,8 @@
-using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Parser;
 
 namespace NzbDrone.Core.Movies.AlternativeTitles
 {
-    public class AlternativeTitle : ModelBase
+    public class AlternativeTitle : Entity<AlternativeTitle>
     {
         public SourceType SourceType { get; set; }
         public int MovieMetadataId { get; set; }
@@ -23,9 +22,7 @@ namespace NzbDrone.Core.Movies.AlternativeTitles
 
         public override bool Equals(object obj)
         {
-            var item = obj as AlternativeTitle;
-
-            if (item == null)
+            if (obj is not AlternativeTitle item)
             {
                 return false;
             }

--- a/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitleService.cs
+++ b/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitleService.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
-using NzbDrone.Core.ChangeTracker;
+using NzbDrone.Core.ChangeDetector;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Movies.Events;
@@ -88,7 +88,7 @@ namespace NzbDrone.Core.Movies.AlternativeTitles
             // Now find titles to delete, update and insert.
             var existingTitles = _titleRepo.FindByMovieMetadataId(movieMetadataId);
 
-            ChangeTracker<AlternativeTitle>.DetectChanges(titles, existingTitles, t => t, out var insert, out var update, out var delete);
+            ChangeDetector<AlternativeTitle>.DetectChanges(titles, existingTitles, t => t, out var insert, out var update, out var delete);
 
             _logger.Debug("UpdateTitles({0}): [{1}] inserts, [{2}] updates, [{3}] deletes", titles.Count, insert.Count, update.Count, delete.Count);
 

--- a/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitleService.cs
+++ b/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitleService.cs
@@ -88,7 +88,7 @@ namespace NzbDrone.Core.Movies.AlternativeTitles
             // Now find titles to delete, update and insert.
             var existingTitles = _titleRepo.FindByMovieMetadataId(movieMetadataId);
 
-            ChangeDetector<AlternativeTitle>.DetectChanges(titles, existingTitles, t => t, out var insert, out var update, out var delete);
+            ChangeDetector<AlternativeTitle>.DetectChanges(titles, existingTitles, t => t.CleanTitle, out var insert, out var update, out var delete);
 
             _logger.Debug("UpdateTitles({0}): [{1}] inserts, [{2}] updates, [{3}] deletes", titles.Count, insert.Count, update.Count, delete.Count);
 

--- a/src/NzbDrone.Core/Movies/Credits/Credit.cs
+++ b/src/NzbDrone.Core/Movies/Credits/Credit.cs
@@ -1,9 +1,8 @@
 using System.Collections.Generic;
-using NzbDrone.Core.Datastore;
 
 namespace NzbDrone.Core.Movies.Credits
 {
-    public class Credit : ModelBase
+    public class Credit : Entity<Credit>
     {
         public Credit()
         {

--- a/src/NzbDrone.Core/Movies/Credits/CreditService.cs
+++ b/src/NzbDrone.Core/Movies/Credits/CreditService.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
-using NzbDrone.Core.ChangeTracker;
+using NzbDrone.Core.ChangeDetector;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Movies.Events;
 
@@ -74,7 +74,7 @@ namespace NzbDrone.Core.Movies.Credits
             // Should never have multiple credits with same credit_id, but check to ensure incase TMDB is on fritz
             var dupeFreeCredits = credits.DistinctBy(m => m.CreditTmdbId).ToList();
 
-            ChangeTracker<Credit>.DetectChanges(dupeFreeCredits, existingCredits, t => t.CreditTmdbId, out var insert, out var update, out var delete);
+            ChangeDetector<Credit>.DetectChanges(dupeFreeCredits, existingCredits, t => t.CreditTmdbId, out var insert, out var update, out var delete);
 
             _logger.Debug("CreditService({0}): [{1}] inserts, [{2}] updates, [{3}] deletes", credits.Count, insert.Count, update.Count, delete.Count);
             _creditRepo.DeleteMany(delete);

--- a/src/NzbDrone.Core/Movies/Credits/CreditService.cs
+++ b/src/NzbDrone.Core/Movies/Credits/CreditService.cs
@@ -77,6 +77,7 @@ namespace NzbDrone.Core.Movies.Credits
             ChangeDetector<Credit>.DetectChanges(dupeFreeCredits, existingCredits, t => t.CreditTmdbId, out var insert, out var update, out var delete);
 
             _logger.Debug("CreditService({0}): [{1}] inserts, [{2}] updates, [{3}] deletes", credits.Count, insert.Count, update.Count, delete.Count);
+
             _creditRepo.DeleteMany(delete);
             _creditRepo.UpdateMany(update);
             _creditRepo.InsertMany(insert);

--- a/src/NzbDrone.Core/Movies/Translations/MovieTranslation.cs
+++ b/src/NzbDrone.Core/Movies/Translations/MovieTranslation.cs
@@ -1,9 +1,8 @@
-using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Languages;
 
 namespace NzbDrone.Core.Movies.Translations
 {
-    public class MovieTranslation : ModelBase
+    public class MovieTranslation : Entity<MovieTranslation>
     {
         public int MovieMetadataId { get; set; }
         public string Title { get; set; }

--- a/src/NzbDrone.Core/Movies/Translations/MovieTranslationService.cs
+++ b/src/NzbDrone.Core/Movies/Translations/MovieTranslationService.cs
@@ -61,6 +61,7 @@ namespace NzbDrone.Core.Movies.Translations
             ChangeDetector<MovieTranslation>.DetectChanges(translations, existingTranslations, t => t.Language, out var insert, out var update, out var delete);
 
             _logger.Debug("UpdateTranslation({0}): [{1}] inserts, [{2}] updates, [{3}] deletes", translations.Count, insert.Count, update.Count, delete.Count);
+
             _translationRepo.DeleteMany(delete);
             _translationRepo.UpdateMany(update);
             _translationRepo.InsertMany(insert);

--- a/src/NzbDrone.Core/Movies/Translations/MovieTranslationService.cs
+++ b/src/NzbDrone.Core/Movies/Translations/MovieTranslationService.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
-using NzbDrone.Core.ChangeTracker;
+using NzbDrone.Core.ChangeDetector;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Movies.Events;
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Movies.Translations
             // Now find translations to delete, update and insert
             var existingTranslations = _translationRepo.FindByMovieMetadataId(movieMetadataId);
 
-            ChangeTracker<MovieTranslation>.DetectChanges(translations, existingTranslations, t => t.Language, out var insert, out var update, out var delete);
+            ChangeDetector<MovieTranslation>.DetectChanges(translations, existingTranslations, t => t.Language, out var insert, out var update, out var delete);
 
             _logger.Debug("UpdateTranslation({0}): [{1}] inserts, [{2}] updates, [{3}] deletes", translations.Count, insert.Count, update.Count, delete.Count);
             _translationRepo.DeleteMany(delete);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Detect changes between existing metadata on database and retrieved online. Only executes SQL Updates on metadata that actually changed.
Used the existing NuGet package Equ available on `Radarr.Core` to perform Deep Equality between objects.
Also added some unit test to ensure no regression on metadata that need actual CRUD operation.

#### Context
On my Synology NAS (HDD), "RefreshMovie" takes around 4 hours with version 5.18.4.9674 for 443 films.
With this PR, the same task went down to ~12 minutes. A single file is about 30 seconds on average, depending on the number of metadata. The same film, but with change detection is a lot faster if there is no change to metadata (or very few).

<ins>Version 5.18.4.9674:</ins>
```
2025-02-27 18:23:22.2|Info|RefreshMovieService|Updating info for 10 Things I Hate About You
2025-02-27 18:23:46.0|Info|DiskScanService|Scanning disk for 10 Things I Hate About You
2025-02-27 18:23:46.1|Info|DiskScanService|Completed scanning disk for 10 Things I Hate About You
2025-02-27 18:23:46.1|Info|ExistingMetadataImporter|Found 0 existing metadata files
2025-02-27 18:23:46.1|Info|ExistingSubtitleImporter|Found 0 existing subtitle files
2025-02-27 18:23:46.1|Info|ExistingOtherExtraImporter|Found 0 existing other extra files
2025-02-27 18:23:46.1|Info|ExistingExtraFileService|Found 0 possible extra files, imported 0 files.
```

<ins>With change:</ins>
```
2025-02-27 08:22:59.8|Info|RefreshMovieService|Updating info for 10 Things I Hate About You
2025-02-27 08:23:00.3|Info|DiskScanService|Scanning disk for 10 Things I Hate About You
2025-02-27 08:23:00.4|Info|DiskScanService|Completed scanning disk for 10 Things I Hate About You
2025-02-27 08:23:00.4|Info|ExistingMetadataImporter|Found 0 existing metadata files
2025-02-27 08:23:00.4|Info|ExistingSubtitleImporter|Found 0 existing subtitle files
2025-02-27 08:23:00.4|Info|ExistingOtherExtraImporter|Found 0 existing other extra files
2025-02-27 08:23:00.4|Info|ExistingExtraFileService|Found 0 possible extra files, imported 0 files.
```

With an SSD (Laptop, Windows 10), the difference is a lot less impressive, but is still noticeable:
Version 5.18.4.9674: 3mn
With change: 2mn

Here are the performance I witnessed on my devices:
| Disk | Version | Duration | Ratio |
| ----- | -------- | --------- | ------ |
| HDD | 5.18.4.9674 | 03:46:17 | 1.0 |
| HDD | latest + PR | 00:11:17 | 0.04 |
| SSD | 5.18.4.9674 | 00:03:08 | 1.0 |
| SSD | latest + PR | 00:02:03 |  0.65 |