### PR TITLE
Fixed: Update AutoTags on movie add

### DIFF
--- a/src/NzbDrone.Core/Movies/AddMovieService.cs
+++ b/src/NzbDrone.Core/Movies/AddMovieService.cs
@@ -56,6 +56,8 @@ namespace NzbDrone.Core.Movies
             _movieMetadataService.Upsert(newMovie.MovieMetadata.Value);
             newMovie.MovieMetadataId = newMovie.MovieMetadata.Value.Id;
 
+            _movieService.UpdateTags(newMovie);
+
             _movieService.AddMovie(newMovie);
 
             return newMovie;

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -205,8 +205,14 @@ namespace NzbDrone.Core.Movies
             }
         }
 
-        private void UpdateTags(Movie movie)
+        private void UpdateTags(Movie movie, bool isNew)
         {
+            if (isNew)
+            {
+                _logger.Trace("Skipping tag update for {0}. Reason: New movie", movie);
+                return;
+            }
+
             var tagsUpdated = _movieService.UpdateTags(movie);
 
             if (tagsUpdated)
@@ -230,11 +236,7 @@ namespace NzbDrone.Core.Movies
                     try
                     {
                         movie = RefreshMovieInfo(movieId);
-                        if (!isNew)
-                        {
-                            UpdateTags(movie);
-                        }
-
+                        UpdateTags(movie, isNew);
                         RescanMovie(movie, isNew, trigger);
                     }
                     catch (MovieNotFoundException)
@@ -244,7 +246,7 @@ namespace NzbDrone.Core.Movies
                     catch (Exception e)
                     {
                         _logger.Error(e, "Couldn't refresh info for {0}", movie);
-                        UpdateTags(movie);
+                        UpdateTags(movie, isNew);
                         RescanMovie(movie, isNew, trigger);
                         throw;
                     }
@@ -281,13 +283,13 @@ namespace NzbDrone.Core.Movies
                             _logger.Error(e, "Couldn't refresh info for {0}", movieLocal);
                         }
 
-                        UpdateTags(movie);
+                        UpdateTags(movie, false);
                         RescanMovie(movieLocal, false, trigger);
                     }
                     else
                     {
                         _logger.Debug("Skipping refresh of movie: {0}", movieLocal.Title);
-                        UpdateTags(movie);
+                        UpdateTags(movie, false);
                         RescanMovie(movieLocal, false, trigger);
                     }
                 }

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -230,7 +230,11 @@ namespace NzbDrone.Core.Movies
                     try
                     {
                         movie = RefreshMovieInfo(movieId);
-                        UpdateTags(movie);
+                        if (!isNew)
+                        {
+                            UpdateTags(movie);
+                        }
+
                         RescanMovie(movie, isNew, trigger);
                     }
                     catch (MovieNotFoundException)

--- a/src/NzbDrone.Integration.Test/ApiTests/MovieFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/MovieFixture.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
+using Radarr.Api.V3.AutoTagging;
+using Radarr.Http.ClientSchema;
 
 namespace NzbDrone.Integration.Test.ApiTests
 {
@@ -27,6 +29,53 @@ namespace NzbDrone.Integration.Test.ApiTests
 
             result.Should().NotBeNull();
             result.Tags.Should().Equal(tag.Id);
+        }
+
+        [Test]
+        [Order(0)]
+        public void add_movie_should_trigger_autotag()
+        {
+            var tag = EnsureTag("autotag-test");
+            var movie = Movies.Lookup("imdb:tt0110912").Single();
+            movie.Genres = new List<string> { "Thriller" };
+
+            var item = AutoTagging.Post(new AutoTaggingResource
+            {
+                Name = "Test",
+                RemoveTagsAutomatically = false,
+                Tags = new HashSet<int> { tag.Id },
+                Specifications = new List<AutoTaggingSpecificationSchema>
+                {
+                    new AutoTaggingSpecificationSchema
+                    {
+                        Name = "Test",
+                        Implementation = "GenreSpecification",
+                        ImplementationName = "Genre",
+                        Negate = false,
+                        Required = false,
+                        Fields = new List<Field>
+                        {
+                            new Field
+                            {
+                                Name = "value",
+                                Label = "Genre(s)",
+                                Type = "tag",
+                                Value = new List<string> { "Thriller" }
+                            }
+                        }
+                    }
+                }
+            });
+
+            EnsureNoMovie(680, "Pulp Fiction");
+
+            movie.QualityProfileId = 1;
+            movie.Path = Path.Combine(MovieRootFolder, movie.Title);
+
+            var result = Movies.Post(movie);
+
+            result.Should().NotBeNull();
+            result.Tags.Should().Contain(tag.Id);
         }
 
         [Test]

--- a/src/NzbDrone.Integration.Test/IntegrationTestBase.cs
+++ b/src/NzbDrone.Integration.Test/IntegrationTestBase.cs
@@ -17,6 +17,7 @@ using NzbDrone.Core.Qualities;
 using NzbDrone.Integration.Test.Client;
 using NzbDrone.SignalR;
 using NzbDrone.Test.Common.Categories;
+using Radarr.Api.V3.AutoTagging;
 using Radarr.Api.V3.Blocklist;
 using Radarr.Api.V3.Config;
 using Radarr.Api.V3.DownloadClient;
@@ -36,6 +37,7 @@ namespace NzbDrone.Integration.Test
     {
         protected RestClient RestClient { get; private set; }
 
+        public ClientBase<AutoTaggingResource> AutoTagging;
         public ClientBase<BlocklistResource> Blocklist;
         public CommandClient Commands;
         public ClientBase<TaskResource> Tasks;
@@ -99,6 +101,7 @@ namespace NzbDrone.Integration.Test
             RestClient.AddDefaultHeader("Authentication", ApiKey);
             RestClient.AddDefaultHeader("X-Api-Key", ApiKey);
 
+            AutoTagging = new ClientBase<AutoTaggingResource>(RestClient, ApiKey);
             Blocklist = new ClientBase<BlocklistResource>(RestClient, ApiKey);
             Commands = new CommandClient(RestClient, ApiKey);
             Tasks = new ClientBase<TaskResource>(RestClient, ApiKey, "system/task");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Simple fix to apply tags before the `AddMovie` event is published so that autotag notification filters function for "On Movie Added" events. Have also conditionally skipped adding tags  when RefreshMovie executes on a newly added movie to avoid the unnecessary double tag update. 

Have also added this condition as an integration test.

#### Todos
- [x] Tests
- N/A Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- N/A [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
* Fixes #10861 