### PR TITLE
Fixed: Modal disappearing on mobile Discover page

### DIFF
--- a/frontend/src/Components/Modal/Modal.css
+++ b/frontend/src/Components/Modal/Modal.css
@@ -30,12 +30,6 @@
   overflow: hidden !important;
 }
 
-.modalOpenIOS {
-  position: fixed;
-  right: 0;
-  left: 0;
-}
-
 /*
  * Sizes
  */

--- a/frontend/src/Components/Modal/Modal.css.d.ts
+++ b/frontend/src/Components/Modal/Modal.css.d.ts
@@ -10,7 +10,6 @@ interface CssExports {
   'modalBackdrop': string;
   'modalContainer': string;
   'modalOpen': string;
-  'modalOpenIOS': string;
   'small': string;
 }
 export const cssExports: CssExports;

--- a/frontend/src/Components/Modal/Modal.tsx
+++ b/frontend/src/Components/Modal/Modal.tsx
@@ -12,7 +12,7 @@ import FocusLock from 'react-focus-lock';
 import ErrorBoundary from 'Components/Error/ErrorBoundary';
 import usePrevious from 'Helpers/Hooks/usePrevious';
 import { Size } from 'Helpers/Props/sizes';
-import { isIOS } from 'Utilities/browser';
+import { isMobile } from 'Utilities/browser';
 import * as keyCodes from 'Utilities/Constants/keyCodes';
 import { setScrollLock } from 'Utilities/scrollLock';
 import ModalError from './ModalError';
@@ -27,6 +27,21 @@ function removeFromOpenModals(id: string) {
   if (index >= 0) {
     openModals.splice(index, 1);
   }
+}
+
+// Mobile scroll lock: block touchmove outside the modal portal. Avoids
+// mutating body position/overflow — doing so resets window.scrollY to 0,
+// which causes react-virtualized WindowScroller to unmount the row that
+// owns the just-opened modal (Discover page regression).
+function preventTouchScroll(event: TouchEvent) {
+  let target = event.target as HTMLElement | null;
+  while (target) {
+    if (target.id === 'portal-root') {
+      return;
+    }
+    target = target.parentElement;
+  }
+  event.preventDefault();
 }
 
 function findEventTarget(event: TouchEvent | MouseEvent) {
@@ -70,7 +85,6 @@ function Modal({
 }: ModalProps) {
   const backgroundRef = useRef<HTMLDivElement>(null);
   const isBackdropPressed = useRef(false);
-  const bodyScrollTop = useRef(0);
   const wasOpen = usePrevious(isOpen);
   const modalId = useId();
 
@@ -125,10 +139,14 @@ function Modal({
       openModals.push(modalId);
 
       if (openModals.length === 1) {
-        if (isIOS()) {
+        if (isMobile()) {
+          // Don't mutate body position/overflow on mobile — it resets
+          // window.scrollY which makes WindowScroller unmount this row's
+          // modal. Use a touchmove listener to block scroll instead.
           setScrollLock(true);
-          bodyScrollTop.current = document.body.scrollTop;
-          elementClass(document.body).add(styles.modalOpenIOS);
+          document.addEventListener('touchmove', preventTouchScroll, {
+            passive: false,
+          });
         } else {
           elementClass(document.body).add(styles.modalOpen);
         }
@@ -139,9 +157,8 @@ function Modal({
       if (openModals.length === 0) {
         setScrollLock(false);
 
-        if (isIOS()) {
-          elementClass(document.body).remove(styles.modalOpenIOS);
-          document.body.scrollTop = bodyScrollTop.current;
+        if (isMobile()) {
+          document.removeEventListener('touchmove', preventTouchScroll);
         } else {
           elementClass(document.body).remove(styles.modalOpen);
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
On mobile browsers, the iOS scroll lock in `Modal.tsx` applies `position: fixed` to `<body>` to prevent background scrolling while a modal is open. Because `<body>` is the scroll container on mobile (see `index.css`), this resets `window.scrollY` to 0.

Discover's `WindowScroller` listens to `window.scrollY` and unmounts rows that move out of view. When `scrollY` drops to 0, it unmounts the row the user just tapped — taking the newly-rendered modal down with it. Visible symptom: modal flashes for a frame then disappears; list snaps to the top.

This PR replaces the body-mutating lock with a non-passive `touchmove` listener that calls `preventDefault()` on anything outside `#portal-root`. Modal content stays scrollable; body touch-scroll is blocked without changing scroll state; `WindowScroller` doesn't see a scroll event so the row (and its modal) stays mounted.

Tested on iOS Safari (reporter) and a headless Android WebView. Desktop code path is unchanged.

#### Screenshot (if UI related)
No UI change — pure behavior fix. Before/after videos available on request.

#### Todos
- [x] Tests — no new behavior; existing modal tests cover open/close flow
- [x] Translation Keys — none added or changed
- [x] Wiki Updates — not needed

#### Issues Fixed or Closed by this PR

* Fixes #11438