### PR TITLE
fix: Notifications always include imdb link.

### DIFF
--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -45,18 +45,13 @@ namespace NzbDrone.Core.Notifications
         private string GetMessage(Movie movie, QualityModel quality)
         {
             var qualityString = quality.Quality.ToString();
-            var imdbUrl = "https://www.imdb.com/title/" + movie.MovieMetadata.Value.ImdbId + "/";
 
             if (quality.Revision.Version > 1)
             {
                 qualityString += " Proper";
             }
 
-            return string.Format("{0} ({1}) [{2}] {3}",
-                                    movie.Title,
-                                    movie.Year,
-                                    qualityString,
-                                    imdbUrl);
+            return string.Format("{0} ({1}) [{2}]", movie.Title, movie.Year, qualityString);
         }
 
         private bool ShouldHandleMovie(ProviderDefinition definition, Movie movie)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
IMDB link is included in the Notifications message always. Notification provider configuration is ignored. This PR removes the default link, only must be added if active in each Notification Provider.

#### Screenshot

Telegram Example with IMDB disabled:
<img width="769" height="258" alt="image" src="https://github.com/user-attachments/assets/1d3ac1df-e197-45fe-b0dc-31fa0aed34cc" />
 
<img width="440" height="579" alt="image" src="https://github.com/user-attachments/assets/8673cfcf-7ca2-4bcc-a241-0829f5d036cf" />

#### Todos
- [-] Tests
- [-] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [-] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX