### PR TITLE
Skip proxy tests on MacOsX

### DIFF
--- a/src/NzbDrone.Core.Test/Http/HttpProxySettingsProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/Http/HttpProxySettingsProviderFixture.cs
@@ -8,6 +8,7 @@ using NzbDrone.Test.Common;
 namespace NzbDrone.Core.Test.Http
 {
     [TestFixture]
+    [Platform(Exclude = "MacOsX")]
     public class HttpProxySettingsProviderFixture : TestBase<HttpProxySettingsProvider>
     {
         private HttpProxySettings GetProxySettings()


### PR DESCRIPTION
Skips flakey proxy tests on MacOsX - DNS issues within the devops agent causing it