### PR TITLE
New: Extend Postgres support to enable all connection string options

### DIFF
--- a/src/NzbDrone.Core.Test/Framework/DbTest.cs
+++ b/src/NzbDrone.Core.Test/Framework/DbTest.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using Npgsql;
 using NUnit.Framework;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Options;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Datastore.Migration.Framework;
@@ -179,6 +180,7 @@ namespace NzbDrone.Core.Test.Framework
 
             // Set up remaining container services
             Mocker.SetConstant(Options.Create(postgresOptions));
+            Mocker.GetMock<IOptions<LogOptions>>().Setup(v => v.Value).Returns(new LogOptions());
             Mocker.SetConstant<IConfigFileProvider>(Mocker.Resolve<ConfigFileProvider>());
             Mocker.SetConstant<IConnectionStringFactory>(Mocker.Resolve<ConnectionStringFactory>());
             Mocker.SetConstant<IMigrationController>(Mocker.Resolve<MigrationController>());

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -65,6 +65,8 @@ namespace NzbDrone.Core.Configuration
         string PostgresPassword { get; }
         string PostgresMainDb { get; }
         string PostgresLogDb { get; }
+        string PostgresMainDbConnectionString { get; }
+        string PostgresLogDbConnectionString { get; }
         string Theme { get; }
         bool TrustCgnatIpAddresses { get; }
     }
@@ -251,6 +253,8 @@ namespace NzbDrone.Core.Configuration
         public string PostgresMainDb => _postgresOptions?.MainDb ?? GetValue("PostgresMainDb", "radarr-main", persist: false);
         public string PostgresLogDb => _postgresOptions?.LogDb ?? GetValue("PostgresLogDb", "radarr-log", persist: false);
         public int PostgresPort => (_postgresOptions?.Port ?? 0) != 0 ? _postgresOptions.Port : GetValueInt("PostgresPort", 5432, persist: false);
+        public string PostgresMainDbConnectionString => _postgresOptions?.MainDbConnectionString ?? GetValue("PostgresMainDbConnectionString", string.Empty, persist: false);
+        public string PostgresLogDbConnectionString => _postgresOptions?.LogDbConnectionString ?? GetValue("PostgresLogDbConnectionString", string.Empty, persist: false);
         public bool LogDbEnabled => _logOptions.DbEnabled ?? GetValueBoolean("LogDbEnabled", true, persist: false);
         public bool LogSql => _logOptions.Sql ?? GetValueBoolean("LogSql", false, persist: false);
         public int LogRotate => _logOptions.Rotate ?? GetValueInt("LogRotate", 50, persist: false);

--- a/src/NzbDrone.Core/Datastore/ConnectionStringFactory.cs
+++ b/src/NzbDrone.Core/Datastore/ConnectionStringFactory.cs
@@ -17,16 +17,32 @@ namespace NzbDrone.Core.Datastore
     public class ConnectionStringFactory : IConnectionStringFactory
     {
         private readonly IConfigFileProvider _configFileProvider;
+        private bool _usePostgres;
+        private bool _usePostgresConnectionStrings;
 
         public ConnectionStringFactory(IAppFolderInfo appFolderInfo, IConfigFileProvider configFileProvider)
         {
             _configFileProvider = configFileProvider;
 
-            MainDbConnection = _configFileProvider.PostgresHost.IsNotNullOrWhiteSpace() ? GetPostgresConnectionString(_configFileProvider.PostgresMainDb) :
-                GetConnectionString(appFolderInfo.GetDatabase());
+            ValidatePostgresOptions();
 
-            LogDbConnection = _configFileProvider.PostgresHost.IsNotNullOrWhiteSpace() ? GetPostgresConnectionString(_configFileProvider.PostgresLogDb) :
-                GetConnectionString(appFolderInfo.GetLogDatabase());
+            if (_usePostgres)
+            {
+                if (_usePostgresConnectionStrings)
+                {
+                    MainDbConnection = GetPostgresConnectionInfoFromConnectionString(_configFileProvider.PostgresMainDbConnectionString);
+                    LogDbConnection = GetPostgresConnectionInfoFromConnectionString(_configFileProvider.PostgresLogDbConnectionString);
+                    return;
+                }
+
+                MainDbConnection = GetPostgresConnectionInfoFromIndividualValues(_configFileProvider.PostgresMainDb);
+                LogDbConnection = GetPostgresConnectionInfoFromIndividualValues(_configFileProvider.PostgresLogDb);
+                return;
+            }
+
+            // Default to sqlite
+            MainDbConnection = GetConnectionString(appFolderInfo.GetDatabase());
+            LogDbConnection = GetConnectionString(appFolderInfo.GetLogDatabase());
         }
 
         public DatabaseConnectionInfo MainDbConnection { get; private set; }
@@ -60,9 +76,9 @@ namespace NzbDrone.Core.Datastore
             return new DatabaseConnectionInfo(DatabaseType.SQLite, connectionBuilder.ConnectionString);
         }
 
