### PR TITLE
Upgrade StyleCop.Analyzers to Unstable 1.2.0.556

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -138,9 +138,9 @@
   <!-- Set up stylecop -->
   <ItemGroup Condition="'$(RadarrProject)'=='true' and '$(EnableAnalyzers)'!='false'">
     <!-- StyleCop analysis -->
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <AdditionalFiles Include="$(SolutionDir)stylecop.json" />
   </ItemGroup>

--- a/src/NzbDrone.Api.Test/v3/Qualities/QualityDefinitionResourceValidatorTest.cs
+++ b/src/NzbDrone.Api.Test/v3/Qualities/QualityDefinitionResourceValidatorTest.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Api.Test.v3.Qualities;
 [Parallelizable(ParallelScope.All)]
 public class QualityDefinitionResourceValidatorTests
 {
-    private readonly QualityDefinitionResourceValidator _validator = new ();
+    private readonly QualityDefinitionResourceValidator _validator = new();
 
     [Test]
     public void Validate_fails_when_min_size_is_below_min_limit()

--- a/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Common.Test.Http
         private string _httpBinHost;
         private string _httpBinHost2;
 
-        private System.Net.Http.HttpClient _httpClient = new ();
+        private System.Net.Http.HttpClient _httpClient = new();
 
         [OneTimeSetUp]
         public void FixtureSetUp()

--- a/src/NzbDrone.Common/Disk/OsPath.cs
+++ b/src/NzbDrone.Common/Disk/OsPath.cs
@@ -296,7 +296,7 @@ namespace NzbDrone.Common.Disk
             return _path.Split(new char[] { '\\', '/' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
-        public static OsPath Null => new (null);
+        public static OsPath Null => new(null);
 
         public override string ToString()
         {

--- a/src/NzbDrone.Common/Extensions/DictionaryExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/DictionaryExtensions.cs
@@ -31,7 +31,7 @@ namespace NzbDrone.Common.Extensions
         }
 
         public static IDictionary<TNewKey, TNewValue> SelectDictionary<TKey, TValue, TNewKey, TNewValue>(this IDictionary<TKey, TValue> dictionary,
-            Func<KeyValuePair<TKey, TValue>, ValueTuple<TNewKey, TNewValue>> selection)
+            Func<KeyValuePair<TKey, TValue>, (TNewKey Item1, TNewValue Item2)> selection)
         {
             return dictionary.Select(selection).ToDictionary(t => t.Item1, t => t.Item2);
         }

--- a/src/NzbDrone.Common/Http/HttpResponse.cs
+++ b/src/NzbDrone.Common/Http/HttpResponse.cs
@@ -9,7 +9,7 @@ namespace NzbDrone.Common.Http
 {
     public class HttpResponse
     {
-        private static readonly Regex RegexSetCookie = new ("^(.*?)=(.*?)(?:;|$)", RegexOptions.Compiled);
+        private static readonly Regex RegexSetCookie = new("^(.*?)=(.*?)(?:;|$)", RegexOptions.Compiled);
 
         public HttpResponse(HttpRequest request, HttpHeader headers, byte[] binaryData, HttpStatusCode statusCode = HttpStatusCode.OK, Version version = null)
         {

--- a/src/NzbDrone.Common/Instrumentation/CleanseLogMessage.cs
+++ b/src/NzbDrone.Common/Instrumentation/CleanseLogMessage.cs
@@ -10,56 +10,56 @@ namespace NzbDrone.Common.Instrumentation
         private static readonly Regex[] CleansingRules =
         {
             // Url
-            new (@"(?<=\?|&|: )(apikey|(?:access[-_]?)?token|passkey|auth|authkey|user|uid|api|[a-z_]*apikey|account|passwd)=(?<secret>[^&=]+?)(?=[ ""&=]|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"(?<=\?|&)[^=]*?(username|password)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"rss(24h)?\.torrentleech\.org/(?!rss)(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"torrentleech\.org/rss/download/[0-9]+/(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"iptorrents\.com/[/a-z0-9?&;]*?(?:[?&;](u|tp)=(?<secret>[^&=;]+?))+(?= |;|&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"/fetch/[a-z0-9]{32}/(?<secret>[a-z0-9]{32})", RegexOptions.Compiled),
-            new (@"getnzb.*?(?<=\?|&)(r)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"\b(\w*)?(_?(?<!use|get_)token|username|passwo?rd)=(?<secret>[^&=]+?)(?= |&|$|;)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"-hd.me/torrent/[a-z0-9-]\.[0-9]+\.(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"(?<=\?|&|: )(apikey|(?:access[-_]?)?token|passkey|auth|authkey|user|uid|api|[a-z_]*apikey|account|passwd)=(?<secret>[^&=]+?)(?=[ ""&=]|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"(?<=\?|&)[^=]*?(username|password)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"rss(24h)?\.torrentleech\.org/(?!rss)(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"torrentleech\.org/rss/download/[0-9]+/(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"iptorrents\.com/[/a-z0-9?&;]*?(?:[?&;](u|tp)=(?<secret>[^&=;]+?))+(?= |;|&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"/fetch/[a-z0-9]{32}/(?<secret>[a-z0-9]{32})", RegexOptions.Compiled),
+            new(@"getnzb.*?(?<=\?|&)(r)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"\b(\w*)?(_?(?<!use|get_)token|username|passwo?rd)=(?<secret>[^&=]+?)(?= |&|$|;)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"-hd.me/torrent/[a-z0-9-]\.[0-9]+\.(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Trackers Announce Keys; Designed for Qbit Json; should work for all in theory
-            new (@"announce(\.php)?(/|%2f|%3fpasskey%3d)(?<secret>[a-z0-9]{16,})|(?<secret>[a-z0-9]{16,})(/|%2f)announce", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"announce(\.php)?(/|%2f|%3fpasskey%3d)(?<secret>[a-z0-9]{16,})|(?<secret>[a-z0-9]{16,})(/|%2f)announce", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Path
-            new (@"C:\\Users\\(?<secret>[^\""]+?)(\\|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"/(home|Users)/(?<secret>[^/""]+?)(/|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"C:\\Users\\(?<secret>[^\""]+?)(\\|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"/(home|Users)/(?<secret>[^/""]+?)(/|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // NzbGet
-            new (@"""Name""\s*:\s*""[^""]*(username|password)""\s*,\s*""Value""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"""Name""\s*:\s*""[^""]*(username|password)""\s*,\s*""Value""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Sabnzbd
-            new (@"""[^""]*(username|password|api_?key|nzb_key)""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"""email_(account|to|from|pwd)""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"""[^""]*(username|password|api_?key|nzb_key)""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"""email_(account|to|from|pwd)""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // uTorrent
-            new (@"\[""[a-z._]*(username|password)"",\d,""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"\[""(boss_key|boss_key_salt|proxy\.proxy)"",\d,""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"\[""[a-z._]*(username|password)"",\d,""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"\[""(boss_key|boss_key_salt|proxy\.proxy)"",\d,""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Deluge
-            new (@"auth.login\(""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"auth.login\(""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // BroadcastheNet
-            new (@"""?method""?\s*:\s*""(getTorrents)"",\s*""?params""?\s*:\s*\[\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"getTorrents\(""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"(?<=\?|&)(authkey|torrent_pass)=(?<secret>[^&=]+?)(?=""|&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"""?method""?\s*:\s*""(getTorrents)"",\s*""?params""?\s*:\s*\[\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"getTorrents\(""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"(?<=\?|&)(authkey|torrent_pass)=(?<secret>[^&=]+?)(?=""|&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Plex
-            new (@"(?<=\?|&)(X-Plex-Client-Identifier|X-Plex-Token)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"(?<=\?|&)(X-Plex-Client-Identifier|X-Plex-Token)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Notifiarr
-            new (@"api/v[0-9]/notification/radarr/(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"api/v[0-9]/notification/radarr/(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Discord
-            new (@"discord.com/api/webhooks/((?<secret>[\w-]+)/)?(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"discord.com/api/webhooks/((?<secret>[\w-]+)/)?(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Telegram
-            new (@"api.telegram.org/bot(?<id>[\d]+):(?<secret>[\w-]+)/", RegexOptions.Compiled | RegexOptions.IgnoreCase)
+            new(@"api.telegram.org/bot(?<id>[\d]+):(?<secret>[\w-]+)/", RegexOptions.Compiled | RegexOptions.IgnoreCase)
         };
 
-        private static readonly Regex CleanseRemoteIPRegex = new (@"(?:Auth-\w+(?<!Failure|Unauthorized) ip|from) (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})", RegexOptions.Compiled);
+        private static readonly Regex CleanseRemoteIPRegex = new(@"(?:Auth-\w+(?<!Failure|Unauthorized) ip|from) (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})", RegexOptions.Compiled);
 
         public static string Cleanse(string message)
         {

--- a/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
+++ b/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
@@ -15,8 +15,8 @@ namespace NzbDrone.Common.Instrumentation
         private const string FileLogLayout = @"${date:format=yyyy-MM-dd HH\:mm\:ss.f}|${level}|${logger}|${message}${onexception:inner=${newline}${newline}[v${assembly-version}] ${exception:format=ToString}${newline}${exception:format=Data}${newline}}";
         private const string ConsoleFormat = "[${level}] ${logger}: ${message} ${onexception:inner=${newline}${newline}[v${assembly-version}] ${exception:format=ToString}${newline}${exception:format=Data}${newline}}";
 
-        private static readonly CleansingConsoleLogLayout CleansingConsoleLayout  = new (ConsoleFormat);
-        private static readonly CleansingClefLogLayout ClefLogLayout = new ();
+        private static readonly CleansingConsoleLogLayout CleansingConsoleLayout  = new(ConsoleFormat);
+        private static readonly CleansingClefLogLayout ClefLogLayout = new();
 
         private static bool _isConfigured;
 

--- a/src/NzbDrone.Common/TPL/LimitedConcurrencyLevelTaskScheduler.cs
+++ b/src/NzbDrone.Common/TPL/LimitedConcurrencyLevelTaskScheduler.cs
@@ -94,7 +94,8 @@ namespace NzbDrone.Common.TPL
                     {
                         _currentThreadIsProcessingItems = false;
                     }
-                }, null);
+                },
+                null);
         }
 
         /// <summary>Attempts to execute the specified task on the current thread.</summary>

--- a/src/NzbDrone.Common/TPL/TaskExtensions.cs
+++ b/src/NzbDrone.Common/TPL/TaskExtensions.cs
@@ -20,7 +20,8 @@ namespace NzbDrone.Common.TPL
                             Logger.Error(exception, "Task Error");
                         }
                     }
-                }, TaskContinuationOptions.OnlyOnFaulted);
+                },
+                TaskContinuationOptions.OnlyOnFaulted);
 
             return task;
         }

--- a/src/NzbDrone.Core.Test/Datastore/Migration/178_new_list_serverFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/178_new_list_serverFixture.cs
@@ -49,43 +49,50 @@ namespace NzbDrone.Core.Test.Datastore.Migration
                     {
                         APIURL = url,
                         Path = "/imdb/top250"
-                    }, _serializerSettings))
+                    },
+                        _serializerSettings))
                     .TheNext(1)
                     .With(x => x.Settings = JsonSerializer.Serialize(new new_list_server.RadarrListSettings177
                     {
                         APIURL = url,
                         Path = "/imdb/popular"
-                    }, _serializerSettings))
+                    },
+                        _serializerSettings))
                     .TheNext(1)
                     .With(x => x.Settings = JsonSerializer.Serialize(new new_list_server.RadarrListSettings177
                     {
                         APIURL = url,
                         Path = "/imdb/missing"
-                    }, _serializerSettings))
+                    },
+                        _serializerSettings))
                     .TheNext(1)
                     .With(x => x.Settings = JsonSerializer.Serialize(new new_list_server.RadarrListSettings177
                     {
                         APIURL = url,
                         Path = "/imdb/list?listId=ls001"
-                    }, _serializerSettings))
+                    },
+                        _serializerSettings))
                     .TheNext(1)
                     .With(x => x.Settings = JsonSerializer.Serialize(new new_list_server.RadarrListSettings177
                     {
                         APIURL = url,
                         Path = "/imdb/list?listId=ls00ad"
-                    }, _serializerSettings))
+                    },
+                        _serializerSettings))
                     .TheNext(1)
                     .With(x => x.Settings = JsonSerializer.Serialize(new new_list_server.RadarrListSettings177
                     {
                         APIURL = url,
                         Path = "/imdb/list?listId=ur002"
-                    }, _serializerSettings))
+                    },
+                        _serializerSettings))
                     .TheNext(1)
                     .With(x => x.Settings = JsonSerializer.Serialize(new new_list_server.RadarrListSettings177
                     {
                         APIURL = url,
                         Path = "/imdb/list?listId=ur002/"
-                    }, _serializerSettings))
+                    },
+                        _serializerSettings))
                     .BuildListOfNew();
 
                 var i = 1;
