### PR TITLE
Fix: incompatibility with reverse proxy forward auth providers

### DIFF
--- a/frontend/src/Utilities/createAjaxRequest.js
+++ b/frontend/src/Utilities/createAjaxRequest.js
@@ -27,6 +27,7 @@ function addContentType(ajaxOptions) {
 
 export default function createAjaxRequest(originalAjaxOptions) {
   const requestXHR = new window.XMLHttpRequest();
+  requestXHR.withCredentials = true; // Needed for CORS requests with cookies, which some reverse proxies with forward auth require
   let aborted = false;
   let complete = false;
 

--- a/src/NzbDrone.Common/Options/ServerOptions.cs
+++ b/src/NzbDrone.Common/Options/ServerOptions.cs
@@ -4,6 +4,7 @@ public class ServerOptions
 {
     public string UrlBase { get; set; }
     public string BindAddress { get; set; }
+    public string AllowedCORSOrigins { get; set; }  // TODO
     public int? Port { get; set; }
     public bool? EnableSsl { get; set; }
     public int? SslPort { get; set; }

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -31,6 +31,7 @@ namespace NzbDrone.Core.Configuration
         void EnsureDefaultConfigFile();
 
         string BindAddress { get; }
+        string AllowedCORSOrigins { get; }
         int Port { get; }
         int SslPort { get; }
         bool EnableSsl { get; }
@@ -173,6 +174,8 @@ namespace NzbDrone.Core.Configuration
                 return bindAddress;
             }
         }
+
+        public string AllowedCORSOrigins => _serverOptions.AllowedCORSOrigins ?? GetValue("AllowedCORSOrigins", "*");
 
         public int Port => _serverOptions.Port ?? GetValueInt("Port", 7878);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description

> [!NOTE]
> I will be filing a PR upstream with Sonarr prior to pulling this out of draft. I was already setup to develop this against Radarr, so I started here. I'm opening this for a little bit of visibility, as well as to help me keep track of it.

Radarr is currently partially incompatible with reverse proxy forward auth providers, like [Authentik](https://github.com/goauthentik/authentik), which need the client/front-end to submit cookies via CORS for credential renewal. Reverse proxies like Envoy Gateway and Istio respond to client requests with expired credentials with a redirect to the forward auth provider, which then handles credential renewal. Typically the redirected request to the forward auth provider will need to provide cookies (under the auth provider domain, but with an origin of the Radarr domain). For forward auth providers that support this, renewal can be handled without any user interaction (like refreshing the page).

The problem is that for this to work properly, any requests made via XMLHTTPRequest needs to allow for sending the forward auth provider's cookie to the forward auth provider, when the XMLHTTPRequest is redirected to it. This requires setting `XMLHTTPRequest.withCredentials = true`.

When this field is set to `true`, CORS preflight responses must include the HTTP `Origin` domain name rather than the `*` that is currently set. This should only be set if the provided `Origin` header matches an application-configured value. They also need to respond with the `Access-Control-Allow-Credentials` header.

I've added support for all of this, and I've made the application-configured CORS supported origin value configurable. This has not been plumbed up to the UI. When I open a PR with this change up against the Sonarr repo, I'm going to request feedback on what info should be presented in the UI and how.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

N/A