-        private DatabaseConnectionInfo GetPostgresConnectionString(string dbName)
+        private DatabaseConnectionInfo GetPostgresConnectionInfoFromIndividualValues(string dbName)
         {
-            var connectionBuilder = new NpgsqlConnectionStringBuilder
+            var connectionBuilder = new NpgsqlConnectionStringBuilder()
             {
                 Database = dbName,
                 Host = _configFileProvider.PostgresHost,
@@ -73,6 +89,62 @@ namespace NzbDrone.Core.Datastore
             };
 
             return new DatabaseConnectionInfo(DatabaseType.PostgreSQL, connectionBuilder.ConnectionString);
+        }
+
+        private DatabaseConnectionInfo GetPostgresConnectionInfoFromConnectionString(string connectionString)
+        {
+            var connectionBuilder = new NpgsqlConnectionStringBuilder(connectionString)
+            {
+                Enlist = false
+            };
+
+            return new DatabaseConnectionInfo(DatabaseType.PostgreSQL, connectionBuilder.ConnectionString);
+        }
+
+        /// <summary>
+        /// Validates that either Postgres connection strings are both set or neither are set, and that either connection strings or
+        /// other Postgres settings are set, but not both.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when configuration is invalid.</exception>
+        private void ValidatePostgresOptions()
+        {
+            var isMainDBConnectionStringSet = !string.IsNullOrWhiteSpace(_configFileProvider.PostgresMainDbConnectionString);
+            var isLogDBConnectionStringSet = !string.IsNullOrWhiteSpace(_configFileProvider.PostgresLogDbConnectionString);
+            var isHostSet = !string.IsNullOrWhiteSpace(_configFileProvider.PostgresHost);
+
+            if (!isHostSet && !isMainDBConnectionStringSet && !isLogDBConnectionStringSet)
+            {
+                // No Postgres settings are set, so nothing to validate
+                return;
+            }
+
+            _usePostgres = true;
+
+            if (_configFileProvider.LogDbEnabled)
+            {
+                if (!isMainDBConnectionStringSet && isLogDBConnectionStringSet)
+                {
+                    throw new ArgumentException("Postgres MainDbConnectionString is set but LogDbConnectionString is not. Both must be set or neither.");
+                }
+
+                if (isLogDBConnectionStringSet && !isMainDBConnectionStringSet)
+                {
+                    throw new ArgumentException("Postgres LogDbConnectionString is set but MainDbConnectionString is not. Both must be set or neither.");
+                }
+            }
+
+            // At this point either all required connection strings are set or neither, so only one needs to be checked
+            var areConnectionStringConfigsSet = isMainDBConnectionStringSet;
+
+            // This one _must_ be set if connection strings are not being used, so it is used as a test to see if the user attempted configuration via individual settings
+            var areOtherPostgresConfigsSet = _configFileProvider.PostgresHost.IsNotNullOrWhiteSpace();
+
+            if (areConnectionStringConfigsSet && areOtherPostgresConfigsSet)
+            {
+                throw new ArgumentException($"Either both Postgres connection strings must be set, or the other Postgres settings must be set, but not both.");
+            }
+
+            _usePostgresConnectionStrings = areConnectionStringConfigsSet;
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/PostgresOptions.cs
+++ b/src/NzbDrone.Core/Datastore/PostgresOptions.cs
@@ -10,6 +10,8 @@ namespace NzbDrone.Core.Datastore
         public string Password { get; set; }
         public string MainDb { get; set; }
         public string LogDb { get; set; }
+        public string MainDbConnectionString { get; set; }
+        public string LogDbConnectionString { get; set; }
 
         public static PostgresOptions GetOptions()
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR enables support for all Postgres connection string options supported by the underlying Npgsql library. It does this by allowing users to specify a `PostgresConnectionString` parameter. If this parameter is provided, it is passed to the Npgsql connection string builder directly. Backwards compatibility is maintained by allowing existing config values to override any values in the connection string.

This will allow users to (if they explicitly choose to):
* Require connections to use TLS
* Configure the trusted CA for the server's serving cert
* Specify a client certificate to use for mTLS (this is what I personally want this for)
* Configure database pooling

I plan on porting this to other `*arr` tools as well.

[Here's an example of another tool](https://github.com/zoriya/Kyoo/pull/902/files#diff-5ed2d22798616ba5910316edcb4f3ab862263508a15bc2350401cefe38073e75) where I added this same support in a nearly identical manner, and [here's how this can be used](https://github.com/solidDoWant/infra-mk3/blob/575598aef2282445c4771e6c24829cb1c27bcb5b/cluster/gitops/media/kyoo/app/hr.yaml#L65-L75).

This has not yet been tested. If this general approach is acceptable to reviewers, then I'll deploy this code against a PG 17 cluster to verify that everything works as expected.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

Fixes https://github.com/Radarr/Radarr/issues/10821