### PR TITLE
Fixed: Deprecate MovieFile on movies endpoints

### DIFF
--- a/frontend/src/Movie/Index/ProgressBar/MovieIndexProgressBar.tsx
+++ b/frontend/src/Movie/Index/ProgressBar/MovieIndexProgressBar.tsx
@@ -13,7 +13,7 @@ import styles from './MovieIndexProgressBar.css';
 
 interface MovieIndexProgressBarProps {
   movieId: number;
-  movieFile: MovieFile;
+  movieFile?: MovieFile;
   monitored: boolean;
   status: MovieStatus;
   hasFile: boolean;
@@ -24,20 +24,18 @@ interface MovieIndexProgressBarProps {
   isStandAlone?: boolean;
 }
 
-function MovieIndexProgressBar(props: MovieIndexProgressBarProps) {
-  const {
-    movieId,
-    movieFile,
-    monitored,
-    status,
-    hasFile,
-    isAvailable,
-    width,
-    detailedProgressBar,
-    bottomRadius,
-    isStandAlone,
-  } = props;
-
+function MovieIndexProgressBar({
+  movieId,
+  movieFile,
+  monitored,
+  status,
+  hasFile,
+  isAvailable,
+  width,
+  detailedProgressBar,
+  bottomRadius,
+  isStandAlone,
+}: MovieIndexProgressBarProps) {
   const queueDetails: MovieQueueDetails = useSelector(
     createMovieQueueItemsDetailsSelector(movieId)
   );

--- a/src/Radarr.Api.V3/Movies/MovieResource.cs
+++ b/src/Radarr.Api.V3/Movies/MovieResource.cs
@@ -80,7 +80,6 @@ namespace Radarr.Api.V3.Movies
         public DateTime Added { get; set; }
         public AddMovieOptions AddOptions { get; set; }
         public Ratings Ratings { get; set; }
-        public MovieFileResource MovieFile { get; set; }
         public MovieCollectionResource Collection { get; set; }
         public float Popularity { get; set; }
         public DateTime? LastSearchTime { get; set; }
@@ -95,6 +94,9 @@ namespace Radarr.Api.V3.Movies
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         [SwaggerIgnore]
         public bool IsExcluded { get; set; }
+
+        [Obsolete("Deprecated")]
+        public MovieFileResource MovieFile { get; set; }
     }
 
     public static class MovieResourceMapper
@@ -158,12 +160,15 @@ namespace Radarr.Api.V3.Movies
                 AddOptions = model.AddOptions,
                 AlternateTitles = model.MovieMetadata.Value.AlternativeTitles.ToResource(),
                 Ratings = model.MovieMetadata.Value.Ratings,
-                MovieFile = movieFile,
                 YouTubeTrailerId = model.MovieMetadata.Value.YouTubeTrailerId,
                 Studio = model.MovieMetadata.Value.Studio,
                 Collection = collection,
                 Popularity = model.MovieMetadata.Value.Popularity,
                 LastSearchTime = model.LastSearchTime,
+
+#pragma warning disable CS0618
+                MovieFile = movieFile,
+#pragma warning restore CS0618
             };
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
MovieFile on the movies resources slows down loading of the `/movie` endpoint, and eventually need to be removed when multi-part files support will be added.

The only use-case for this property is the use of quality in `MovieIndexProgressBar`.