### PR TITLE
Fixed: Parse HTTP URI templates culture-invariantly

### DIFF
--- a/src/NzbDrone.Common.Test/Http/HttpUriFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpUriFixture.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Common.Http;
@@ -15,6 +16,32 @@ namespace NzbDrone.Common.Test.Http
         {
             var newUri = new HttpUri(uri);
             newUri.FullUri.Should().Be(uri);
+        }
+
+        [Test]
+        public void should_parse_uri_template_regardless_of_culture()
+        {
+            var currentCulture = CultureInfo.CurrentCulture;
+            var currentUiCulture = CultureInfo.CurrentUICulture;
+
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("tr-TR");
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("tr-TR");
+
+            try
+            {
+                var uri = "https://api.themoviedb.org/{api}/{route}/{id}{secondaryRoute}";
+                var newUri = new HttpUri(uri);
+
+                newUri.FullUri.Should().Be(uri);
+                newUri.Scheme.Should().Be("https");
+                newUri.Host.Should().Be("api.themoviedb.org");
+                newUri.Path.Should().Be("/{api}/{route}/{id}{secondaryRoute}");
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = currentCulture;
+                CultureInfo.CurrentUICulture = currentUiCulture;
+            }
         }
 
         [TestCase("", "", "")]

--- a/src/NzbDrone.Common/Http/HttpUri.cs
+++ b/src/NzbDrone.Common/Http/HttpUri.cs
@@ -11,7 +11,7 @@ namespace NzbDrone.Common.Http
         private readonly string _uri;
         public string FullUri => _uri;
 
-        [GeneratedRegex(@"^(?:(?<scheme>[a-z]+):)?(?://(?<host>[-_A-Z0-9.]+|\[[[A-F0-9:]+\])(?::(?<port>[0-9]{1,5}))?)?(?<path>(?:(?:(?<=^)|/+)[^/?#\r\n]+)+/*|/+)?(?:\?(?<query>[^#\r\n]*))?(?:\#(?<fragment>.*))?$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+        [GeneratedRegex(@"^(?:(?<scheme>[a-z]+):)?(?://(?<host>[-_A-Z0-9.]+|\[[[A-F0-9:]+\])(?::(?<port>[0-9]{1,5}))?)?(?<path>(?:(?:(?<=^)|/+)[^/?#\r\n]+)+/*|/+)?(?:\?(?<query>[^#\r\n]*))?(?:\#(?<fragment>.*))?$", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant)]
         private static partial Regex UriRegex();
 
         public HttpUri(string uri)


### PR DESCRIPTION
### Summary
- Make HTTP URI template parsing culture-invariant
- Add a tr-TR regression test for the TMDb URI template startup crash

Closes #11316

### Tests
- DOTNET_ROOT=/tmp/dotnet-8.0.421 PATH=/tmp/dotnet-8.0.421:$PATH dotnet test src/NzbDrone.Common.Test/Radarr.Common.Test.csproj --filter "FullyQualifiedName~HttpUriFixture" -p:RunAnalyzers=false