### PR TITLE
Fix: RefreshMonitoredDownloads should run at a high priority

### DIFF
--- a/src/Radarr.Api.V3/Commands/CommandController.cs
+++ b/src/Radarr.Api.V3/Commands/CommandController.cs
@@ -7,6 +7,7 @@ using NzbDrone.Common.Composition;
 using NzbDrone.Common.Serializer;
 using NzbDrone.Common.TPL;
 using NzbDrone.Core.Datastore.Events;
+using NzbDrone.Core.Download;
 using NzbDrone.Core.MediaFiles.MovieImport.Manual;
 using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Messaging.Events;
@@ -62,7 +63,7 @@ namespace Radarr.Api.V3.Commands
             using (var reader = new StreamReader(Request.Body))
             {
                 var body = reader.ReadToEnd();
-                var priority = commandType == typeof(ManualImportCommand)
+                var priority = commandType == typeof(ManualImportCommand) || commandType == typeof(RefreshMonitoredDownloadsCommand)
                     ? CommandPriority.High
                     : CommandPriority.Normal;
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When adding an import list or searching for lots of things at the same time, the download queue builds up. When users click the refresh button in the UI or apps like nzbdav/decypharr manually issue a refresh, this gets added to the end of the queue blocking the scheduled Refresh job from running