### PR TITLE
Fix: (#11303) collection API error when using `Movie CollectionThe`

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.tsx
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.tsx
@@ -121,7 +121,7 @@ const movieTokens = [
   },
   {
     token: '{Movie CleanCollectionThe}',
-    example: 'Movies CleanCollection, The',
+    example: 'Movies Collection, The',
     footNotes: '1',
   },
   { token: '{Movie Certification}', example: 'R' },

--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.tsx
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.tsx
@@ -116,7 +116,12 @@ const movieTokens = [
   },
   {
     token: '{Movie CollectionThe}',
-    example: 'Movie Collection, The',
+    example: "Movie's Collection, The",
+    footNotes: '1',
+  },
+  {
+    token: '{Movie CleanCollectionThe}',
+    example: 'Movies CleanCollection, The',
     footNotes: '1',
   },
   { token: '{Movie Certification}', example: 'R' },

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanCollectionTheFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanCollectionTheFixture.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
+{
+    [TestFixture]
+    public class CleanCollectionTheFixture : CoreTest<FileNameBuilder>
+    {
+        private Movie _movie;
+        private MovieFile _movieFile;
+        private NamingConfig _namingConfig;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movie = Builder<Movie>
+                    .CreateNew()
+                    .With(e => e.Title = "Movie Title")
+                    .Build();
+
+            _movieFile = new MovieFile { Quality = new QualityModel(Quality.HDTV720p), ReleaseGroup = "RadarrTest" };
+
+            _namingConfig = NamingConfig.Default;
+            _namingConfig.RenameMovies = true;
+
+            Mocker.GetMock<INamingConfigService>()
+                  .Setup(c => c.GetConfig()).Returns(_namingConfig);
+
+            Mocker.GetMock<IQualityDefinitionService>()
+                .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
+                .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+
+            Mocker.GetMock<ICustomFormatService>()
+                .Setup(v => v.All())
+                .Returns(new List<CustomFormat>());
+        }
+
+        [TestCase("The Badger's Collection", "Badgers Collection, The")]
+        [TestCase("@ The Movies Collection", "@ The Movies Collection")] // This doesn't seem right; see: FileNameBuilder.ScenifyRemoveChars, looks like it has the "at sign" in the regex
+        [TestCase("A Stupid/Idiotic Collection", "Stupid Idiotic Collection, A")]
+        [TestCase("An Astounding & Amazing Collection", "Astounding and Amazing Collection, An")]
+        [TestCase("The Amazing Animal-Hero's Collection (2001)", "Amazing Animal-Heros Collection, The 2001")]
+        [TestCase("A Different Movië (AU)", "Different Movie, A AU")]
+        [TestCase("The Repairër (ZH) (2015)", "Repairer, The ZH 2015")]
+        [TestCase("The Eighth Sensë 2 (Thai)", "Eighth Sense 2, The Thai")]
+        [TestCase("The Astonishing Jæg (Latin America)", "Astonishing Jaeg, The Latin America")]
+        [TestCase("The Hampster Pack (B&F)", "Hampster Pack, The BandF")]
+        [TestCase("The Gásm: I (Almost) Got Away With It (1900)", "Gasm I Almost Got Away With It, The 1900")]
+        [TestCase(null, "")]
+        public void should_get_expected_title_back(string collection, string expected)
+        {
+            SetCollectionName(_movie, collection);
+            _namingConfig.StandardMovieFormat = "{Movie CleanCollectionThe}";
+
+            Subject.BuildFileName(_movie, _movieFile)
+                   .Should().Be(expected);
+        }
+
+        [TestCase("A")]
+        [TestCase("Anne")]
+        [TestCase("Theodore")]
+        [TestCase("3%")]
+        public void should_not_change_title(string collection)
+        {
+            SetCollectionName(_movie, collection);
+            _namingConfig.StandardMovieFormat = "{Movie CleanCollectionThe}";
+
+            Subject.BuildFileName(_movie, _movieFile)
+                   .Should().Be(collection);
+        }
+
+        private void SetCollectionName(Movie movie, string collectionName)
+        {
+            var metadata = new MovieMetadata()
+            {
+                CollectionTitle = collectionName,
+            };
+            movie.MovieMetadata = new Core.Datastore.LazyLoaded<MovieMetadata>(metadata);
+            movie.MovieMetadata.Value.CollectionTitle = collectionName;
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleTheFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleTheFixture.cs
@@ -53,6 +53,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [TestCase("The Amazing Race (Latin America)", "Amazing Race, The Latin America")]
         [TestCase("The Rat Pack (A&E)", "Rat Pack, The AandE")]
         [TestCase("The Climax: I (Almost) Got Away With It (2016)", "Climax I Almost Got Away With It, The 2016")]
+        [TestCase(null, "")]
         public void should_get_expected_title_back(string title, string expected)
         {
             _movie.Title = title;

--- a/src/NzbDrone.Core.Test/OrganizerTests/GetMovieFolderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/GetMovieFolderFixture.cs
@@ -37,6 +37,7 @@ namespace NzbDrone.Core.Test.OrganizerTests
         [TestCase("The Y-Women Collection", "The Y-Women 14", 2005, "{Movie CollectionThe}/{Movie TitleThe} ({Release Year})", "Y-Women Collection, The", "Y-Women 14, The (2005)")]
         [TestCase("A Decade of Changes", "The First Year", 1980, "{Movie CollectionThe}/{Movie TitleThe} ({Release Year})", "Decade of Changes, A", "First Year, The (1980)")]
         [TestCase(null, "Just a Movie", 1999, "{Movie Title} ({Release Year})", null, "Just a Movie (1999)")]
+        [TestCase(null, "Collectionless Slop", 1949, "{Movie CollectionThe}/{Movie TitleThe} ({Release Year})", null, "Collectionless Slop (1949)")]
         public void should_use_movieFolderFormat_and_CollectionFormat_to_build_folder_name(string collectionTitle, string movieTitle, int year, string format, string expectedCollection, string expectedTitle)
         {
             _namingConfig.MovieFolderFormat = format;

--- a/src/NzbDrone.Core.Test/OrganizerTests/GetMovieFolderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/GetMovieFolderFixture.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.Movies;
@@ -31,6 +32,26 @@ namespace NzbDrone.Core.Test.OrganizerTests
             var movie = new Movie { Title = movieTitle, Year = year };
 
             Subject.GetMovieFolder(movie).Should().Be(expected);
+        }
+
+        [TestCase("The Y-Women Collection", "The Y-Women 14", 2005, "{Movie CollectionThe}/{Movie TitleThe} ({Release Year})", "Y-Women Collection, The", "Y-Women 14, The (2005)")]
+        public void should_use_movieFolderFormat_and_CollectionFormat_to_build_folder_name(string collectionTitle, string movieTitle, int year, string format, string expectedCollection, string expectedTitle)
+        {
+            _namingConfig.MovieFolderFormat = format;
+
+            var movie = new Movie
+            {
+                MovieMetadata = new MovieMetadata
+                {
+                    CollectionTitle = collectionTitle,
+                    Title = movieTitle,
+                    Year = year,
+                },
+            };
+
+            var result = Subject.GetMovieFolder(movie);
+            var expected = Path.Combine(expectedCollection, expectedTitle);
+            result.Should().Be(expected);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/OrganizerTests/GetMovieFolderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/GetMovieFolderFixture.cs
@@ -36,6 +36,7 @@ namespace NzbDrone.Core.Test.OrganizerTests
 
         [TestCase("The Y-Women Collection", "The Y-Women 14", 2005, "{Movie CollectionThe}/{Movie TitleThe} ({Release Year})", "Y-Women Collection, The", "Y-Women 14, The (2005)")]
         [TestCase("A Decade of Changes", "The First Year", 1980, "{Movie CollectionThe}/{Movie TitleThe} ({Release Year})", "Decade of Changes, A", "First Year, The (1980)")]
+        [TestCase(null, "Just a Movie", 1999, "{Movie Title} ({Release Year})", null, "Just a Movie (1999)")]
         public void should_use_movieFolderFormat_and_CollectionFormat_to_build_folder_name(string collectionTitle, string movieTitle, int year, string format, string expectedCollection, string expectedTitle)
         {
             _namingConfig.MovieFolderFormat = format;
@@ -51,7 +52,9 @@ namespace NzbDrone.Core.Test.OrganizerTests
             };
 
             var result = Subject.GetMovieFolder(movie);
-            var expected = Path.Combine(expectedCollection, expectedTitle);
+            var expected = !string.IsNullOrWhiteSpace(expectedCollection)
+                ? Path.Combine(expectedCollection, expectedTitle)
+                : expectedTitle;
             result.Should().Be(expected);
         }
     }

--- a/src/NzbDrone.Core.Test/OrganizerTests/GetMovieFolderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/GetMovieFolderFixture.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.Test.OrganizerTests
         }
 
         [TestCase("The Y-Women Collection", "The Y-Women 14", 2005, "{Movie CollectionThe}/{Movie TitleThe} ({Release Year})", "Y-Women Collection, The", "Y-Women 14, The (2005)")]
-        [TestCase("A Decade of Changes", "The First Year", 1980, "{Movie CollectionThe}/{Movie TitleThe} ({Release Year})", "Decade of Changes, A", "First Year, The (1980)")]
+        [TestCase("A Decade's Worth of Changes", "The First Year", 1980, "{Movie CleanCollectionThe}/{Movie TitleThe} ({Release Year})", "Decades Worth of Changes, A", "First Year, The (1980)")]
         [TestCase(null, "Just a Movie", 1999, "{Movie Title} ({Release Year})", null, "Just a Movie (1999)")]
         [TestCase(null, "Collectionless Slop", 1949, "{Movie CollectionThe}/{Movie TitleThe} ({Release Year})", null, "Collectionless Slop (1949)")]
         public void should_use_movieFolderFormat_and_CollectionFormat_to_build_folder_name(string collectionTitle, string movieTitle, int year, string format, string expectedCollection, string expectedTitle)

--- a/src/NzbDrone.Core.Test/OrganizerTests/GetMovieFolderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/GetMovieFolderFixture.cs
@@ -35,6 +35,7 @@ namespace NzbDrone.Core.Test.OrganizerTests
         }
 
         [TestCase("The Y-Women Collection", "The Y-Women 14", 2005, "{Movie CollectionThe}/{Movie TitleThe} ({Release Year})", "Y-Women Collection, The", "Y-Women 14, The (2005)")]
+        [TestCase("A Decade of Changes", "The First Year", 1980, "{Movie CollectionThe}/{Movie TitleThe} ({Release Year})", "Decade of Changes, A", "First Year, The (1980)")]
         public void should_use_movieFolderFormat_and_CollectionFormat_to_build_folder_name(string collectionTitle, string movieTitle, int year, string format, string expectedCollection, string expectedTitle)
         {
             _namingConfig.MovieFolderFormat = format;

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -223,6 +223,11 @@ namespace NzbDrone.Core.Organizer
 
         public static string CleanTitleThe(string title)
         {
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                return string.Empty;
+            }
+
             if (TitlePrefixRegex.IsMatch(title))
             {
                 var splitResult = TitlePrefixRegex.Split(title);
@@ -274,6 +279,7 @@ namespace NzbDrone.Core.Organizer
             tokenHandlers["{Movie Certification}"] = m => movie.MovieMetadata.Value.Certification ?? string.Empty;
             tokenHandlers["{Movie Collection}"] = m => Truncate(movie.MovieMetadata.Value.CollectionTitle, m.CustomFormat) ?? string.Empty;
             tokenHandlers["{Movie CollectionThe}"] = m => Truncate(TitleThe(movie.MovieMetadata.Value.CollectionTitle), m.CustomFormat) ?? string.Empty;
+            tokenHandlers["{Movie CleanCollectionThe}"] = m => Truncate(CleanTitleThe(movie.MovieMetadata.Value.CollectionTitle), m.CustomFormat) ?? string.Empty;
         }
 
         private string GetLanguageTitle(Movie movie, string isoCodes)

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -217,10 +217,8 @@ namespace NzbDrone.Core.Organizer
             {
                 return string.Empty;
             }
-            else
-            {
-                return TitlePrefixRegex.Replace(title, "$2, $1$3");
-            }
+
+            return TitlePrefixRegex.Replace(title, "$2, $1$3");
         }
 
         public static string CleanTitleThe(string title)

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -211,21 +211,16 @@ namespace NzbDrone.Core.Organizer
             return title.RemoveDiacritics();
         }
 
