### PR TITLE
Reuse healthy queued and paused tracked downloads

### DIFF
--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -102,6 +102,7 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
             var trackedDownload = Subject.TrackDownload(client, item);
             var refreshedTrackedDownload = Subject.TrackDownload(client, updatedItem);
 
+            trackedDownload.State.Should().Be(TrackedDownloadState.Downloading);
             refreshedTrackedDownload.Should().BeSameAs(trackedDownload);
             refreshedTrackedDownload.DownloadItem.Should().BeSameAs(updatedItem);
 
@@ -125,6 +126,7 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
             var trackedDownload = Subject.TrackDownload(client, item);
             var refreshedTrackedDownload = Subject.TrackDownload(client, updatedItem);
 
+            trackedDownload.State.Should().Be(TrackedDownloadState.Downloading);
             refreshedTrackedDownload.Should().BeSameAs(trackedDownload);
             refreshedTrackedDownload.DownloadItem.Should().BeSameAs(updatedItem);
 

--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -89,38 +89,15 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
                   });
         }
 
-        [Test]
-        public void should_reuse_stable_queued_downloading_tracked_download()
+        [TestCase(DownloadItemStatus.Queued)]
+        [TestCase(DownloadItemStatus.Paused)]
+        public void should_reuse_stable_waiting_downloading_tracked_download(DownloadItemStatus status)
         {
             GivenTrackedDownloadCanBeMapped();
 
             var client = CreateDownloadClient();
-            var item = CreateDownloadItem(DownloadItemStatus.Queued);
-            var updatedItem = CreateDownloadItem(DownloadItemStatus.Queued);
-            updatedItem.RemainingSize = 250;
-
-            var trackedDownload = Subject.TrackDownload(client, item);
-            var refreshedTrackedDownload = Subject.TrackDownload(client, updatedItem);
-
-            trackedDownload.State.Should().Be(TrackedDownloadState.Downloading);
-            refreshedTrackedDownload.Should().BeSameAs(trackedDownload);
-            refreshedTrackedDownload.DownloadItem.Should().BeSameAs(updatedItem);
-
-            Mocker.GetMock<IHistoryService>()
-                  .Verify(s => s.FindByDownloadId(It.IsAny<string>()), Times.Once());
-
-            Mocker.GetMock<IParsingService>()
-                  .Verify(s => s.Map(It.IsAny<ParsedMovieInfo>(), It.IsAny<string>(), It.IsAny<int>(), null), Times.Once());
-        }
-
-        [Test]
-        public void should_reuse_stable_paused_downloading_tracked_download()
-        {
-            GivenTrackedDownloadCanBeMapped();
-
-            var client = CreateDownloadClient();
-            var item = CreateDownloadItem(DownloadItemStatus.Paused);
-            var updatedItem = CreateDownloadItem(DownloadItemStatus.Paused);
+            var item = CreateDownloadItem(status);
+            var updatedItem = CreateDownloadItem(status);
             updatedItem.RemainingSize = 250;
 
             var trackedDownload = Subject.TrackDownload(client, item);
@@ -407,6 +384,70 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
             var trackedDownloads = Subject.GetTrackedDownloads();
             trackedDownloads.Should().HaveCount(1);
             trackedDownloads.First().RemoteMovie.Should().BeNull();
+        }
+
+        [Test]
+        public void should_update_tracked_download_when_movie_edited()
+        {
+            var originalMovie = new Movie { Id = 3, TmdbId = 10, Title = "A Movie" };
+            var updatedMovie = new Movie { Id = 3, TmdbId = 10, Title = "A Movie Updated" };
+
+            var remoteMovie = new RemoteMovie
+            {
+                Movie = originalMovie,
+                ParsedMovieInfo = new ParsedMovieInfo
+                {
+                    MovieTitles = { "A Movie" },
+                    Year = 1998
+                }
+            };
+
+            var updatedRemoteMovie = new RemoteMovie
+            {
+                Movie = updatedMovie,
+                ParsedMovieInfo = new ParsedMovieInfo
+                {
+                    MovieTitles = { "A Movie" },
+                    Year = 1998
+                }
+            };
+
+            Mocker.GetMock<IParsingService>()
+                  .SetupSequence(s => s.Map(It.IsAny<ParsedMovieInfo>(), It.IsAny<string>(), It.IsAny<int>(), null))
+                  .Returns(remoteMovie)
+                  .Returns(updatedRemoteMovie);
+
+            Mocker.GetMock<IHistoryService>()
+                  .Setup(s => s.FindByDownloadId(It.IsAny<string>()))
+                  .Returns(new List<MovieHistory>());
+
+            var client = new DownloadClientDefinition
+            {
+                Id = 1,
+                Protocol = DownloadProtocol.Torrent
+            };
+
+            var item = new DownloadClientItem
+            {
+                Title = "A Movie 1998",
+                DownloadId = "12345",
+                DownloadClientInfo = new DownloadClientItemClientInfo
+                {
+                    Id = 1,
+                    Type = "Blackhole",
+                    Name = "Blackhole Client",
+                    Protocol = DownloadProtocol.Torrent
+                }
+            };
+
+            Subject.TrackDownload(client, item);
+
+            Subject.Handle(new MovieEditedEvent(updatedMovie, originalMovie));
+
+            var trackedDownloads = Subject.GetTrackedDownloads();
+            trackedDownloads.Should().HaveCount(1);
+            trackedDownloads.First().RemoteMovie.Should().BeSameAs(updatedRemoteMovie);
+            trackedDownloads.First().RemoteMovie.Movie.Title.Should().Be("A Movie Updated");
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -177,6 +177,65 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
         }
 
         [Test]
