### PR TITLE
Fixed: Correctly handle {Original Title} naming format

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/OriginalTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/OriginalTitleFixture.cs
@@ -84,5 +84,22 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             Subject.BuildFileName(_movie, _movieFile)
                    .Should().Be("My Movie");
         }
+        
+        [Test]
+        public void should_use_movie_title_when_changing_to_original_title_format()
+        {
+            // Given a movie with a title and an existing filename
+            _movie.Title = "The Matrix";
+            _movie.MovieMetadata.Value.OriginalTitle = "The Matrix (1999)";
+            _movieFile.RelativePath = "The.Matrix.1999.1080p.BluRay.x264-RELEASE";
+            _movieFile.Movie = _movie;
+
+            // When changing the format to {Original Title}
+            _namingConfig.StandardMovieFormat = "{Original Title}";
+
+            // Then it should use the movie's original title, not the current filename
+            var result = Subject.BuildFileName(_movie, _movieFile);
+            result.Should().Be("The Matrix (1999)");
+        }
     }
 }

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -647,6 +647,16 @@ namespace NzbDrone.Core.Organizer
 
         private string GetOriginalTitle(MovieFile movieFile, bool multipleTokens)
         {
+            // If we're using {Original Title} as the format, we should use the movie's original title
+            // instead of the current filename to avoid circular references
+            if (movieFile.Movie != null &&
+                _namingConfigService.GetConfig().StandardMovieFormat?.Trim() == "{Original Title}")
+            {
+                return movieFile.Movie.MovieMetadata.Value.OriginalTitle ??
+                       movieFile.Movie.Title ??
+                       GetOriginalFileName(movieFile, multipleTokens);
+            }
+
             if (movieFile.SceneName.IsNullOrWhiteSpace())
             {
                 return CleanFileName(GetOriginalFileName(movieFile, multipleTokens));


### PR DESCRIPTION
Fixes #10910

When the naming format is set to {Original Title}, use the movie's original title from metadata instead of the current filename to prevent circular references. Added unit test to verify the behavior.

#### Database Migration
NO 

## Description
#### Fixed
- Fixed issue where changing the naming format to `{Original Title}` would not update movie names correctly
- The code was incorrectly using the old naming format as the original title, causing naming inconsistencies

#### Changes
- Modified `FileNameBuilder.GetOriginalTitle` to detect when the naming format is exactly `{Original Title}`
- When detected, it now uses the movie's original title from metadata (`MovieMetadata.Value.OriginalTitle`) or the movie's title
- Added unit tests to verify the behavior

#### Testing
- Added unit test [should_use_movie_title_when_changing_to_original_title_format] to verify the fix
- Verified existing tests to ensure no regressions
- Manually tested by changing the naming format to `{Original Title}` and verifying the correct title is used


#### Todos
- [X] Tests: Added a unit test to verify the fix
- [X] Translation Keys: No changes needed (existing key used)
- [X] Wiki Updates: No changes needed (existing functionality)

#### Issues Fixed or Closed by this PR

* Fixes #10910
