### PR TITLE
Don't associate MovieImage extras with the movie file, to survive upgrade (#4650)

### DIFF
--- a/frontend/src/MovieFile/Extras/ExtraFileTableContentConnector.js
+++ b/frontend/src/MovieFile/Extras/ExtraFileTableContentConnector.js
@@ -14,7 +14,12 @@ function createMapStateToProps() {
       movieId,
       extraFiles
     ) => {
-      const filesForMovie = extraFiles.items.filter((file) => file.movieId === movieId);
+      const filesForMovie = extraFiles.items.filter((file) => file.movieId === movieId).reduce((acc, file) => {
+        if (!acc.some(f => f.relativePath === file.relativePath)) {
+          acc.push(file);
+        }
+        return acc;
+      }, []);
 
       return {
         items: filesForMovie,

--- a/frontend/src/MovieFile/Extras/ExtraFileTableContentConnector.js
+++ b/frontend/src/MovieFile/Extras/ExtraFileTableContentConnector.js
@@ -15,7 +15,7 @@ function createMapStateToProps() {
       extraFiles
     ) => {
       const filesForMovie = extraFiles.items.filter((file) => file.movieId === movieId).reduce((acc, file) => {
-        if (!acc.some(f => f.relativePath === file.relativePath)) {
+        if (!acc.some((f) => f.relativePath === file.relativePath)) {
           acc.push(file);
         }
         return acc;

--- a/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/FindMetadataFileFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/FindMetadataFileFixture.cs
@@ -61,5 +61,16 @@ namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.Xbmc
             Mocker.GetMock<IDetectXbmcNfo>()
                   .Verify(v => v.IsXbmcNfoFile(It.IsAny<string>()), Times.Once());
         }
+
+        [TestCase("poster.jpg")]
+        [TestCase("background.jpg")]
+        [TestCase("fanart-1.jpg")]
+        [TestCase("the.move.2017-poster.jpg")]
+        public void should_return_movie_image_for_images_in_movie_folder(string filename)
+        {
+            var path = Path.Combine(_movie.Path, filename);
+
+            Subject.FindMetadataFile(_movie, path).Type.Should().Be(MetadataType.MovieImage);
+        }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/243_set_metadata_images_to_null_move_file_id.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/243_set_metadata_images_to_null_move_file_id.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(243)]
+    public class set_metadata_images_to_null_move_file_id : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Execute.Sql("UPDATE \"MetadataFiles\" SET \"MovieFileId\" = NULL WHERE \"Type\" = 2");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -49,8 +49,8 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
             _movieTranslationsService = movieTranslationsService;
         }
 
-        private static readonly Regex MovieImagesRegex = new Regex(@"^(?<type>poster|banner|fanart|clearart|discart|keyart|landscape|logo|backdrop|clearlogo)\.(?:png|jpe?g)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex MovieFileImageRegex = new Regex(@"(?<type>-thumb|-poster|-banner|-fanart|-clearart|-discart|-keyart|-landscape|-logo|-backdrop|-clearlogo)\.(?:png|jpe?g)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex MovieImagesRegex = new Regex(@"^((folder|poster|cover|default|movie|clearart|backdrop|fanart|background|art)(-\d+)?|(banner|disc|cdart|logo|thumb|landscape|discart|keyart|clearlogo))\.(png|jpe?g|tbn|gif)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex MovieFileImageRegex = new Regex(@"(-poster|-cover|-default|-movie|-clearart|-banner|-disc|-cdart|-logo|-thumb|-landscape|-discart|-keyart|-clearlogo|-fanart|-logo|-backdrop)\.(png|jpe?g|tbn|gif)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public override string Name => "Kodi (XBMC) / Emby";
 

--- a/src/NzbDrone.Core/Extras/Metadata/ExistingMetadataImporter.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/ExistingMetadataImporter.cs
@@ -67,7 +67,11 @@ namespace NzbDrone.Core.Extras.Metadata
                             continue;
                         }
 
-                        metadata.MovieFileId = movie.MovieFileId;
+                        // Don't associate MovieImage files with the MovieFileId, as they're generally not specific to the quality
+                        if (metadata.Type == MetadataType.MovieMetadata)
+                        {
+                            metadata.MovieFileId = movie.MovieFileId;
+                        }
                     }
 
                     metadata.Extension = Path.GetExtension(possibleMetadataFile);


### PR DESCRIPTION
#### Database Migration
YES - 243

#### Description
* MovieImages created by Metadata providers follow this same pattern
* Updates the list of MovieImages supported by Emby metadata to the latest list
* Groups extras by name in UI so doubles aren't shown
* Migrates database to remove MovieFileId from existing MovieImages

Update images lists:
* https://emby.media/support/articles/Movie-Naming.html#video-images
* https://support.plex.tv/articles/200220677-local-media-assets-movies/

See [MetadataService.ProcessMovieImages](https://github.com/Radarr/Radarr/blob/develop/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs#L280-L287) to see how Radarr created images are not linked to MovieFileId.

I have an additional small change to add an `Ignore Other Extras` pattern in Media Management to let users disallow Radarr managing files that might end up in "Other" (which does currently link to MovieFileId), but I'll put that up separately.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [n/a] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [n/a] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #4650 