### PR TITLE
Fixed: Add On Movie Added to Plex Media Server connection

### DIFF
--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServer.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServer.cs
@@ -37,6 +37,11 @@ namespace NzbDrone.Core.Notifications.Plex.Server
             UpdateIfEnabled(message.Movie);
         }
 
+        public override void OnMovieAdded(Movie movie)
+        {
+            UpdateIfEnabled(movie);
+        }
+
         public override void OnMovieRename(Movie movie, List<RenamedMovieFile> renamedFiles)
         {
             UpdateIfEnabled(movie);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Sonarr added the OnSeriesAdd connection event (and added it to the Plex Media Server connection) in https://github.com/Sonarr/Sonarr/commit/dec6e140365981f0391a759db33f4f5de46adc24. Radarr added OnMovieAdded at some point and has added it for most connections, but it's missing from the Plex Media Server one.

Note: I suspect the implementation here is fine, but I did note that Sonarr created a [SeriesAddMessage ](https://github.com/Sonarr/Sonarr/blob/develop/src/NzbDrone.Core/Notifications/SeriesAddMessage.cs) whereas Radarr just opts to leverage the Movie class. Additionally, this may have been intentionally left out since it's somewhat pointless to do a scan on movie add because there's no files yet, and import/rename/etc. should pick that up instead.

#### Screenshot (if UI related)
<img width="709" height="1063" alt="image" src="https://github.com/user-attachments/assets/b1376fee-cf02-4843-a490-7a13d8349c18" />

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* N/A