### PR TITLE
Fixed: Prevent using Original names with other movie file tokens

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameValidation.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameValidation.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Organizer
                 return false;
             }
 
-            return (FileNameBuilder.MovieTitleRegex.IsMatch(value) && FileNameBuilder.ReleaseYearRegex.IsMatch(value)) && !FileNameValidation.OriginalTokenRegex.IsMatch(value); ||
+            return (FileNameBuilder.MovieTitleRegex.IsMatch(value) && FileNameBuilder.ReleaseYearRegex.IsMatch(value)) && !FileNameValidation.OriginalTokenRegex.IsMatch(value) ||
                    FileNameValidation.OriginalTokenRegex.IsMatch(value);
         }
     }

--- a/src/NzbDrone.Core/Organizer/FileNameValidation.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameValidation.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Organizer
                 return false;
             }
 
-            return (FileNameBuilder.MovieTitleRegex.IsMatch(value) && FileNameBuilder.ReleaseYearRegex.IsMatch(value)) && !FileNameValidation.OriginalTokenRegex.IsMatch(value) ||
+            return (FileNameBuilder.MovieTitleRegex.IsMatch(value) && FileNameBuilder.ReleaseYearRegex.IsMatch(value) && !FileNameValidation.OriginalTokenRegex.IsMatch(value)) ||
                    FileNameValidation.OriginalTokenRegex.IsMatch(value);
         }
     }

--- a/src/NzbDrone.Core/Organizer/FileNameValidation.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameValidation.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.Organizer
 
     public class ValidMovieFormatValidator : PropertyValidator
     {
-        protected override string GetDefaultMessageTemplate() => "Must contain movie title and release year OR Original Title";
+        protected override string GetDefaultMessageTemplate() => "Must contain either movie title and release year OR Original Title/Filename";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Organizer
                 return false;
             }
 
-            return (FileNameBuilder.MovieTitleRegex.IsMatch(value) && FileNameBuilder.ReleaseYearRegex.IsMatch(value)) ||
+            return (FileNameBuilder.MovieTitleRegex.IsMatch(value) && FileNameBuilder.ReleaseYearRegex.IsMatch(value)) && !FileNameValidation.OriginalTokenRegex.IsMatch(value); ||
                    FileNameValidation.OriginalTokenRegex.IsMatch(value);
         }
     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description

- Original Filename
- Original Title
OR
- Filename tokens 

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [x]Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes UX