### PR TITLE
Fix parsing already imported items from download clients

### DIFF
--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.Download;
+using NzbDrone.Core.Download.History;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.History;
 using NzbDrone.Core.Indexers;
@@ -269,6 +270,62 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
             var trackedDownloads = Subject.GetTrackedDownloads();
             trackedDownloads.Should().HaveCount(1);
             trackedDownloads.First().RemoteMovie.Should().BeNull();
+        }
+
+        [Test]
+        public void should_track_downloads_using_the_movie_id_for_already_imported_downloads()
+        {
+            Mocker.GetMock<IHistoryService>()
+                .Setup(s => s.FindByDownloadId(It.Is<string>(sr => sr == "35238")))
+                .Returns([]);
+
+            Mocker.GetMock<IDownloadHistoryService>()
+                .Setup(s => s.GetLatestDownloadHistoryItem(It.Is<string>(sr => sr == "35238")))
+                .Returns(new DownloadHistory
+                {
+                    MovieId = 5,
+                    EventType = DownloadHistoryEventType.DownloadImported,
+                });
+
+            var remoteMovie = new RemoteMovie
+            {
+                Movie = new Movie { Id = 5 },
+                ParsedMovieInfo = new ParsedMovieInfo
+                {
+                    MovieTitles = { "A Movie" },
+                    Year = 1998
+                },
+            };
+
+            Mocker.GetMock<IParsingService>()
+                .Setup(s => s.Map(It.Is<ParsedMovieInfo>(i => i.Year == 1998 && i.MovieTitle == "A Movie"), It.IsAny<int>()))
+                .Returns(remoteMovie);
+
+            var client = new DownloadClientDefinition
+            {
+                Id = 1,
+                Protocol = DownloadProtocol.Torrent
+            };
+
+            var item = new DownloadClientItem
+            {
+                Title = "A Movie 1998",
+                DownloadId = "35238",
+                DownloadClientInfo = new DownloadClientItemClientInfo
+                {
+                    Protocol = client.Protocol,
+                    Id = client.Id,
+                    Name = client.Name
+                }
+            };
+
+            var trackedDownload = Subject.TrackDownload(client, item);
+
+            trackedDownload.Should().NotBeNull();
+            trackedDownload.RemoteMovie.Should().NotBeNull();
+            trackedDownload.RemoteMovie.Movie.Should().NotBeNull();
+            trackedDownload.RemoteMovie.Movie.Id.Should().Be(5);
+            trackedDownload.RemoteMovie.ParsedMovieInfo.Year.Should().Be(1998);
         }
     }
 }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -197,7 +197,8 @@ namespace NzbDrone.Core.Download.TrackedDownloads
             catch (Exception e)
             {
                 _logger.Debug(e, "Failed to find movie for " + downloadItem.Title);
-                return null;
+
+                trackedDownload.Warn("Unable to parse movie from title");
             }
 
             LogItemChange(trackedDownload, existingItem?.DownloadItem, trackedDownload.DownloadItem);

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using NLog;
 using NzbDrone.Common.Cache;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.Configuration;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Download.Aggregation;
 using NzbDrone.Core.Download.History;
@@ -35,33 +34,32 @@ namespace NzbDrone.Core.Download.TrackedDownloads
     {
         private readonly IParsingService _parsingService;
         private readonly IHistoryService _historyService;
-        private readonly IEventAggregator _eventAggregator;
         private readonly IDownloadHistoryService _downloadHistoryService;
-        private readonly IConfigService _config;
         private readonly IRemoteMovieAggregationService _aggregationService;
         private readonly ICustomFormatCalculationService _formatCalculator;
+        private readonly IEventAggregator _eventAggregator;
         private readonly Logger _logger;
+
         private readonly ICached<TrackedDownload> _cache;
 
         public TrackedDownloadService(IParsingService parsingService,
-                                      ICacheManager cacheManager,
                                       IHistoryService historyService,
-                                      IConfigService config,
+                                      IDownloadHistoryService downloadHistoryService,
                                       IRemoteMovieAggregationService aggregationService,
                                       ICustomFormatCalculationService formatCalculator,
                                       IEventAggregator eventAggregator,
-                                      IDownloadHistoryService downloadHistoryService,
+                                      ICacheManager cacheManager,
                                       Logger logger)
         {
             _parsingService = parsingService;
             _historyService = historyService;
-            _cache = cacheManager.GetCache<TrackedDownload>(GetType());
-            _config = config;
+            _downloadHistoryService = downloadHistoryService;
             _aggregationService = aggregationService;
             _formatCalculator = formatCalculator;
             _eventAggregator = eventAggregator;
-            _downloadHistoryService = downloadHistoryService;
             _logger = logger;
+
+            _cache = cacheManager.GetCache<TrackedDownload>(GetType());
         }
 
         public TrackedDownload Find(string downloadId)
@@ -117,17 +115,6 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
             try
             {
-                var historyItems = _historyService.FindByDownloadId(downloadItem.DownloadId)
-                    .OrderByDescending(h => h.Date)
-                    .ToList();
-
-                var parsedMovieInfo = Parser.Parser.ParseMovieTitle(trackedDownload.DownloadItem.Title);
-
-                if (parsedMovieInfo != null)
-                {
-                    trackedDownload.RemoteMovie = _parsingService.Map(parsedMovieInfo, "", 0, null);
-                }
-
                 var downloadHistory = _downloadHistoryService.GetLatestDownloadHistoryItem(downloadItem.DownloadId);
 
                 if (downloadHistory != null)
@@ -135,6 +122,19 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                     var state = GetStateFromHistory(downloadHistory.EventType);
                     trackedDownload.State = state;
                 }
+
+                var parsedMovieInfo = Parser.Parser.ParseMovieTitle(trackedDownload.DownloadItem.Title);
+
+                if (parsedMovieInfo != null)
+                {
+                    trackedDownload.RemoteMovie = downloadHistory is { EventType: DownloadHistoryEventType.DownloadImported }
+                        ? _parsingService.Map(parsedMovieInfo, downloadHistory.MovieId)
+                        : _parsingService.Map(parsedMovieInfo, "", 0, null);
+                }
+
+                var historyItems = _historyService.FindByDownloadId(downloadItem.DownloadId)
+                    .OrderByDescending(h => h.Date)
+                    .ToList();
 
                 if (historyItems.Any())
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
For download clients that don't use a post-import category, TrackedDownloadService is tracking everything in the client including already imported items who might throw `MultipleMoviesFoundException` when having multiple movies with same name, and while this is okay in queue as it allows manually importing this items, it's an issue after a restart when the items throwing this exception will reappear in queue with an error.

The change will reuse the MovieId from the download history if the last event is imported, to keep the current behavior to display items with multiple movies found to allow manual import.

- https://github.com/Sonarr/Sonarr/commit/1cd5bc2e6d8c3643803805a7e3167435b3d12347
- https://github.com/Sonarr/Sonarr/commit/789a8f53013a247cd195f864484089c27b5f3858