### PR TITLE
Fixed: Parsing quality and languages when manual importing item with multiple movies error

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportItem.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportItem.cs
@@ -15,18 +15,13 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
         public long Size { get; set; }
         public Movie Movie { get; set; }
         public int? MovieFileId { get; set; }
-        public QualityModel Quality { get; set; }
-        public List<Language> Languages { get; set; }
+        public QualityModel Quality { get; set; } = new();
+        public List<Language> Languages { get; set; } = new();
         public string ReleaseGroup { get; set; }
         public string DownloadId { get; set; }
-        public List<CustomFormat> CustomFormats { get; set; }
+        public List<CustomFormat> CustomFormats { get; set; } = new();
         public int CustomFormatScore { get; set; }
         public int IndexerFlags { get; set; }
-        public IEnumerable<ImportRejection> Rejections { get; set; }
-
-        public ManualImportItem()
-        {
-            CustomFormats = new List<CustomFormat>();
-        }
+        public IEnumerable<ImportRejection> Rejections { get; set; } = new List<ImportRejection>();
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
If you try to manual import a file for a movie that throws `MultipleMoviesFoundException`, the fields aren't autocompleted after you pick a movie.

Cherry picked from https://github.com/Sonarr/Sonarr/commit/de0f1d461df8792857471746b81338203bf793f7