### PR TITLE
New: Add Romansh language

### DIFF
--- a/src/NzbDrone.Core.Test/Languages/LanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/Languages/LanguageFixture.cs
@@ -66,7 +66,8 @@ namespace NzbDrone.Core.Test.Languages
                 new object[] { 51, Language.Afrikaans },
                 new object[] { 52, Language.Marathi },
                 new object[] { 53, Language.Tagalog },
-                new object[] { 54, Language.Urdu }
+                new object[] { 54, Language.Urdu },
+                new object[] { 55, Language.Romansh }
             };
 
         public static object[] ToIntCases =
@@ -127,7 +128,8 @@ namespace NzbDrone.Core.Test.Languages
                 new object[] { Language.Afrikaans, 51 },
                 new object[] { Language.Marathi, 52 },
                 new object[] { Language.Tagalog, 53 },
-                new object[] { Language.Urdu, 54 }
+                new object[] { Language.Urdu, 54 },
+                new object[] { Language.Romansh, 55 }
             };
 
         [Test]

--- a/src/NzbDrone.Core.Test/ParserTests/IsoLanguagesFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/IsoLanguagesFixture.cs
@@ -93,7 +93,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("rm")]
         [TestCase("roh")]
         [TestCase("rm-CH")]
-        public void should_return_urdu(string isoCode)
+        public void should_return_romansh(string isoCode)
         {
             var result = IsoLanguages.Find(isoCode);
             result.Language.Should().Be(Language.Romansh);

--- a/src/NzbDrone.Core.Test/ParserTests/IsoLanguagesFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/IsoLanguagesFixture.cs
@@ -89,5 +89,14 @@ namespace NzbDrone.Core.Test.ParserTests
             var result = IsoLanguages.Find(isoCode);
             result.Language.Should().Be(Language.Urdu);
         }
+
+        [TestCase("rm")]
+        [TestCase("roh")]
+        [TestCase("rm-CH")]
+        public void should_return_urdu(string isoCode)
+        {
+            var result = IsoLanguages.Find(isoCode);
+            result.Language.Should().Be(Language.Romansh);
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -506,7 +506,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("The.Movie.Name.2016.Romansh.WEB-DL.h264-RlsGrp")]
         [TestCase("The.Movie.Name.2016.Rumantsch.WEB.DL.h264-RlsGrp")]
         [TestCase("The Movie Name 2016 Romansch WEB DL h264-RlsGrp")]
-        public void should_parse_language_urdu(string postTitle)
+        public void should_parse_language_romansh(string postTitle)
         {
             var result = LanguageParser.ParseLanguages(postTitle);
             result.Should().Contain(Language.Romansh);

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -503,6 +503,15 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Should().Contain(Language.Urdu);
         }
 
+        [TestCase("The.Movie.Name.2016.Romansh.WEB-DL.h264-RlsGrp")]
+        [TestCase("The.Movie.Name.2016.Rumantsch.WEB.DL.h264-RlsGrp")]
+        [TestCase("The Movie Name 2016 Romansch WEB DL h264-RlsGrp")]
+        public void should_parse_language_urdu(string postTitle)
+        {
+            var result = LanguageParser.ParseLanguages(postTitle);
+            result.Should().Contain(Language.Romansh);
+        }
+
         [TestCase("Movie.Title.en.sub")]
         [TestCase("Movie Title.eng.sub")]
         [TestCase("Movie.Title.eng.forced.sub")]

--- a/src/NzbDrone.Core/ImportLists/TMDb/TMDbLanguageCodes.cs
+++ b/src/NzbDrone.Core/ImportLists/TMDb/TMDbLanguageCodes.cs
@@ -71,6 +71,8 @@ namespace NzbDrone.Core.ImportLists.TMDb
         [FieldOption(Hint = "Tagalog")]
         tl,
         [FieldOption(Hint = "Urdu")]
-        ur
+        ur,
+        [FieldOption(Hint = "Raeto-Romance")]
+        rm
     }
 }

--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -125,6 +125,7 @@ namespace NzbDrone.Core.Languages
         public static Language Marathi => new Language(52, "Marathi");
         public static Language Tagalog => new Language(53, "Tagalog");
         public static Language Urdu => new Language(54, "Urdu");
+        public static Language Romansh => new Language(55, "Romansh");
         public static Language Any => new Language(-1, "Any");
         public static Language Original => new Language(-2, "Original");
 
@@ -189,6 +190,7 @@ namespace NzbDrone.Core.Languages
                     Marathi,
                     Tagalog,
                     Urdu,
+                    Romansh,
                     Any,
                     Original
                 };

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -63,7 +63,8 @@ namespace NzbDrone.Core.Parser
                                                                new IsoLanguage("af", "", "afr", "Afrikaans", Language.Afrikaans),
                                                                new IsoLanguage("mr", "", "mar", "Marathi", Language.Marathi),
                                                                new IsoLanguage("tl", "", "tgl", "Tagalog", Language.Tagalog),
-                                                               new IsoLanguage("ur", "", "urd", "Urdu", Language.Urdu)
+                                                               new IsoLanguage("ur", "", "urd", "Urdu", Language.Urdu),
+                                                               new IsoLanguage("rm", "", "roh", "Romansh", Language.Romansh)
                                                            };
 
         private static readonly Dictionary<string, Language> AlternateIsoCodeMappings = new ()

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Parser
                                                                             (?<japanese>\bJAP\b)|
                                                                             (?<korean>\bKOR\b)|
                                                                             (?<urdu>\burdu\b)|
-                                                                            (?<romansh>\b(?:romansh|rumantsch|romansch|)\b)|
+                                                                            (?<romansh>\b(?:romansh|rumantsch|romansch)\b)|
                                                                             (?<original>\b(?:orig|original)\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -38,6 +38,7 @@ namespace NzbDrone.Core.Parser
                                                                             (?<japanese>\bJAP\b)|
                                                                             (?<korean>\bKOR\b)|
                                                                             (?<urdu>\burdu\b)|
+                                                                            (?<romansh>\b(?:romansh|rumantsch|romansch|)\b)|
                                                                             (?<original>\b(?:orig|original)\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
@@ -424,6 +425,11 @@ namespace NzbDrone.Core.Parser
                 if (match.Groups["urdu"].Success)
                 {
                     languages.Add(Language.Urdu);
+                }
+
+                if (match.Groups["romansh"].Success)
+                {
+                    languages.Add(Language.Romansh);
                 }
 
                 if (match.Groups["original"].Success)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add "Romansh" language: https://en.wikipedia.org/wiki/Romansh_language
TMDB seems to use `Raeto-Romance` as language name which is the name of the parent language family: https://en.wikipedia.org/wiki/Rhaeto-Romance_languages

```
  {
    "iso_639_1": "rm",
    "english_name": "Raeto-Romance",
    "name": ""
  },
  ```

#### Screenshot (if UI related)

#### Todos
- [X] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Partly addresses #7788 