### PR TITLE
New: Add Year sorting to Discover page

### DIFF
--- a/frontend/src/DiscoverMovie/Menus/DiscoverMovieSortMenu.js
+++ b/frontend/src/DiscoverMovie/Menus/DiscoverMovieSortMenu.js
@@ -48,6 +48,15 @@ function DiscoverMovieSortMenu(props) {
         </SortMenuItem>
 
         <SortMenuItem
+          name="year"
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          onPress={onSortSelect}
+        >
+          {translate('Year')}
+        </SortMenuItem>
+
+        <SortMenuItem
           name="inCinemas"
           sortKey={sortKey}
           sortDirection={sortDirection}

--- a/frontend/src/DiscoverMovie/Table/DiscoverMovieHeader.css
+++ b/frontend/src/DiscoverMovie/Table/DiscoverMovieHeader.css
@@ -36,7 +36,8 @@
 .imdbRating,
 .rottenTomatoesRating,
 .traktRating,
-.runtime {
+.runtime,
+.year {
   composes: headerCell from '~Components/Table/VirtualTableHeaderCell.css';
 
   flex: 0 0 90px;

--- a/frontend/src/DiscoverMovie/Table/DiscoverMovieHeader.css.d.ts
+++ b/frontend/src/DiscoverMovie/Table/DiscoverMovieHeader.css.d.ts
@@ -22,6 +22,7 @@ interface CssExports {
   'studio': string;
   'tmdbRating': string;
   'traktRating': string;
+  'year': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/frontend/src/DiscoverMovie/Table/DiscoverMovieRow.css
+++ b/frontend/src/DiscoverMovie/Table/DiscoverMovieRow.css
@@ -61,7 +61,8 @@
 .imdbRating,
 .rottenTomatoesRating,
 .traktRating,
-.runtime {
+.runtime,
+.year {
   composes: cell;
 
   flex: 0 0 90px;

--- a/frontend/src/DiscoverMovie/Table/DiscoverMovieRow.css.d.ts
+++ b/frontend/src/DiscoverMovie/Table/DiscoverMovieRow.css.d.ts
@@ -28,6 +28,7 @@ interface CssExports {
   'studio': string;
   'tmdbRating': string;
   'traktRating': string;
+  'year': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/frontend/src/DiscoverMovie/Table/DiscoverMovieRow.js
+++ b/frontend/src/DiscoverMovie/Table/DiscoverMovieRow.js
@@ -167,6 +167,14 @@ class DiscoverMovieRow extends Component {
               );
             }
 
+            if (name === 'year') {
+              return (
+                <VirtualTableRowCell key={name} className={styles[name]}>
+                  {year}
+                </VirtualTableRowCell>
+              );
+            }
+
             if (name === 'collection') {
               return (
                 <VirtualTableRowCell

--- a/frontend/src/Store/Actions/discoverMovieActions.js
+++ b/frontend/src/Store/Actions/discoverMovieActions.js
@@ -134,6 +134,12 @@ export const defaultState = {
       isVisible: true
     },
     {
+      name: 'year',
+      label: () => translate('Year'),
+      isSortable: true,
+      isVisible: false
+    },
+    {
       name: 'inCinemas',
       label: () => translate('InCinemas'),
       isSortable: true,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add Year sorting to the Discover page. Year also added as a customizable column to the table view.

#### Screenshot (if UI related)

<img width="1856" height="969" alt="474659230-82de8740-c721-4b1d-9598-d55d21724e03" src="https://github.com/user-attachments/assets/53cc23ae-adce-4a42-85e4-5d570de95f6a" />

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #10901 