### PR TITLE
Fix: progress info was hidden when a move has long name

### DIFF
--- a/frontend/src/Components/ProgressBar.css
+++ b/frontend/src/Components/ProgressBar.css
@@ -1,5 +1,6 @@
 .container {
   position: relative;
+  flex-shrink: 0;
   overflow: hidden;
   width: 100%;
   border-radius: 4px;


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The text under the movie poster is there but when the text is really long, the progress bar was hidden. Now it'll be there.

#### Screenshot (if UI related)

BEFORE
<img width="795" height="273" alt="image" src="https://github.com/user-attachments/assets/e484578d-3ad7-43c7-9a10-454f57980a47" />

AFTER
<img width="816" height="295" alt="image" src="https://github.com/user-attachments/assets/47ffb48c-4a17-4bf3-bf32-e95c1120df19" />