+        public void should_reprocess_when_waiting_download_has_warning_status()
+        {
+            GivenTrackedDownloadCanBeMapped();
+
+            var client = CreateDownloadClient();
+            var item = CreateDownloadItem(DownloadItemStatus.Queued);
+            var updatedItem = CreateDownloadItem(DownloadItemStatus.Queued);
+            updatedItem.RemainingSize = 250;
+
+            var trackedDownload = Subject.TrackDownload(client, item);
+            trackedDownload.Warn("Temporary warning");
+
+            var refreshedTrackedDownload = Subject.TrackDownload(client, updatedItem);
+
+            refreshedTrackedDownload.Should().NotBeSameAs(trackedDownload);
+
+            Mocker.GetMock<IHistoryService>()
+                  .Verify(s => s.FindByDownloadId(It.IsAny<string>()), Times.Exactly(2));
+
+            Mocker.GetMock<IParsingService>()
+                  .Verify(s => s.Map(It.IsAny<ParsedMovieInfo>(), It.IsAny<string>(), It.IsAny<int>(), null), Times.Exactly(2));
+        }
+
+        [Test]
+        public void should_reprocess_when_waiting_download_is_not_mapped()
+        {
+            Mocker.GetMock<IHistoryService>()
+                  .Setup(s => s.FindByDownloadId(It.IsAny<string>()))
+                  .Returns(new List<MovieHistory>());
+
+            Mocker.GetMock<IParsingService>()
+                  .Setup(s => s.Map(It.IsAny<ParsedMovieInfo>(), It.IsAny<string>(), It.IsAny<int>(), null))
+                  .Returns(new RemoteMovie
+                  {
+                      ParsedMovieInfo = new ParsedMovieInfo
+                      {
+                          MovieTitles = new List<string> { "A Movie" },
+                          Year = 1998
+                      }
+                  });
+
+            var client = CreateDownloadClient();
+            var item = CreateDownloadItem(DownloadItemStatus.Queued);
+            var updatedItem = CreateDownloadItem(DownloadItemStatus.Queued);
+            updatedItem.RemainingSize = 250;
+
+            var trackedDownload = Subject.TrackDownload(client, item);
+            var refreshedTrackedDownload = Subject.TrackDownload(client, updatedItem);
+
+            refreshedTrackedDownload.Should().NotBeSameAs(trackedDownload);
+
+            Mocker.GetMock<IHistoryService>()
+                  .Verify(s => s.FindByDownloadId(It.IsAny<string>()), Times.Exactly(2));
+
+            Mocker.GetMock<IParsingService>()
+                  .Verify(s => s.Map(It.IsAny<ParsedMovieInfo>(), It.IsAny<string>(), It.IsAny<int>(), null), Times.Exactly(2));
+        }
+
+        [Test]
         public void should_track_downloads_using_the_source_title_if_it_cannot_be_found_using_the_download_title()
         {
             GivenDownloadHistory();

--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -40,6 +40,140 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
                 });
         }
 
