### PR TITLE
Add 'Is Empty' and 'Is Not Empty' operators to filters. specifically …

### DIFF
--- a/frontend/src/Components/Filter/Builder/FilterBuilderRow.js
+++ b/frontend/src/Components/Filter/Builder/FilterBuilderRow.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import SelectInput from 'Components/Form/SelectInput';
 import IconButton from 'Components/Link/IconButton';
 import { filterBuilderTypes, filterBuilderValueTypes, icons } from 'Helpers/Props';
+import * as filterTypes from 'Helpers/Props/filterTypes';
 import sortByProp from 'Utilities/Array/sortByProp';
 import BoolFilterBuilderRowValue from './BoolFilterBuilderRowValue';
 import DateFilterBuilderRowValue from './DateFilterBuilderRowValue';
@@ -226,6 +227,13 @@ class FilterBuilderRow extends Component {
 
     const selectedFilterBuilderProp = this.selectedFilterBuilderProp;
 
+    const operatorsWithoutValue = [
+      filterTypes.IS_EMPTY,
+      filterTypes.IS_NOT_EMPTY
+    ];
+
+    const requiresValue = !operatorsWithoutValue.includes(filterType);
+
     const keyOptions = filterBuilderProps.map((availablePropFilter) => {
       const { name, label } = availablePropFilter;
 
@@ -262,10 +270,11 @@ class FilterBuilderRow extends Component {
               />
           }
         </div>
-
-        <div className={styles.valueInputContainer}>
-          {
-            filterValue != null && !!selectedFilterBuilderProp &&
+        {
+          requiresValue &&
+          filterValue != null &&
+          !!selectedFilterBuilderProp &&
+            <div className={styles.valueInputContainer}>
               <ValueComponent
                 filterType={filterType}
                 filterValue={filterValue}
@@ -273,8 +282,8 @@ class FilterBuilderRow extends Component {
                 sectionItems={sectionItems}
                 onChange={this.onFilterChange}
               />
-          }
-        </div>
+            </div>
+        }
 
         <div className={styles.actionsContainer}>
           <IconButton

--- a/frontend/src/Helpers/Props/filterBuilderTypes.js
+++ b/frontend/src/Helpers/Props/filterBuilderTypes.js
@@ -28,6 +28,14 @@ export const possibleFilterTypes = {
     {
       key: filterTypes.NOT_CONTAINS,
       value: () => translate('FilterDoesNotContain')
+    },
+    {
+      key: filterTypes.IS_EMPTY,
+      value: () => translate('FilterIsEmpty')
+    },
+    {
+      key: filterTypes.IS_NOT_EMPTY,
+      value: () => translate('FilterIsNotEmpty')
     }
   ],
 

--- a/frontend/src/Helpers/Props/filterTypePredicates.js
+++ b/frontend/src/Helpers/Props/filterTypePredicates.js
@@ -55,6 +55,31 @@ const filterTypePredicates = {
 
   [filterTypes.NOT_ENDS_WITH]: function(itemValue, filterValue) {
     return !itemValue.toLowerCase().endsWith(filterValue.toLowerCase());
+  },
+
+  [filterTypes.IS_EMPTY]: function(itemValue, filterValue) {
+    console.log('isEmpty', { itemValue });
+    if (itemValue === null || itemValue === undefined) {
+      return true;
+    }
+
+    if (Array.isArray(itemValue) || typeof itemValue === 'string') {
+      return itemValue.length === 0;
+    }
+
+    return false;
+  },
+
+  [filterTypes.IS_NOT_EMPTY]: function(itemValue, filterValue) {
+    if (itemValue === null || itemValue === undefined) {
+      return false;
+    }
+
+    if (Array.isArray(itemValue) || typeof itemValue === 'string') {
+      return itemValue.length > 0;
+    }
+
+    return true;
   }
 };
 

--- a/frontend/src/Helpers/Props/filterTypePredicates.js
+++ b/frontend/src/Helpers/Props/filterTypePredicates.js
@@ -58,7 +58,6 @@ const filterTypePredicates = {
   },
 
   [filterTypes.IS_EMPTY]: function(itemValue, filterValue) {
-    console.log('isEmpty', { itemValue });
     if (itemValue === null || itemValue === undefined) {
       return true;
     }

--- a/frontend/src/Helpers/Props/filterTypes.js
+++ b/frontend/src/Helpers/Props/filterTypes.js
@@ -14,6 +14,8 @@ export const STARTS_WITH = 'startsWith';
 export const NOT_STARTS_WITH = 'notStartsWith';
 export const ENDS_WITH = 'endsWith';
 export const NOT_ENDS_WITH = 'notEndsWith';
+export const IS_EMPTY = 'isEmpty';
+export const IS_NOT_EMPTY = 'isNotEmpty';
 
 export const all = [
   CONTAINS,
@@ -31,5 +33,7 @@ export const all = [
   STARTS_WITH,
   NOT_STARTS_WITH,
   ENDS_WITH,
-  NOT_ENDS_WITH
+  NOT_ENDS_WITH,
+  IS_EMPTY,
+  IS_NOT_EMPTY
 ];

--- a/frontend/src/Store/Selectors/createClientSideCollectionSelector.js
+++ b/frontend/src/Store/Selectors/createClientSideCollectionSelector.js
@@ -43,7 +43,7 @@ function filter(items, state) {
       if (filterPredicates && filterPredicates.hasOwnProperty(key)) {
         const predicate = filterPredicates[key];
 
-        if (Array.isArray(value)) {
+        if (Array.isArray(value) && value.length > 0) {
           if (
             type === filterTypes.NOT_CONTAINS ||
             type === filterTypes.NOT_EQUAL

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -697,6 +697,8 @@
   "FilterNotInLast": "not in the last",
   "FilterNotInNext": "not in the next",
   "FilterStartsWith": "starts with",
+  "FilterIsEmpty": "is empty",
+  "FilterIsNotEmpty": "is NOT empty",
   "Filters": "Filters",
   "FilterMoviePropertiesOnlyNotFileWarning": "Filters are available only for the properties of a movie, they are not available for properties of the file(s) you may have for that movie.",
   "FirstDayOfWeek": "First Day of Week",


### PR DESCRIPTION
…to allow a user to filter movies that are part of a collection or not a part of a collection

#### Database Migration
 NO

#### Description
Adds two new filter operators, Is Empty and Is Not Empty, allowing users to filter items based on whether a field has a value.

This improves filtering for fields such as Collection, making it possible to quickly find movies that belong to a collection or those that do not.

Changes include:
- Added IS_EMPTY and IS_NOT_EMPTY filter types
- Updated filter predicates to support value-less operators
- Updated filter builder UI to hide the value input for these operators
- Adjusted filtering logic to correctly evaluate filters with empty values

#### Screenshot (if UI related)

#### Todos
-Tests (not applicable, frontend-only change)
-Translation Keys (added FilterIsEmpty and FilterIsNotEmpty)
- Wiki Updates (not needed)

#### Issues Fixed or Closed by this PR

* Related to #6936