### PR TITLE
Fixed: bug #11426.

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -70,6 +70,7 @@ namespace NzbDrone.Core.Test.ParserTests
 
         [TestCase("[MTBB] Kimi no Na wa. (2016) v2 [97681524].mkv", "Kimi no Na wa", "MTBB", 2016)]
         [TestCase("[sam] Toward the Terra (1980) [BD 1080p TrueHD].mkv", "Toward the Terra", "sam", 1980)]
+        [TestCase("[Inka-Subs] Rokudenashi Blues 1993 (1993) [VHS]", "Rokudenashi Blues 1993", "Inka-Subs", 1993)]
         public void should_parse_anime_movie_title(string postTitle, string title, string releaseGroup, int year)
         {
             var movie = Parser.Parser.ParseMovieTitle(postTitle);

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -24,6 +24,10 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex[] ReportMovieTitleRegex = new[]
         {
+            // Anime [Subgroup] with year explicitly in parentheses, e.g. [Sub] Title 1993 (1993) [VHS]
+            // This must come before the generic anime+year regex to correctly handle titles that contain a year as part of the name
+            new Regex(@"^(?:\[(?<subgroup>.+?)\][-_. ]?)(?<title>(?![(\[]).+?)\s*\((?<year>(1(8|9)|20)\d{2})\).*?(?<hash>\[\w{8}\])?(?:$|\.)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
             // Anime [Subgroup] and Year
             new Regex(@"^(?:\[(?<subgroup>.+?)\][-_. ]?)(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)\[!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|x|\d+|\]|\W\d+)))+.*?(?<hash>\[\w{8}\])?(?:$|\.)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
 


### PR DESCRIPTION
This bug was caused by an Anime that had the year into the title and it was removed from the parser. The anime in question was called "[Inka-Subs] Rokudenashi Blues 1993 (1993) [VHS]" and the title by the parser was extracted as "Rokudenashi Blues" instead of "Rokudenashi Blues 1993". This new regex handes this case.

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes #11426