@@ -119,32 +126,38 @@ namespace NzbDrone.Core.Test.Datastore.Migration
                 .With(x => x.Settings = JsonSerializer.Serialize(new new_list_server.StevenLuSettings178
                     {
                         Link = "https://s3.amazonaws.com/popular-movies/movies.json"
-                    }, _serializerSettings))
+                    },
+                    _serializerSettings))
                 .TheNext(1)
                 .With(x => x.Settings = JsonSerializer.Serialize(new new_list_server.StevenLuSettings178
                     {
                         Link = "https://s3.amazonaws.com/popular-movies/movies-metacritic-min50.json"
-                    }, _serializerSettings))
+                    },
+                    _serializerSettings))
                 .TheNext(1)
                 .With(x => x.Settings = JsonSerializer.Serialize(new new_list_server.StevenLuSettings178
                     {
                         Link = "https://s3.amazonaws.com/popular-movies/movies-imdb-min8.json"
-                    }, _serializerSettings))
+                    },
+                    _serializerSettings))
                 .TheNext(1)
                 .With(x => x.Settings = JsonSerializer.Serialize(new new_list_server.StevenLuSettings178
                     {
                         Link = "https://s3.amazonaws.com/popular-movies/movies-rottentomatoes-min70.json"
-                    }, _serializerSettings))
+                    },
+                    _serializerSettings))
                 .TheNext(1)
                 .With(x => x.Settings = JsonSerializer.Serialize(new new_list_server.StevenLuSettings178
                     {
                         Link = "https://s3.amazonaws.com/popular-movies/movies-min70.json"
-                    }, _serializerSettings))
+                    },
+                    _serializerSettings))
                 .TheNext(1)
                 .With(x => x.Settings = JsonSerializer.Serialize(new new_list_server.StevenLuSettings178
                     {
                         Link = "https://aapjeisbaas.nl/api/v1/popular-movies/imdb?fresh=True&max=20&rating=6&votes=50000"
-                    }, _serializerSettings))
+                    },
+                    _serializerSettings))
                 .BuildListOfNew();
 
             var db = WithMigrationTestDb(c =>

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeSpecificationFixture.cs
@@ -18,8 +18,8 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
     public class UpgradeSpecificationFixture : CoreTest<UpgradableSpecification>
     {
-        private static readonly CustomFormat CustomFormat1 = new ("My Format 1", new ResolutionSpecification { Value = (int)Resolution.R1080p }) { Id = 1 };
-        private static readonly CustomFormat CustomFormat2 = new ("My Format 2", new ResolutionSpecification { Value = (int)Resolution.R480p }) { Id = 2 };
+        private static readonly CustomFormat CustomFormat1 = new("My Format 1", new ResolutionSpecification { Value = (int)Resolution.R1080p }) { Id = 1 };
+        private static readonly CustomFormat CustomFormat2 = new("My Format 2", new ResolutionSpecification { Value = (int)Resolution.R480p }) { Id = 2 };
 
         public static object[] IsUpgradeTestCases =
         {

--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ImportFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ImportFixture.cs
@@ -101,17 +101,21 @@ namespace NzbDrone.Core.Test.Download
         public void should_not_mark_as_imported_if_all_files_were_rejected()
         {
             Mocker.GetMock<IDownloadedMovieImportService>()
-                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Movie>(), It.IsAny<DownloadClientItem>()))
-                  .Returns(new List<ImportResult>
-                           {
-                               new ImportResult(
-                                   new ImportDecision(
-                                       new LocalMovie { Path = @"C:\TestPath\Droned.1998.mkv" }, new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")), "Test Failure"),
+                .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Movie>(), It.IsAny<DownloadClientItem>()))
+                .Returns(new List<ImportResult>
+                {
+                    new ImportResult(
+                        new ImportDecision(
+                            new LocalMovie { Path = @"C:\TestPath\Droned.1998.mkv" },
+                            new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")),
+                        "Test Failure"),
 
-                               new ImportResult(
-                                   new ImportDecision(
-                                       new LocalMovie { Path = @"C:\TestPath\Droned.1999.mkv" }, new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")), "Test Failure")
-                           });
+                    new ImportResult(
+                        new ImportDecision(
+                            new LocalMovie { Path = @"C:\TestPath\Droned.1999.mkv" },
+                            new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")),
+                        "Test Failure")
+                });
 
             Subject.Import(_trackedDownload);
 
@@ -125,17 +129,21 @@ namespace NzbDrone.Core.Test.Download
         public void should_not_mark_as_imported_if_no_movies_were_parsed()
         {
             Mocker.GetMock<IDownloadedMovieImportService>()
-                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Movie>(), It.IsAny<DownloadClientItem>()))
-                  .Returns(new List<ImportResult>
-                           {
-                               new ImportResult(
-                                   new ImportDecision(
-                                       new LocalMovie { Path = @"C:\TestPath\Droned.1998.mkv" }, new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")), "Test Failure"),
+                .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Movie>(), It.IsAny<DownloadClientItem>()))
+                .Returns(new List<ImportResult>
+                {
+                    new ImportResult(
+                        new ImportDecision(
+                            new LocalMovie { Path = @"C:\TestPath\Droned.1998.mkv" },
+                            new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")),
+                        "Test Failure"),
 
-                               new ImportResult(
-                                   new ImportDecision(
-                                       new LocalMovie { Path = @"C:\TestPath\Droned.1998.mkv" }, new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")), "Test Failure")
-                           });
+                    new ImportResult(
+                        new ImportDecision(
+                            new LocalMovie { Path = @"C:\TestPath\Droned.1998.mkv" },
+                            new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")),
+                        "Test Failure")
+                });
 
             _trackedDownload.RemoteMovie.Movie = new Movie();
 

--- a/src/NzbDrone.Core.Test/Download/DownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadServiceFixture.cs
@@ -158,7 +158,8 @@ namespace NzbDrone.Core.Test.Download
 
             Mocker.GetMock<IIndexerStatusService>()
                 .Verify(v => v.RecordFailure(It.IsAny<int>(),
-                    It.IsInRange<TimeSpan>(TimeSpan.FromMinutes(4.9), TimeSpan.FromMinutes(5.1), Moq.Range.Inclusive)), Times.Once());
+                    It.IsInRange<TimeSpan>(TimeSpan.FromMinutes(4.9), TimeSpan.FromMinutes(5.1), Moq.Range.Inclusive)),
+                    Times.Once());
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/DownloadClientRootFolderCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/DownloadClientRootFolderCheckFixture.cs
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
 
             GivenRootFolder(rootFolderPath);
 
-            _clientStatus.OutputRootFolders = new List<OsPath> { new (downloadRootPath) };
+            _clientStatus.OutputRootFolders = new List<OsPath> { new(downloadRootPath) };
 
             Subject.Check().ShouldBeWarning();
         }

--- a/src/NzbDrone.Core.Test/IndexerTests/IndexerBaseFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/IndexerBaseFixture.cs
@@ -41,7 +41,7 @@ public class IndexerBaseFixture : CoreTest<IndexerBase<TestIndexerSettings>>
     [TestCase("The.Movie.Name.2016.Multi.DTS.720p.BluRay.x264-RlsGrp")]
     public void should_parse_multi_language(string postTitle)
     {
-        var result = _indexer.CleanupReleases(new ReleaseInfo[] { new () { Title = postTitle, Languages = new List<Language>() } });
+        var result = _indexer.CleanupReleases(new ReleaseInfo[] { new() { Title = postTitle, Languages = new List<Language>() } });
         result.Single().Languages.Count.Should().Be(2);
         result.Single().Languages.Should().Contain(Language.German);
         result.Single().Languages.Should().Contain(Language.English);

--- a/src/NzbDrone.Core.Test/MediaFiles/MovieFileMovingServiceTests/MoveMovieFileFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MovieFileMovingServiceTests/MoveMovieFileFixture.cs
@@ -93,7 +93,8 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieFileMovingServiceTests
 
             Mocker.GetMock<IEventAggregator>()
                   .Verify(s => s.PublishEvent<MovieFolderCreatedEvent>(It.Is<MovieFolderCreatedEvent>(p =>
-                      p.MovieFolder.IsNotNullOrWhiteSpace())), Times.Once());
+                      p.MovieFolder.IsNotNullOrWhiteSpace())),
+                      Times.Once());
         }
 
         [Test]
@@ -107,7 +108,8 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieFileMovingServiceTests
 
             Mocker.GetMock<IEventAggregator>()
                   .Verify(s => s.PublishEvent<MovieFolderCreatedEvent>(It.Is<MovieFolderCreatedEvent>(p =>
-                      p.MovieFolder.IsNotNullOrWhiteSpace())), Times.Never());
+                      p.MovieFolder.IsNotNullOrWhiteSpace())),
+                      Times.Never());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/NotificationTests/SynologyIndexerFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/SynologyIndexerFixture.cs
@@ -38,11 +38,13 @@ namespace NzbDrone.Core.Test.NotificationTests
                     new DeletedMovieFile(new MovieFile
                     {
                         RelativePath = "oldmoviefile1.mkv"
-                    }, null),
+                    },
+                        null),
                     new DeletedMovieFile(new MovieFile
                     {
                         RelativePath = "oldmoviefile2.mkv"
-                    }, null)
+                    },
+                        null)
                 }
             };
 

--- a/src/NzbDrone.Core.Test/NotificationTests/TraktTests/TraktServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/TraktTests/TraktServiceFixture.cs
@@ -84,7 +84,8 @@ namespace NzbDrone.Core.Test.NotificationTests
                     t.Movies.First().Resolution == "uhd_4k" &&
                     t.Movies.First().MediaType == "bluray" &&
                     t.Movies.First().Hdr == "hdr10"),
-                  It.IsAny<string>()), Times.Once());
+                  It.IsAny<string>()),
+                      Times.Once());
         }
 
         [Test]
@@ -101,7 +102,8 @@ namespace NzbDrone.Core.Test.NotificationTests
                     t.Movies.First().Resolution == "uhd_4k" &&
                     t.Movies.First().MediaType == "bluray" &&
                     t.Movies.First().Hdr == "hdr10"),
-                  It.IsAny<string>()), Times.Once());
+                  It.IsAny<string>()),
+                      Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core/AutoTagging/Specifications/GenreSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/GenreSpecification.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class GenreSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly GenreSpecificationValidator Validator = new ();
+        private static readonly GenreSpecificationValidator Validator = new();
 
         public override int Order => 2;
         public override string ImplementationName => "Genre";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/KeywordSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/KeywordSpecification.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class KeywordSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly KeywordSpecificationValidator Validator = new ();
+        private static readonly KeywordSpecificationValidator Validator = new();
 
         public override int Order => 2;
         public override string ImplementationName => "Keyword";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/MonitoredSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/MonitoredSpecification.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class MonitoredSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly MonitoredSpecificationValidator Validator = new ();
+        private static readonly MonitoredSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Monitored";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/OriginalLanguageSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/OriginalLanguageSpecification.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class OriginalLanguageSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly OriginalLanguageSpecificationValidator Validator = new ();
+        private static readonly OriginalLanguageSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Original Language";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/QualityProfileSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/QualityProfileSpecification.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class QualityProfileSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly QualityProfileSpecificationValidator Validator = new ();
+        private static readonly QualityProfileSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Quality Profile";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/RootFolderSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/RootFolderSpecification.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class RootFolderSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly RootFolderSpecificationValidator Validator = new ();
+        private static readonly RootFolderSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Root Folder";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/RuntimeSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/RuntimeSpecification.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class RuntimeSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly RuntimeSpecificationValidator Validator = new ();
+        private static readonly RuntimeSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Runtime";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/StatusSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/StatusSpecification.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class StatusSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly StatusSpecificationValidator Validator = new ();
+        private static readonly StatusSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Status";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/StudioSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/StudioSpecification.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class StudioSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly StudioSpecificationValidator Validator = new ();
+        private static readonly StudioSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Studio";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/TagSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/TagSpecification.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class TagSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly TagSpecificationValidator Validator = new ();
+        private static readonly TagSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Tag";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/YearSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/YearSpecification.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class YearSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly YearSpecificationValidator Validator = new ();
+        private static readonly YearSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Year";

