### PR TITLE
New: Search by IMDb ID without the "imdb:" prefix

### DIFF
--- a/frontend/src/AddMovie/AddNewMovie/AddNewMovie.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewMovie.js
@@ -103,7 +103,7 @@ class AddNewMovie extends Component {
               className={styles.searchInput}
               name="movieLookup"
               value={term}
-              placeholder="e.g. The Dark Knight, tmdb:155, imdb:tt0468569"
+              placeholder="e.g. The Dark Knight, tmdb:155, imdb:tt0468569, tt0468569"
               autoFocus={true}
               onChange={this.onSearchInputChange}
             />

--- a/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxySearchFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxySearchFixture.cs
@@ -23,6 +23,7 @@ namespace NzbDrone.Core.Test.MetadataSource.SkyHook
         // [TestCase("The Man from U.N.C.L.E.", "The Man from U.N.C.L.E.")]
         [TestCase("imdb:tt2527336", "Star Wars: The Last Jedi")]
         [TestCase("imdb:tt2798920", "Annihilation")]
+        [TestCase("tt2527336", "Star Wars: The Last Jedi")]
         [TestCase("https://www.imdb.com/title/tt0033467/", "Citizen Kane")]
         [TestCase("https://www.themoviedb.org/movie/775-le-voyage-dans-la-lune", "A Trip to the Moon")]
         public void successful_search(string title, string expected)

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -37,7 +37,7 @@
   "AddNewMovie": "Add New Movie",
   "AddNewMovieRootFolderHelpText": "'{folder}' subfolder will be created automatically",
   "AddNewRestriction": "Add new restriction",
-  "AddNewTmdbIdMessage": "You can also search using TMDb Id of a movie. e.g. 'tmdb:71663'",
+  "AddNewTmdbIdMessage": "You can also search using the TMDb Id or IMDb Id of a movie. e.g. 'tmdb:71663' or 'tt0468569'",
   "AddNotificationError": "Unable to add a new notification, please try again.",
   "AddQualityProfile": "Add Quality Profile",
   "AddQualityProfileError": "Unable to add a new quality profile, please try again.",

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -412,6 +412,10 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 {
                     title = "imdb:" + match.Groups[1].Value;
                 }
+                else if ((match = new Regex(@"^(tt\d{7,})$", RegexOptions.IgnoreCase).Match(title.Trim())).Success)
+                {
+                    title = "imdb:" + match.Groups[1].Value;
+                }
                 else
                 {
                     match = new Regex(@"\bthemoviedb\.org/movie/(\d+)\b", RegexOptions.IgnoreCase).Match(title);


### PR DESCRIPTION
Allow the Add New Movie search to accept a bare IMDb ID (e.g. tt0468569) in addition to the existing "imdb:" prefix and full imdb.com URL forms. Also surfaces the new format in the search placeholder and helper text.

#### Database Migration
NO

#### Description
Allow the Add New Movie search to accept a bare IMDb ID (e.g. tt0468569) in addition to the existing "imdb:" prefix and full imdb.com URL forms. Also surfaces the new format in the search placeholder and helper text. 

#### Screenshot (if UI related)
<img width="1715" height="515" alt="image" src="https://github.com/user-attachments/assets/5d007c98-ec35-40d8-a5db-4f8bf279bd38" />
<img width="1702" height="572" alt="image" src="https://github.com/user-attachments/assets/b9c4622d-12f9-42cf-88a8-a31b5881fc2a" />


#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #9395