### PR TITLE
Reuse authentification cookies for qBittorrent calls

### DIFF
--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -12,6 +12,6 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v3
+      - uses: dessant/label-actions@v5
         with:
           process-only: 'issues'

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,7 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v4
+      - uses: dessant/lock-threads@v6
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: '90'

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -363,14 +363,14 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
         private string ProcessRequest(HttpRequestBuilder requestBuilder, QBittorrentSettings settings)
         {
-            var request = requestBuilder.Build();
-            request.LogResponseContent = true;
-
             if (settings.ApiKey.IsNotNullOrWhiteSpace())
             {
+                var requestWithApiKey = requestBuilder.Build();
+                requestWithApiKey.LogResponseContent = true;
+
                 try
                 {
-                    return _httpClient.Execute(request).Content;
+                    return _httpClient.Execute(requestWithApiKey).Content;
                 }
                 catch (HttpException ex)
                 {
@@ -391,6 +391,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
             AuthenticateClient(requestBuilder, settings);
 
+            var request = requestBuilder.Build();
+            request.LogResponseContent = true;
             request.SuppressHttpErrorStatusCodes = new[] { HttpStatusCode.Forbidden };
 
             try


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Minor regression since eec3efdb317bdfc81d1a18c0d3af76d6d10cb096 due to the fact `AuthenticateClient` sets the auth cookies to the request builder which requires `HttpRequestBuilder.Build()` to be called after each `AuthenticateClient` call in order to use the cached cookies.