### PR TITLE
Fixed: Parse HDDVDRip as BluRay

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -294,6 +294,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie.Name.2016.German.DTS.DL.1080p.UHDBD.x265-TDO.mkv", false)]
         [TestCase("Movie.Name.2021.1080p.BDLight.x265-AVCDVD", false)]
         [TestCase("Movie.Title.2012.German.DL.1080p.UHD2BD.x264-QfG", false)]
+        [TestCase("Movie.Title.2005.1080p.HDDVDRip.x264", false)]
         public void should_parse_bluray1080p_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, QualitySource.BLURAY, proper, Resolution.R1080p);

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Parser
                                                             (?<webdl>WEB[-_. ]?DL(?:mux)?|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?5[. ]1)|[. ](?-i:WEB)$|(?:\d{3,4}0p)[-. ](?:Hybrid[-_. ]?)?WEB[-. ]|[-. ]WEB[-. ]\d{3,4}0p|\b\s\/\sWEB\s\/\s\b|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip))|
                                                             (?<webrip>WebRip|Web-Rip|WEBMux)|
                                                             (?<hdtv>HDTV)|
-                                                            (?<bdrip>BDRip|BDLight)|
+                                                            (?<bdrip>BDRip|BDLight|HD[-_. ]?DVDRip)|
                                                             (?<brrip>BRRip)|
                                                             (?<dvdr>\d?x?M?DVD-?[R59])|
                                                             (?<dvd>DVD(?!-R)|DVDRip|xvidvd)|


### PR DESCRIPTION
`HDDVDRip` is currently not parsed. This commit fixes it by parsing it as `BluRay`.