### PR TITLE
New: Lower IMDb list minimum refresh interval to 30 minutes

### DIFF
--- a/src/NzbDrone.Core/ImportLists/RadarrList2/IMDb/IMDbListImport.cs
+++ b/src/NzbDrone.Core/ImportLists/RadarrList2/IMDb/IMDbListImport.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.ImportLists.RadarrList2.IMDbList
         public override string Name => "IMDb Lists";
 
         public override ImportListType ListType => ImportListType.Other;
-        public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(12);
+        public override TimeSpan MinRefreshInterval => TimeSpan.FromMinutes(30);
         public override bool Enabled => true;
         public override bool EnableAuto => false;
 


### PR DESCRIPTION
Drops the IMDb-specific MinRefreshInterval from 12 hours to 30 minutes so newly added entries on watched IMDb lists are picked up promptly by the scheduled ImportListSyncCommand. Other list types are unchanged.

#### Database Migration
YES - XXXX | NO

#### Description
A few sentences describing the overall goals of the pull request's commits.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX