### PR TITLE
Fixed: Spelling in IMDb List Validator (mist -> must)

### DIFF
--- a/src/NzbDrone.Core/ImportLists/RadarrList2/IMDb/IMDbListSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/RadarrList2/IMDb/IMDbListSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.ImportLists.RadarrList2.IMDbList
         {
             RuleFor(c => c.ListId)
                 .Matches(@"^top250$|^popular$|^ls\d+$|^ur\d+$")
-                .WithMessage("List ID mist be 'top250', 'popular', an IMDb List ID of the form 'ls12345678' or an IMDb user watchlist of the form 'ur12345678'");
+                .WithMessage("List ID must be 'top250', 'popular', an IMDb List ID of the form 'ls12345678' or an IMDb user watchlist of the form 'ur12345678'");
         }
     }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This Pull Request fixes a _very important_ spelling mistake on the IMDb List Validation.

#### Screenshot (if UI related)
<img width="557" alt="image" src="https://github.com/user-attachments/assets/0e4c61e0-a3c3-400a-9090-30d781cb971e" />

#### Todos
- [n/a] Tests
- [n/a] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [n/a] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

n/a