### PR TITLE
Fixed WantMoreControlAddACustomFormat settings/customformats for Spanish translation

### DIFF
--- a/src/NzbDrone.Core/Localization/Core/es.json
+++ b/src/NzbDrone.Core/Localization/Core/es.json
@@ -1369,7 +1369,7 @@
     "TableOptionsButton": "Botón de opciones de tabla",
     "TorrentBlackholeSaveMagnetFilesExtension": "Guardar extensión de archivos magnet",
     "TorrentBlackholeTorrentFolder": "Carpeta de torrent",
-    "WantMoreControlAddACustomFormat": "¿Quieres más control sobre qué descargas son preferidas? Añade un [formato personalizado](/opciones/formatospersonalizados)",
+    "WantMoreControlAddACustomFormat": "¿Quieres más control sobre qué descargas son preferidas? Añade un [formato personalizado](/settings/customformats)",
     "RemoveQueueItem": "Eliminar - {sourceTitle}",
     "NotificationsGotifySettingsAppTokenHelpText": "El token de aplicación generado por Gotify",
     "NotificationsJoinSettingsDeviceNames": "Nombres de dispositivo",


### PR DESCRIPTION
Corrected the mistranslated URL segment for Spanish translation to ensure proper navigation, preventing redirect to non-existent page

#### Database Migration
NO

#### Description
It should be /settings/customformats, like in other translations
Instead of /opciones/formatospersonalizados

I searched for “WantMoreControlAddACustomFormat” to see whether it was a common issue in other translations, but it seems to only affect the Spanish one.


#### Screenshot (if UI related)


#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/es.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
There was no open issue for this