### PR TITLE
New: Create MetadataType.MovieTheme for theme.xxx audio files

### DIFF
--- a/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/FindMetadataFileFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/FindMetadataFileFixture.cs
@@ -61,5 +61,18 @@ namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.Xbmc
             Mocker.GetMock<IDetectXbmcNfo>()
                   .Verify(v => v.IsXbmcNfoFile(It.IsAny<string>()), Times.Once());
         }
+
+        [TestCase("theme.mp3", MetadataType.MovieTheme)]
+        [TestCase("theme.mpa", MetadataType.MovieTheme)]
+        [TestCase("Theme.x-flac", MetadataType.MovieTheme)]
+        public void should_return_expected_metadata_type(string fileName, MetadataType metadataType)
+        {
+            var path = Path.Combine(_movie.Path, fileName.AsOsAgnostic());
+
+            var metadataFile = Subject.FindMetadataFile(_movie, path);
+
+            metadataFile.Should().NotBeNull();
+            metadataFile.Type.Should().Be(metadataType);
+        }
     }
 }

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -83,6 +83,12 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                 RelativePath = movie.Path.GetRelativePath(path)
             };
 
+            if (Path.GetFileNameWithoutExtension(filename).Equals("theme", StringComparison.OrdinalIgnoreCase))
+            {
+                metadata.Type = MetadataType.MovieTheme;
+                return metadata;
+            }
+
             if (MovieImagesRegex.IsMatch(filename))
             {
                 metadata.Type = MetadataType.MovieImage;

--- a/src/NzbDrone.Core/Extras/Metadata/MetadataType.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/MetadataType.cs
@@ -4,6 +4,7 @@ namespace NzbDrone.Core.Extras.Metadata
     {
         Unknown = 0,
         MovieMetadata = 1,
-        MovieImage = 2
+        MovieImage = 2,
+        MovieTheme = 3
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Per the conversation on https://github.com/Radarr/Radarr/issues/11078 this creates a new metadata type, MovieTheme and will treat files named theme.xxx (where xxx is any extension) as MetadataType.MovieTheme. This prevents them from being renamed when the movie is renamed.

As a bonus, I verified when upgrading a movie file, it did not delete these them files.

#### Screenshot (if UI related)

![image](https://github.com/user-attachments/assets/768c81fa-016c-4053-98e4-b5b647d5f63c)


#### Todos
- [X] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #11078