+        private static DownloadClientDefinition CreateDownloadClient()
+        {
+            return new DownloadClientDefinition()
+            {
+                Id = 1,
+                Protocol = DownloadProtocol.Usenet
+            };
+        }
+
+        private static DownloadClientItem CreateDownloadItem(DownloadItemStatus status)
+        {
+            return new DownloadClientItem()
+            {
+                Title = "A Movie 1998",
+                DownloadId = "35238",
+                Category = "radarr",
+                TotalSize = 1000,
+                RemainingSize = 500,
+                Status = status,
+                DownloadClientInfo = new DownloadClientItemClientInfo
+                {
+                    Id = 1,
+                    Type = "NZBGet",
+                    Name = "NZBGet",
+                    Protocol = DownloadProtocol.Usenet
+                }
+            };
+        }
+
+        private void GivenTrackedDownloadCanBeMapped()
+        {
+            Mocker.GetMock<IHistoryService>()
+                  .Setup(s => s.FindByDownloadId(It.IsAny<string>()))
+                  .Returns(new List<MovieHistory>());
+
+            Mocker.GetMock<IParsingService>()
+                  .Setup(s => s.Map(It.IsAny<ParsedMovieInfo>(), It.IsAny<string>(), It.IsAny<int>(), null))
+                  .Returns(new RemoteMovie
+                  {
+                      Release = new ReleaseInfo { Title = "A Movie 1998" },
+                      Movie = new Movie() { Id = 3 },
+                      ParsedMovieInfo = new ParsedMovieInfo()
+                      {
+                          MovieTitles = new List<string> { "A Movie" },
+                          Year = 1998
+                      }
+                  });
+        }
+
+        [Test]
+        public void should_reuse_stable_queued_downloading_tracked_download()
+        {
+            GivenTrackedDownloadCanBeMapped();
+
+            var client = CreateDownloadClient();
+            var item = CreateDownloadItem(DownloadItemStatus.Queued);
+            var updatedItem = CreateDownloadItem(DownloadItemStatus.Queued);
+            updatedItem.RemainingSize = 250;
+
+            var trackedDownload = Subject.TrackDownload(client, item);
+            var refreshedTrackedDownload = Subject.TrackDownload(client, updatedItem);
+
+            refreshedTrackedDownload.Should().BeSameAs(trackedDownload);
+            refreshedTrackedDownload.DownloadItem.Should().BeSameAs(updatedItem);
+
+            Mocker.GetMock<IHistoryService>()
+                  .Verify(s => s.FindByDownloadId(It.IsAny<string>()), Times.Once());
+
+            Mocker.GetMock<IParsingService>()
+                  .Verify(s => s.Map(It.IsAny<ParsedMovieInfo>(), It.IsAny<string>(), It.IsAny<int>(), null), Times.Once());
+        }
+
+        [Test]
+        public void should_reuse_stable_paused_downloading_tracked_download()
+        {
+            GivenTrackedDownloadCanBeMapped();
+
+            var client = CreateDownloadClient();
+            var item = CreateDownloadItem(DownloadItemStatus.Paused);
+            var updatedItem = CreateDownloadItem(DownloadItemStatus.Paused);
+            updatedItem.RemainingSize = 250;
+
+            var trackedDownload = Subject.TrackDownload(client, item);
+            var refreshedTrackedDownload = Subject.TrackDownload(client, updatedItem);
+
+            refreshedTrackedDownload.Should().BeSameAs(trackedDownload);
+            refreshedTrackedDownload.DownloadItem.Should().BeSameAs(updatedItem);
+
+            Mocker.GetMock<IHistoryService>()
+                  .Verify(s => s.FindByDownloadId(It.IsAny<string>()), Times.Once());
+
+            Mocker.GetMock<IParsingService>()
+                  .Verify(s => s.Map(It.IsAny<ParsedMovieInfo>(), It.IsAny<string>(), It.IsAny<int>(), null), Times.Once());
+        }
+
+        [Test]
+        public void should_reprocess_when_waiting_download_starts_downloading()
+        {
+            GivenTrackedDownloadCanBeMapped();
+
+            var client = CreateDownloadClient();
+            var item = CreateDownloadItem(DownloadItemStatus.Queued);
+            var updatedItem = CreateDownloadItem(DownloadItemStatus.Downloading);
+
+            Subject.TrackDownload(client, item);
+            Subject.TrackDownload(client, updatedItem);
+
+            Mocker.GetMock<IHistoryService>()
+                  .Verify(s => s.FindByDownloadId(It.IsAny<string>()), Times.Exactly(2));
+
+            Mocker.GetMock<IParsingService>()
+                  .Verify(s => s.Map(It.IsAny<ParsedMovieInfo>(), It.IsAny<string>(), It.IsAny<int>(), null), Times.Exactly(2));
+        }
+
+        [Test]
+        public void should_reprocess_when_waiting_download_identity_changes()
+        {
+            GivenTrackedDownloadCanBeMapped();
+
+            var client = CreateDownloadClient();
+            var item = CreateDownloadItem(DownloadItemStatus.Queued);
+            var updatedItem = CreateDownloadItem(DownloadItemStatus.Queued);
+            updatedItem.TotalSize = 2000;
+
+            Subject.TrackDownload(client, item);
+            Subject.TrackDownload(client, updatedItem);
+
+            Mocker.GetMock<IHistoryService>()
+                  .Verify(s => s.FindByDownloadId(It.IsAny<string>()), Times.Exactly(2));
+
+            Mocker.GetMock<IParsingService>()
+                  .Verify(s => s.Map(It.IsAny<ParsedMovieInfo>(), It.IsAny<string>(), It.IsAny<int>(), null), Times.Exactly(2));
+        }
+
         [Test]
         public void should_track_downloads_using_the_source_title_if_it_cannot_be_found_using_the_download_title()
         {

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -229,13 +229,20 @@ namespace NzbDrone.Core.Download.TrackedDownloads
             }
 
             return IsStableWaitingDownload(downloadItem) &&
