### PR TITLE
Fixed: Allow opening curly bracket as prefix

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/EditionTagsFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/EditionTagsFixture.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
                 .With(m => m.Title = "Movie Title")
                 .Build();
 
-            _movieFile = new MovieFile { Quality = new QualityModel(), ReleaseGroup = "RadarrTest" };
+            _movieFile = new MovieFile { Quality = new QualityModel(), ReleaseGroup = "RadarrTest", Edition = "Uncut" };
 
             _namingConfig = NamingConfig.Default;
             _namingConfig.RenameMovies = true;
@@ -47,21 +47,41 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [Test]
         public void should_add_edition_tag()
         {
-            _movieFile.Edition = "Uncut";
             _namingConfig.StandardMovieFormat = "{Movie Title} [{Edition Tags}]";
 
             Subject.BuildFileName(_movie, _movieFile)
                    .Should().Be("Movie Title [Uncut]");
         }
 
+        [TestCase("{Movie Title} {Edition Tags}")]
+        [TestCase("{Movie Title} {{Edition Tags}}")]
         [TestCase("{Movie Title} {edition-{Edition Tags}}")]
-        public void should_conditional_hide_edition_tags_in_plex_format(string movieFormat)
+        [TestCase("{Movie Title} {{edition-{Edition Tags}}}")]
+        public void should_conditional_hide_edition_tags(string movieFormat)
         {
             _movieFile.Edition = "";
             _namingConfig.StandardMovieFormat = movieFormat;
 
             Subject.BuildFileName(_movie, _movieFile)
                    .Should().Be("Movie Title");
+        }
+
+        [TestCase("{Movie Title} {{Edition Tags}}")]
+        public void should_handle_edition_curly_brackets(string movieFormat)
+        {
+            _namingConfig.StandardMovieFormat = movieFormat;
+
+            Subject.BuildFileName(_movie, _movieFile)
+                .Should().Be("Movie Title {Uncut}");
+        }
+
+        [TestCase("{Movie Title} {{edition-{Edition Tags}}}")]
+        public void should_handle_edition_tag_curly_brackets(string movieFormat)
+        {
+            _namingConfig.StandardMovieFormat = movieFormat;
+
+            Subject.BuildFileName(_movie, _movieFile)
+                .Should().Be("Movie Title {{edition-Uncut}}");
         }
 
         [TestCase("1st anniversary edition", "{Movie Title} [{Edition Tags}]", "Movie Title [1st Anniversary Edition]")]

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/IdFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/IdFixture.cs
@@ -56,15 +56,36 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
                    .Should().Be($"Movie Title {{imdb-{_movie.ImdbId}}}");
         }
 
-        [Test]
-        public void should_skip_imdb_tag_if_null()
+        [TestCase("{Movie Title} {imdb-{ImdbId}}")]
+        [TestCase("{Movie Title} {imdbid-{ImdbId}}")]
+        [TestCase("{Movie Title} {{imdb-{ImdbId}}}")]
+        [TestCase("{Movie Title} {{imdbid-{ImdbId}}}")]
+        public void should_skip_imdb_tag_if_null(string movieFormat)
         {
-            _namingConfig.MovieFolderFormat = "{Movie Title} {imdb-{ImdbId}}";
+            _namingConfig.MovieFolderFormat = movieFormat;
 
             _movie.ImdbId = null;
 
             Subject.GetMovieFolder(_movie)
-                   .Should().Be($"Movie Title");
+                   .Should().Be("Movie Title");
+        }
+
+        [TestCase("{Movie Title} {{imdb-{ImdbId}}}")]
+        public void should_handle_imdb_tag_curly_brackets(string movieFormat)
+        {
+            _namingConfig.MovieFolderFormat = movieFormat;
+
+            Subject.GetMovieFolder(_movie)
+                .Should().Be($"Movie Title {{{{imdb-{_movie.ImdbId}}}}}");
+        }
+
+        [TestCase("{Movie Title} {{tmdb-{TmdbId}}}")]
+        public void should_handle_tmdb_tag_curly_brackets(string movieFormat)
+        {
+            _namingConfig.MovieFolderFormat = movieFormat;
+
+            Subject.GetMovieFolder(_movie)
+                .Should().Be($"Movie Title {{{{tmdb-{_movie.TmdbId}}}}}");
         }
     }
 }

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Organizer
         private readonly ICustomFormatCalculationService _formatCalculator;
         private readonly Logger _logger;
 
-        private static readonly Regex TitleRegex = new Regex(@"(?<tag>\{(?:imdb-|edition-))?\{(?<prefix>[- ._\[(]*)(?<token>(?:[a-z0-9]+)(?:(?<separator>[- ._]+)(?:[a-z0-9]+))?)(?::(?<customFormat>[ ,a-z0-9|+-]+(?<![- ])))?(?<suffix>[-} ._)\]]*)\}",
+        private static readonly Regex TitleRegex = new Regex(@"(?<tag>\{(?<prefix>[-{ ._\[(]*)(?:imdb(?:id)?-|edition-))?\{(?<prefix>[-{ ._\[(]*)(?<token>(?:[a-z0-9]+)(?:(?<separator>[- ._]+)(?:[a-z0-9]+))?)(?::(?<customFormat>[ ,a-z0-9|+-]+(?<![- ])))?(?<suffix>[-} ._)\]]*)\}",
                                                              RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
         public static readonly Regex ReleaseYearRegex = new Regex(@"\{[\[\(]?Release[- ._]Year[\]\)]?\}", RegexOptions.Compiled | RegexOptions.IgnoreCase);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This changes the `TitleRegex` in the FileNameBuilder to include `{` as a possible prefix to allow naming such as `{{Edition Tags}}`. Before this change an empty edition in that example would result in `{`. Simpler implementation of #11105 

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
Fixes leftover `{` after token replacement when using double curly brackets.