### PR TITLE
Fix: Fix ffprobe call causing unnecessary disk reads #8363

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -119,7 +119,6 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 {
                     var videoStreamIndex = analysis.VideoStreams.FindIndex(stream => stream.Index == primaryVideoStream?.Index);
                     videoStreamIndex = videoStreamIndex == -1 ? 0 : videoStreamIndex;
-                    _logger.Debug("Reading video stream at index {0} with relative index v:{1}", primaryVideoStream?.Index, videoStreamIndex);
                     var frameOutput = FFProbe.GetFrameJson(filename, ffOptions: new () { ExtraArguments = $"-read_intervals \"%+#1\" -select_streams v:{videoStreamIndex}" });
                     mediaInfoModel.RawFrameData = frameOutput;
 

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -118,8 +118,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 if (PqTransferFunctions.Contains(mediaInfoModel.VideoTransferCharacteristics))
                 {
                     var videoStreamIndex = analysis.VideoStreams.FindIndex(stream => stream.Index == primaryVideoStream?.Index);
-                    videoStreamIndex = videoStreamIndex == -1 ? 0 : videoStreamIndex;
-                    var frameOutput = FFProbe.GetFrameJson(filename, ffOptions: new () { ExtraArguments = $"-read_intervals \"%+#1\" -select_streams v:{videoStreamIndex}" });
+                    var frameOutput = FFProbe.GetFrameJson(filename, ffOptions: new () { ExtraArguments = $"-read_intervals \"%+#1\" -select_streams v:{(videoStreamIndex == -1 ? 0 : videoStreamIndex)}" });
                     mediaInfoModel.RawFrameData = frameOutput;
 
                     frames = FFProbe.AnalyseFrameJson(frameOutput);

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -117,7 +117,10 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 // if it looks like PQ10 or similar HDR, do a frame analysis to figure out which type it is
                 if (PqTransferFunctions.Contains(mediaInfoModel.VideoTransferCharacteristics))
                 {
-                    var frameOutput = FFProbe.GetFrameJson(filename, ffOptions: new () { ExtraArguments = $"-read_intervals \"%+#1\" -select_streams v:{primaryVideoStream?.Index ?? 0}" });
+                    var videoStreamIndex = analysis.VideoStreams.FindIndex(stream => stream.Index == primaryVideoStream?.Index);
+                    videoStreamIndex = videoStreamIndex == -1 ? 0 : videoStreamIndex;
+                    _logger.Debug("Reading video stream at index {0} with relative index v:{1}", primaryVideoStream?.Index, videoStreamIndex);
+                    var frameOutput = FFProbe.GetFrameJson(filename, ffOptions: new () { ExtraArguments = $"-read_intervals \"%+#1\" -select_streams v:{videoStreamIndex}" });
                     mediaInfoModel.RawFrameData = frameOutput;
 
                     frames = FFProbe.AnalyseFrameJson(frameOutput);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- We currently pass the global stream index of the primary video stream with v:index.
- ffprobe expects the index to be filtered by the stream type. If the video appears at index 2 but is the only video stream in the file, we should pass v:0. Passing v:2 will cause ffprobe to unnecessarily read the entire file during analysis to find a video stream at index 2 which doesn't exist
#### Screenshot (if UI related)

#### Steps to reproduce bug
1. Find a video file where the video stream is at a non-zero global index, let's say it's at index 2.
2. Current behavior: Run `ffprobe -loglevel error -print_format json -show_frames -v verbose -sexagesimal -read_intervals %+#1 -select_streams v:2 <filename>`. Notice the total bytes read equals the size of the file.
3. Repeat with v:0 assuming the file only has one video stream. The total bytes read will be a lot lower (<100KB usually)

Corresponding sonarr PR: https://github.com/Sonarr/Sonarr/pull/8363