### PR TITLE
feat: Default Manual Import to Copy when copyUsingHardlinks is enabled

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
@@ -6,6 +6,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation.Extensions;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.TrackedDownloads;
@@ -40,6 +41,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
         private readonly IDownloadedMovieImportService _downloadedMovieImportService;
         private readonly IMediaFileService _mediaFileService;
         private readonly ICustomFormatCalculationService _formatCalculator;
+        private readonly IConfigService _configService;
         private readonly IEventAggregator _eventAggregator;
         private readonly Logger _logger;
 
@@ -54,6 +56,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
                                    IDownloadedMovieImportService downloadedMovieImportService,
                                    IMediaFileService mediaFileService,
                                    ICustomFormatCalculationService formatCalculator,
+                                   IConfigService configService,
                                    IEventAggregator eventAggregator,
                                    Logger logger)
         {
@@ -68,6 +71,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
             _downloadedMovieImportService = downloadedMovieImportService;
             _mediaFileService = mediaFileService;
             _formatCalculator = formatCalculator;
+            _configService = configService;
             _eventAggregator = eventAggregator;
             _logger = logger;
         }
@@ -406,6 +410,16 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
         {
             _logger.ProgressTrace("Manually importing {0} files using mode {1}", message.Files.Count, message.ImportMode);
 
+            var importMode = message.ImportMode;
+
+            // When ImportMode is Auto and CopyUsingHardlinks is enabled, default to Copy
+            // to preserve original files for seeding and use hardlinks instead of moving.
+            if (importMode == ImportMode.Auto && _configService.CopyUsingHardlinks)
+            {
+                importMode = ImportMode.Copy;
+                _logger.Debug("ImportMode Auto resolved to Copy because CopyUsingHardlinks is enabled");
+            }
+
             var imported = new List<ImportResult>();
             var importedTrackedDownload = new List<ManuallyImportedFile>();
 
@@ -463,11 +477,11 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
 
                 if (trackedDownload == null)
                 {
-                    imported.AddRange(_importApprovedMovie.Import(new List<ImportDecision> { importDecision }, !existingFile, null, message.ImportMode));
+                    imported.AddRange(_importApprovedMovie.Import(new List<ImportDecision> { importDecision }, !existingFile, null, importMode));
                 }
                 else
                 {
-                    var importResult = _importApprovedMovie.Import(new List<ImportDecision> { importDecision }, true, trackedDownload.DownloadItem, message.ImportMode).First();
+                    var importResult = _importApprovedMovie.Import(new List<ImportDecision> { importDecision }, true, trackedDownload.DownloadItem, importMode).First();
 
                     imported.Add(importResult);
 


### PR DESCRIPTION
## Summary

When `ImportMode` is `Auto` (the default) and `copyUsingHardlinks` is enabled in Media Management settings, Manual Import now resolves to **Copy** mode instead of falling through to **Move**.

Fixes #11418

## Changes

**`src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs`**:
- Added `IConfigService` dependency to check `CopyUsingHardlinks` setting
- In `Execute(ManualImportCommand)`, when `ImportMode.Auto` and `CopyUsingHardlinks` is true, resolve to `ImportMode.Copy`
- Changed `_importApprovedMovie.Import()` calls to use the resolved `importMode` instead of `message.ImportMode`

## Why

Currently, `ImportMode.Auto` resolves to Move when there's no download client item (the common case for manual imports):

```csharp
case ImportMode.Auto:
    copyOnly = downloadClientItem is { CanMoveFiles: false };
    break;
```

When `downloadClientItem` is null (manual import without tracked download), `copyOnly` is always `false` → **Move**. This:

1. Removes the original file from the download client's directory
2. Breaks active torrents (status becomes `missingFiles`)
3. Contradicts the `copyUsingHardlinks: true` setting

The Completed Download Handler (automatic import) correctly uses hardlinks because it has access to the download client item. Manual Import lacks this context, so it should fall back to the user's configured preference.

## Behavior

| `ImportMode` | `CopyUsingHardlinks` | Before | After |
|---|---|---|---|
| `Auto` | `true` | Move | **Copy** |
| `Auto` | `false` | Move | Move (unchanged) |
| `Move` | any | Move | Move (unchanged) |
| `Copy` | any | Copy | Copy (unchanged) |

This is backward-compatible: explicit `importMode: "move"` or `importMode: "copy"` in API calls still work as before.