### PR TITLE
Fixed: Increase initial Sentry log level to reduce startup noise

### DIFF
--- a/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
+++ b/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
@@ -87,7 +87,7 @@ namespace NzbDrone.Common.Instrumentation
                 Layout = "${message}"
             };
 
-            var loggingRule = new LoggingRule("*", updateClient ? LogLevel.Trace : LogLevel.Debug, target);
+            var loggingRule = new LoggingRule("*", updateClient ? LogLevel.Trace : LogLevel.Warn, target);
             LogManager.Configuration.AddTarget("sentryTarget", target);
             LogManager.Configuration.LoggingRules.Add(loggingRule);
 


### PR DESCRIPTION
#### Database Migration
 NO

#### Description
Right now, Radarr registers Sentry at the `Debug` level during early startup. Since this happens before `config.xml` is even read, the Sentry SDK "wake up" and pings `sentry.servarr.com` on every boot, even if the user has analytics disabled.

I did a deep dive and confirmed two things:
1.  Radarr is much noisier than Sonarr on boot because of this `Debug` threshold.
2.  I verified that Radarr's `IsSentryMessage` filter correctly blocks Trace/Info logs from actually being uploaded. The pings you see in DNS logs are just a side-effect of the SDK initializing too aggressively, and no data is sent.

This PR changes the initial level to `Warn` to [match Sonarr](https://github.com/Sonarr/Sonarr/blob/main/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs#L103). It keeps the startup sequence silent and private during a healthy boot, but still allows Sentry to catch actual crashes if they happen before the config loads.

#### Todos
   - [x] Verified via patching: DNS pings are eliminated on startup.
   - [x] Confirmed existing filters properly catch/block Info/Trace data before transmission.
