### PR TITLE
Fixed: Handling movies with empty IMDB IDs in lists clean library

### DIFF
--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -196,7 +196,9 @@ namespace NzbDrone.Core.ImportLists
 
             foreach (var movie in moviesInLibrary)
             {
-                var movieExists = listMovies.Any(c => c.TmdbId == movie.TmdbId || (c.ImdbId.IsNotNullOrWhiteSpace() && c.ImdbId == movie.ImdbId));
+                var movieExists = listMovies.Any(c =>
+                    c.TmdbId == movie.TmdbId ||
+                    (c.ImdbId.IsNotNullOrWhiteSpace() && movie.ImdbId.IsNotNullOrWhiteSpace() && c.ImdbId == movie.ImdbId));
 
                 if (!movieExists)
                 {

--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -196,7 +196,7 @@ namespace NzbDrone.Core.ImportLists
 
             foreach (var movie in moviesInLibrary)
             {
-                var movieExists = listMovies.Any(c => c.TmdbId == movie.TmdbId || c.ImdbId == movie.ImdbId);
+                var movieExists = listMovies.Any(c => c.TmdbId == movie.TmdbId || (c.ImdbId.IsNotNullOrWhiteSpace() && c.ImdbId == movie.ImdbId));
 
                 if (!movieExists)
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixed import list sync cleanup which was not cleaning up **all** movies without an ImdbId if the import lists contained movies without an ImdbId as well, despite no match on TmdbId. This was observed with Trakt Popular lists for 2026 which include movies like https://trakt.tv/movies/valkryie-2026.