-        public static string CollectionTitleThe(string collectionTitle)
+        public static string TitleThe(string title)
         {
-            if (string.IsNullOrEmpty(collectionTitle))
+            if (string.IsNullOrWhiteSpace(title))
             {
                 return string.Empty;
             }
             else
             {
-                return TitleThe(collectionTitle);
+                return TitlePrefixRegex.Replace(title, "$2, $1$3");
             }
-        }
-
-        public static string TitleThe(string title)
-        {
-            return TitlePrefixRegex.Replace(title, "$2, $1$3");
         }
 
         public static string CleanTitleThe(string title)
@@ -280,7 +275,7 @@ namespace NzbDrone.Core.Organizer
 
             tokenHandlers["{Movie Certification}"] = m => movie.MovieMetadata.Value.Certification ?? string.Empty;
             tokenHandlers["{Movie Collection}"] = m => Truncate(movie.MovieMetadata.Value.CollectionTitle, m.CustomFormat) ?? string.Empty;
-            tokenHandlers["{Movie CollectionThe}"] = m => Truncate(CollectionTitleThe(movie.MovieMetadata.Value.CollectionTitle), m.CustomFormat) ?? string.Empty;
+            tokenHandlers["{Movie CollectionThe}"] = m => Truncate(TitleThe(movie.MovieMetadata.Value.CollectionTitle), m.CustomFormat) ?? string.Empty;
         }
 
         private string GetLanguageTitle(Movie movie, string isoCodes)

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -211,6 +211,18 @@ namespace NzbDrone.Core.Organizer
             return title.RemoveDiacritics();
         }
 
