### PR TITLE
Fixed: Parse EN from release titles as English

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -11,6 +11,8 @@ namespace NzbDrone.Core.Test.ParserTests
     public class LanguageParserFixture : CoreTest
     {
         [TestCase("Movie.Title.1994.English.1080p.XviD-LOL")]
+        [TestCase("Movie Title 1994 Eng 1080p XviD-GROUP")]
+        [TestCase("Movie Title 1994 EN 1080p XviD-GROUP")]
         public void should_parse_language_english(string postTitle)
         {
             var result = Parser.Parser.ParseMovieTitle(postTitle, true);
@@ -22,6 +24,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie.Title.2018.2160p.WEBRip.x265.10bit.HDR.DD5.1-GASMASK")]
         [TestCase("Movie.Title.2010.720p.BluRay.x264.-[YTS.LT]")]
         [TestCase("Movie.Title.2010.SUBFRENCH.1080p.WEB.x264-GROUP")]
+        [TestCase("Movie.Title.2010.En.1080p.WEB.x264-GROUP")]
         public void should_parse_language_unknown(string postTitle)
         {
             var result = Parser.Parser.ParseMovieTitle(postTitle, true);

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -41,7 +41,8 @@ namespace NzbDrone.Core.Parser
                                                                             (?<original>\b(?:orig|original)\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
-        private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?:(?i)(?<!SUB[\W|_|^]))(?:(?<lithuanian>\bLT\b)|
+        private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?:(?i)(?<!SUB[\W|_|^]))(?:(?<english>\bEN\b)|
+                                                                                                          (?<lithuanian>\bLT\b)|
                                                                                                           (?<czech>\bCZ\b)|
                                                                                                           (?<polish>\bPL\b)|
                                                                                                           (?<bulgarian>\bBG\b)|
@@ -259,6 +260,11 @@ namespace NzbDrone.Core.Parser
 
             foreach (Match match in caseSensitiveMatches)
             {
+                if (match.Groups["english"].Captures.Any())
+                {
+                    languages.Add(Language.English);
+                }
+
                 if (match.Groups["lithuanian"].Captures.Any())
                 {
                     languages.Add(Language.Lithuanian);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adding case sensitive matching for `EN` as the English language. 