### PR TITLE
Fixed: ManualImport command hangs in 'started' state when ffprobe throws on a file

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/AggregationService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/AggregationService.cs
@@ -57,14 +57,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation
 
             if (isMediaFile && (!localMovie.ExistingFile || _configService.EnableMediaInfo))
             {
-                try
-                {
-                    localMovie.MediaInfo = _videoFileInfoReader.GetMediaInfo(localMovie.Path);
-                }
-                catch (Exception ex)
-                {
-                    _logger.Warn(ex, "Unable to read media info for '{0}'", localMovie.Path);
-                }
+                localMovie.MediaInfo = _videoFileInfoReader.GetMediaInfo(localMovie.Path);
             }
 
             foreach (var augmenter in _augmenters)

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/AggregationService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/AggregationService.cs
@@ -57,7 +57,14 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation
 
             if (isMediaFile && (!localMovie.ExistingFile || _configService.EnableMediaInfo))
             {
-                localMovie.MediaInfo = _videoFileInfoReader.GetMediaInfo(localMovie.Path);
+                try
+                {
+                    localMovie.MediaInfo = _videoFileInfoReader.GetMediaInfo(localMovie.Path);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn(ex, "Unable to read media info for '{0}'. Continuing without media info.", localMovie.Path);
+                }
             }
 
             foreach (var augmenter in _augmenters)

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/AggregationService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/AggregationService.cs
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation
                 }
                 catch (Exception ex)
                 {
-                    _logger.Warn(ex, "Unable to read media info for '{0}'. Continuing without media info.", localMovie.Path);
+                    _logger.Warn(ex, "Unable to read media info for '{0}'", localMovie.Path);
                 }
             }
 

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
@@ -413,69 +413,76 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
             {
                 _logger.ProgressTrace("Processing file {0} of {1}", i + 1, message.Files.Count);
 
-                var file = message.Files[i];
-                var movie = _movieService.GetMovie(file.MovieId);
-                var fileMovieInfo = Parser.Parser.ParseMoviePath(file.Path) ?? new ParsedMovieInfo();
-                var existingFile = movie.Path.IsParentPath(file.Path);
-                TrackedDownload trackedDownload = null;
-
-                var localMovie = new LocalMovie
+                try
                 {
-                    ExistingFile = existingFile,
-                    FileMovieInfo = fileMovieInfo,
-                    Path = file.Path,
-                    ReleaseGroup = file.ReleaseGroup,
-                    Quality = file.Quality,
-                    Languages = file.Languages,
-                    IndexerFlags = (IndexerFlags)file.IndexerFlags,
-                    Movie = movie,
-                    Size = 0
-                };
+                    var file = message.Files[i];
+                    var movie = _movieService.GetMovie(file.MovieId);
+                    var fileMovieInfo = Parser.Parser.ParseMoviePath(file.Path) ?? new ParsedMovieInfo();
+                    var existingFile = movie.Path.IsParentPath(file.Path);
+                    TrackedDownload trackedDownload = null;
 
-                if (file.DownloadId.IsNotNullOrWhiteSpace())
-                {
-                    trackedDownload = _trackedDownloadService.Find(file.DownloadId);
-                    localMovie.DownloadClientMovieInfo = trackedDownload?.RemoteMovie?.ParsedMovieInfo;
-                    localMovie.DownloadItem = trackedDownload?.DownloadItem;
-                }
-
-                if (file.FolderName.IsNotNullOrWhiteSpace())
-                {
-                    localMovie.FolderMovieInfo = Parser.Parser.ParseMovieTitle(file.FolderName);
-                    localMovie.SceneSource = !existingFile;
-                }
-
-                // Augment movie file so imported files have all additional information an automatic import would
-                localMovie = _aggregationService.Augment(localMovie, trackedDownload?.DownloadItem);
-
-                // Apply the user-chosen values.
-                localMovie.Movie = movie;
-                localMovie.ReleaseGroup = file.ReleaseGroup;
-                localMovie.Quality = file.Quality;
-                localMovie.Languages = file.Languages;
-                localMovie.IndexerFlags = (IndexerFlags)file.IndexerFlags;
-
-                localMovie.CustomFormats = _formatCalculator.ParseCustomFormat(localMovie);
-                localMovie.CustomFormatScore = localMovie.Movie.QualityProfile?.CalculateCustomFormatScore(localMovie.CustomFormats) ?? 0;
-
-                // TODO: Cleanup non-tracked downloads
-                var importDecision = new ImportDecision(localMovie);
-
-                if (trackedDownload == null)
-                {
-                    imported.AddRange(_importApprovedMovie.Import(new List<ImportDecision> { importDecision }, !existingFile, null, message.ImportMode));
-                }
-                else
-                {
-                    var importResult = _importApprovedMovie.Import(new List<ImportDecision> { importDecision }, true, trackedDownload.DownloadItem, message.ImportMode).First();
-
-                    imported.Add(importResult);
-
-                    importedTrackedDownload.Add(new ManuallyImportedFile
+                    var localMovie = new LocalMovie
                     {
-                        TrackedDownload = trackedDownload,
-                        ImportResult = importResult
-                    });
+                        ExistingFile = existingFile,
+                        FileMovieInfo = fileMovieInfo,
+                        Path = file.Path,
+                        ReleaseGroup = file.ReleaseGroup,
+                        Quality = file.Quality,
+                        Languages = file.Languages,
+                        IndexerFlags = (IndexerFlags)file.IndexerFlags,
+                        Movie = movie,
+                        Size = 0
+                    };
+
+                    if (file.DownloadId.IsNotNullOrWhiteSpace())
+                    {
+                        trackedDownload = _trackedDownloadService.Find(file.DownloadId);
+                        localMovie.DownloadClientMovieInfo = trackedDownload?.RemoteMovie?.ParsedMovieInfo;
+                        localMovie.DownloadItem = trackedDownload?.DownloadItem;
+                    }
+
+                    if (file.FolderName.IsNotNullOrWhiteSpace())
+                    {
+                        localMovie.FolderMovieInfo = Parser.Parser.ParseMovieTitle(file.FolderName);
+                        localMovie.SceneSource = !existingFile;
+                    }
+
+                    // Augment movie file so imported files have all additional information an automatic import would
+                    localMovie = _aggregationService.Augment(localMovie, trackedDownload?.DownloadItem);
+
+                    // Apply the user-chosen values.
+                    localMovie.Movie = movie;
+                    localMovie.ReleaseGroup = file.ReleaseGroup;
+                    localMovie.Quality = file.Quality;
+                    localMovie.Languages = file.Languages;
+                    localMovie.IndexerFlags = (IndexerFlags)file.IndexerFlags;
+
+                    localMovie.CustomFormats = _formatCalculator.ParseCustomFormat(localMovie);
+                    localMovie.CustomFormatScore = localMovie.Movie.QualityProfile?.CalculateCustomFormatScore(localMovie.CustomFormats) ?? 0;
+
+                    // TODO: Cleanup non-tracked downloads
+                    var importDecision = new ImportDecision(localMovie);
+
+                    if (trackedDownload == null)
+                    {
+                        imported.AddRange(_importApprovedMovie.Import(new List<ImportDecision> { importDecision }, !existingFile, null, message.ImportMode));
+                    }
+                    else
+                    {
+                        var importResult = _importApprovedMovie.Import(new List<ImportDecision> { importDecision }, true, trackedDownload.DownloadItem, message.ImportMode).First();
+
+                        imported.Add(importResult);
+
+                        importedTrackedDownload.Add(new ManuallyImportedFile
+                        {
+                            TrackedDownload = trackedDownload,
+                            ImportResult = importResult
+                        });
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn(ex, "Failed to process file during manual import: {0}", message.Files[i].Path);
                 }
             }
 


