### PR TITLE
New: (NFO Metadata) Include the TMDB Collection ID

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -280,6 +280,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                 {
                     var setElement = new XElement("set");
 
+                    setElement.SetAttributeValue("tmdbcolid", movie.MovieMetadata.Value.CollectionTmdbId);
                     setElement.Add(new XElement("name", movie.MovieMetadata.Value.CollectionTitle));
                     setElement.Add(new XElement("overview"));
 


### PR DESCRIPTION
#### Database Migration

NO

#### Description

When the option to store collection information in the NFO is enabled this will currently only set the name. However, other sources of collection information in Jellyfin (such as the TMDb Metadata Provider) will also set the ID of the collection, and some things depend on this (such as the official [Jellyfin TMDb Box Sets Plugin](https://github.com/jellyfin/jellyfin-plugin-tmdbboxsets)).

Jellyfin supports reading this ID from the NFO file as an attribute `tmdbcolid` on the `<set>` ([example](https://github.com/jellyfin/jellyfin/blob/ba0f61ef2defdd961a4fb874b0b0e0daac74d9c7/tests/Jellyfin.XbmcMetadata.Tests/Test%20Data/Justice%20League.nfo#L105)), this PR makes it so that Radarr will set that attribute.

#### Screenshot (if UI related)

N/A

#### Todos

- [ ] Tests - There do not appear to be any automated tests for the NFO generation that I could add this change to. I have of course tested this manually.
- [ ] Translation Keys - Not applicable, this doesn't make any changes to the interface.
- [ ] Wiki Updates - Not applicable, the wiki doesn't contain any details about the generated NFO.

#### Issues Fixed or Closed by this PR

None.