--- a/src/NzbDrone.Core/CustomFormats/Specifications/IndexerFlagSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/IndexerFlagSpecification.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.CustomFormats
 
     public class IndexerFlagSpecification : CustomFormatSpecificationBase
     {
-        private static readonly IndexerFlagSpecificationValidator Validator = new ();
+        private static readonly IndexerFlagSpecificationValidator Validator = new();
 
         public override int Order => 4;
         public override string ImplementationName => "Indexer Flag";

--- a/src/NzbDrone.Core/CustomFormats/Specifications/YearSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/YearSpecification.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.CustomFormats
 
     public class YearSpecification : CustomFormatSpecificationBase
     {
-        private static readonly YearSpecificationValidator Validator = new ();
+        private static readonly YearSpecificationValidator Validator = new();
 
         public override int Order => 10;
         public override string ImplementationName => "Year";

--- a/src/NzbDrone.Core/Datastore/DatabaseVersionParser.cs
+++ b/src/NzbDrone.Core/Datastore/DatabaseVersionParser.cs
@@ -5,7 +5,7 @@ namespace NzbDrone.Core.Datastore;
 
 public static class DatabaseVersionParser
 {
-    private static readonly Regex VersionRegex = new (@"^[^ ]+", RegexOptions.Compiled);
+    private static readonly Regex VersionRegex = new(@"^[^ ]+", RegexOptions.Compiled);
 
     public static Version ParseServerVersion(string serverVersion)
     {

--- a/src/NzbDrone.Core/Datastore/Migration/168_custom_format_rework.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/168_custom_format_rework.cs
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.Datastore.Migration
                     return new IndexerFlagSpecification { Value = (int)ParseIndexerFlag(value) };
                 case "g":
                     var minMax = ParseSize(value);
-                    return new SizeSpecification { Min = minMax.Item1, Max = minMax.Item2 };
+                    return new SizeSpecification { Min = minMax.Min, Max = minMax.Max };
                 case "c":
                 default:
                     return new ReleaseTitleSpecification { Value = ParseString(value, isRegex) };
@@ -195,7 +195,7 @@ namespace NzbDrone.Core.Datastore.Migration
             return default;
         }
 
-        private (double, double) ParseSize(string value)
+        private (double Min, double Max) ParseSize(string value)
         {
             var matches = SizeTagRegex.Match(value);
             var min = double.Parse(matches.Groups["min"].Value, CultureInfo.InvariantCulture);

--- a/src/NzbDrone.Core/Datastore/Migration/199_mediainfo_to_ffmpeg.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/199_mediainfo_to_ffmpeg.cs
@@ -365,7 +365,7 @@ namespace NzbDrone.Core.Datastore.Migration
                 }
             }
 
-            return VideoFileInfoReader.GetHdrFormat(mediaInfo.VideoBitDepth, mediaInfo.VideoColourPrimaries, mediaInfo.VideoTransferCharacteristics, new ());
+            return VideoFileInfoReader.GetHdrFormat(mediaInfo.VideoBitDepth, mediaInfo.VideoColourPrimaries, mediaInfo.VideoTransferCharacteristics, new());
         }
 
         private void MigrateAudioCodec(MediaInfo198 mediaInfo, MediaInfo199 m)

--- a/src/NzbDrone.Core/DecisionEngine/DownloadSpecDecision.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadSpecDecision.cs
@@ -6,7 +6,7 @@
         public DownloadRejectionReason Reason { get; set; }
         public string Message { get; private set; }
 
-        private static readonly DownloadSpecDecision AcceptDownloadSpecDecision = new () { Accepted = true };
+        private static readonly DownloadSpecDecision AcceptDownloadSpecDecision = new() { Accepted = true };
         private DownloadSpecDecision()
         {
         }

--- a/src/NzbDrone.Core/Download/Clients/Aria2/Aria2Settings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Aria2/Aria2Settings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Download.Clients.Aria2
 
     public class Aria2Settings : DownloadClientSettingsBase<Aria2Settings>
     {
-        private static readonly Aria2SettingsValidator Validator = new ();
+        private static readonly Aria2SettingsValidator Validator = new();
 
         public Aria2Settings()
         {

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackholeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackholeSettings.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
             ReadOnly = true;
         }
 
-        private static readonly TorrentBlackholeSettingsValidator Validator = new ();
+        private static readonly TorrentBlackholeSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "TorrentBlackholeTorrentFolder", Type = FieldType.Path, HelpText = "BlackholeFolderHelpText")]
         [FieldToken(TokenField.HelpText, "TorrentBlackholeTorrentFolder", "extension", ".torrent")]

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackholeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackholeSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
 
     public class UsenetBlackholeSettings : DownloadClientSettingsBase<UsenetBlackholeSettings>
     {
-        private static readonly UsenetBlackholeSettingsValidator Validator = new ();
+        private static readonly UsenetBlackholeSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "UsenetBlackholeNzbFolder", Type = FieldType.Path, HelpText = "BlackholeFolderHelpText")]
         [FieldToken(TokenField.HelpText, "UsenetBlackholeNzbFolder", "extension", ".nzb")]

--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
     public class DelugeSettings : DownloadClientSettingsBase<DelugeSettings>
     {
-        private static readonly DelugeSettingsValidator Validator = new ();
+        private static readonly DelugeSettingsValidator Validator = new();
 
         public DelugeSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationSettings.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
     public class DownloadStationSettings : DownloadClientSettingsBase<DownloadStationSettings>
     {
-        private static readonly DownloadStationSettingsValidator Validator = new ();
+        private static readonly DownloadStationSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox)]
         public string Host { get; set; }