### PR DESCRIPTION
## What does this fix?

When a ManualImport batch contains a file that causes ffprobe to throw
(`TaskCanceledException` / `IOException`) — e.g. a large file (9.6 GB+)
accessed over NFS/SMB — the `Execute()` loop in `ManualImportService` has no
per-file exception handling. The unhandled exception escapes `Execute()`,
leaving the command frozen in `"Processing file N of M"` state indefinitely.

Because `ProcessMonitoredDownloads` queues behind `ManualImportCommand`, this
creates a zombie command that blocks the entire Radarr command queue
indefinitely.

Observed stack trace (from production logs):
```
System.Threading.Tasks.TaskCanceledException: The operation was canceled.
  at System.IO.IOException: Unable to read data from the transport connection: Operation canceled.
  at FFMpegCore.FFProbe.GetStreamJson(...)
  at NzbDrone.Core.MediaFiles.MediaInfo.VideoFileInfoReader.GetMediaInfo(...)
  at NzbDrone.Core.MediaFiles.MovieImport.Aggregation.AggregationService.Augment(...)
  at NzbDrone.Core.MediaFiles.MovieImport.Manual.ManualImportService.Execute(...)
```

## Changes

### `AggregationService.cs`
Wrap the `_videoFileInfoReader.GetMediaInfo()` call in a try/catch. If ffprobe
cannot read the file (timeout, I/O cancellation, network error), log a warning
and continue with `MediaInfo = null` rather than propagating the exception.
This is consistent with how every augmenter in the `foreach` block below is
already guarded against exceptions.

### `ManualImportService.cs` — `Execute()`
Wrap the entire per-file body inside the `for` loop in a try/catch. If any
exception escapes processing a single file, log a warning and skip to the next
file rather than aborting the whole batch and leaving the command in a zombie
state. This mirrors the identical pattern already used in `ProcessFile()` (the
file-browser path, line ~304).

## Behavior after this fix

- A file that causes ffprobe to time out or be canceled is skipped with a
  `[Warn]` log entry; the import continues with the remaining files.
- `ManualImportCommand` always reaches a completed or failed terminal state —
  it never stays frozen in `"started"`.
- `ProcessMonitoredDownloads` and other queued commands are no longer blocked
  by a zombie `ManualImportCommand`.
- Files that import successfully are completely unaffected.