### PR TITLE
Fixed: Stack overflow in SizeSuffix and overflow in Fluent.Round

### DIFF
--- a/src/NzbDrone.Common.Test/ExtensionTests/NumberExtensionFixture.cs
+++ b/src/NzbDrone.Common.Test/ExtensionTests/NumberExtensionFixture.cs
@@ -17,6 +17,8 @@ namespace NzbDrone.Common.Test.ExtensionTests
         [TestCase(-1000000, "-976.6 KB")]
         [TestCase(-377487360, "-360.0 MB")]
         [TestCase(-1255864686, "-1.2 GB")]
+        [TestCase(long.MinValue, "-8.0 EB")]
+        [TestCase(long.MaxValue, "8.0 EB")]
         public void should_calculate_string_correctly(long bytes, string expected)
         {
             bytes.SizeSuffix().Should().Be(expected);

--- a/src/NzbDrone.Common/Extensions/NumberExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/NumberExtensions.cs
@@ -11,14 +11,19 @@ namespace NzbDrone.Common.Extensions
         {
             const int bytesInKb = 1024;
 
-            if (bytes < 0)
-            {
-                return "-" + SizeSuffix(-bytes);
-            }
-
             if (bytes == 0)
             {
                 return "0 B";
+            }
+
+            if (bytes == long.MinValue)
+            {
+                return "-" + SizeSuffix(long.MaxValue);
+            }
+
+            if (bytes < 0)
+            {
+                return "-" + SizeSuffix(Math.Abs(bytes));
             }
 
             var mag = (int)Math.Log(bytes, bytesInKb);

--- a/src/NzbDrone.Core.Test/FluentTest.cs
+++ b/src/NzbDrone.Core.Test/FluentTest.cs
@@ -175,7 +175,9 @@ namespace NzbDrone.Core.Test
         [TestCase(199, 100, 100)]
         [TestCase(1000, 100, 1000)]
         [TestCase(0, 100, 0)]
-        public void round_to_level(long number, int level, int result)
+        [TestCase(long.MinValue, 1000, -9223372036854775000L)]
+        [TestCase(long.MaxValue, 1000, 9223372036854775000L)]
+        public void round_to_level(long number, int level, long result)
         {
             number.Round(level).Should().Be(result);
         }

--- a/src/NzbDrone.Core/Fluent.cs
+++ b/src/NzbDrone.Core/Fluent.cs
@@ -22,7 +22,9 @@ namespace NzbDrone.Core
 
         public static long Round(this long number, long level)
         {
-            return Convert.ToInt64(Math.Floor((decimal)number / level) * level);
+            return number < 0
+                ? Convert.ToInt64(Math.Ceiling((decimal)number / level) * level)
+                : Convert.ToInt64(Math.Floor((decimal)number / level) * level);
         }
 
         public static string ToBestDateString(this DateTime dateTime)


### PR DESCRIPTION
#### Database Migration
NO

#### Description

`NumberExtensions.SizeSuffix(long.MinValue)` recurses forever — `-bytes` overflows back to `long.MinValue` (no representable positive twin in `Int64`), the `bytes < 0` branch always re-fires, and the .NET runtime kills the process with an uncatchable `StackOverflowException`. This actually fires in the wild: an indexer returned a release whose parsed size landed at `long.MinValue`, `RssSyncService` → `DownloadDecisionMaker` → `AcceptableSizeSpecification` called `SizeSuffix` on it, and Radarr was killed mid-RSS-sync. The deterministic process kill also explains a class of \"unable to load results for this movie search\" UI symptoms — collateral interactive searches in flight when the RSS sync crashes get their connections dropped, surfacing as a vague UI error.

`Fluent.Round` had a related but separate overflow on extreme values: `Math.Floor((decimal)long.MinValue / level) * level` produced a double slightly less than `long.MinValue`, which `Convert.ToInt64` then rejected. Guarding with `Math.Ceiling` for negatives keeps the result representable.

This is a straight port of Sonarr/Sonarr@be4a564456818fc18138bded9d981c93bb2cdd14 (by @mynameisbogdan), [as suggested by them](https://github.com/Radarr/Radarr/issues/11404#issuecomment-3050081773) on the Radarr issue. Diff is byte-equivalent across all four files.

Repro for reviewers (no test data needed):

\`\`\`
SizeSuffix(long.MinValue)  →  StackOverflowException (before)
SizeSuffix(long.MinValue)  →  \"-8.0 EB\"               (after)
Round(long.MinValue, 1000) →  OverflowException       (before)
Round(long.MinValue, 1000) →  -9223372036854775000    (after)
\`\`\`

#### Todos
- [x] Tests (added `long.MinValue` / `long.MaxValue` cases to `NumberExtensionFixture` and `FluentTest`)
- [ ] Translation Keys (n/a)
- [ ] Wiki Updates (n/a)

#### Issues Fixed or Closed by this PR

* Fixes #11404