### PR TITLE
Log media info title used to augment quality

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateQuality.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateQuality.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators
                     continue;
                 }
 
-                _logger.Trace("Considering Source {0} ({1}) Resolution {2} ({3}) Revision {4} from {5}", augmentedQuality.Source, augmentedQuality.SourceConfidence, augmentedQuality.Resolution, augmentedQuality.ResolutionConfidence, augmentedQuality.Revision, augmentQuality.Name);
+                _logger.Trace("Considering Source {0} ({1}) Resolution {2} ({3}) Modifier {4} ({5}) Revision {6} from {7}", augmentedQuality.Source, augmentedQuality.SourceConfidence, augmentedQuality.Resolution, augmentedQuality.ResolutionConfidence, augmentedQuality.Modifier, augmentedQuality.ModifierConfidence, augmentedQuality.Revision, augmentQuality.Name);
 
                 if (source == QualitySource.UNKNOWN ||
                     (augmentedQuality.SourceConfidence > sourceConfidence && augmentedQuality.Source != QualitySource.UNKNOWN))
@@ -85,7 +85,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators
                 }
             }
 
-            _logger.Trace("Selected Source {0} ({1}) Resolution {2} ({3}) Revision {4}", source, sourceConfidence, resolution, resolutionConfidence, revision);
+            _logger.Trace("Selected Source {0} ({1}) Resolution {2} ({3}) Modifier {4} ({5}) Revision {6}", source, sourceConfidence, resolution, resolutionConfidence, modifier, modifierConfidence, revision);
 
             var quality = new QualityModel(QualityFinder.FindBySourceAndResolution(source, resolution, modifier), revision);
 

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfo.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfo.cs
@@ -30,6 +30,8 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenter
             var height = localMovie.MediaInfo.Height;
             var source = QualitySource.UNKNOWN;
             var sourceConfidence = Confidence.Default;
+            var modifier = Modifier.NONE;
+            var modifierConfidence = Confidence.Default;
             var title = localMovie.MediaInfo.Title?.Trim();
 
             if (title.IsNotNullOrWhiteSpace())
@@ -44,37 +46,39 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenter
                 {
                     source = parsedQuality.Quality.Source;
                     sourceConfidence = Confidence.MediaInfo;
+                    modifier = parsedQuality.Quality.Modifier;
+                    modifierConfidence = Confidence.MediaInfo;
                 }
             }
 
             if (width >= 3200 || height >= 2100)
             {
                 _logger.Trace("Resolution {0}x{1} considered 2160p", width, height);
-                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R2160p, Confidence.MediaInfo);
+                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R2160p, Confidence.MediaInfo, modifier, modifierConfidence);
             }
 
             if (width >= 1800 || height >= 1000)
             {
                 _logger.Trace("Resolution {0}x{1} considered 1080p", width, height);
-                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R1080p, Confidence.MediaInfo);
+                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R1080p, Confidence.MediaInfo, modifier, modifierConfidence);
             }
 
             if (width >= 1200 || height >= 700)
             {
                 _logger.Trace("Resolution {0}x{1} considered 720p", width, height);
-                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R720p, Confidence.MediaInfo);
+                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R720p, Confidence.MediaInfo, modifier, modifierConfidence);
             }
 
             if (width >= 1000 || height >= 560)
             {
                 _logger.Trace("Resolution {0}x{1} considered 576p", width, height);
-                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R576p, Confidence.MediaInfo);
+                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R576p, Confidence.MediaInfo, modifier, modifierConfidence);
             }
 
             if (width > 0 && height > 0)
             {
                 _logger.Trace("Resolution {0}x{1} considered 480p", width, height);
-                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R480p, Confidence.MediaInfo);
+                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R480p, Confidence.MediaInfo, modifier, modifierConfidence);
             }
 
             _logger.Trace("Resolution {0}x{1}", width, height);

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfo.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfo.cs
@@ -30,11 +30,13 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenter
             var height = localMovie.MediaInfo.Height;
             var source = QualitySource.UNKNOWN;
             var sourceConfidence = Confidence.Default;
-            var title = localMovie.MediaInfo.Title;
+            var title = localMovie.MediaInfo.Title?.Trim();
 
             if (title.IsNotNullOrWhiteSpace())
             {
-                var parsedQuality = QualityParser.ParseQualityName(title.Trim());
+                _logger.Debug("Parsing quality from media info title '{0}'", title);
+
+                var parsedQuality = QualityParser.ParseQualityName(title);
 
                 // Only use the quality if it's not unknown and the source is from the name (which is MediaInfo's title in this case)
                 if (parsedQuality.Quality.Source != QualitySource.UNKNOWN &&

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityResult.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityResult.cs
@@ -43,14 +43,9 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenter
             return new AugmentQualityResult(QualitySource.UNKNOWN, Confidence.Default, resolution, resolutionConfidence, Modifier.NONE, Confidence.Default, null, Confidence.Default);
         }
 
-        public static AugmentQualityResult ModifierOnly(Modifier modifier, Confidence modifierConfidence)
+        public static AugmentQualityResult SourceAndResolutionOnly(QualitySource source, Confidence sourceConfidence, int resolution, Confidence resolutionConfidence, Modifier modifier, Confidence modifierConfidence)
         {
-            return new AugmentQualityResult(QualitySource.UNKNOWN, Confidence.Default, 0, Confidence.Default, modifier, modifierConfidence, null, Confidence.Default);
-        }
-
-        public static AugmentQualityResult SourceAndResolutionOnly(QualitySource source, Confidence sourceConfidence, int resolution, Confidence resolutionConfidence)
-        {
-            return new AugmentQualityResult(source, sourceConfidence, resolution, resolutionConfidence, Modifier.NONE, Confidence.Default, null, Confidence.Default);
+            return new AugmentQualityResult(source, sourceConfidence, resolution, resolutionConfidence, modifier, modifierConfidence, null, Confidence.Default);
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Quality can be overridden if media info contains a parsable title, but there's no way to know which title was being used in the process.

Properly include quality modifier, otherwise REMUX files are import as plain BLURAY.