### PR TITLE
feat(metadata): save nfo without movie file

### DIFF
--- a/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/MediaBrowser/MediaBrowserMetadataFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/MediaBrowser/MediaBrowserMetadataFixture.cs
@@ -1,0 +1,50 @@
+namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.MediaBrowser
+{
+    using FizzWare.NBuilder;
+    using FluentAssertions;
+    using NUnit.Framework;
+    using NzbDrone.Core.Extras.Metadata;
+    using NzbDrone.Core.Extras.Metadata.Consumers.MediaBrowser;
+    using NzbDrone.Core.Movies;
+    using NzbDrone.Core.Test.Framework;
+    using NzbDrone.Core.ThingiProvider;
+    using NzbDrone.Test.Common;
+
+    [TestFixture]
+    public class MediaBrowserMetadataFixture : CoreTest<MediaBrowserMetadata>
+    {
+        private Movie _movie;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movie = Builder<Movie>.CreateNew()
+                                     .With(s => s.Path = @"C:\Test\Movies\The.Movie".AsOsAgnostic())
+                                     .Build();
+
+            Subject.Definition = new MetadataDefinition
+            {
+                Settings = new MediaBrowserMetadataSettings()
+            };
+        }
+
+        private MediaBrowserMetadataSettings Settings => (MediaBrowserMetadataSettings)Subject.Definition.Settings;
+
+        [Test]
+        public void should_always_support_metadata_without_video_file()
+        {
+            Subject.SupportsMetadataWithoutVideoFile.Should().BeTrue();
+        }
+
+        [Test]
+        public void MovieMetadata_should_return_result_when_movieFile_is_null()
+        {
+            Settings.MovieMetadata = true;
+
+            var result = Subject.MovieMetadata(_movie, null);
+
+            result.Should().NotBeNull();
+            result.RelativePath.Should().Be("movie.xml");
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/MediaBrowser/MediaBrowserMetadataFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/MediaBrowser/MediaBrowserMetadataFixture.cs
@@ -7,7 +7,6 @@ namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.MediaBrowser
     using NzbDrone.Core.Extras.Metadata.Consumers.MediaBrowser;
     using NzbDrone.Core.Movies;
     using NzbDrone.Core.Test.Framework;
-    using NzbDrone.Core.ThingiProvider;
     using NzbDrone.Test.Common;
 
     [TestFixture]

--- a/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/MediaBrowser/MediaBrowserMetadataFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/MediaBrowser/MediaBrowserMetadataFixture.cs
@@ -1,14 +1,14 @@
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Extras.Metadata;
+using NzbDrone.Core.Extras.Metadata.Consumers.MediaBrowser;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
 namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.MediaBrowser
 {
-    using FizzWare.NBuilder;
-    using FluentAssertions;
-    using NUnit.Framework;
-    using NzbDrone.Core.Extras.Metadata;
-    using NzbDrone.Core.Extras.Metadata.Consumers.MediaBrowser;
-    using NzbDrone.Core.Movies;
-    using NzbDrone.Core.Test.Framework;
-    using NzbDrone.Test.Common;
-
     [TestFixture]
     public class MediaBrowserMetadataFixture : CoreTest<MediaBrowserMetadata>
     {

--- a/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFixture.cs
@@ -1,0 +1,76 @@
+namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.Xbmc
+{
+    using System;
+    using System.Collections.Generic;
+    using FizzWare.NBuilder;
+    using FluentAssertions;
+    using Moq;
+    using NUnit.Framework;
+    using NzbDrone.Core.Extras.Metadata;
+    using NzbDrone.Core.Extras.Metadata.Consumers.Xbmc;
+    using NzbDrone.Core.Movies;
+    using NzbDrone.Core.Movies.Credits;
+    using NzbDrone.Core.Test.Framework;
+    using NzbDrone.Core.ThingiProvider;
+    using NzbDrone.Test.Common;
+
+    [TestFixture]
+    public class XbmcMetadataFixture : CoreTest<XbmcMetadata>
+    {
+        private Movie _movie;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movie = Builder<Movie>.CreateNew()
+                                     .With(s => s.Path = @"C:\Test\Movies\The.Movie".AsOsAgnostic())
+                                     .Build();
+
+            Subject.Definition = new MetadataDefinition
+            {
+                Settings = new XbmcMetadataSettings()
+            };
+        }
+
+        private XbmcMetadataSettings Settings => (XbmcMetadataSettings)Subject.Definition.Settings;
+
+        [Test]
+        public void should_support_metadata_without_video_file_when_UseMovieNfo_is_true()
+        {
+            Settings.UseMovieNfo = true;
+            Subject.SupportsMetadataWithoutVideoFile.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_not_support_metadata_without_video_file_when_UseMovieNfo_is_false()
+        {
+            Settings.UseMovieNfo = false;
+            Subject.SupportsMetadataWithoutVideoFile.Should().BeFalse();
+        }
+
+        [Test]
+        public void MovieMetadata_should_return_result_when_movieFile_is_null_and_UseMovieNfo_is_true()
+        {
+            Settings.UseMovieNfo = true;
+            Settings.MovieMetadata = true;
+
+            Mocker.GetMock<ICreditService>()
+                  .Setup(v => v.GetAllCreditsForMovieMetadata(It.IsAny<int>()))
+                  .Returns(new List<Credit>());
+
+            var result = Subject.MovieMetadata(_movie, null);
+
+            result.Should().NotBeNull();
+            result.RelativePath.Should().Be("movie.nfo");
+        }
+
+        [Test]
+        public void MovieMetadata_should_throw_ArgumentException_when_movieFile_is_null_and_UseMovieNfo_is_false()
+        {
+            Settings.UseMovieNfo = false;
+            Settings.MovieMetadata = true;
+
+            Assert.Throws<ArgumentException>(() => Subject.MovieMetadata(_movie, null));
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFixture.cs
@@ -1,18 +1,18 @@
+using System;
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Extras.Metadata;
+using NzbDrone.Core.Extras.Metadata.Consumers.Xbmc;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Credits;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
 namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.Xbmc
 {
-    using System;
-    using System.Collections.Generic;
-    using FizzWare.NBuilder;
-    using FluentAssertions;
-    using Moq;
-    using NUnit.Framework;
-    using NzbDrone.Core.Extras.Metadata;
-    using NzbDrone.Core.Extras.Metadata.Consumers.Xbmc;
-    using NzbDrone.Core.Movies;
-    using NzbDrone.Core.Movies.Credits;
-    using NzbDrone.Core.Test.Framework;
-    using NzbDrone.Test.Common;
-
     [TestFixture]
     public class XbmcMetadataFixture : CoreTest<XbmcMetadata>
     {

--- a/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFixture.cs
@@ -11,7 +11,6 @@ namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.Xbmc
     using NzbDrone.Core.Movies;
     using NzbDrone.Core.Movies.Credits;
     using NzbDrone.Core.Test.Framework;
-    using NzbDrone.Core.ThingiProvider;
     using NzbDrone.Test.Common;
 
     [TestFixture]

--- a/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFixture.cs
@@ -8,6 +8,8 @@ using NzbDrone.Core.Extras.Metadata;
 using NzbDrone.Core.Extras.Metadata.Consumers.Xbmc;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Credits;
+using NzbDrone.Core.Movies.Translations;
+using NzbDrone.Core.Tags;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Test.Common;
 
@@ -25,6 +27,18 @@ namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.Xbmc
                                      .With(s => s.Path = @"C:\Test\Movies\The.Movie".AsOsAgnostic())
                                      .Build();
 
+            Mocker.GetMock<IMovieTranslationService>()
+                  .Setup(v => v.GetAllTranslationsForMovieMetadata(It.IsAny<int>()))
+                  .Returns(new List<MovieTranslation>());
+
+            Mocker.GetMock<ICreditService>()
+                  .Setup(v => v.GetAllCreditsForMovieMetadata(It.IsAny<int>()))
+                  .Returns(new List<Credit>());
+
+            Mocker.GetMock<ITagRepository>()
+                  .Setup(v => v.GetTags(It.IsAny<HashSet<int>>()))
+                  .Returns(new List<Tag>());
+
             Subject.Definition = new MetadataDefinition
             {
                 Settings = new XbmcMetadataSettings()
@@ -34,14 +48,14 @@ namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.Xbmc
         private XbmcMetadataSettings Settings => (XbmcMetadataSettings)Subject.Definition.Settings;
 
         [Test]
-        public void should_support_metadata_without_video_file_when_UseMovieNfo_is_true()
+        public void Metadata_should_support_without_video_file_when_UseMovieNfo_is_true()
         {
             Settings.UseMovieNfo = true;
             Subject.SupportsMetadataWithoutVideoFile.Should().BeTrue();
         }
 
         [Test]
-        public void should_not_support_metadata_without_video_file_when_UseMovieNfo_is_false()
+        public void Metadata_should_not_support_without_video_file_when_UseMovieNfo_is_false()
         {
             Settings.UseMovieNfo = false;
             Subject.SupportsMetadataWithoutVideoFile.Should().BeFalse();
@@ -52,10 +66,6 @@ namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.Xbmc
         {
             Settings.UseMovieNfo = true;
             Settings.MovieMetadata = true;
-
-            Mocker.GetMock<ICreditService>()
-                  .Setup(v => v.GetAllCreditsForMovieMetadata(It.IsAny<int>()))
-                  .Returns(new List<Credit>());
 
             var result = Subject.MovieMetadata(_movie, null);
 

--- a/src/NzbDrone.Core.Test/Extras/Metadata/MetadataServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/MetadataServiceFixture.cs
@@ -1,18 +1,18 @@
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Disk;
+using NzbDrone.Core.Extras.Metadata;
+using NzbDrone.Core.Extras.Metadata.Files;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
 namespace NzbDrone.Core.Test.Extras.Metadata
 {
-    using System.Collections.Generic;
-    using FizzWare.NBuilder;
-    using FluentAssertions;
-    using Moq;
-    using NUnit.Framework;
-    using NzbDrone.Common.Disk;
-    using NzbDrone.Core.Extras.Metadata;
-    using NzbDrone.Core.Extras.Metadata.Files;
-    using NzbDrone.Core.MediaFiles;
-    using NzbDrone.Core.Movies;
-    using NzbDrone.Core.Test.Framework;
-    using NzbDrone.Test.Common;
-
     [TestFixture]
     public class MetadataServiceFixture : CoreTest<MetadataService>
     {

--- a/src/NzbDrone.Core.Test/Extras/Metadata/MetadataServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/MetadataServiceFixture.cs
@@ -1,0 +1,80 @@
+namespace NzbDrone.Core.Test.Extras.Metadata
+{
+    using System.Collections.Generic;
+    using FizzWare.NBuilder;
+    using Moq;
+    using NUnit.Framework;
+    using NzbDrone.Common.Disk;
+    using NzbDrone.Core.Extras.Metadata;
+    using NzbDrone.Core.Extras.Metadata.Files;
+    using NzbDrone.Core.MediaFiles;
+    using NzbDrone.Core.Movies;
+    using NzbDrone.Core.Test.Framework;
+    using NzbDrone.Test.Common;
+
+    [TestFixture]
+    public class MetadataServiceFixture : CoreTest<MetadataService>
+    {
+        private Movie _movie;
+        private Mock<IMetadata> _consumer;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movie = Builder<Movie>.CreateNew()
+                                     .With(s => s.Path = @"C:\Test\Movies\The.Movie".AsOsAgnostic())
+                                     .Build();
+
+            _consumer = new Mock<IMetadata>();
+            _consumer.SetupGet(c => c.SupportsMetadataWithoutVideoFile).Returns(true);
+
+            Mocker.GetMock<IMetadataFactory>()
+                  .Setup(v => v.Enabled())
+                  .Returns(new List<IMetadata> { _consumer.Object });
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(v => v.FolderExists(_movie.Path))
+                  .Returns(true);
+
+            Mocker.GetMock<IMetadataFileService>()
+                  .Setup(v => v.GetFilesByMovie(_movie.Id))
+                  .Returns(new List<MetadataFile>());
+        }
+
+        [Test]
+        public void CreateAfterMovieScan_should_call_MovieMetadata_with_null_movieFile_if_no_files_and_supported()
+        {
+            Subject.CreateAfterMovieScan(_movie, new List<MovieFile>());
+
+            _consumer.Verify(v => v.MovieMetadata(_movie, null), Times.Once());
+        }
+
+        [Test]
+        public void CreateAfterMovieScan_should_not_call_MovieMetadata_with_null_movieFile_if_no_files_and_not_supported()
+        {
+            _consumer.SetupGet(c => c.SupportsMetadataWithoutVideoFile).Returns(false);
+
+            Subject.CreateAfterMovieScan(_movie, new List<MovieFile>());
+
+            _consumer.Verify(v => v.MovieMetadata(_movie, null), Times.Never());
+        }
+
+        [Test]
+        public void CreateAfterMovieFolder_should_call_MovieMetadata_with_null_movieFile_if_supported()
+        {
+            Subject.CreateAfterMovieFolder(_movie, _movie.Path);
+
+            _consumer.Verify(v => v.MovieMetadata(_movie, null), Times.Once());
+        }
+
+        [Test]
+        public void CreateAfterMovieFolder_should_not_call_MovieMetadata_with_null_movieFile_if_not_supported()
+        {
+            _consumer.SetupGet(c => c.SupportsMetadataWithoutVideoFile).Returns(false);
+
+            Subject.CreateAfterMovieFolder(_movie, _movie.Path);
+
+            _consumer.Verify(v => v.MovieMetadata(_movie, null), Times.Never());
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/Extras/Metadata/MetadataServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/MetadataServiceFixture.cs
@@ -2,6 +2,7 @@ namespace NzbDrone.Core.Test.Extras.Metadata
 {
     using System.Collections.Generic;
     using FizzWare.NBuilder;
+    using FluentAssertions;
     using Moq;
     using NUnit.Framework;
     using NzbDrone.Common.Disk;
@@ -27,6 +28,8 @@ namespace NzbDrone.Core.Test.Extras.Metadata
 
             _consumer = new Mock<IMetadata>();
             _consumer.SetupGet(c => c.SupportsMetadataWithoutVideoFile).Returns(true);
+            _consumer.Setup(v => v.MovieImages(It.IsAny<Movie>()))
+                     .Returns(new List<ImageFileResult>());
 
             Mocker.GetMock<IMetadataFactory>()
                   .Setup(v => v.Enabled())
@@ -75,6 +78,34 @@ namespace NzbDrone.Core.Test.Extras.Metadata
             Subject.CreateAfterMovieFolder(_movie, _movie.Path);
 
             _consumer.Verify(v => v.MovieMetadata(_movie, null), Times.Never());
+        }
+
+        [Test]
+        public void CreateAfterMovieScan_should_update_existing_metadata_with_MovieFileId_0_if_path_matches()
+        {
+            var movieFile = Builder<MovieFile>.CreateNew().With(f => f.Id = 123).Build();
+            var existingMetadata = new MetadataFile
+            {
+                Id = 456,
+                MovieId = _movie.Id,
+                MovieFileId = 0,
+                RelativePath = "movie.nfo",
+                Type = MetadataType.MovieMetadata,
+                Consumer = _consumer.Object.GetType().Name
+            };
+
+            Mocker.GetMock<IMetadataFileService>()
+                  .Setup(v => v.GetFilesByMovie(_movie.Id))
+                  .Returns(new List<MetadataFile> { existingMetadata });
+
+            _consumer.Setup(c => c.MovieMetadata(_movie, movieFile))
+                     .Returns(new MetadataFileResult("movie.nfo", "content"));
+
+            Subject.CreateAfterMovieScan(_movie, new List<MovieFile> { movieFile });
+
+            existingMetadata.MovieFileId.Should().Be(movieFile.Id);
+            Mocker.GetMock<IMetadataFileService>()
+                  .Verify(v => v.Upsert(It.Is<List<MetadataFile>>(l => l.Contains(existingMetadata))), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Kometa/KometaMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Kometa/KometaMetadata.cs
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Kometa
             return null;
         }
 
-        public override MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile)
+        public override MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile = null)
         {
             return null;
         }

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/MediaBrowser/MediaBrowserMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/MediaBrowser/MediaBrowserMetadata.cs
@@ -28,6 +28,8 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.MediaBrowser
 
         public override string Name => "Emby (Legacy)";
 
+        public override bool SupportsMetadataWithoutVideoFile => true;
+
         public override ProviderMessage Message => new (_localizationService.GetLocalizedString("MetadataMediaBrowserDeprecated", new Dictionary<string, object> { { "version", "v6" } }), ProviderMessageType.Warning);
 
         public override MetadataFile FindMetadataFile(Movie movie, string path)
@@ -55,7 +57,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.MediaBrowser
             return null;
         }
 
-        public override MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile)
+        public override MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile = null)
         {
             if (!Settings.MovieMetadata)
             {

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
@@ -92,7 +92,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
             return null;
         }
 
-        public override MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile)
+        public override MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile = null)
         {
             if (!Settings.MovieMetadata)
             {

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Wdtv/WdtvMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Wdtv/WdtvMetadata.cs
@@ -86,7 +86,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
             return null;
         }
 
-        public override MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile)
+        public override MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile = null)
         {
             if (!Settings.MovieMetadata)
             {

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -54,6 +54,8 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 
         public override string Name => "Kodi (XBMC) / Emby";
 
+        public override bool SupportsMetadataWithoutVideoFile => Settings.UseMovieNfo;
+
         public override string GetFilenameAfterMove(Movie movie, MovieFile movieFile, MetadataFile metadataFile)
         {
             var movieFilePath = Path.Combine(movie.Path, movieFile.RelativePath);
@@ -115,13 +117,20 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
             return null;
         }
 
-        public override MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile)
+        public override MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile = null)
         {
             var xmlResult = string.Empty;
 
             if (Settings.MovieMetadata)
             {
-                _logger.Debug("Generating Movie Metadata for: {0}", Path.Combine(movie.Path, movieFile.RelativePath));
+                if (movieFile != null)
+                {
+                    _logger.Debug("Generating Movie Metadata for: {0}", Path.Combine(movie.Path, movieFile.RelativePath));
+                }
+                else
+                {
+                    _logger.Debug("Generating Movie Metadata for: {0}", movie.Path);
+                }
 
                 var movieMetadataLanguage = Settings.MovieMetadataLanguage == (int)Language.Original ?
                     (int)movie.MovieMetadata.Value.OriginalLanguage :
@@ -133,7 +142,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 
                 var credits = _creditService.GetAllCreditsForMovieMetadata(movie.MovieMetadataId);
 
-                var watched = GetExistingWatchedStatus(movie, movieFile.RelativePath);
+                var watched = movieFile != null && GetExistingWatchedStatus(movie, movieFile.RelativePath);
 
                 var thumbnail = movie.MovieMetadata.Value.Images.SingleOrDefault(i => i.CoverType == MediaCoverTypes.Screenshot);
                 var posters = movie.MovieMetadata.Value.Images.Where(i => i.CoverType == MediaCoverTypes.Poster).ToList();
@@ -328,7 +337,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 
                 details.Add(new XElement("watched", watched));
 
-                if (movieFile.MediaInfo != null)
+                if (movieFile?.MediaInfo != null)
                 {
                     var sceneName = movieFile.GetSceneOrFileName();
 
@@ -440,7 +449,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                 xmlResult += Environment.NewLine;
             }
 
-            var metadataFileName = GetMovieMetadataFilename(movieFile.RelativePath);
+            var metadataFileName = GetMovieMetadataFilename(movieFile?.RelativePath);
 
             return string.IsNullOrEmpty(xmlResult) ? null : new MetadataFileResult(metadataFileName, xmlResult.Trim(Environment.NewLine.ToCharArray()));
         }
@@ -470,10 +479,15 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
         {
             if (Settings.UseMovieNfo)
             {
-                return Path.Combine(Path.GetDirectoryName(movieFilePath), "movie.nfo");
+                return Path.Combine(Path.GetDirectoryName(movieFilePath) ?? string.Empty, "movie.nfo");
             }
             else
             {
+                if (movieFilePath.IsNullOrWhiteSpace())
+                {
+                    throw new ArgumentException("movieFilePath cannot be null or empty when UseMovieNfo is false");
+                }
+
                 return Path.ChangeExtension(movieFilePath, "nfo");
             }
         }

--- a/src/NzbDrone.Core/Extras/Metadata/IMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/IMetadata.cs
@@ -10,7 +10,8 @@ namespace NzbDrone.Core.Extras.Metadata
     {
         string GetFilenameAfterMove(Movie movie, MovieFile movieFile, MetadataFile metadataFile);
         MetadataFile FindMetadataFile(Movie movie, string path);
-        MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile);
+        MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile = null);
         List<ImageFileResult> MovieImages(Movie movie);
+        bool SupportsMetadataWithoutVideoFile { get; }
     }
 }

--- a/src/NzbDrone.Core/Extras/Metadata/MetadataBase.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/MetadataBase.cs
@@ -38,8 +38,10 @@ namespace NzbDrone.Core.Extras.Metadata
 
         public abstract MetadataFile FindMetadataFile(Movie movie, string path);
 
-        public abstract MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile);
+        public abstract MetadataFileResult MovieMetadata(Movie movie, MovieFile movieFile = null);
         public abstract List<ImageFileResult> MovieImages(Movie movie);
+
+        public virtual bool SupportsMetadataWithoutVideoFile => false;
 
         public virtual object RequestAction(string action, IDictionary<string, string> query)
         {

--- a/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
@@ -231,10 +231,12 @@ namespace NzbDrone.Core.Extras.Metadata
             _otherExtraFileRenamer.RenameOtherExtraFile(movie, fullPath);
 
             var existingMetadata = GetMetadataFile(movie, existingMetadataFiles, c => c.Type == MetadataType.MovieMetadata &&
-                                                                                  c.MovieFileId == (movieFile?.Id ?? 0));
+                                                                                  (c.MovieFileId == (movieFile?.Id ?? 0) || c.RelativePath == movieFileMetadata.RelativePath));
 
             if (existingMetadata != null)
             {
+                existingMetadata.MovieFileId = movieFile?.Id ?? 0;
+
                 var existingFullPath = Path.Combine(movie.Path, existingMetadata.RelativePath);
                 if (fullPath.PathNotEquals(existingFullPath))
                 {

--- a/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
@@ -105,6 +105,11 @@ namespace NzbDrone.Core.Extras.Metadata
                 {
                     files.AddIfNotNull(ProcessMovieMetadata(consumer, movie, movieFile, consumerFiles));
                 }
+
+                if (movieFiles.Empty() && consumer.SupportsMetadataWithoutVideoFile)
+                {
+                    files.AddIfNotNull(ProcessMovieMetadata(consumer, movie, null, consumerFiles));
+                }
             }
 
             _metadataFileService.Upsert(files);
@@ -144,6 +149,11 @@ namespace NzbDrone.Core.Extras.Metadata
                 if (movieFolder.IsNotNullOrWhiteSpace())
                 {
                     files.AddRange(ProcessMovieImages(consumer, movie, consumerFiles));
+
+                    if (consumer.SupportsMetadataWithoutVideoFile)
+                    {
+                        files.AddIfNotNull(ProcessMovieMetadata(consumer, movie, null, consumerFiles));
+                    }
                 }
             }
 
@@ -221,7 +231,7 @@ namespace NzbDrone.Core.Extras.Metadata
             _otherExtraFileRenamer.RenameOtherExtraFile(movie, fullPath);
 
             var existingMetadata = GetMetadataFile(movie, existingMetadataFiles, c => c.Type == MetadataType.MovieMetadata &&
-                                                                                  c.MovieFileId == movieFile.Id);
+                                                                                  c.MovieFileId == (movieFile?.Id ?? 0));
 
             if (existingMetadata != null)
             {
@@ -239,7 +249,7 @@ namespace NzbDrone.Core.Extras.Metadata
                            new MetadataFile
                            {
                                MovieId = movie.Id,
-                               MovieFileId = movieFile.Id,
+                               MovieFileId = movieFile?.Id ?? 0,
                                Consumer = consumer.GetType().Name,
                                Type = MetadataType.MovieMetadata,
                                RelativePath = movieFileMetadata.RelativePath,


### PR DESCRIPTION
#### Database Migration
No

#### Description
In the event that a metadata consumer supports this capability, save the metadata file even when no movie file is present.

Affected consumers:
1. Kodi if `UseMovieNfo` is turned on
2. Emby (Legacy)

This change was generated using AI and verified manually

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (`./src/NzbDrone.Core/Localization/Core/en.json`) (not required)
- [x] [Wiki Updates](https://wiki.servarr.com) (not required)

#### Issues Fixed or Closed by this PR

None