### PR TITLE
Rename PTP_Golden and PTP_Approved flags to be more generic

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
@@ -200,8 +200,8 @@ namespace NzbDrone.Core.DecisionEngine
                     {
                         case IndexerFlags.G_DoubleUpload:
                         case IndexerFlags.G_Freeleech:
-                        case IndexerFlags.PTP_Approved:
-                        case IndexerFlags.PTP_Golden:
+                        case IndexerFlags.G_Approved:
+                        case IndexerFlags.G_Golden:
                         case IndexerFlags.G_Internal:
                             score += 2;
                             break;

--- a/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornParser.cs
+++ b/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornParser.cs
@@ -51,12 +51,12 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
 
                     if (torrent.GoldenPopcorn)
                     {
-                        flags |= IndexerFlags.PTP_Golden;
+                        flags |= IndexerFlags.G_Golden;
                     }
 
                     if (torrent.Checked)
                     {
-                        flags |= IndexerFlags.PTP_Approved;
+                        flags |= IndexerFlags.G_Approved;
                     }
 
                     switch (torrent.FreeleechType?.ToUpperInvariant())

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
@@ -263,6 +263,16 @@ namespace NzbDrone.Core.Indexers.Torznab
                 flags |= IndexerFlags.G_Scene;
             }
 
+            if (tags.Any(t => t.EqualsIgnoreCase("approved")))
+            {
+                flags |= IndexerFlags.G_Approved;
+            }
+
+            if (tags.Any(t => t.EqualsIgnoreCase("golden")))
+            {
+                flags |= IndexerFlags.G_Golden;
+            }
+
             return flags;
         }
 

--- a/src/NzbDrone.Core/Parser/Model/IndexerFlags.cs
+++ b/src/NzbDrone.Core/Parser/Model/IndexerFlags.cs
@@ -21,14 +21,14 @@ namespace NzbDrone.Core.Parser.Model
         G_DoubleUpload = 4,
 
         /// <summary>
-        /// Torrent is a very high quality encode, as applied manually by the PTP staff
+        /// Torrent is a very high quality encode
         /// </summary>
-        PTP_Golden = 8,
+        G_Golden = 8,
 
         /// <summary>
-        /// Torrent from PTP that has been checked (by staff or torrent checkers) for release description requirements
+        /// Torrent that has been checked for release description requirements
         /// </summary>
-        PTP_Approved = 16,
+        G_Approved = 16,
 
         /// <summary>
         /// Uploader is an internal release group


### PR DESCRIPTION
Update TorznabRSSParser to look for golden and approved tags and apply the appropriate indexer flags.

#### Database Migration
NO

#### Description
This renames the PTP specific indexer flags to make them more generic. It also updates the TorznabRSSParser to apply these flags when it finds the approved or golden tags, as sent by Prowlarr.

#### Issues Fixed or Closed by this PR

* Fixes https://github.com/Radarr/Radarr/issues/11173