### PR TITLE
Fixed: Improve times for refreshing movies

### DIFF
--- a/src/NzbDrone.Core.Test/MovieTests/CreditTests/CreditServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/CreditTests/CreditServiceFixture.cs
@@ -53,7 +53,7 @@ namespace NzbDrone.Core.Test.MovieTests.AlternativeTitleServiceTests
             Subject.UpdateCredits(titles, _movie);
 
             Mocker.GetMock<ICreditRepository>().Verify(r => r.InsertMany(inserts), Times.Once());
-            Mocker.GetMock<ICreditRepository>().Verify(r => r.UpdateMany(updates), Times.Once());
+            Mocker.GetMock<ICreditRepository>().Verify(r => r.UpdateMany(new List<Credit>()), Times.Once());
             Mocker.GetMock<ICreditRepository>().Verify(r => r.DeleteMany(deletes), Times.Once());
         }
 
@@ -91,9 +91,12 @@ namespace NzbDrone.Core.Test.MovieTests.AlternativeTitleServiceTests
             var updateCredit = existingCredit.JsonClone();
             updateCredit.Id = 0;
 
-            Subject.UpdateCredits(new List<Credit> { updateCredit }, _movie);
+            var result = Subject.UpdateCredits(new List<Credit> { updateCredit }, _movie);
 
-            Mocker.GetMock<ICreditRepository>().Verify(r => r.UpdateMany(It.Is<IList<Credit>>(list => list.First().Id == existingCredit.Id)), Times.Once());
+            result.Should().HaveCount(1);
+            result.First().Id.Should().Be(existingCredit.Id);
+
+            Mocker.GetMock<ICreditRepository>().Verify(r => r.UpdateMany(It.Is<IList<Credit>>(l => l.Count == 0)), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/ModelBase.cs
+++ b/src/NzbDrone.Core/Datastore/ModelBase.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 namespace NzbDrone.Core.Datastore
 {

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -617,7 +617,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             var newAlternativeTitle = new AlternativeTitle
             {
                 Title = arg.Title,
-                SourceType = SourceType.TMDB,
+                SourceType = SourceType.Tmdb,
                 CleanTitle = arg.Title.CleanMovieTitle()
             };
 

--- a/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitle.cs
+++ b/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitle.cs
@@ -1,9 +1,8 @@
-using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Parser;
 
 namespace NzbDrone.Core.Movies.AlternativeTitles
 {
-    public class AlternativeTitle : ModelBase
+    public class AlternativeTitle : Entity<AlternativeTitle>
     {
         public SourceType SourceType { get; set; }
         public int MovieMetadataId { get; set; }
@@ -14,39 +13,22 @@ namespace NzbDrone.Core.Movies.AlternativeTitles
         {
         }
 
-        public AlternativeTitle(string title, SourceType sourceType = SourceType.TMDB, int sourceId = 0)
+        public AlternativeTitle(string title, SourceType sourceType = SourceType.Tmdb)
         {
             Title = title;
             CleanTitle = title.CleanMovieTitle();
             SourceType = sourceType;
         }
 
-        public override bool Equals(object obj)
-        {
-            var item = obj as AlternativeTitle;
-
-            if (item == null)
-            {
-                return false;
-            }
-
-            return item.CleanTitle == CleanTitle;
-        }
-
-        public override int GetHashCode()
-        {
-            return CleanTitle.GetHashCode();
-        }
-
         public override string ToString()
         {
-            return Title;
+            return $"{Title} [{CleanTitle}]";
         }
     }
 
     public enum SourceType
     {
-        TMDB = 0,
+        Tmdb = 0,
         Mappings = 1,
         User = 2,
         Indexer = 3

--- a/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitleRepository.cs
+++ b/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitleRepository.cs
@@ -7,6 +7,7 @@ namespace NzbDrone.Core.Movies.AlternativeTitles
     public interface IAlternativeTitleRepository : IBasicRepository<AlternativeTitle>
     {
         List<AlternativeTitle> FindByMovieMetadataId(int movieId);
+        List<AlternativeTitle> FindByCleanTitles(List<string> cleanTitles);
         void DeleteForMovies(List<int> movieIds);
     }
 
@@ -20,6 +21,11 @@ namespace NzbDrone.Core.Movies.AlternativeTitles
         public List<AlternativeTitle> FindByMovieMetadataId(int movieId)
         {
             return Query(x => x.MovieMetadataId == movieId);
+        }
+
+        public List<AlternativeTitle> FindByCleanTitles(List<string> cleanTitles)
+        {
+            return Query(x => cleanTitles.Contains(x.CleanTitle));
         }
 
         public void DeleteForMovies(List<int> movieIds)

--- a/src/NzbDrone.Core/Movies/Credits/Credit.cs
+++ b/src/NzbDrone.Core/Movies/Credits/Credit.cs
@@ -1,9 +1,8 @@
 using System.Collections.Generic;
-using NzbDrone.Core.Datastore;
 
 namespace NzbDrone.Core.Movies.Credits
 {
-    public class Credit : ModelBase
+    public class Credit : Entity<Credit>
     {
         public Credit()
         {

--- a/src/NzbDrone.Core/Movies/Ratings.cs
+++ b/src/NzbDrone.Core/Movies/Ratings.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.Movies
         public RatingChild Trakt { get; set; }
     }
 
-    public class RatingChild
+    public class RatingChild : MemberwiseEquatable<RatingChild>
     {
         public int Votes { get; set; }
         public decimal Value { get; set; }

--- a/src/NzbDrone.Core/Movies/Translations/MovieTranslation.cs
+++ b/src/NzbDrone.Core/Movies/Translations/MovieTranslation.cs
@@ -1,9 +1,8 @@
-using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Languages;
 
 namespace NzbDrone.Core.Movies.Translations
 {
-    public class MovieTranslation : ModelBase
+    public class MovieTranslation : Entity<MovieTranslation>
     {
         public int MovieMetadataId { get; set; }
         public string Title { get; set; }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Update movie credits, alternative titles and translation only if changes are detected.

Taking inspiration from #10913, this should also handle an issue with duplicated translations with the same language.