### PR TITLE
New: Show language column on alternative titles

### DIFF
--- a/frontend/src/Movie/Details/Titles/MovieTitlesRow.tsx
+++ b/frontend/src/Movie/Details/Titles/MovieTitlesRow.tsx
@@ -1,17 +1,25 @@
 import React from 'react';
 import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import TableRow from 'Components/Table/TableRow';
+import languageToFlag from 'Utilities/String/languageToFlag';
 import titleCase from 'Utilities/String/titleCase';
 
 interface MovieTitlesRowProps {
   title: string;
+  language?: string;
   sourceType: string;
 }
 
-function MovieTitlesRow({ title, sourceType }: MovieTitlesRowProps) {
+function MovieTitlesRow({ title, language, sourceType }: MovieTitlesRowProps) {
   return (
     <TableRow>
       <TableRowCell>{title}</TableRowCell>
+
+      <TableRowCell>
+        {language && language !== 'Unknown'
+          ? `${languageToFlag(language)} ${language}`
+          : '-'}
+      </TableRowCell>
 
       <TableRowCell>{titleCase(sourceType)}</TableRowCell>
     </TableRow>

--- a/frontend/src/Movie/Details/Titles/MovieTitlesTable.tsx
+++ b/frontend/src/Movie/Details/Titles/MovieTitlesTable.tsx
@@ -20,6 +20,11 @@ const columns: Column[] = [
     isVisible: true,
   },
   {
+    name: 'language',
+    label: () => translate('Language'),
+    isVisible: true,
+  },
+  {
     name: 'sourceType',
     label: () => translate('Type'),
     isVisible: true,
@@ -81,6 +86,7 @@ function MovieTitlesTable({ movieId }: MovieTitlesProps) {
               <MovieTitlesRow
                 key={item.id}
                 title={item.title}
+                language={item.language?.name}
                 sourceType={item.sourceType}
               />
             ))}

--- a/frontend/src/Movie/Movie.ts
+++ b/frontend/src/Movie/Movie.ts
@@ -48,6 +48,7 @@ export interface Ratings {
 export interface AlternativeTitle extends ModelBase {
   sourceType: string;
   title: string;
+  language: Language;
 }
 
 export interface MovieAddOptions {

--- a/frontend/src/Utilities/String/languageToFlag.ts
+++ b/frontend/src/Utilities/String/languageToFlag.ts
@@ -1,0 +1,82 @@
+function countryCodeToFlag(countryCode: string): string {
+  const codePoints = countryCode
+    .toUpperCase()
+    .split('')
+    .map((char) => 0x1f1e6 + char.charCodeAt(0) - 65);
+
+  return String.fromCodePoint(...codePoints);
+}
+
+const languageFlagMap: Record<string, string> = {
+  English: 'GB',
+  French: 'FR',
+  Spanish: 'ES',
+  German: 'DE',
+  Italian: 'IT',
+  Danish: 'DK',
+  Dutch: 'NL',
+  Japanese: 'JP',
+  Icelandic: 'IS',
+  Chinese: 'CN',
+  Russian: 'RU',
+  Polish: 'PL',
+  Vietnamese: 'VN',
+  Swedish: 'SE',
+  Norwegian: 'NO',
+  Finnish: 'FI',
+  Turkish: 'TR',
+  Portuguese: 'PT',
+  Flemish: 'BE',
+  Greek: 'GR',
+  Korean: 'KR',
+  Hungarian: 'HU',
+  Hebrew: 'IL',
+  Lithuanian: 'LT',
+  Czech: 'CZ',
+  Hindi: 'IN',
+  Romanian: 'RO',
+  Thai: 'TH',
+  Bulgarian: 'BG',
+  'Portuguese (Brazil)': 'BR',
+  Arabic: 'SA',
+  Ukrainian: 'UA',
+  Persian: 'IR',
+  Bengali: 'BD',
+  Slovak: 'SK',
+  Latvian: 'LV',
+  'Spanish (Latino)': 'MX',
+  Catalan: 'ES',
+  Croatian: 'HR',
+  Serbian: 'RS',
+  Bosnian: 'BA',
+  Estonian: 'EE',
+  Tamil: 'IN',
+  Indonesian: 'ID',
+  Telugu: 'IN',
+  Macedonian: 'MK',
+  Slovenian: 'SI',
+  Malayalam: 'IN',
+  Kannada: 'IN',
+  Albanian: 'AL',
+  Afrikaans: 'ZA',
+  Marathi: 'IN',
+  Tagalog: 'PH',
+  Urdu: 'PK',
+  Romansh: 'CH',
+  Mongolian: 'MN',
+  Georgian: 'GE',
+};
+
+export default function languageToFlag(languageName?: string): string | null {
+  if (!languageName) {
+    return null;
+  }
+
+  const countryCode = languageFlagMap[languageName];
+
+  if (!countryCode) {
+    return null;
+  }
+
+  return countryCodeToFlag(countryCode);
+}

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.405"
+    "version": "8.0.125",
+    "rollForward": "latestFeature"
   }
 }

--- a/src/NzbDrone.Core/Datastore/Converters/LanguageIntConverter.cs
+++ b/src/NzbDrone.Core/Datastore/Converters/LanguageIntConverter.cs
@@ -13,7 +13,7 @@ namespace NzbDrone.Core.Datastore.Converters
         {
             if (value == null)
             {
-                throw new InvalidOperationException("Attempted to save a language that isn't really a language");
+                parameter.Value = DBNull.Value;
             }
             else
             {
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.Datastore.Converters
         {
             if (value == null || value is DBNull)
             {
-                return Language.Unknown;
+                return null;
             }
 
             return (Language)Convert.ToInt32(value);

--- a/src/NzbDrone.Core/Datastore/Migration/243_add_language_to_alternative_titles.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/243_add_language_to_alternative_titles.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(243)]
+    public class add_language_to_alternative_titles : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("AlternativeTitles").AddColumn("Language").AsInt64().Nullable();
+        }
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -619,7 +619,8 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             {
                 Title = arg.Title,
                 SourceType = SourceType.Tmdb,
-                CleanTitle = arg.Title.CleanMovieTitle()
+                CleanTitle = arg.Title.CleanMovieTitle(),
+                Language = IsoLanguages.Find(arg.Language?.ToLower())?.Language
             };
 
             return newAlternativeTitle;

--- a/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitle.cs
+++ b/src/NzbDrone.Core/Movies/AlternativeTitles/AlternativeTitle.cs
@@ -1,3 +1,4 @@
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.Parser;
 
 namespace NzbDrone.Core.Movies.AlternativeTitles
@@ -8,6 +9,7 @@ namespace NzbDrone.Core.Movies.AlternativeTitles
         public int MovieMetadataId { get; set; }
         public string Title { get; set; }
         public string CleanTitle { get; set; }
+        public Language Language { get; set; }
 
         public AlternativeTitle()
         {

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -76,6 +76,11 @@ namespace NzbDrone.Core.Parser
 
         public static IsoLanguage Find(string isoCode)
         {
+            if (isoCode == null)
+            {
+                return null;
+            }
+
             var isoArray = isoCode.Split('-');
             var langCode = isoArray[0].ToLower();
 

--- a/src/Radarr.Api.V3/Movies/AlternativeTitleResource.cs
+++ b/src/Radarr.Api.V3/Movies/AlternativeTitleResource.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.Movies.AlternativeTitles;
 using Radarr.Http.REST;
 
@@ -14,6 +15,7 @@ namespace Radarr.Api.V3.Movies
         public int MovieMetadataId { get; set; }
         public string Title { get; set; }
         public string CleanTitle { get; set; }
+        public Language Language { get; set; }
 
         // TODO: Add series statistics as a property of the series (instead of individual properties)
     }
@@ -32,7 +34,8 @@ namespace Radarr.Api.V3.Movies
                 Id = model.Id,
                 SourceType = model.SourceType,
                 MovieMetadataId = model.MovieMetadataId,
-                Title = model.Title
+                Title = model.Title,
+                Language = model.Language
             };
         }
 
@@ -48,7 +51,8 @@ namespace Radarr.Api.V3.Movies
                 Id = resource.Id,
                 SourceType = resource.SourceType,
                 MovieMetadataId = resource.MovieMetadataId,
-                Title = resource.Title
+                Title = resource.Title,
+                Language = resource.Language
             };
         }
 


### PR DESCRIPTION
#### Database Migration
Yes, to add a language column to the AlternativeTitles table.

#### Description
Show a language table int he alternative titles list. This makes identifying a proper naming easier.   The intention came actually from a debugging aid for another idea to improve Radarr.

One issue I am seeing is that Skyhook reports for various language "en" instead of the proper language code. A separate [bug report was opened](https://github.com/Radarr/Radarr/issues/11475) for this. As result some alternative titles are wrongly marked as English. Due to this I was considering a global config to turn it on/off, but decided against it.

#### Screenshot (if UI related)
<img width="864" height="633" alt="image" src="https://github.com/user-attachments/assets/94c014c6-8c14-421b-ac0c-76fdf696ac90" />

#### Todos
- [X] Tests
- [X] N/A - Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] N/A - [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
N/A