### PR TITLE
Fixed: Treat periods as separators in movie search titles

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
@@ -13,12 +13,16 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         [TestCase("Star Wars: The Clone Wars", "Star+Wars+The+Clone+Wars")]
         [TestCase("Hawaii Five-0", "Hawaii+Five+0")]
         [TestCase("Franklin & Bash", "Franklin+and+Bash")]
-        [TestCase("Chicago P.D.", "Chicago+PD")]
+        [TestCase("Chicago P.D.", "Chicago+P+D")]
         [TestCase("Kourtney And Khlo\u00E9 Take The Hamptons", "Kourtney+And+Khloe+Take+The+Hamptons")]
         [TestCase("Betty White`s Off Their Rockers", "Betty+Whites+Off+Their+Rockers")]
         [TestCase("Betty White\u00b4s Off Their Rockers", "Betty+Whites+Off+Their+Rockers")]
         [TestCase("Betty White‘s Off Their Rockers", "Betty+Whites+Off+Their+Rockers")]
         [TestCase("Betty White’s Off Their Rockers", "Betty+Whites+Off+Their+Rockers")]
+        [TestCase("Snake Eyes: G.I. Joe Origins", "Snake+Eyes+G+I+Joe+Origins")]
+        [TestCase("Sniper: G.R.I.T. - Global Response & Intelligence Team", "Sniper+G+R+I+T+Global+Response+and+Intelligence+Team")]
+        [TestCase("Ghost in the Shell 2.0", "Ghost+in+the+Shell+2+0")]
+        [TestCase("G.O.A.T", "G+O+A+T")]
         public void should_replace_some_special_characters(string input, string expected)
         {
             Subject.SceneTitles = new List<string> { input };

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -9,8 +9,8 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 {
     public abstract class SearchCriteriaBase
     {
-        private static readonly Regex SpecialCharacter = new Regex(@"['.\u0060\u00B4\u2018\u2019]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex NonWord = new Regex(@"[\W]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex SpecialCharacter = new Regex(@"['\u0060\u00B4\u2018\u2019]+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex NonWord = new Regex(@"[\W]+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex BeginningThe = new Regex(@"^the\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public Movie Movie { get; set; }
@@ -28,6 +28,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
             var cleanTitle = BeginningThe.Replace(title, string.Empty);
 
             cleanTitle = cleanTitle.Replace("&", "and");
+            cleanTitle = cleanTitle.Replace(".", "+");
             cleanTitle = SpecialCharacter.Replace(cleanTitle, "");
             cleanTitle = NonWord.Replace(cleanTitle, "+");
 


### PR DESCRIPTION
### Summary
- Treat periods in movie search titles as separators instead of removing them
- Add regression cases for titles such as Snake Eyes: G.I. Joe Origins and G.R.I.T.

Closes #11457

### Tests
- DOTNET_ROOT=/tmp/dotnet-8.0.421 PATH=/tmp/dotnet-8.0.421:$PATH dotnet test src/NzbDrone.Core.Test/Radarr.Core.Test.csproj --filter "FullyQualifiedName~SearchDefinitionFixture" -p:RunAnalyzers=false