### PR TITLE
Fixed: update server to send full certificate chain when provided

### DIFF
--- a/src/NzbDrone.Common/Http/SslCertificateLoader.cs
+++ b/src/NzbDrone.Common/Http/SslCertificateLoader.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Linq;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace NzbDrone.Common.Http
+{
+    public class SslCertificateLoadException : Exception
+    {
+        public SslCertificateLoadException(string message)
+            : base(message)
+        {
+        }
+    }
+
+    public static class SslCertificateLoader
+    {
+        public static SslStreamCertificateContext LoadCertificateContext(string certPath, string certPassword)
+        {
+            var certificateCollection = new X509Certificate2Collection();
+
+            certificateCollection.Import(certPath, certPassword, X509KeyStorageFlags.DefaultKeySet);
+
+            var leafCert = certificateCollection.FirstOrDefault(c => c.HasPrivateKey);
+            if (leafCert == null)
+            {
+                throw new SslCertificateLoadException(
+                    $"The SSL certificate file {certPath} does not contain a certificate with an associated private key");
+            }
+
+            return SslStreamCertificateContext.Create(leafCert, certificateCollection, offline: true);
+        }
+    }
+}

--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Data.SQLite;
 using System.IO;
+using System.Linq;
+using System.Net.Security;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -192,7 +194,13 @@ namespace NzbDrone.Host
                         {
                             options.ConfigureHttpsDefaults(configureOptions =>
                             {
-                                configureOptions.ServerCertificate = ValidateSslCertificate(sslCertPath, sslCertPassword);
+                                var sslContext = ValidateSslCertificate(sslCertPath, sslCertPassword);
+
+                                configureOptions.ServerCertificate = sslContext.TargetCertificate;
+                                configureOptions.OnAuthenticate = (context, authOptions) =>
+                                {
+                                    authOptions.ServerCertificateContext = sslContext;
+                                };
                             });
                         }
                     });
@@ -272,13 +280,13 @@ namespace NzbDrone.Host
             return $"{scheme}://{bindAddress}:{port}";
         }
 
-        private static X509Certificate2 ValidateSslCertificate(string cert, string password)
+        private static SslStreamCertificateContext ValidateSslCertificate(string cert, string password)
         {
-            X509Certificate2 certificate;
+            var certificateCollection = new X509Certificate2Collection();
 
             try
             {
-                certificate = new X509Certificate2(cert, password, X509KeyStorageFlags.DefaultKeySet);
+                certificateCollection.Import(cert, password, X509KeyStorageFlags.DefaultKeySet);
             }
             catch (CryptographicException ex)
             {
@@ -291,7 +299,17 @@ namespace NzbDrone.Host
                 throw new RadarrStartupException(ex);
             }
 
-            return certificate;
+            var leafCert = certificateCollection.FirstOrDefault(c => c.HasPrivateKey);
+
+            if (leafCert == null)
+            {
+                throw new RadarrStartupException(
+                    $"The SSL certificate file {cert} does not contain a certificate with an associated private key");
+            }
+
+            certificateCollection.Remove(leafCert);
+
+            return SslStreamCertificateContext.Create(leafCert, certificateCollection, offline: true);
         }
     }
 }

--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -2,11 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Data.SQLite;
 using System.IO;
-using System.Linq;
 using System.Net.Security;
 using System.Reflection;
 using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using DryIoc;
 using DryIoc.Microsoft.DependencyInjection;
@@ -21,6 +19,7 @@ using NzbDrone.Common.Composition.Extensions;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Exceptions;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
 using NzbDrone.Common.Instrumentation;
 using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Common.Options;
@@ -282,11 +281,11 @@ namespace NzbDrone.Host
 
         private static SslStreamCertificateContext ValidateSslCertificate(string cert, string password)
         {
-            var certificateCollection = new X509Certificate2Collection();
+            SslStreamCertificateContext certificateContext;
 
             try
             {
-                certificateCollection.Import(cert, password, X509KeyStorageFlags.DefaultKeySet);
+                certificateContext = SslCertificateLoader.LoadCertificateContext(cert, password);
             }
             catch (CryptographicException ex)
             {
@@ -299,17 +298,7 @@ namespace NzbDrone.Host
                 throw new RadarrStartupException(ex);
             }
 
-            var leafCert = certificateCollection.FirstOrDefault(c => c.HasPrivateKey);
-
-            if (leafCert == null)
-            {
-                throw new RadarrStartupException(
-                    $"The SSL certificate file {cert} does not contain a certificate with an associated private key");
-            }
-
-            certificateCollection.Remove(leafCert);
-
-            return SslStreamCertificateContext.Create(leafCert, certificateCollection, offline: true);
+            return certificateContext;
         }
     }
 }

