### PR TITLE
Fixed: Freebox download client throws when task list is empty

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/FreeboxDownload/FreeboxDownloadProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/FreeboxDownload/FreeboxDownloadProxy.cs
@@ -110,7 +110,7 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload
         {
             var request = BuildRequest(settings).Resource("/downloads/").Build();
 
-            return ProcessRequest<List<FreeboxDownloadTask>>(request, settings).Result;
+            return ProcessRequest<List<FreeboxDownloadTask>>(request, settings).Result ?? new List<FreeboxDownloadTask>();
         }
 
         private static string BuildCachedHeaderKey(FreeboxDownloadSettings settings)


### PR DESCRIPTION
## What does this PR do?

Fixes #11388

When the Freebox download queue is empty, the API returns `{ "success": true }` with no `result` field. `GetTasks` was returning this `null` directly, causing an `ArgumentNullException` in `GetTorrents` when `.Where()` was called on the null list.

## How was this tested?

The fix returns an empty `List<FreeboxDownloadTask>` via null-coalescing when `Result` is null, matching the behaviour expected by all callers.

## Change

`FreeboxDownloadProxy.GetTasks` — one line:

```csharp
// before
return ProcessRequest<List<FreeboxDownloadTask>>(request, settings).Result;

// after
return ProcessRequest<List<FreeboxDownloadTask>>(request, settings).Result ?? new List<FreeboxDownloadTask>();
```