### PR TITLE
Fixed: Prevent new imports without deleting old movie files

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateMovie.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateMovie.cs
@@ -1,0 +1,25 @@
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators
+{
+    public class AggregateMovie : IAggregateLocalMovie
+    {
+        public int Order => 1;
+
+        private readonly IMovieService _movieService;
+
+        public AggregateMovie(IMovieService movieService)
+        {
+            _movieService = movieService;
+        }
+
+        public LocalMovie Aggregate(LocalMovie localMovie, DownloadClientItem downloadClientItem)
+        {
+            localMovie.Movie = _movieService.GetMovie(localMovie.Movie.Id);
+
+            return localMovie;
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Since movie is eager loaded for tracked downloads, 2 or more queue items for the same movie wouldn't be able see previously imported files for the same loop import execution.