### PR TITLE
Fix: search movie with german umlaut

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -30,6 +30,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
             cleanTitle = cleanTitle.Replace("&", "and");
             cleanTitle = SpecialCharacter.Replace(cleanTitle, "");
             cleanTitle = NonWord.Replace(cleanTitle, "+");
+            cleanTitle = Parser.Parser.ReplaceGermanUmlauts(cleanTitle);
 
             // remove any repeating +s
             cleanTitle = Regex.Replace(cleanTitle, @"\+{2,}", "+");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Replace german umlauts in cleantitle. ä => ae instead of ä =>a
Exisiting code was reused to accomplish this.

#### Issues Fixed or Closed by this PR

* Fixes #9283