### PR TITLE
Handle null values for Items and FormatItems

### DIFF
--- a/src/Radarr.Api.V3/Profiles/Quality/QualityProfileResource.cs
+++ b/src/Radarr.Api.V3/Profiles/Quality/QualityProfileResource.cs
@@ -105,11 +105,11 @@ namespace Radarr.Api.V3.Profiles.Quality
                 Name = resource.Name,
                 UpgradeAllowed = resource.UpgradeAllowed,
                 Cutoff = resource.Cutoff,
-                Items = resource.Items.ConvertAll(ToModel),
+                Items = resource.Items?.ConvertAll(ToModel) ?? new List<QualityProfile>(),
                 MinFormatScore = resource.MinFormatScore,
                 CutoffFormatScore = resource.CutoffFormatScore,
                 MinUpgradeFormatScore = resource.MinUpgradeFormatScore,
-                FormatItems = resource.FormatItems.ConvertAll(ToModel),
+                FormatItems = resource.FormatItems?.ConvertAll(ToModel) ?? new List<QualityProfileQualityItem>(),
                 Language = resource.Language
             };
         }
@@ -126,7 +126,7 @@ namespace Radarr.Api.V3.Profiles.Quality
                 Id = resource.Id,
                 Name = resource.Name,
                 Quality = resource.Quality != null ? (NzbDrone.Core.Qualities.Quality)resource.Quality.Id : null,
-                Items = resource.Items.ConvertAll(ToModel),
+                Items = resource.Items?.ConvertAll(ToModel) ?? new List<QualityProfileQualityItem>(),
                 Allowed = resource.Allowed
             };
         }


### PR DESCRIPTION
This pull request makes the `ToModel` conversion methods in `QualityProfileResource.cs` more robust by adding null checks to list conversions. This prevents possible null reference exceptions when `Items` or `FormatItems` are null in the source resource.

**Null safety improvements:**

* Added null checks to the conversion of `Items` and `FormatItems` in the `ToModel` method for `QualityProfileResource`, ensuring that if these properties are null, empty lists are assigned instead of causing exceptions.
* Added a null check to the conversion of `Items` in the `ToModel` method for `QualityProfileQualityItemResource`, assigning an empty list if `Items` is null.Updated the conversion of Items and FormatItems to handle null values gracefully by providing default empty lists.