-                   HasSameDownloadIdentity(existingItem.DownloadItem, downloadItem);
+                   HasSameDownloadIdentity(existingItem.DownloadItem, downloadItem) &&
+                   HasHealthyWaitingCache(existingItem);
         }
 
         private static bool IsStableWaitingDownload(DownloadClientItem downloadItem)
         {
             return downloadItem.Status == DownloadItemStatus.Queued ||
                    downloadItem.Status == DownloadItemStatus.Paused;
+        }
+
+        private static bool HasHealthyWaitingCache(TrackedDownload existingItem)
+        {
+            return existingItem.Status == TrackedDownloadStatus.Ok &&
+                   existingItem.RemoteMovie?.Movie != null;
         }
 
         private static bool HasSameDownloadIdentity(DownloadClientItem existingItem, DownloadClientItem downloadItem)

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -96,7 +96,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
         {
             var existingItem = Find(downloadItem.DownloadId);
 
-            if (existingItem != null && existingItem.State != TrackedDownloadState.Downloading)
+            if (existingItem != null && CanReuseTrackedDownload(existingItem, downloadItem))
             {
                 LogItemChange(existingItem, existingItem.DownloadItem, downloadItem);
 
@@ -219,6 +219,32 @@ namespace NzbDrone.Core.Download.TrackedDownloads
             {
                 trackedDownload.IsTrackable = false;
             }
+        }
+
+        private static bool CanReuseTrackedDownload(TrackedDownload existingItem, DownloadClientItem downloadItem)
+        {
+            if (existingItem.State != TrackedDownloadState.Downloading)
+            {
+                return true;
+            }
+
+            return IsStableWaitingDownload(downloadItem) &&
+                   HasSameDownloadIdentity(existingItem.DownloadItem, downloadItem);
+        }
+
+        private static bool IsStableWaitingDownload(DownloadClientItem downloadItem)
+        {
+            return downloadItem.Status == DownloadItemStatus.Queued ||
+                   downloadItem.Status == DownloadItemStatus.Paused;
+        }
+
+        private static bool HasSameDownloadIdentity(DownloadClientItem existingItem, DownloadClientItem downloadItem)
+        {
+            return existingItem.DownloadId == downloadItem.DownloadId &&
+                   existingItem.Title == downloadItem.Title &&
+                   existingItem.Category == downloadItem.Category &&
+                   existingItem.TotalSize == downloadItem.TotalSize &&
+                   existingItem.DownloadClientInfo?.Id == downloadItem.DownloadClientInfo?.Id;
         }
 
         private void UpdateCachedItem(TrackedDownload trackedDownload)

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -263,6 +263,16 @@ namespace NzbDrone.Core.Download.TrackedDownloads
             _aggregationService.Augment(trackedDownload.RemoteMovie);
         }
 