+        public static string CollectionTitleThe(string collectionTitle)
+        {
+            if (string.IsNullOrEmpty(collectionTitle))
+            {
+                return string.Empty;
+            }
+            else
+            {
+                return TitleThe(collectionTitle);
+            }
+        }
+
         public static string TitleThe(string title)
         {
             return TitlePrefixRegex.Replace(title, "$2, $1$3");
@@ -268,7 +280,7 @@ namespace NzbDrone.Core.Organizer
 
             tokenHandlers["{Movie Certification}"] = m => movie.MovieMetadata.Value.Certification ?? string.Empty;
             tokenHandlers["{Movie Collection}"] = m => Truncate(movie.MovieMetadata.Value.CollectionTitle, m.CustomFormat) ?? string.Empty;
-            tokenHandlers["{Movie CollectionThe}"] = m => Truncate(TitleThe(movie.MovieMetadata.Value.CollectionTitle), m.CustomFormat) ?? string.Empty;
+            tokenHandlers["{Movie CollectionThe}"] = m => Truncate(CollectionTitleThe(movie.MovieMetadata.Value.CollectionTitle), m.CustomFormat) ?? string.Empty;
         }
 
         private string GetLanguageTitle(Movie movie, string isoCodes)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds in a null check around `Movie CollectionThe` handling (in a new method) to allow for `null` values for the `Movie.Metadata.Value.CollectionTitle`

#### Screenshot (if UI related)

#### Todos
- [X] Tests

#### Issues Fixed or Closed by this PR
Fixes #11303