### PR TITLE
New: Changing icon during import to blue

### DIFF
--- a/frontend/src/Activity/Queue/QueueStatus.tsx
+++ b/frontend/src/Activity/Queue/QueueStatus.tsx
@@ -90,7 +90,7 @@ function QueueStatus(props: QueueStatusProps) {
 
     if (trackedDownloadState === 'importing') {
       title += ` - ${translate('Importing')}`;
-      iconKind = kinds.PURPLE;
+      iconKind = kinds.PRIMARY;
     }
 
     if (trackedDownloadState === 'failedPending') {

--- a/frontend/src/Components/Icon.css
+++ b/frontend/src/Components/Icon.css
@@ -26,6 +26,10 @@
   color: var(--warningColor);
 }
 
+.primary {
+  color: var(--primaryColor);
+}
+
 .purple {
   color: var(--purple);
 }

--- a/frontend/src/Components/Icon.css.d.ts
+++ b/frontend/src/Components/Icon.css.d.ts
@@ -6,6 +6,7 @@ interface CssExports {
   'disabled': string;
   'info': string;
   'pink': string;
+  'primary': string;
   'purple': string;
   'success': string;
   'warning': string;


### PR DESCRIPTION


#### Database Migration
NO

#### Description
Changes the icon color for downloads being imported to blue (Primary).

#### Screenshot (if UI related)
<img width="66" height="82" alt="image" src="https://github.com/user-attachments/assets/b687779c-6586-4753-afcf-f38d9707f5f5" />

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

