### PR TITLE
New: pass multiple movieIds in Rename API

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/RenameMovieFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/RenameMovieFileService.cs
@@ -17,6 +17,7 @@ namespace NzbDrone.Core.MediaFiles
 {
     public interface IRenameMovieFileService
     {
+        List<RenameMovieFilePreview> GetRenamePreviews();
         List<RenameMovieFilePreview> GetRenamePreviews(int movieId);
     }
 
@@ -47,6 +48,21 @@ namespace NzbDrone.Core.MediaFiles
             _filenameBuilder = filenameBuilder;
             _diskProvider = diskProvider;
             _logger = logger;
+        }
+
+        public List<RenameMovieFilePreview> GetRenamePreviews()
+        {
+            var movies = _movieService.GetAllMovies();
+            var filesList = new List<RenameMovieFilePreview>();
+
+            foreach (var movie in movies)
+            {
+                var files = _mediaFileService.GetFilesByMovie(movie.Id);
+
+                filesList.AddRange(GetPreviews(movie, files).ToList());
+            }
+
+            return filesList.OrderByDescending(m => m.MovieId).ToList();
         }
 
         public List<RenameMovieFilePreview> GetRenamePreviews(int movieId)

--- a/src/NzbDrone.Core/MediaFiles/RenameMovieFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/RenameMovieFileService.cs
@@ -52,12 +52,15 @@ namespace NzbDrone.Core.MediaFiles
         public List<RenameMovieFilePreview> GetRenamePreviews(List<int> movieIds)
         {
             var movies = _movieService.GetMovies(movieIds);
+            var movieFiles = _mediaFileService.GetFilesByMovies(movieIds).ToLookup(f => f.MovieId);
 
             return movies.SelectMany(m =>
             {
-                var files = _mediaFileService.GetFilesByMovie(m.Id);
+                var files = movieFiles[m.Id].ToList();
+
                 return GetPreviews(m, files);
-            }).OrderByDescending(r => r.MovieId).ToList();
+            })
+                .ToList();
         }
 
         private IEnumerable<RenameMovieFilePreview> GetPreviews(Movie movie, List<MovieFile> files)

--- a/src/NzbDrone.Core/MediaFiles/RenameMovieFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/RenameMovieFileService.cs
@@ -54,12 +54,12 @@ namespace NzbDrone.Core.MediaFiles
             var movies = _movieService.GetMovies(movieIds);
             var movieFiles = _mediaFileService.GetFilesByMovies(movieIds).ToLookup(f => f.MovieId);
 
-            return movies.SelectMany(m =>
-            {
-                var files = movieFiles[m.Id].ToList();
+            return movies.SelectMany(movie =>
+                {
+                    var files = movieFiles[movie.Id].ToList();
 
-                return GetPreviews(m, files);
-            })
+                    return GetPreviews(movie, files);
+                })
                 .ToList();
         }
 

--- a/src/NzbDrone.Core/MediaFiles/RenameMovieFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/RenameMovieFileService.cs
@@ -51,21 +51,13 @@ namespace NzbDrone.Core.MediaFiles
 
         public List<RenameMovieFilePreview> GetRenamePreviews(List<int> movieIds)
         {
-            var moviesById = _movieService.GetMovies(movieIds).ToDictionary(m => m.Id);
-            var filesById = _mediaFileService.GetFilesByMovies(movieIds).ToLookup(f => f.MovieId);
+            var movies = _movieService.GetMovies(movieIds);
 
-            var filesList = movieIds.SelectMany(id =>
+            return movies.SelectMany(m =>
             {
-                if (!moviesById.TryGetValue(id, out var movie))
-                {
-                    return Enumerable.Empty<RenameMovieFilePreview>();
-                }
-
-                var files = filesById[id].ToList();
-                return GetPreviews(movie, files);
-            });
-
-            return filesList.OrderByDescending(m => m.MovieId).ToList();
+                var files = _mediaFileService.GetFilesByMovie(m.Id);
+                return GetPreviews(m, files);
+            }).OrderByDescending(r => r.MovieId).ToList();
         }
 
         private IEnumerable<RenameMovieFilePreview> GetPreviews(Movie movie, List<MovieFile> files)

--- a/src/Radarr.Api.V3/Movies/RenameMovieController.cs
+++ b/src/Radarr.Api.V3/Movies/RenameMovieController.cs
@@ -16,14 +16,9 @@ namespace Radarr.Api.V3.Movies
         }
 
         [HttpGet]
-        public List<RenameMovieResource> GetMovies(int? movieId)
+        public List<RenameMovieResource> GetMovies([FromQuery(Name = "movieId")] List<int> movieIds)
         {
-            if (movieId.HasValue)
-            {
-                return _renameMovieFileService.GetRenamePreviews(movieId.Value).ToResource();
-            }
-
-            return _renameMovieFileService.GetRenamePreviews().ToResource();
+            return _renameMovieFileService.GetRenamePreviews(movieIds).ToResource();
         }
     }
 }

--- a/src/Radarr.Api.V3/Movies/RenameMovieController.cs
+++ b/src/Radarr.Api.V3/Movies/RenameMovieController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.MediaFiles;
 using Radarr.Http;
+using Radarr.Http.REST;
 
 namespace Radarr.Api.V3.Movies
 {

--- a/src/Radarr.Api.V3/Movies/RenameMovieController.cs
+++ b/src/Radarr.Api.V3/Movies/RenameMovieController.cs
@@ -18,6 +18,11 @@ namespace Radarr.Api.V3.Movies
         [HttpGet]
         public List<RenameMovieResource> GetMovies([FromQuery(Name = "movieId")] List<int> movieIds)
         {
+            if (movieIds is not { Count: not 0 })
+            {
+                throw new BadRequestException("movieId must be provided");
+            }
+
             return _renameMovieFileService.GetRenamePreviews(movieIds).ToResource();
         }
     }

--- a/src/Radarr.Api.V3/Movies/RenameMovieController.cs
+++ b/src/Radarr.Api.V3/Movies/RenameMovieController.cs
@@ -16,9 +16,14 @@ namespace Radarr.Api.V3.Movies
         }
 
         [HttpGet]
-        public List<RenameMovieResource> GetMovies(int movieId)
+        public List<RenameMovieResource> GetMovies(int? movieId)
         {
-            return _renameMovieFileService.GetRenamePreviews(movieId).ToResource();
+            if (movieId.HasValue)
+            {
+                return _renameMovieFileService.GetRenamePreviews(movieId.Value).ToResource();
+            }
+
+            return _renameMovieFileService.GetRenamePreviews().ToResource();
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This adds functionality to the API to retrieve any number of movies that need renames at once. This removes the need to make a call for each movie individually when you want to know the rename status for multiple movies.

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)