+        private void RefreshCachedItems(List<TrackedDownload> cachedItems)
+        {
+            if (cachedItems.Any())
+            {
+                cachedItems.ForEach(UpdateCachedItem);
+
+                _eventAggregator.PublishEvent(new TrackedDownloadRefreshedEvent(GetTrackedDownloads()));
+            }
+        }
+
         private static TrackedDownloadState GetStateFromHistory(DownloadHistoryEventType eventType)
         {
             switch (eventType)
@@ -304,12 +314,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                     message.Movie?.TmdbId == t.RemoteMovie.Movie.TmdbId)
                 .ToList();
 
-            if (cachedItems.Any())
-            {
-                cachedItems.ForEach(UpdateCachedItem);
-
-                _eventAggregator.PublishEvent(new TrackedDownloadRefreshedEvent(GetTrackedDownloads()));
-            }
+            RefreshCachedItems(cachedItems);
         }
 
         public void Handle(MovieEditedEvent message)
@@ -320,12 +325,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                     (t.RemoteMovie.Movie.Id == message.Movie?.Id || t.RemoteMovie.Movie.TmdbId == message.Movie?.TmdbId))
                 .ToList();
 
-            if (cachedItems.Any())
-            {
-                cachedItems.ForEach(UpdateCachedItem);
-
-                _eventAggregator.PublishEvent(new TrackedDownloadRefreshedEvent(GetTrackedDownloads()));
-            }
+            RefreshCachedItems(cachedItems);
         }
 
         public void Handle(MoviesBulkEditedEvent message)
@@ -336,12 +336,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                     message.Movies.Any(m => m.Id == t.RemoteMovie.Movie.Id || m.TmdbId == t.RemoteMovie.Movie.TmdbId))
                 .ToList();
 
-            if (cachedItems.Any())
-            {
-                cachedItems.ForEach(UpdateCachedItem);
-
-                _eventAggregator.PublishEvent(new TrackedDownloadRefreshedEvent(GetTrackedDownloads()));
-            }
+            RefreshCachedItems(cachedItems);
         }
 
         public void Handle(MoviesDeletedEvent message)
@@ -352,12 +347,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                     message.Movies.Any(m => m.Id == t.RemoteMovie.Movie.Id || m.TmdbId == t.RemoteMovie.Movie.TmdbId))
                 .ToList();
 
-            if (cachedItems.Any())
-            {
-                cachedItems.ForEach(UpdateCachedItem);
-
-                _eventAggregator.PublishEvent(new TrackedDownloadRefreshedEvent(GetTrackedDownloads()));
-            }
+            RefreshCachedItems(cachedItems);
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description

This reduces repeated work during monitored download refreshes for queued and paused downloads that remain unchanged across refreshes.

Large paused queues can keep the same downloads visible for many refresh cycles. Rebuilding tracked-download metadata every time does extra parsing and history lookup work without changing queue visibility or import behavior.

This PR reuses an existing tracked download only when the queue item is still `Queued` or `Paused`, its identity is unchanged, and the cached tracked download is still healthy and mapped.

It still rebuilds tracked downloads when:
- a waiting item starts actively downloading
- the queue item identity changes
- the cached tracked download is warning-bearing or unmapped

Validation on a local instance with a paused NZBGet queue:
- before: the old process consumed 2h 11m 44s CPU over 3h 36m 46s wall clock, about 60.8% of one core on average
- after: the live queue had 145 records with paused items present; manual `RefreshMonitoredDownloads` runs completed in 1s using 0.13s and 0.28s CPU
- after: a 180s steady-state sample used 0.36 CPU seconds, about 0.20% of one core

Focused `TrackedDownloadServiceFixture` tests passed: 11 tests.

#### Screenshot (if UI related)

N/A

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) - N/A
- [ ] [Wiki Updates](https://wiki.servarr.com) - N/A

#### Issues Fixed or Closed by this PR

* N/A
