### PR TITLE
Prevent command-line data paths with multiple consecutive slashes from causing backups to fail

### DIFF
--- a/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
@@ -547,17 +547,11 @@ namespace NzbDrone.Common.Test.DiskTests
 
             var root = GetFilledTempFolder();
             var rootDir = root.FullName;
-            var fromFileName = "source-file";
-            var from = Path.Combine(rootDir, fromFileName);
-            var to = Path.Combine(rootDir, "destination-file");
-
-            var oneSlash = new string(Path.DirectorySeparatorChar, 1);
-            var threeSlashes = new string(Path.DirectorySeparatorChar, 3);
-            var overSlashed = Path.Combine(rootDir.Replace(oneSlash, threeSlashes), fromFileName);
-
+            var from = Path.Combine(rootDir, "source-file");
+            var toRootDir = rootDir.Replace(Path.DirectorySeparatorChar.ToString(), new string(Path.DirectorySeparatorChar, 3));
+            var to = Path.Combine(toRootDir, "destination-file");
             File.WriteAllText(from, "Source file");
-
-            var mode = Subject.TransferFile(overSlashed, to, TransferMode.Copy);
+            var mode = Subject.TransferFile(from, to, TransferMode.Copy);
             mode.Should().Be(TransferMode.Copy);
         }
 

--- a/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
@@ -541,6 +541,27 @@ namespace NzbDrone.Common.Test.DiskTests
         }
 
         [Test]
+        public void TransferFile_should_find_files_with_multiple_slashes_within_their_path()
+        {
+            WithRealDiskProvider();
+
+            var root = GetFilledTempFolder();
+            var rootDir = root.FullName;
+            var fromFileName = "source-file";
+            var from = Path.Combine(rootDir, fromFileName);
+            var to = Path.Combine(rootDir, "destination-file");
+
+            var oneSlash = new string(Path.DirectorySeparatorChar, 1);
+            var threeSlashes = new string(Path.DirectorySeparatorChar, 3);
+            var overSlashed = Path.Combine(rootDir.Replace(oneSlash, threeSlashes), fromFileName);
+
+            File.WriteAllText(from, "Source file");
+
+            var mode = Subject.TransferFile(overSlashed, to, TransferMode.Copy);
+            mode.Should().Be(TransferMode.Copy);
+        }
+
+        [Test]
         public void should_throw_if_destination_is_readonly()
         {
             Mocker.GetMock<IDiskProvider>()

--- a/src/NzbDrone.Common/Disk/DiskTransferService.cs
+++ b/src/NzbDrone.Common/Disk/DiskTransferService.cs
@@ -28,15 +28,21 @@ namespace NzbDrone.Common.Disk
 
         private string ResolveRealParentPath(string path)
         {
-            var parentPath = path.GetParentPath();
-            if (!_diskProvider.FolderExists(parentPath))
+            var testExists = path.GetParentPath();
+            if (!_diskProvider.FolderExists(testExists))
             {
                 return path;
             }
 
-            var realParentPath = parentPath.GetActualCasing();
+            var cleanPath = path.GetCleanPath();
+            if (cleanPath != path)
+            {
+                _logger.Warn($"Path '{path}' is not clean, using '{cleanPath}' to resolve the parent path instead");
+            }
 
-            var partialChildPath = path.Substring(parentPath.Length);
+            var parentPath = cleanPath.GetParentPath();
+            var realParentPath = parentPath.GetActualCasing();
+            var partialChildPath = cleanPath.Substring(parentPath.Length);
 
             return realParentPath + partialChildPath;
         }

--- a/src/NzbDrone.Common/Disk/DiskTransferService.cs
+++ b/src/NzbDrone.Common/Disk/DiskTransferService.cs
@@ -28,18 +28,12 @@ namespace NzbDrone.Common.Disk
 
         private string ResolveRealParentPath(string path)
         {
-            var testExists = path.GetParentPath();
-            if (!_diskProvider.FolderExists(testExists))
+            if (!_diskProvider.FolderExists(path.GetParentPath()))
             {
                 return path;
             }
 
             var cleanPath = path.GetCleanPath();
-            if (cleanPath != path)
-            {
-                _logger.Warn($"Path '{path}' is not clean, using '{cleanPath}' to resolve the parent path instead");
-            }
-
             var parentPath = cleanPath.GetParentPath();
             var realParentPath = parentPath.GetActualCasing();
             var partialChildPath = cleanPath.Substring(parentPath.Length);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR addresses [Issue 11300](https://github.com/Radarr/Radarr/issues/11300) by checking a path is 'clean' before resolving its parent path. Specifically, in this case, that the path doesn't include any multiple path separators. If it does, a warning is issued to the logger and a 'clean' copy of the path is used instead.

#### Todos
- [ x ] Tests
- [ n/a ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ n/a ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #11300