--- a/src/Radarr.Api.V3/Config/CertificateValidator.cs
+++ b/src/Radarr.Api.V3/Config/CertificateValidator.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography.X509Certificates;
 using FluentValidation;
 using FluentValidation.Validators;
 using NLog;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation;
 
 namespace Radarr.Api.V3.Config
@@ -33,11 +34,11 @@ namespace Radarr.Api.V3.Config
                 return true;
             }
 
+            var certificateCollection = new X509Certificate2Collection();
+
             try
             {
-                new X509Certificate2(resource.SslCertPath, resource.SslCertPassword, X509KeyStorageFlags.DefaultKeySet);
-
-                return true;
+                certificateCollection.Import(resource.SslCertPath, resource.SslCertPassword, X509KeyStorageFlags.DefaultKeySet);
             }
             catch (CryptographicException ex)
             {
@@ -47,6 +48,19 @@ namespace Radarr.Api.V3.Config
 
                 return false;
             }
+
+            if (certificateCollection.None(c => c.HasPrivateKey))
+            {
+                var message = $"The SSL certificate file {resource.SslCertPath} does not contain a certificate with an associated private key";
+
+                Logger.Debug($"{message}");
+
+                context.MessageFormatter.AppendArgument("message", message);
+
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/src/Radarr.Api.V3/Config/CertificateValidator.cs
+++ b/src/Radarr.Api.V3/Config/CertificateValidator.cs
@@ -1,9 +1,8 @@
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
+using System;
 using FluentValidation;
 using FluentValidation.Validators;
 using NLog;
-using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
 using NzbDrone.Common.Instrumentation;
 
 namespace Radarr.Api.V3.Config
@@ -34,13 +33,13 @@ namespace Radarr.Api.V3.Config
                 return true;
             }
 
-            var certificateCollection = new X509Certificate2Collection();
-
             try
             {
-                certificateCollection.Import(resource.SslCertPath, resource.SslCertPassword, X509KeyStorageFlags.DefaultKeySet);
+                SslCertificateLoader.LoadCertificateContext(resource.SslCertPath, resource.SslCertPassword);
+
+                return true;
             }
-            catch (CryptographicException ex)
+            catch (Exception ex)
             {
                 Logger.Debug(ex, "Invalid SSL certificate file or password. {0}", ex.Message);
 
@@ -48,19 +47,6 @@ namespace Radarr.Api.V3.Config
 
                 return false;
             }
-
-            if (certificateCollection.None(c => c.HasPrivateKey))
-            {
-                var message = $"The SSL certificate file {resource.SslCertPath} does not contain a certificate with an associated private key";
-
-                Logger.Debug($"{message}");
-
-                context.MessageFormatter.AppendArgument("message", message);
-
-                return false;
-            }
-
-            return true;
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR updates the server to support sending a full certificate chain when it's provided in the pfx file.

Behavior remains unchanged when the file includes a single certificate, with the only difference being a more descriptive error message when given a pfk file that has no private keys. Before, the server would fail to start with `System.NotSupportedException: The server mode SSL must use a certificate with the associated private key.`, now it fails to start with `NzbDrone.Common.Http.SslCertificateLoadException: The SSL certificate file {path} does not contain a certificate with an associated private key`.

This PR also updates the config validator to match the startup behavior, and refactors that logic into a common helper.

Could be useful to review changes commit by commit for readability. Happy to make any changes to match the code style!

#### Screenshot (if UI related)
N/A

#### Todos
- [x] Tests
- [x] ~Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)~
- [x] ~[Wiki Updates](https://wiki.servarr.com)~

#### Issues Fixed or Closed by this PR

* Fixes #11330