--- a/src/NzbDrone.Core/Download/Clients/Flood/FloodSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Flood/FloodSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Download.Clients.Flood
 
     public class FloodSettings : DownloadClientSettingsBase<FloodSettings>
     {
-        private static readonly FloodSettingsValidator Validator = new ();
+        private static readonly FloodSettingsValidator Validator = new();
 
         public FloodSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/FreeboxDownload/FreeboxDownloadSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/FreeboxDownload/FreeboxDownloadSettings.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload
 
     public class FreeboxDownloadSettings : DownloadClientSettingsBase<FreeboxDownloadSettings>
     {
-        private static readonly FreeboxDownloadSettingsValidator Validator = new ();
+        private static readonly FreeboxDownloadSettingsValidator Validator = new();
 
         public FreeboxDownloadSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/HadoukenSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/HadoukenSettings.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
 
     public class HadoukenSettings : DownloadClientSettingsBase<HadoukenSettings>
     {
-        private static readonly HadoukenSettingsValidator Validator = new ();
+        private static readonly HadoukenSettingsValidator Validator = new();
 
         public HadoukenSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortexSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortexSettings.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
 
     public class NzbVortexSettings : DownloadClientSettingsBase<NzbVortexSettings>
     {
-        private static readonly NzbVortexSettingsValidator Validator = new ();
+        private static readonly NzbVortexSettingsValidator Validator = new();
 
         public NzbVortexSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetSettings.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
 
     public class NzbgetSettings : DownloadClientSettingsBase<NzbgetSettings>
     {
-        private static readonly NzbgetSettingsValidator Validator = new ();
+        private static readonly NzbgetSettingsValidator Validator = new();
 
         public NzbgetSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/Pneumatic/PneumaticSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Pneumatic/PneumaticSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
 
     public class PneumaticSettings : DownloadClientSettingsBase<PneumaticSettings>
     {
-        private static readonly PneumaticSettingsValidator Validator = new ();
+        private static readonly PneumaticSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "DownloadClientPneumaticSettingsNzbFolder", Type = FieldType.Path, HelpText = "DownloadClientPneumaticSettingsNzbFolderHelpText")]
         public string NzbFolder { get; set; }

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -397,7 +397,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
             var request = requestBuilder.Build();
             request.LogResponseContent = true;
-            request.SuppressHttpErrorStatusCodes = new[] { HttpStatusCode.Forbidden };
+            request.SuppressHttpErrorStatusCodes = [HttpStatusCode.Forbidden];
 
             try
             {

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
     public class QBittorrentSettings : DownloadClientSettingsBase<QBittorrentSettings>
     {
-        private static readonly QBittorrentSettingsValidator Validator = new ();
+        private static readonly QBittorrentSettingsValidator Validator = new();
 
         public QBittorrentSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdSettings.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
 
     public class SabnzbdSettings : DownloadClientSettingsBase<SabnzbdSettings>
     {
-        private static readonly SabnzbdSettingsValidator Validator = new ();
+        private static readonly SabnzbdSettingsValidator Validator = new();
 
         public SabnzbdSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/TorrentSeedConfiguration.cs
+++ b/src/NzbDrone.Core/Download/Clients/TorrentSeedConfiguration.cs
@@ -4,7 +4,7 @@ namespace NzbDrone.Core.Download.Clients
 {
     public class TorrentSeedConfiguration
     {
-        public static TorrentSeedConfiguration DefaultConfiguration = new ();
+        public static TorrentSeedConfiguration DefaultConfiguration = new();
 
         public double? Ratio { get; set; }
         public TimeSpan? SeedTime { get; set; }

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
     public class TransmissionSettings : DownloadClientSettingsBase<TransmissionSettings>
     {
-        private static readonly TransmissionSettingsValidator Validator = new ();
+        private static readonly TransmissionSettingsValidator Validator = new();
 
         // This constructor is used when creating a new instance, such as the user adding a new Transmission client.
         public TransmissionSettings()

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
 
     public class RTorrentSettings : DownloadClientSettingsBase<RTorrentSettings>
     {
-        private static readonly RTorrentSettingsValidator Validator = new ();
+        private static readonly RTorrentSettingsValidator Validator = new();
 
         public RTorrentSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
@@ -105,7 +105,7 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
 
         public override string Name => "uTorrent";
 
-        public override ProviderMessage Message => new (_localizationService.GetLocalizedString("DownloadClientUTorrentProviderMessage"), ProviderMessageType.Warning);
+        public override ProviderMessage Message => new(_localizationService.GetLocalizedString("DownloadClientUTorrentProviderMessage"), ProviderMessageType.Warning);
 
         public override IEnumerable<DownloadClientItem> GetItems()
         {

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
 
     public class UTorrentSettings : DownloadClientSettingsBase<UTorrentSettings>
     {
-        private static readonly UTorrentSettingsValidator Validator = new ();
+        private static readonly UTorrentSettingsValidator Validator = new();
 
         public UTorrentSettings()
         {

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Kometa/KometaMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Kometa/KometaMetadata.cs
@@ -12,13 +12,13 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Kometa
 {
     public class KometaMetadata : MetadataBase<KometaMetadataSettings>
     {
-        private static readonly Regex MovieImagesRegex = new (@"^(?:poster|background)\.(?:png|jpe?g)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex MovieImagesRegex = new(@"^(?:poster|background)\.(?:png|jpe?g)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private readonly ILocalizationService _localizationService;
 
         public override string Name => "Kometa";
 
-        public override ProviderMessage Message => new (_localizationService.GetLocalizedString("MetadataKometaDeprecated"), ProviderMessageType.Warning);
+        public override ProviderMessage Message => new(_localizationService.GetLocalizedString("MetadataKometaDeprecated"), ProviderMessageType.Warning);
 
         public KometaMetadata(ILocalizationService localizationService)
         {

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Kometa/KometaMetadataSettings.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Kometa/KometaMetadataSettings.cs
@@ -11,7 +11,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Kometa
 
     public class KometaMetadataSettings : IProviderConfig
     {
-        private static readonly KometaSettingsValidator Validator = new ();
+        private static readonly KometaSettingsValidator Validator = new();
 
         public KometaMetadataSettings()
         {

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/MediaBrowser/MediaBrowserMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/MediaBrowser/MediaBrowserMetadata.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.MediaBrowser
 
         public override string Name => "Emby (Legacy)";
 
-        public override ProviderMessage Message => new (_localizationService.GetLocalizedString("MetadataMediaBrowserDeprecated", new Dictionary<string, object> { { "version", "v6" } }), ProviderMessageType.Warning);
+        public override ProviderMessage Message => new(_localizationService.GetLocalizedString("MetadataMediaBrowserDeprecated", new Dictionary<string, object> { { "version", "v6" } }), ProviderMessageType.Warning);
 
         public override MetadataFile FindMetadataFile(Movie movie, string path)
         {

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleFileExtensions.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleFileExtensions.cs
@@ -5,7 +5,7 @@ namespace NzbDrone.Core.Extras.Subtitles
 {
     public static class SubtitleFileExtensions
     {
-        public static HashSet<string> Extensions => new (StringComparer.OrdinalIgnoreCase)
+        public static HashSet<string> Extensions => new(StringComparer.OrdinalIgnoreCase)
         {
             ".aqt",
             ".ass",

--- a/src/NzbDrone.Core/HealthCheck/Checks/RemotePathMappingCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/RemotePathMappingCheck.cs
@@ -333,7 +333,8 @@ namespace NzbDrone.Core.HealthCheck.Checks
                                     { "downloadClientName", client.Definition.Name },
                                     { "path", dlpath },
                                     { "osName", _osInfo.Name }
-                                }), "#bad-remote-path-mapping");
+                                }),
+                            "#bad-remote-path-mapping");
                     }
 
                     // path mappings shouldn't be needed locally so probably a permissions issue

--- a/src/NzbDrone.Core/ImportLists/CouchPotato/CouchPotatoSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/CouchPotato/CouchPotatoSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.ImportLists.CouchPotato
 
     public class CouchPotatoSettings : ImportListSettingsBase<CouchPotatoSettings>
     {
-        private static readonly CouchPotatoSettingsValidator Validator = new ();
+        private static readonly CouchPotatoSettingsValidator Validator = new();
 
         public CouchPotatoSettings()
         {

--- a/src/NzbDrone.Core/ImportLists/Plex/PlexListSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Plex/PlexListSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.ImportLists.Plex
 
     public class PlexListSettings : ImportListSettingsBase<PlexListSettings>
     {
-        private static readonly PlexListSettingsValidator Validator = new ();
+        private static readonly PlexListSettingsValidator Validator = new();
 
         public PlexListSettings()
         {

--- a/src/NzbDrone.Core/ImportLists/RSSImport/RSSImportSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/RSSImport/RSSImportSettings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.ImportLists.RSSImport
 
     public class RSSImportSettings : ImportListSettingsBase<RSSImportSettings>
     {
-        private static readonly RSSImportSettingsValidator Validator = new ();
+        private static readonly RSSImportSettingsValidator Validator = new();
 
         public RSSImportSettings()
         {

--- a/src/NzbDrone.Core/ImportLists/Radarr/RadarrSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Radarr/RadarrSettings.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.ImportLists.Radarr
 
     public class RadarrSettings : ImportListSettingsBase<RadarrSettings>
     {
-        private static readonly RadarrSettingsValidator Validator = new ();
+        private static readonly RadarrSettingsValidator Validator = new();
 
         public RadarrSettings()
         {

--- a/src/NzbDrone.Core/ImportLists/RadarrList/RadarrListSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/RadarrList/RadarrListSettings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.ImportLists.RadarrList
 
     public class RadarrListSettings : ImportListSettingsBase<RadarrListSettings>
     {
-        private static readonly RadarrSettingsValidator Validator = new ();
+        private static readonly RadarrSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "List URL", HelpText = "The URL for the movie list")]
         public string Url { get; set; }

--- a/src/NzbDrone.Core/ImportLists/RadarrList2/IMDb/IMDbListSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/RadarrList2/IMDb/IMDbListSettings.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.ImportLists.RadarrList2.IMDbList
 
     public class IMDbListSettings : ImportListSettingsBase<IMDbListSettings>
     {
-        private static readonly IMDbSettingsValidator Validator = new ();
+        private static readonly IMDbSettingsValidator Validator = new();
 
         [FieldDefinition(1, Label = "List/User ID", HelpText = "IMDb user ID (e.g. ur12345678), 'top250' or 'popular'")]
         public string ListId { get; set; }

--- a/src/NzbDrone.Core/ImportLists/RadarrList2/StevenLu/StevenLu2Settings.cs
+++ b/src/NzbDrone.Core/ImportLists/RadarrList2/StevenLu/StevenLu2Settings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.ImportLists.RadarrList2.StevenLu
 
     public class StevenLu2Settings : ImportListSettingsBase<StevenLu2Settings>
     {
-        private static readonly StevenLu2SettingsValidator Validator = new ();
+        private static readonly StevenLu2SettingsValidator Validator = new();
 
         public StevenLu2Settings()
         {

--- a/src/NzbDrone.Core/ImportLists/Rss/Plex/PlexRssImportSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Rss/Plex/PlexRssImportSettings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.ImportLists.Rss.Plex
 
     public class PlexRssImportSettings : RssImportBaseSettings<PlexRssImportSettings>
     {
-        private static readonly PlexRssImportSettingsValidator Validator = new ();
+        private static readonly PlexRssImportSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Url", Type = FieldType.Textbox, HelpLink = "https://app.plex.tv/desktop/#!/settings/watchlist")]
         public override string Url { get; set; }

--- a/src/NzbDrone.Core/ImportLists/Rss/RssImportBaseSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Rss/RssImportBaseSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.ImportLists.Rss
     public class RssImportBaseSettings<TSettings> : ImportListSettingsBase<TSettings>
         where TSettings : RssImportBaseSettings<TSettings>
     {
-        private static readonly RssImportSettingsValidator<TSettings> Validator = new ();
+        private static readonly RssImportSettingsValidator<TSettings> Validator = new();
 
         [FieldDefinition(0, Label = "Url", Type = FieldType.Textbox)]
         public virtual string Url { get; set; }

--- a/src/NzbDrone.Core/ImportLists/Simkl/SimklSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Simkl/SimklSettingsBase.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.ImportLists.Simkl
     public class SimklSettingsBase<TSettings> : ImportListSettingsBase<TSettings>
         where TSettings : SimklSettingsBase<TSettings>
     {
-        private static readonly SimklSettingsBaseValidator<TSettings> Validator = new ();
+        private static readonly SimklSettingsBaseValidator<TSettings> Validator = new();
 
         public SimklSettingsBase()
         {

--- a/src/NzbDrone.Core/ImportLists/Simkl/User/SimklUserSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Simkl/User/SimklUserSettings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.ImportLists.Simkl.User
 
     public class SimklUserSettings : SimklSettingsBase<SimklUserSettings>
     {
-        private static readonly SimklUserSettingsValidator Validator = new ();
+        private static readonly SimklUserSettingsValidator Validator = new();
 
         public SimklUserSettings()
         {

--- a/src/NzbDrone.Core/ImportLists/StevenLu/StevenLuSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/StevenLu/StevenLuSettings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.ImportLists.StevenLu
 
     public class StevenLuSettings : ImportListSettingsBase<StevenLuSettings>
     {
-        private static readonly StevenLuSettingsValidator Validator = new ();
+        private static readonly StevenLuSettingsValidator Validator = new();
 
         public StevenLuSettings()
         {

--- a/src/NzbDrone.Core/ImportLists/TMDb/Company/TMDbCompanySettings.cs
+++ b/src/NzbDrone.Core/ImportLists/TMDb/Company/TMDbCompanySettings.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.ImportLists.TMDb.Company
 
     public class TMDbCompanySettings : TMDbSettingsBase<TMDbCompanySettings>
     {
-        private static readonly TMDbCompanySettingsValidator Validator = new ();
+        private static readonly TMDbCompanySettingsValidator Validator = new();
 
         public TMDbCompanySettings()
         {

--- a/src/NzbDrone.Core/ImportLists/TMDb/Keyword/TMDbKeywordSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/TMDb/Keyword/TMDbKeywordSettings.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.ImportLists.TMDb.Keyword
 
     public class TMDbKeywordSettings : TMDbSettingsBase<TMDbKeywordSettings>
     {
-        private static readonly TMDbKeywordSettingsValidator Validator = new ();
+        private static readonly TMDbKeywordSettingsValidator Validator = new();
 
         public TMDbKeywordSettings()
         {

--- a/src/NzbDrone.Core/ImportLists/TMDb/List/TMDbListSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/TMDb/List/TMDbListSettings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.ImportLists.TMDb.List
 
     public class TMDbListSettings : TMDbSettingsBase<TMDbListSettings>
     {
-        private static readonly TMDbListSettingsValidator Validator = new ();
+        private static readonly TMDbListSettingsValidator Validator = new();
 
         public TMDbListSettings()
         {

--- a/src/NzbDrone.Core/ImportLists/TMDb/Person/TMDbPersonSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/TMDb/Person/TMDbPersonSettings.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.ImportLists.TMDb.Person
 
     public class TMDbPersonSettings : TMDbSettingsBase<TMDbPersonSettings>
     {
-        private static readonly TMDbPersonSettingsValidator Validator = new ();
+        private static readonly TMDbPersonSettingsValidator Validator = new();
 
         public TMDbPersonSettings()
         {

--- a/src/NzbDrone.Core/ImportLists/TMDb/Popular/TMDbPopularSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/TMDb/Popular/TMDbPopularSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.ImportLists.TMDb.Popular
 
     public class TMDbPopularSettings : TMDbSettingsBase<TMDbPopularSettings>
     {
-        private static readonly TMDbPopularSettingsValidator Validator = new ();
+        private static readonly TMDbPopularSettingsValidator Validator = new();
 
         public TMDbPopularSettings()
         {
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.ImportLists.TMDb.Popular
         public int TMDbListType { get; set; }
 
         [FieldDefinition(2)]
-        public TMDbFilterSettings FilterCriteria { get; set; } = new ();
+        public TMDbFilterSettings FilterCriteria { get; set; } = new();
 
         public override NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/ImportLists/TMDb/TMDbSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/TMDb/TMDbSettings.cs
@@ -11,7 +11,7 @@ namespace NzbDrone.Core.ImportLists.TMDb
     public class TMDbSettingsBase<TSettings> : ImportListSettingsBase<TSettings>
         where TSettings : TMDbSettingsBase<TSettings>
     {
-        private static readonly TMDbSettingsBaseValidator<TSettings> Validator = new ();
+        private static readonly TMDbSettingsBaseValidator<TSettings> Validator = new();
 
         public override NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/ImportLists/TMDb/User/TMDbUserSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/TMDb/User/TMDbUserSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.ImportLists.TMDb.User
 
     public class TMDbUserSettings : TMDbSettingsBase<TMDbUserSettings>
     {
-        private static readonly TMDbUserSettingsValidator Validator = new ();
+        private static readonly TMDbUserSettingsValidator Validator = new();
 
         public TMDbUserSettings()
         {

--- a/src/NzbDrone.Core/ImportLists/Trakt/List/TraktListSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/List/TraktListSettings.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.ImportLists.Trakt.List
 
     public class TraktListSettings : TraktSettingsBase<TraktListSettings>
     {
-        private static readonly TraktListSettingsValidator Validator = new ();
+        private static readonly TraktListSettingsValidator Validator = new();
 
         [FieldDefinition(1, Label = "Username", Privacy = PrivacyLevel.UserName, HelpText = "Username for the List to import from")]
         public string Username { get; set; }

--- a/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularSettings.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
 
     public class TraktPopularSettings : TraktSettingsBase<TraktPopularSettings>
     {
-        private static readonly TraktPopularSettingsValidator Validator = new ();
+        private static readonly TraktPopularSettingsValidator Validator = new();
 
         public TraktPopularSettings()
         {

--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktSettingsBase.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.ImportLists.Trakt
     public class TraktSettingsBase<TSettings> : ImportListSettingsBase<TSettings>
         where TSettings : TraktSettingsBase<TSettings>
     {
-        private static readonly TraktSettingsBaseValidator<TSettings> Validator = new ();
+        private static readonly TraktSettingsBaseValidator<TSettings> Validator = new();
 
         public TraktSettingsBase()
         {

--- a/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserSettings.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
 
     public class TraktUserSettings : TraktSettingsBase<TraktUserSettings>
     {
-        private static readonly TraktUserSettingsValidator Validator = new ();
+        private static readonly TraktUserSettingsValidator Validator = new();
 
         public TraktUserSettings()
         {

--- a/src/NzbDrone.Core/Indexers/FileList/FileListSettings.cs
+++ b/src/NzbDrone.Core/Indexers/FileList/FileListSettings.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.Indexers.FileList
 
     public class FileListSettings : PropertywiseEquatable<FileListSettings>, ITorrentIndexerSettings
     {
-        private static readonly FileListSettingsValidator Validator = new ();
+        private static readonly FileListSettingsValidator Validator = new();
 
         public FileListSettings()
         {
@@ -61,7 +61,7 @@ namespace NzbDrone.Core.Indexers.FileList
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(5)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new();
 
         [FieldDefinition(6, Type = FieldType.Checkbox, Label = "IndexerSettingsRejectBlocklistedTorrentHashes", HelpText = "IndexerSettingsRejectBlocklistedTorrentHashesHelpText", Advanced = true)]
         public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }

--- a/src/NzbDrone.Core/Indexers/HDBits/HDBitsSettings.cs
+++ b/src/NzbDrone.Core/Indexers/HDBits/HDBitsSettings.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Indexers.HDBits
 
     public class HDBitsSettings : PropertywiseEquatable<HDBitsSettings>, ITorrentIndexerSettings
     {
-        private static readonly HDBitsSettingsValidator Validator = new ();
+        private static readonly HDBitsSettingsValidator Validator = new();
 
         public HDBitsSettings()
         {
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Indexers.HDBits
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(7)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new();
 
         [FieldDefinition(8, Type = FieldType.Checkbox, Label = "IndexerSettingsRejectBlocklistedTorrentHashes", HelpText = "IndexerSettingsRejectBlocklistedTorrentHashesHelpText", Advanced = true)]
         public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }

--- a/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrentsSettings.cs
+++ b/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrentsSettings.cs
@@ -29,7 +29,7 @@ namespace NzbDrone.Core.Indexers.IPTorrents
 
     public class IPTorrentsSettings : PropertywiseEquatable<IPTorrentsSettings>, ITorrentIndexerSettings
     {
-        private static readonly IPTorrentsSettingsValidator Validator = new ();
+        private static readonly IPTorrentsSettingsValidator Validator = new();
 
         public IPTorrentsSettings()
         {
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Indexers.IPTorrents
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(2)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new();
 
         [FieldDefinition(3, Type = FieldType.Checkbox, Label = "IndexerSettingsRejectBlocklistedTorrentHashes", HelpText = "IndexerSettingsRejectBlocklistedTorrentHashesHelpText", Advanced = true)]
         public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
@@ -29,7 +29,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             return settings.BaseUrl != null && ApiKeyWhiteList.Any(c => settings.BaseUrl.ToLowerInvariant().Contains(c));
         }
 
-        private static readonly Regex AdditionalParametersRegex = new (@"(&.+?\=.+?)+", RegexOptions.Compiled);
+        private static readonly Regex AdditionalParametersRegex = new(@"(&.+?\=.+?)+", RegexOptions.Compiled);
 
         public NewznabSettingsValidator()
         {
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Indexers.Newznab
 
     public class NewznabSettings : PropertywiseEquatable<NewznabSettings>, IIndexerSettings
     {
-        private static readonly NewznabSettingsValidator Validator = new ();
+        private static readonly NewznabSettingsValidator Validator = new();
 
         public NewznabSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Nyaa/NyaaSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Nyaa/NyaaSettings.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Indexers.Nyaa
 
     public class NyaaSettings : PropertywiseEquatable<NyaaSettings>, ITorrentIndexerSettings
     {
-        private static readonly NyaaSettingsValidator Validator = new ();
+        private static readonly NyaaSettingsValidator Validator = new();
 
         public NyaaSettings()
         {
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.Indexers.Nyaa
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(3)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new();
 
         [FieldDefinition(4, Type = FieldType.Checkbox, Label = "IndexerSettingsRejectBlocklistedTorrentHashes", HelpText = "IndexerSettingsRejectBlocklistedTorrentHashesHelpText", Advanced = true)]
         public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }

--- a/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornSettings.cs
+++ b/src/NzbDrone.Core/Indexers/PassThePopcorn/PassThePopcornSettings.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
 
     public class PassThePopcornSettings : PropertywiseEquatable<PassThePopcornSettings>, ITorrentIndexerSettings
     {
-        private static readonly PassThePopcornSettingsValidator Validator = new ();
+        private static readonly PassThePopcornSettingsValidator Validator = new();
 
         public PassThePopcornSettings()
         {
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(4)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new();
 
         [FieldDefinition(5, Type = FieldType.Checkbox, Label = "IndexerSettingsRejectBlocklistedTorrentHashes", HelpText = "IndexerSettingsRejectBlocklistedTorrentHashesHelpText", Advanced = true)]
         public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }

--- a/src/NzbDrone.Core/Indexers/TorrentPotato/TorrentPotatoSettings.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentPotato/TorrentPotatoSettings.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
 
     public class TorrentPotatoSettings : PropertywiseEquatable<TorrentPotatoSettings>, ITorrentIndexerSettings
     {
-        private static readonly TorrentPotatoSettingsValidator Validator = new ();
+        private static readonly TorrentPotatoSettingsValidator Validator = new();
 
         public TorrentPotatoSettings()
         {
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(4)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new();
 
         [FieldDefinition(5, Type = FieldType.Checkbox, Label = "IndexerSettingsRejectBlocklistedTorrentHashes", HelpText = "IndexerSettingsRejectBlocklistedTorrentHashesHelpText", Advanced = true)]
         public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }

--- a/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssIndexerSettings.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssIndexerSettings.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Indexers.TorrentRss
 
     public class TorrentRssIndexerSettings : PropertywiseEquatable<TorrentRssIndexerSettings>, ITorrentIndexerSettings
     {
-        private static readonly TorrentRssIndexerSettingsValidator Validator = new ();
+        private static readonly TorrentRssIndexerSettingsValidator Validator = new();
 
         public TorrentRssIndexerSettings()
         {
@@ -46,7 +46,7 @@ namespace NzbDrone.Core.Indexers.TorrentRss
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(4)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new();
 
         [FieldDefinition(5, Type = FieldType.Checkbox, Label = "IndexerSettingsRejectBlocklistedTorrentHashes", HelpText = "IndexerSettingsRejectBlocklistedTorrentHashesHelpText", Advanced = true)]
         public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Indexers.Torznab
             return settings.BaseUrl != null && ApiKeyWhiteList.Any(c => settings.BaseUrl.ToLowerInvariant().Contains(c));
         }
 
-        private static readonly Regex AdditionalParametersRegex = new (@"(&.+?\=.+?)+", RegexOptions.Compiled);
+        private static readonly Regex AdditionalParametersRegex = new(@"(&.+?\=.+?)+", RegexOptions.Compiled);
 
         public TorznabSettingsValidator()
         {
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.Indexers.Torznab
 
     public class TorznabSettings : NewznabSettings, ITorrentIndexerSettings, IEquatable<TorznabSettings>
     {
-        private static readonly TorznabSettingsValidator Validator = new ();
+        private static readonly TorznabSettingsValidator Validator = new();
 
         private static readonly MemberwiseEqualityComparer<TorznabSettings> Comparer = MemberwiseEqualityComparer<TorznabSettings>.ByProperties;
 
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Indexers.Torznab
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(10)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new();
 
         [FieldDefinition(11, Type = FieldType.Checkbox, Label = "IndexerSettingsRejectBlocklistedTorrentHashes", HelpText = "IndexerSettingsRejectBlocklistedTorrentHashesHelpText", Advanced = true)]
         public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }

--- a/src/NzbDrone.Core/MediaFiles/FileExtensions.cs
+++ b/src/NzbDrone.Core/MediaFiles/FileExtensions.cs
@@ -6,7 +6,7 @@ namespace NzbDrone.Core.MediaFiles
 {
     public static class FileExtensions
     {
-        private static readonly Regex FileExtensionRegex = new (@"\.[a-z0-9]{2,4}$",
+        private static readonly Regex FileExtensionRegex = new(@"\.[a-z0-9]{2,4}$",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly HashSet<string> UsenetExtensions = new HashSet<string>()
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.MediaFiles
             ".nzb"
         };
 
-        public static HashSet<string> ArchiveExtensions => new (StringComparer.OrdinalIgnoreCase)
+        public static HashSet<string> ArchiveExtensions => new(StringComparer.OrdinalIgnoreCase)
         {
             ".7z",
             ".bz2",
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.MediaFiles
             ".tgz",
             ".zip"
         };
-        public static HashSet<string> DangerousExtensions => new (StringComparer.OrdinalIgnoreCase)
+        public static HashSet<string> DangerousExtensions => new(StringComparer.OrdinalIgnoreCase)
         {
             ".arj",
             ".lnk",
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.MediaFiles
             ".vbs",
             ".zipx"
         };
-        public static HashSet<string> ExecutableExtensions => new (StringComparer.OrdinalIgnoreCase)
+        public static HashSet<string> ExecutableExtensions => new(StringComparer.OrdinalIgnoreCase)
         {
             ".bat",
             ".cmd",

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -118,14 +118,14 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 if (PqTransferFunctions.Contains(mediaInfoModel.VideoTransferCharacteristics))
                 {
                     var videoStreamIndex = analysis.VideoStreams.FindIndex(stream => stream.Index == primaryVideoStream?.Index);
-                    var frameOutput = FFProbe.GetFrameJson(filename, ffOptions: new () { ExtraArguments = $"-read_intervals \"%+#1\" -select_streams v:{(videoStreamIndex == -1 ? 0 : videoStreamIndex)}" });
+                    var frameOutput = FFProbe.GetFrameJson(filename, ffOptions: new() { ExtraArguments = $"-read_intervals \"%+#1\" -select_streams v:{(videoStreamIndex == -1 ? 0 : videoStreamIndex)}" });
                     mediaInfoModel.RawFrameData = frameOutput;
 
                     frames = FFProbe.AnalyseFrameJson(frameOutput);
                 }
 
-                var streamSideData = primaryVideoStream?.SideDataList ?? new ();
-                var framesSideData = frames?.Frames?.Count > 0 ? frames?.Frames[0]?.SideDataList ?? new () : new ();
+                var streamSideData = primaryVideoStream?.SideDataList ?? new();
+                var framesSideData = frames?.Frames?.Count > 0 ? frames?.Frames[0]?.SideDataList ?? new() : new();
 
                 var sideData = streamSideData.Concat(framesSideData).ToList();
                 mediaInfoModel.VideoHdrFormat = GetHdrFormat(mediaInfoModel.VideoBitDepth, mediaInfoModel.VideoColourPrimaries, mediaInfoModel.VideoTransferCharacteristics, sideData);

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportSpecDecision.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportSpecDecision.cs
@@ -6,7 +6,7 @@
         public ImportRejectionReason Reason { get; set; }
         public string Message { get; private set; }
 
-        private static readonly ImportSpecDecision AcceptDecision = new () { Accepted = true };
+        private static readonly ImportSpecDecision AcceptDecision = new() { Accepted = true };
         private ImportSpecDecision()
         {
         }

--- a/src/NzbDrone.Core/Messaging/Events/EventAggregator.cs
+++ b/src/NzbDrone.Core/Messaging/Events/EventAggregator.cs
@@ -106,7 +106,8 @@ namespace NzbDrone.Core.Messaging.Events
                 _taskFactory.StartNew(() =>
                 {
                     handlerLocal.HandleAsync(@event);
-                }, TaskCreationOptions.PreferFairness)
+                },
+                        TaskCreationOptions.PreferFairness)
                 .LogExceptions();
             }
 
@@ -119,7 +120,8 @@ namespace NzbDrone.Core.Messaging.Events
                     _logger.Trace("{0} ~> {1}", eventName, handlerLocal.GetType().Name);
                     handlerLocal.HandleAsync(@event);
                     _logger.Trace("{0} <~ {1}", eventName, handlerLocal.GetType().Name);
-                }, TaskCreationOptions.PreferFairness)
+                },
+                        TaskCreationOptions.PreferFairness)
                 .LogExceptions();
             }
         }

--- a/src/NzbDrone.Core/Movies/MovieTitleNormalizer.cs
+++ b/src/NzbDrone.Core/Movies/MovieTitleNormalizer.cs
@@ -4,7 +4,7 @@ namespace NzbDrone.Core.Movies
 {
     public static class MovieTitleNormalizer
     {
-        private static readonly Dictionary<int, string> PreComputedTitles = new ()
+        private static readonly Dictionary<int, string> PreComputedTitles = new()
         {
             { 387354, "a to z" },
             { 1212922, "a to z" },

--- a/src/NzbDrone.Core/Movies/RefreshCollectionService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshCollectionService.cs
@@ -150,7 +150,8 @@ namespace NzbDrone.Core.Movies
                         },
                         Monitored = true,
                         Tags = collection.Tags
-                    }).ToList(), true);
+                    }).ToList(),
+                        true);
                 }
             }
         }

--- a/src/NzbDrone.Core/Notifications/Apprise/AppriseSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Apprise/AppriseSettings.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.Notifications.Apprise
 
     public class AppriseSettings : NotificationSettingsBase<AppriseSettings>
     {
-        private static readonly AppriseSettingsValidator Validator = new ();
+        private static readonly AppriseSettingsValidator Validator = new();
 
         public AppriseSettings()
         {

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScriptSettings.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScriptSettings.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
 
     public class CustomScriptSettings : NotificationSettingsBase<CustomScriptSettings>
     {
-        private static readonly CustomScriptSettingsValidator Validator = new ();
+        private static readonly CustomScriptSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Path", Type = FieldType.FilePath)]
         public string Path { get; set; }

--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -266,7 +266,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 Title = movie.Title,
                 Description = "Movie Added",
                 Color = (int)DiscordColors.Success,
-                Fields = new List<DiscordField> { new () { Name = "Links", Value = GetLinksString(movie) } }
+                Fields = new List<DiscordField> { new() { Name = "Links", Value = GetLinksString(movie) } }
             };
 
             if (Settings.ImportFields.Contains((int)DiscordImportFieldType.Poster))
@@ -323,7 +323,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 Title = movie.Title,
                 Description = deleteMessage.DeletedFilesMessage,
                 Color = (int)DiscordColors.Danger,
-                Fields = new List<DiscordField> { new () { Name = "Links", Value = GetLinksString(movie) } }
+                Fields = new List<DiscordField> { new() { Name = "Links", Value = GetLinksString(movie) } }
             };
 
             if (Settings.ImportFields.Contains((int)DiscordImportFieldType.Poster))
@@ -366,8 +366,8 @@ namespace NzbDrone.Core.Notifications.Discord
                 Color = (int)DiscordColors.Danger,
                 Fields = new List<DiscordField>
                 {
-                    new () { Name = "Reason", Value = reason.ToString() },
-                    new () { Name = "File name", Value = string.Format("```{0}```", deletedFile) }
+                    new() { Name = "Reason", Value = reason.ToString() },
+                    new() { Name = "File name", Value = string.Format("```{0}```", deletedFile) }
                 },
                 Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
             };
@@ -431,12 +431,12 @@ namespace NzbDrone.Core.Notifications.Discord
                 Color = (int)DiscordColors.Standard,
                 Fields = new List<DiscordField>
                 {
-                    new ()
+                    new()
                     {
                         Name = "Previous Version",
                         Value = updateMessage.PreviousVersion.ToString()
                     },
-                    new ()
+                    new()
                     {
                         Name = "New Version",
                         Value = updateMessage.NewVersion.ToString()

--- a/src/NzbDrone.Core/Notifications/Discord/DiscordSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordSettings.cs
@@ -68,7 +68,7 @@ namespace NzbDrone.Core.Notifications.Discord
             };
         }
 
-        private static readonly DiscordSettingsValidator Validator = new ();
+        private static readonly DiscordSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "NotificationsSettingsWebhookUrl", HelpText = "NotificationsDiscordSettingsWebhookUrlHelpText")]
         public string WebHookUrl { get; set; }

--- a/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Notifications.Email
 
     public class EmailSettings : NotificationSettingsBase<EmailSettings>
     {
-        private static readonly EmailSettingsValidator Validator = new ();
+        private static readonly EmailSettingsValidator Validator = new();
 
         public EmailSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Gotify/GotifySettings.cs
+++ b/src/NzbDrone.Core/Notifications/Gotify/GotifySettings.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Notifications.Gotify
 
     public class GotifySettings : NotificationSettingsBase<GotifySettings>
     {
-        private static readonly GotifySettingsValidator Validator = new ();
+        private static readonly GotifySettingsValidator Validator = new();
 
         public GotifySettings()
         {

--- a/src/NzbDrone.Core/Notifications/Join/JoinSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Join/JoinSettings.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.Notifications.Join
 
     public class JoinSettings : NotificationSettingsBase<JoinSettings>
     {
-        private static readonly JoinSettingsValidator Validator = new ();
+        private static readonly JoinSettingsValidator Validator = new();
 
         public JoinSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Mailgun/MailgunSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Mailgun/MailgunSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Notifications.Mailgun
 
     public class MailgunSettings : NotificationSettingsBase<MailgunSettings>
     {
-      private static readonly  MailGunSettingsValidator Validator = new ();
+      private static readonly  MailGunSettingsValidator Validator = new();
 
       public MailgunSettings()
       {

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
@@ -85,7 +85,8 @@ namespace NzbDrone.Core.Notifications.Emby
                     }
 
                     return MediaBrowserMatchQuality.None;
-                }, item => item.Path).OrderBy(group => (int)group.Key).First();
+                },
+                    item => item.Path).OrderBy(group => (int)group.Key).First();
 
                 if (paths.Key == MediaBrowserMatchQuality.None)
                 {

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Notifications.Emby
 
     public class MediaBrowserSettings : NotificationSettingsBase<MediaBrowserSettings>
     {
-        private static readonly MediaBrowserSettingsValidator Validator = new ();
+        private static readonly MediaBrowserSettingsValidator Validator = new();
 
         public MediaBrowserSettings()
         {

--- a/src/NzbDrone.Core/Notifications/MediaServerUpdateQueue.cs
+++ b/src/NzbDrone.Core/Notifications/MediaServerUpdateQueue.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.Notifications
     {
         private class UpdateQueue
         {
-            public Dictionary<int, UpdateQueueItem<TItemInfo>> Pending { get; } = new ();
+            public Dictionary<int, UpdateQueueItem<TItemInfo>> Pending { get; } = new();
             public bool Refreshing { get; set; }
         }
 

--- a/src/NzbDrone.Core/Notifications/Notifiarr/NotifiarrSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Notifiarr/NotifiarrSettings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Notifications.Notifiarr
 
     public class NotifiarrSettings : NotificationSettingsBase<NotifiarrSettings>
     {
-        private static readonly NotifiarrSettingsValidator Validator = new ();
+        private static readonly NotifiarrSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "ApiKey", Privacy = PrivacyLevel.ApiKey, HelpText = "NotificationsNotifiarrSettingsApiKeyHelpText", HelpLink = "https://notifiarr.com")]
         public string APIKey { get; set; }

--- a/src/NzbDrone.Core/Notifications/Ntfy/NtfySettings.cs
+++ b/src/NzbDrone.Core/Notifications/Ntfy/NtfySettings.cs
@@ -20,12 +20,12 @@ namespace NzbDrone.Core.Notifications.Ntfy
             RuleForEach(c => c.Topics).NotEmpty().Matches("[a-zA-Z0-9_-]+").Must(c => !InvalidTopics.Contains(c)).WithMessage("Invalid topic");
         }
 
-        private static List<string> InvalidTopics => new () { "announcements", "app", "docs", "settings", "stats", "mytopic-rw", "mytopic-ro", "mytopic-wo" };
+        private static List<string> InvalidTopics => new() { "announcements", "app", "docs", "settings", "stats", "mytopic-rw", "mytopic-ro", "mytopic-wo" };
     }
 
     public class NtfySettings : NotificationSettingsBase<NtfySettings>
     {
-        private static readonly NtfySettingsValidator Validator = new ();
+        private static readonly NtfySettingsValidator Validator = new();
 
         public NtfySettings()
         {

--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerSettings.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
 
     public class PlexServerSettings : NotificationSettingsBase<PlexServerSettings>
     {
-        private static readonly PlexServerSettingsValidator Validator = new ();
+        private static readonly PlexServerSettingsValidator Validator = new();
 
         public PlexServerSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Prowl/ProwlSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Prowl/ProwlSettings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Notifications.Prowl
 
     public class ProwlSettings : NotificationSettingsBase<ProwlSettings>
     {
-        private static readonly ProwlSettingsValidator Validator = new ();
+        private static readonly ProwlSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "ApiKey", Privacy = PrivacyLevel.ApiKey, HelpLink = "https://www.prowlapp.com/api_settings.php")]
         public string ApiKey { get; set; }

--- a/src/NzbDrone.Core/Notifications/PushBullet/PushBulletSettings.cs
+++ b/src/NzbDrone.Core/Notifications/PushBullet/PushBulletSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Notifications.PushBullet
 
     public class PushBulletSettings : NotificationSettingsBase<PushBulletSettings>
     {
-        private static readonly PushBulletSettingsValidator Validator = new ();
+        private static readonly PushBulletSettingsValidator Validator = new();
 
         public PushBulletSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Pushover/PushoverSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Pushover/PushoverSettings.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Notifications.Pushover
 
     public class PushoverSettings : NotificationSettingsBase<PushoverSettings>
     {
-        private static readonly PushoverSettingsValidator Validator = new ();
+        private static readonly PushoverSettingsValidator Validator = new();
 
         public PushoverSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Pushsafer/PushsaferSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Pushsafer/PushsaferSettings.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Notifications.Pushsafer
 
     public class PushsaferSettings : NotificationSettingsBase<PushsaferSettings>
     {
-        private static readonly PushsaferSettingsValidator Validator = new ();
+        private static readonly PushsaferSettingsValidator Validator = new();
 
         public PushsaferSettings()
         {

--- a/src/NzbDrone.Core/Notifications/SendGrid/SendGridSettings.cs
+++ b/src/NzbDrone.Core/Notifications/SendGrid/SendGridSettings.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Notifications.SendGrid
 
     public class SendGridSettings : NotificationSettingsBase<SendGridSettings>
     {
-        private static readonly SendGridSettingsValidator Validator = new ();
+        private static readonly SendGridSettingsValidator Validator = new();
 
         public SendGridSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Signal/SignalSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Signal/SignalSettings.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.Notifications.Signal
 
     public class SignalSettings : NotificationSettingsBase<SignalSettings>
     {
-        private static readonly SignalSettingsValidator Validator = new ();
+        private static readonly SignalSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox, Placeholder = "localhost")]
         public string Host { get; set; }

--- a/src/NzbDrone.Core/Notifications/Simplepush/SimplepushSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Simplepush/SimplepushSettings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Notifications.Simplepush
 
     public class SimplepushSettings : NotificationSettingsBase<SimplepushSettings>
     {
-        private static readonly SimplepushSettingsValidator Validator = new ();
+        private static readonly SimplepushSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "NotificationsSimplepushSettingsKey", Privacy = PrivacyLevel.ApiKey, HelpLink = "https://simplepush.io/features")]
         public string Key { get; set; }

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -29,7 +29,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Fallback = message.Message,
                     Title = message.Movie.Title,
@@ -46,7 +46,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Fallback = message.Message,
                     Title = message.Movie.Title,
@@ -81,7 +81,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Title = deleteMessage.Movie.Title,
                     Text = Path.Combine(deleteMessage.Movie.Path, deleteMessage.MovieFile.RelativePath)
@@ -97,7 +97,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Title = deleteMessage.Movie.Title,
                     Text = deleteMessage.DeletedFilesMessage
@@ -113,7 +113,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Title = healthCheck.Source.Name,
                     Text = healthCheck.Message,
@@ -130,7 +130,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Title = previousCheck.Source.Name,
                     Text = $"The following issue is now resolved: {previousCheck.Message}",
@@ -147,7 +147,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Title = Environment.MachineName,
                     Text = updateMessage.Message,
@@ -164,7 +164,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Title = Environment.MachineName,
                     Text = message.Message,

--- a/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.Notifications.Slack
 
     public class SlackSettings : NotificationSettingsBase<SlackSettings>
     {
-        private static readonly SlackSettingsValidator Validator = new ();
+        private static readonly SlackSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "NotificationsSettingsWebhookUrl", HelpText = "NotificationsSlackSettingsWebhookUrlHelpText", Type = FieldType.Url, HelpLink = "https://my.slack.com/services/new/incoming-webhook/")]
         public string WebHookUrl { get; set; }

--- a/src/NzbDrone.Core/Notifications/Synology/SynologyIndexerSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Synology/SynologyIndexerSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Notifications.Synology
 
     public class SynologyIndexerSettings : NotificationSettingsBase<SynologyIndexerSettings>
     {
-        private static readonly SynologyIndexerSettingsValidator Validator = new ();
+        private static readonly SynologyIndexerSettingsValidator Validator = new();
 
         public SynologyIndexerSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Telegram/TelegramProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/TelegramProxy.cs
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Notifications.Telegram
 
                 var links = new List<TelegramLink>
                 {
-                    new ("Radarr.video", "https://radarr.video")
+                    new("Radarr.video", "https://radarr.video")
                 };
 
                 var testMessageTitle = settings.IncludeAppNameInTitle ? brandedTitle : title;

--- a/src/NzbDrone.Core/Notifications/Telegram/TelegramSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/TelegramSettings.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Notifications.Telegram
 
     public class TelegramSettings : NotificationSettingsBase<TelegramSettings>
     {
-        private static readonly TelegramSettingsValidator Validator = new ();
+        private static readonly TelegramSettingsValidator Validator = new();
 
         public TelegramSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Trakt/TraktInterlacedTypes.cs
+++ b/src/NzbDrone.Core/Notifications/Trakt/TraktInterlacedTypes.cs
@@ -5,7 +5,7 @@ namespace NzbDrone.Core.Notifications.Trakt
 {
     public static class TraktInterlacedTypes
     {
-        public static readonly HashSet<string> InterlacedTypes = new (StringComparer.OrdinalIgnoreCase)
+        public static readonly HashSet<string> InterlacedTypes = new(StringComparer.OrdinalIgnoreCase)
         {
             "Interlaced", "MBAFF", "PAFF"
         };

--- a/src/NzbDrone.Core/Notifications/Trakt/TraktSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Trakt/TraktSettings.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.Notifications.Trakt
 
     public class TraktSettings : NotificationSettingsBase<TraktSettings>
     {
-        private static readonly TraktSettingsValidator Validator = new ();
+        private static readonly TraktSettingsValidator Validator = new();
 
         public TraktSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Twitter/TwitterSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/TwitterSettings.cs
@@ -29,7 +29,7 @@ namespace NzbDrone.Core.Notifications.Twitter
 
     public class TwitterSettings : NotificationSettingsBase<TwitterSettings>
     {
-        private static readonly TwitterSettingsValidator Validator = new ();
+        private static readonly TwitterSettingsValidator Validator = new();
 
         public TwitterSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Notifications.Webhook
 
     public class WebhookSettings : NotificationSettingsBase<WebhookSettings>
     {
-        private static readonly WebhookSettingsValidator Validator = new ();
+        private static readonly WebhookSettingsValidator Validator = new();
 
         public WebhookSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Xbmc/XbmcSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/XbmcSettings.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
 
     public class XbmcSettings : NotificationSettingsBase<XbmcSettings>
     {
-        private static readonly XbmcSettingsValidator Validator = new ();
+        private static readonly XbmcSettingsValidator Validator = new();
 
         public XbmcSettings()
         {

--- a/src/NzbDrone.Core/Organizer/FileNameValidation.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameValidation.cs
@@ -9,10 +9,10 @@ namespace NzbDrone.Core.Organizer
 {
     public static class FileNameValidation
     {
-        public static readonly Regex DeprecatedMovieFolderTokensRegex = new (@"(\{[- ._\[\(]?(?:Original[- ._](?:Title|Filename)|Release[- ._]Group|Edition[- ._]Tags|Quality[- ._](?:Full|Title|Proper|Real)|MediaInfo[- ._](?:Video|VideoCodec|VideoBitDepth|Audio|AudioCodec|AudioChannels|AudioLanguages|AudioLanguagesAll|SubtitleLanguages|SubtitleLanguagesAll|3D|Simple|Full|VideoDynamicRange|VideoDynamicRangeType))[- ._\]\)]?\})",
+        public static readonly Regex DeprecatedMovieFolderTokensRegex = new(@"(\{[- ._\[\(]?(?:Original[- ._](?:Title|Filename)|Release[- ._]Group|Edition[- ._]Tags|Quality[- ._](?:Full|Title|Proper|Real)|MediaInfo[- ._](?:Video|VideoCodec|VideoBitDepth|Audio|AudioCodec|AudioChannels|AudioLanguages|AudioLanguagesAll|SubtitleLanguages|SubtitleLanguagesAll|3D|Simple|Full|VideoDynamicRange|VideoDynamicRangeType))[- ._\]\)]?\})",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        internal static readonly Regex OriginalTokenRegex = new (@"(\{Original[- ._](?:Title|Filename)\})",
+        internal static readonly Regex OriginalTokenRegex = new(@"(\{Original[- ._](?:Title|Filename)\})",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static IRuleBuilderOptions<T, string> ValidMovieFormat<T>(this IRuleBuilder<T, string> ruleBuilder)

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Parser
                                                                new IsoLanguage("ka", "", "kat", "Georgian", Language.Georgian)
                                                            };
 
-        private static readonly Dictionary<string, Language> AlternateIsoCodeMappings = new ()
+        private static readonly Dictionary<string, Language> AlternateIsoCodeMappings = new()
         {
             { "cn", Language.Chinese }
         };

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -54,8 +54,8 @@ namespace NzbDrone.Core.Parser
                                                                                                           (?<spanish>\b(?<!DTS[._ -])ES\b))(?:(?i)(?![\W|_|^]SUB))",
                                                                 RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
-        private static readonly Regex GermanDualLanguageRegex = new (@"(?<!WEB[-_. ]?)\bDL\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex GermanMultiLanguageRegex = new (@"\bML\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex GermanDualLanguageRegex = new(@"(?<!WEB[-_. ]?)\bDL\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex GermanMultiLanguageRegex = new(@"\bML\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex SubtitleLanguageRegex = new Regex(".+?([-_. ](?<tags>forced|foreign|default|cc|psdh|sdh))*[-_. ](?<iso_code>[a-z]{2,3})([-_. ](?<tags>forced|foreign|default|cc|psdh|sdh))*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -136,7 +136,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly string[] Numbers = new[] { "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine" };
 
-        private static readonly Regex MultiRegex = new (@"[_. ](?<multi>multi)[_. ]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex MultiRegex = new(@"[_. ](?<multi>multi)[_. ]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static Dictionary<string, string> _umlautMappings = new Dictionary<string, string>
         {

--- a/src/NzbDrone.Core/Parser/ParserCommon.cs
+++ b/src/NzbDrone.Core/Parser/ParserCommon.cs
@@ -9,15 +9,15 @@ internal static class ParserCommon
     internal static readonly RegexReplace[] PreSubstitutionRegex = System.Array.Empty<RegexReplace>();
 
     // Valid TLDs http://data.iana.org/TLD/tlds-alpha-by-domain.txt
-    internal static readonly RegexReplace WebsitePrefixRegex = new (@"^(?:(?:\[|\()\s*)?(?:www\.)?[-a-z0-9-]{1,256}\.(?<!Naruto-Kun\.)(?:[a-z]{2,6}\.[a-z]{2,6}|xn--[a-z0-9-]{4,}|[a-z]{2,})\b(?:\s*(?:\]|\))|[ -]{2,})[ -]*",
+    internal static readonly RegexReplace WebsitePrefixRegex = new(@"^(?:(?:\[|\()\s*)?(?:www\.)?[-a-z0-9-]{1,256}\.(?<!Naruto-Kun\.)(?:[a-z]{2,6}\.[a-z]{2,6}|xn--[a-z0-9-]{4,}|[a-z]{2,})\b(?:\s*(?:\]|\))|[ -]{2,})[ -]*",
         string.Empty,
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    internal static readonly RegexReplace WebsitePostfixRegex = new (@"(?:\[\s*)?(?:www\.)?[-a-z0-9-]{1,256}\.(?:xn--[a-z0-9-]{4,}|[a-z]{2,6})\b(?:\s*\])$",
+    internal static readonly RegexReplace WebsitePostfixRegex = new(@"(?:\[\s*)?(?:www\.)?[-a-z0-9-]{1,256}\.(?:xn--[a-z0-9-]{4,}|[a-z]{2,6})\b(?:\s*\])$",
         string.Empty,
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    internal static readonly RegexReplace CleanTorrentSuffixRegex = new (@"\[(?:ettv|rartv|rarbg|cttv|publichd)\]$",
+    internal static readonly RegexReplace CleanTorrentSuffixRegex = new(@"\[(?:ettv|rartv|rarbg|cttv|publichd)\]$",
         string.Empty,
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 }

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Parser
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(QualityParser));
 
-        private static readonly Regex SourceRegex = new (@"\b(?:
+        private static readonly Regex SourceRegex = new(@"\b(?:
                                                             (?<bluray>M?Blu[-_. ]?Ray|HD[-_. ]?DVD|BD(?!$)|UHD2?BD|BDISO|BDMux|BD25|BD50|BR[-_. ]?DISK)|
                                                             (?<webdl>WEB[-_. ]?DL(?:mux)?|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?5[. ]1)|[. ](?-i:WEB)$|(?:\d{3,4}0p)[-. ](?:Hybrid[-_. ]?)?WEB[-. ]|[-. ]WEB[-. ]\d{3,4}0p|\b\s\/\sWEB\s\/\s\b|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip))|
                                                             (?<webrip>WebRip|Web-Rip|WEBMux)|
@@ -36,44 +36,44 @@ namespace NzbDrone.Core.Parser
                                                             )(?:\b|$|[ .])",
                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
-        private static readonly Regex RawHDRegex = new (@"\b(?<rawhd>RawHD|Raw[-_. ]HD)\b",
+        private static readonly Regex RawHDRegex = new(@"\b(?<rawhd>RawHD|Raw[-_. ]HD)\b",
                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex MPEG2Regex = new (@"\b(?<mpeg2>MPEG[-_. ]?2)\b");
+        private static readonly Regex MPEG2Regex = new(@"\b(?<mpeg2>MPEG[-_. ]?2)\b");
 
-        private static readonly Regex BRDISKRegex = new (@"^(?!.*\b((?<!HD[._ -]|HD)DVD|BDRip|720p|MKV|XviD|WMV|d3g|(BD)?REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*[DM]L|((?<=\d{4}).*German.*([DM]L)?)(?=.*\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\b))\b)(((?=.*\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\b)(?=.*\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\b))|^((?=.*\b(((?=.*\b((.*_)?COMPLETE.*|Dis[ck])\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*",
+        private static readonly Regex BRDISKRegex = new(@"^(?!.*\b((?<!HD[._ -]|HD)DVD|BDRip|720p|MKV|XviD|WMV|d3g|(BD)?REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*[DM]L|((?<=\d{4}).*German.*([DM]L)?)(?=.*\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\b))\b)(((?=.*\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\b)(?=.*\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\b))|^((?=.*\b(((?=.*\b((.*_)?COMPLETE.*|Dis[ck])\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*",
                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex ProperRegex = new (@"\b(?<proper>proper)\b",
+        private static readonly Regex ProperRegex = new(@"\b(?<proper>proper)\b",
                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex RepackRegex = new (@"\b(?<repack>repack\d?|rerip\d?)\b",
+        private static readonly Regex RepackRegex = new(@"\b(?<repack>repack\d?|rerip\d?)\b",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex VersionRegex = new (@"\d[-._ ]?v(?<version>\d)[-._ ]|\[v(?<version>\d)\]|repack(?<version>\d)|rerip(?<version>\d)",
+        private static readonly Regex VersionRegex = new(@"\d[-._ ]?v(?<version>\d)[-._ ]|\[v(?<version>\d)\]|repack(?<version>\d)|rerip(?<version>\d)",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex RealRegex = new (@"\b(?<real>REAL)\b",
+        private static readonly Regex RealRegex = new(@"\b(?<real>REAL)\b",
                                                             RegexOptions.Compiled);
 
-        private static readonly Regex ResolutionRegex = new (@"\b(?:(?<R360p>360p)|(?<R480p>480p|480i|640x480|848x480)|(?<R540p>540p)|(?<R576p>576p)|(?<R720p>720p|1280x720|960p)|(?<R1080p>1080p|1920x1080|1440p|FHD|1080i|4kto1080p)|(?<R2160p>2160p|3840x2160|4k[-_. ](?:UHD|HEVC|BD|H\.?265)|(?:UHD|HEVC|BD|H\.?265)[-_. ]4k))\b",
+        private static readonly Regex ResolutionRegex = new(@"\b(?:(?<R360p>360p)|(?<R480p>480p|480i|640x480|848x480)|(?<R540p>540p)|(?<R576p>576p)|(?<R720p>720p|1280x720|960p)|(?<R1080p>1080p|1920x1080|1440p|FHD|1080i|4kto1080p)|(?<R2160p>2160p|3840x2160|4k[-_. ](?:UHD|HEVC|BD|H\.?265)|(?:UHD|HEVC|BD|H\.?265)[-_. ]4k))\b",
                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         // Handle cases where no resolution is in the release name (assume if UHD then 4k) or resolution is non-standard
-        private static readonly Regex AlternativeResolutionRegex = new (@"\b(?<R2160p>UHD)\b|(?<R2160p>\[4K\])",
+        private static readonly Regex AlternativeResolutionRegex = new(@"\b(?<R2160p>UHD)\b|(?<R2160p>\[4K\])",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex CodecRegex = new (@"\b(?:(?<x264>x264)|(?<h264>h264)|(?<xvidhd>XvidHD)|(?<xvid>X-?vid)|(?<divx>divx))\b",
+        private static readonly Regex CodecRegex = new(@"\b(?:(?<x264>x264)|(?<h264>h264)|(?<xvidhd>XvidHD)|(?<xvid>X-?vid)|(?<divx>divx))\b",
                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex OtherSourceRegex = new (@"(?<hdtv>HD[-_. ]TV)|(?<sdtv>SD[-_. ]TV)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex OtherSourceRegex = new(@"(?<hdtv>HD[-_. ]TV)|(?<sdtv>SD[-_. ]TV)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex AnimeBlurayRegex = new (@"bd(?:720|1080|2160)|(?<=[-_. (\[])bd(?=[-_. )\]])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex AnimeWebDlRegex = new (@"\[WEB\]|[\[\(]WEB[ .]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex AnimeBlurayRegex = new(@"bd(?:720|1080|2160)|(?<=[-_. (\[])bd(?=[-_. )\]])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex AnimeWebDlRegex = new(@"\[WEB\]|[\[\(]WEB[ .]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex HighDefPdtvRegex = new (@"hr[-_. ]ws", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex HighDefPdtvRegex = new(@"hr[-_. ]ws", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex RemuxRegex = new (@"(?:[_. \[]|\d{4}p-|\bHybrid-)(?<remux>(?:(BD|UHD)[-_. ]?)?Remux)\b|(?<remux>(?:(BD|UHD)[-_. ]?)?Remux[_. ]\d{4}p)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RemuxRegex = new(@"(?:[_. \[]|\d{4}p-|\bHybrid-)(?<remux>(?:(BD|UHD)[-_. ]?)?Remux)\b|(?<remux>(?:(BD|UHD)[-_. ]?)?Remux[_. ]\d{4}p)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex GermanRemuxRegex = new Regex(@"((?<=\d{4}).*German.*([DM]L)?)(?=.*\b(AVC|HEVC|VC[_. -]?1|MVC|MPEG[_. -]?2))(?=.*Blu-?ray)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static QualityModel ParseQuality(string name)

--- a/src/NzbDrone.Core/Parser/ReleaseGroupParser.cs
+++ b/src/NzbDrone.Core/Parser/ReleaseGroupParser.cs
@@ -6,22 +6,22 @@ namespace NzbDrone.Core.Parser;
 
 public static class ReleaseGroupParser
 {
-    private static readonly Regex ReleaseGroupRegex = new (@"-(?<releasegroup>[a-z0-9]+(?<part2>-[a-z0-9]+)?(?!.+?(?:480p|576p|720p|1080p|2160p)))(?<!(?:WEB-(DL|Rip)|Blu-Ray|480p|576p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES|-ES|-EN|-CAT|-ENG|-JAP|-GER|-FRA|-FRE|-ITA|-HDRip|\d{1,2}-bit|[ ._]\d{4}-\d{2}|-\d{2}|tmdb(id)?-(?<tmdbid>\d+)|(?<imdbid>tt\d{7,8}))(?:\k<part2>)?)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
+    private static readonly Regex ReleaseGroupRegex = new(@"-(?<releasegroup>[a-z0-9]+(?<part2>-[a-z0-9]+)?(?!.+?(?:480p|576p|720p|1080p|2160p)))(?<!(?:WEB-(DL|Rip)|Blu-Ray|480p|576p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES|-ES|-EN|-CAT|-ENG|-JAP|-GER|-FRA|-FRE|-ITA|-HDRip|\d{1,2}-bit|[ ._]\d{4}-\d{2}|-\d{2}|tmdb(id)?-(?<tmdbid>\d+)|(?<imdbid>tt\d{7,8}))(?:\k<part2>)?)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    private static readonly Regex InvalidReleaseGroupRegex = new (@"^([se]\d+|[0-9a-f]{8})$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex InvalidReleaseGroupRegex = new(@"^([se]\d+|[0-9a-f]{8})$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    private static readonly Regex AnimeReleaseGroupRegex = new (@"^(?:\[(?<subgroup>(?!\s).+?(?<!\s))\](?:_|-|\s|\.)?)",
+    private static readonly Regex AnimeReleaseGroupRegex = new(@"^(?:\[(?<subgroup>(?!\s).+?(?<!\s))\](?:_|-|\s|\.)?)",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     // Handle Exception Release Groups that don't follow -RlsGrp; Manual List
     // name only...be very careful with this last; high chance of false positives
-    private static readonly Regex ExceptionReleaseGroupRegexExact = new (@"\b(?<releasegroup>KRaLiMaRKo|E\.N\.D|D\-Z0N3|Koten_Gars|BluDragon|ZØNEHD|HQMUX|VARYG|YIFY|YTS(.(MX|LT|AG))?|TMd|Eml HDTeam|LMain|DarQ|BEN THE MEN|TAoE|QxR|126811)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex ExceptionReleaseGroupRegexExact = new(@"\b(?<releasegroup>KRaLiMaRKo|E\.N\.D|D\-Z0N3|Koten_Gars|BluDragon|ZØNEHD|HQMUX|VARYG|YIFY|YTS(.(MX|LT|AG))?|TMd|Eml HDTeam|LMain|DarQ|BEN THE MEN|TAoE|QxR|126811)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     // groups whose releases end with RlsGroup) or RlsGroup]
-    private static readonly Regex ExceptionReleaseGroupRegex = new (@"(?<=[._ \[])(?<releasegroup>(Silence|afm72|Panda|Ghost|MONOLITH|Tigole|Joy|ImE|UTR|t3nzin|Anime Time|Project Angel|Hakata Ramen|HONE|GiLG|Vyndros|SEV|Garshasp|Kappa|Natty|RCVR|SAMPA|YOGI|r00t|EDGE2020|RZeroX|FreetheFish|Anna|Bandi|Qman|theincognito|HDO|DusIctv|DHD|CtrlHD|-ZR-|ADC|XZVN|RH|Kametsu)(?=\]|\)))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex ExceptionReleaseGroupRegex = new(@"(?<=[._ \[])(?<releasegroup>(Silence|afm72|Panda|Ghost|MONOLITH|Tigole|Joy|ImE|UTR|t3nzin|Anime Time|Project Angel|Hakata Ramen|HONE|GiLG|Vyndros|SEV|Garshasp|Kappa|Natty|RCVR|SAMPA|YOGI|r00t|EDGE2020|RZeroX|FreetheFish|Anna|Bandi|Qman|theincognito|HDO|DusIctv|DHD|CtrlHD|-ZR-|ADC|XZVN|RH|Kametsu)(?=\]|\)))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    private static readonly RegexReplace CleanReleaseGroupRegex = new (@"(-(RP|1|NZBGeek|Obfuscated|Obfuscation|Scrambled|sample|Pre|postbot|xpost|Rakuv[a-z0-9]*|WhiteRev|BUYMORE|AsRequested|AlternativeToRequested|GEROV|Z0iDS3N|Chamele0n|4P|4Planet|AlteZachen|RePACKPOST))+$",
+    private static readonly RegexReplace CleanReleaseGroupRegex = new(@"(-(RP|1|NZBGeek|Obfuscated|Obfuscation|Scrambled|sample|Pre|postbot|xpost|Rakuv[a-z0-9]*|WhiteRev|BUYMORE|AsRequested|AlternativeToRequested|GEROV|Z0iDS3N|Chamele0n|4P|4Planet|AlteZachen|RePACKPOST))+$",
         string.Empty,
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 

--- a/src/NzbDrone.Core/Queue/QueueService.cs
+++ b/src/NzbDrone.Core/Queue/QueueService.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Queue
     public class QueueService : IQueueService, IHandle<TrackedDownloadRefreshedEvent>
     {
         private readonly IEventAggregator _eventAggregator;
-        private static List<Queue> _queue = new ();
+        private static List<Queue> _queue = new();
 
         public QueueService(IEventAggregator eventAggregator)
         {

--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -255,7 +255,7 @@ namespace NzbDrone.Host
             {
                 return new ConfigurationBuilder()
                     .AddXmlFile(configPath, optional: true, reloadOnChange: false)
-                    .AddInMemoryCollection(new List<KeyValuePair<string, string>> { new ("dataProtectionFolder", appFolder.GetDataProtectionPath()) })
+                    .AddInMemoryCollection(new List<KeyValuePair<string, string>> { new("dataProtectionFolder", appFolder.GetDataProtectionPath()) })
                     .AddEnvironmentVariables()
                     .Build();
             }

--- a/src/NzbDrone.Integration.Test/IntegrationTest.cs
+++ b/src/NzbDrone.Integration.Test/IntegrationTest.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Integration.Test
 
         protected int Port { get; private set; }
 
-        protected PostgresOptions PostgresOptions { get; set; } = new ();
+        protected PostgresOptions PostgresOptions { get; set; } = new();
 
         protected override string RootUrl => $"http://localhost:{Port}/";
 

--- a/src/NzbDrone.Mono/Disk/FindDriveType.cs
+++ b/src/NzbDrone.Mono/Disk/FindDriveType.cs
@@ -6,7 +6,7 @@ namespace NzbDrone.Mono.Disk
 {
     public static class FindDriveType
     {
-        private static readonly Dictionary<string, DriveType> DriveTypeMap = new ()
+        private static readonly Dictionary<string, DriveType> DriveTypeMap = new()
         {
             { "afpfs", DriveType.Network },
             { "apfs", DriveType.Fixed },

--- a/src/NzbDrone.Mono/EnvironmentInfo/VersionAdapters/MacOsVersionAdapter.cs
+++ b/src/NzbDrone.Mono/EnvironmentInfo/VersionAdapters/MacOsVersionAdapter.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Mono.EnvironmentInfo.VersionAdapters
     {
         private const string PLIST_DIR = "/System/Library/CoreServices/";
 
-        private static readonly Regex DarwinVersionRegex = new ("<key>ProductVersion<\\/key>\\s*<string>(?<version>1\\d\\.\\d{1,2}\\.?\\d{0,2}?)<\\/string>",
+        private static readonly Regex DarwinVersionRegex = new("<key>ProductVersion<\\/key>\\s*<string>(?<version>1\\d\\.\\d{1,2}\\.?\\d{0,2}?)<\\/string>",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private readonly IDiskProvider _diskProvider;

--- a/src/NzbDrone.Test.Common/AutoMoq/AutoMoqer.cs
+++ b/src/NzbDrone.Test.Common/AutoMoq/AutoMoqer.cs
@@ -112,7 +112,8 @@ namespace NzbDrone.Test.Common.AutoMoq
                                 var mock = (Mock)r.Resolve(mockType);
                                 SetMock(serviceType, mock);
                                 return mock.Object;
-                            }, Reuse.Singleton);
+                            },
+                                Reuse.Singleton);
 
                             return new[] { new DynamicRegistration(mockFactory, IfAlreadyRegistered.Keep) };
                         }

--- a/src/NzbDrone.Test.Common/NzbDroneRunner.cs
+++ b/src/NzbDrone.Test.Common/NzbDroneRunner.cs
@@ -136,7 +136,7 @@ namespace NzbDrone.Test.Common
 
         private void Start(string outputRadarrConsoleExe)
         {
-            StringDictionary envVars = new ();
+            StringDictionary envVars = new();
             if (PostgresOptions?.Host != null)
             {
                 envVars.Add("Radarr__Postgres__Host", PostgresOptions.Host);

--- a/src/Radarr.Api.V3/CustomFormats/CustomFormatBulkResource.cs
+++ b/src/Radarr.Api.V3/CustomFormats/CustomFormatBulkResource.cs
@@ -4,7 +4,7 @@ namespace Radarr.Api.V3.CustomFormats
 {
     public class CustomFormatBulkResource
     {
-        public HashSet<int> Ids { get; set; } = new ();
+        public HashSet<int> Ids { get; set; } = new();
         public bool? IncludeCustomFormatWhenRenaming { get; set; }
     }
 }

--- a/src/Radarr.Api.V3/DownloadClient/DownloadClientController.cs
+++ b/src/Radarr.Api.V3/DownloadClient/DownloadClientController.cs
@@ -8,8 +8,8 @@ namespace Radarr.Api.V3.DownloadClient
     [V3ApiController]
     public class DownloadClientController : ProviderControllerBase<DownloadClientResource, DownloadClientBulkResource, IDownloadClient, DownloadClientDefinition>
     {
-        public static readonly DownloadClientResourceMapper ResourceMapper = new ();
-        public static readonly DownloadClientBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly DownloadClientResourceMapper ResourceMapper = new();
+        public static readonly DownloadClientBulkResourceMapper BulkResourceMapper = new();
 
         public DownloadClientController(IBroadcastSignalRMessage signalRBroadcaster, IDownloadClientFactory downloadClientFactory)
             : base(signalRBroadcaster, downloadClientFactory, "downloadclient", ResourceMapper, BulkResourceMapper)

--- a/src/Radarr.Api.V3/ImportLists/ImportListController.cs
+++ b/src/Radarr.Api.V3/ImportLists/ImportListController.cs
@@ -10,8 +10,8 @@ namespace Radarr.Api.V3.ImportLists
     [V3ApiController]
     public class ImportListController : ProviderControllerBase<ImportListResource, ImportListBulkResource, IImportList, ImportListDefinition>
     {
-        public static readonly ImportListResourceMapper ResourceMapper = new ();
-        public static readonly ImportListBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly ImportListResourceMapper ResourceMapper = new();
+        public static readonly ImportListBulkResourceMapper BulkResourceMapper = new();
 
         public ImportListController(IBroadcastSignalRMessage signalRBroadcaster,
             IImportListFactory importListFactory,

--- a/src/Radarr.Api.V3/ImportLists/ImportListMoviesController.cs
+++ b/src/Radarr.Api.V3/ImportLists/ImportListMoviesController.cs
@@ -177,7 +177,8 @@ namespace Radarr.Api.V3.ImportLists
                 resource.Folder = _fileNameBuilder.GetMovieFolder(new Movie
                 {
                     MovieMetadata = currentMovie.MovieMetadata
-                }, namingConfig);
+                },
+                    namingConfig);
 
                 yield return resource;
             }

--- a/src/Radarr.Api.V3/Indexers/IndexerController.cs
+++ b/src/Radarr.Api.V3/Indexers/IndexerController.cs
@@ -9,8 +9,8 @@ namespace Radarr.Api.V3.Indexers
     [V3ApiController]
     public class IndexerController : ProviderControllerBase<IndexerResource, IndexerBulkResource, IIndexer, IndexerDefinition>
     {
-        public static readonly IndexerResourceMapper ResourceMapper = new ();
-        public static readonly IndexerBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly IndexerResourceMapper ResourceMapper = new();
+        public static readonly IndexerBulkResourceMapper BulkResourceMapper = new();
 
         public IndexerController(IBroadcastSignalRMessage signalRBroadcaster,
             IndexerFactory indexerFactory,

--- a/src/Radarr.Api.V3/Indexers/ReleasePushController.cs
+++ b/src/Radarr.Api.V3/Indexers/ReleasePushController.cs
@@ -76,7 +76,7 @@ namespace Radarr.Api.V3.Indexers
 
             if (decision?.RemoteMovie.ParsedMovieInfo == null)
             {
-                throw new ValidationException(new List<ValidationFailure> { new ("Title", "Unable to parse", release.Title) });
+                throw new ValidationException(new List<ValidationFailure> { new("Title", "Unable to parse", release.Title) });
             }
 
             return MapDecisions(new[] { decision });

--- a/src/Radarr.Api.V3/Metadata/MetadataController.cs
+++ b/src/Radarr.Api.V3/Metadata/MetadataController.cs
@@ -9,8 +9,8 @@ namespace Radarr.Api.V3.Metadata
     [V3ApiController]
     public class MetadataController : ProviderControllerBase<MetadataResource, MetadataBulkResource, IMetadata, MetadataDefinition>
     {
-        public static readonly MetadataResourceMapper ResourceMapper = new ();
-        public static readonly MetadataBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly MetadataResourceMapper ResourceMapper = new();
+        public static readonly MetadataBulkResourceMapper BulkResourceMapper = new();
 
         public MetadataController(IBroadcastSignalRMessage signalRBroadcaster, IMetadataFactory metadataFactory)
             : base(signalRBroadcaster, metadataFactory, "metadata", ResourceMapper, BulkResourceMapper)

--- a/src/Radarr.Api.V3/MovieFiles/MovieFileListResource.cs
+++ b/src/Radarr.Api.V3/MovieFiles/MovieFileListResource.cs
@@ -6,7 +6,7 @@ namespace Radarr.Api.V3.MovieFiles
 {
     public class MovieFileListResource
     {
-        public List<int> MovieFileIds { get; set; } = new ();
+        public List<int> MovieFileIds { get; set; } = new();
         public List<Language> Languages { get; set; }
         public QualityModel Quality { get; set; }
         public string Edition { get; set; }

--- a/src/Radarr.Api.V3/Movies/MovieController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieController.cs
@@ -264,7 +264,8 @@ namespace Radarr.Api.V3.Movies
                     MovieId = movie.Id,
                     SourcePath = sourcePath,
                     DestinationPath = destinationPath
-                }, trigger: CommandTrigger.Manual);
+                },
+                    trigger: CommandTrigger.Manual);
             }
 
             var model = moviesResource.ToModel(movie);

--- a/src/Radarr.Api.V3/Notifications/NotificationController.cs
+++ b/src/Radarr.Api.V3/Notifications/NotificationController.cs
@@ -9,8 +9,8 @@ namespace Radarr.Api.V3.Notifications
     [V3ApiController]
     public class NotificationController : ProviderControllerBase<NotificationResource, NotificationBulkResource, INotification, NotificationDefinition>
     {
-        public static readonly NotificationResourceMapper ResourceMapper = new ();
-        public static readonly NotificationBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly NotificationResourceMapper ResourceMapper = new();
+        public static readonly NotificationBulkResourceMapper BulkResourceMapper = new();
 
         public NotificationController(IBroadcastSignalRMessage signalRBroadcaster, NotificationFactory notificationFactory)
             : base(signalRBroadcaster, notificationFactory, "notification", ResourceMapper, BulkResourceMapper)

--- a/src/Radarr.Api.V3/System/Backup/BackupController.cs
+++ b/src/Radarr.Api.V3/System/Backup/BackupController.cs
@@ -20,7 +20,7 @@ namespace Radarr.Api.V3.System.Backup
         private readonly IAppFolderInfo _appFolderInfo;
         private readonly IDiskProvider _diskProvider;
 
-        private static readonly List<string> ValidExtensions = new () { ".zip", ".db", ".xml" };
+        private static readonly List<string> ValidExtensions = new() { ".zip", ".db", ".xml" };
 
         public BackupController(IBackupService backupService,
                             IAppFolderInfo appFolderInfo,

--- a/src/Radarr.Http/Frontend/Mappers/MediaCoverProxyMapper.cs
+++ b/src/Radarr.Http/Frontend/Mappers/MediaCoverProxyMapper.cs
@@ -10,7 +10,7 @@ namespace Radarr.Http.Frontend.Mappers
 {
     public class MediaCoverProxyMapper : IMapHttpRequestsToDisk
     {
-        private readonly Regex _regex = new (@"/MediaCoverProxy/(?<hash>\w+)/(?<filename>(.+)\.(jpg|png|gif))");
+        private readonly Regex _regex = new(@"/MediaCoverProxy/(?<hash>\w+)/(?<filename>(.+)\.(jpg|png|gif))");
 
         private readonly IMediaCoverProxy _mediaCoverProxy;
         private readonly IContentTypeProvider _mimeTypeProvider;

--- a/src/Radarr.Http/Frontend/StaticResourceController.cs
+++ b/src/Radarr.Http/Frontend/StaticResourceController.cs
@@ -17,7 +17,7 @@ namespace Radarr.Http.Frontend
     {
         private readonly IEnumerable<IMapHttpRequestsToDisk> _requestMappers;
         private readonly Logger _logger;
-        private static readonly Regex InvalidPathRegex = new (@"([\/\\]|%2f|%5c)\.\.|\.\.([\/\\]|%2f|%5c)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex InvalidPathRegex = new(@"([\/\\]|%2f|%5c)\.\.|\.\.([\/\\]|%2f|%5c)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public StaticResourceController(IEnumerable<IMapHttpRequestsToDisk> requestMappers,
             Logger logger)

--- a/src/Radarr.Http/PagingResource.cs
+++ b/src/Radarr.Http/PagingResource.cs
@@ -21,7 +21,7 @@ namespace Radarr.Http
         public string SortKey { get; set; }
         public SortDirection SortDirection { get; set; }
         public int TotalRecords { get; set; }
-        public List<TResource> Records { get; set; } = new ();
+        public List<TResource> Records { get; set; } = new();
 
         public PagingResource()
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Should make it easier for cherry-picking new commits that use the new collection syntax.

Upstream:
- https://github.com/Sonarr/Sonarr/commit/5d7c94f8e9fcf7763c9326e6a34211d863e8c271
- https://github.com/Sonarr/Sonarr/commit/84fbab6ab48e50c13f817aa1bfa1d1c2f720980c
