### PR TITLE
Fixed: Ignore torrentclaw TC tags as Telecine

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -51,6 +51,25 @@ namespace NzbDrone.Core.Test.ParserTests
             ParseAndVerifyQuality(title, QualitySource.CAM, proper, Resolution.Unknown);
         }
 
+        [TestCase("Movie.Name.2024.TC.x264-GROUP")]
+        [TestCase("Movie.Name.2024.[TC].x264-GROUP")]
+        [TestCase("Movie.Name.2024.HD-TC.x264-GROUP")]
+        [TestCase("Movie.Name.2024.HDTC.x264-GROUP")]
+        [TestCase("Movie.Name.2024.TELECINE.x264-GROUP")]
+        public void should_parse_telecine_quality(string title)
+        {
+            ParseAndVerifyQuality(title, QualitySource.TELECINE, false, Resolution.Unknown);
+        }
+
+        [TestCase("Movie.Name.2024.[TC-00]-torrentclaw")]
+        [TestCase("Movie.Name.2024.[TC-12].torrentclaw")]
+        public void should_not_parse_torrentclaw_tc_number_as_telecine(string title)
+        {
+            var result = QualityParser.ParseQuality(title);
+
+            result.Quality.Source.Should().NotBe(QualitySource.TELECINE);
+        }
+
         [TestCase("S07E23 .avi ", false)]
         [TestCase("Movie Name S02E01 HDTV XviD 2HD", false)]
         [TestCase("Movie Name S05E11 PROPER HDTV XviD 2HD", true)]

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Parser
                                                             (?<regional>R[0-9]{1}|REGIONAL)|
                                                             (?<scr>SCR|SCREENER|DVDSCR|DVDSCREENER)|
                                                             (?<ts>TS[-_. ]|TELESYNCH?|HD-TS|HDTS|PDVD|TSRip|HDTSRip)|
-                                                            (?<tc>TC|TELECINE|HD-TC|HDTC)|
+                                                            (?<tc>TC(?!-\d+\])|TELECINE|HD-TC|HDTC)|
                                                             (?<cam>CAMRIP|(?:NEW)?CAM|HD-?CAM(?:Rip)?|HQCAM)|
                                                             (?<wp>WORKPRINT|WP)|
                                                             (?<pdtv>PDTV)|


### PR DESCRIPTION
### Summary
- Avoid matching torrentclaw tags like [TC-00] as Telecine quality
- Keep normal TC, HD-TC, HDTC, and TELECINE parsing intact

Closes #11478

### Tests
- DOTNET_ROOT=/tmp/dotnet-8.0.421 PATH=/tmp/dotnet-8.0.421:$PATH dotnet test src/NzbDrone.Core.Test/Radarr.Core.Test.csproj --filter "FullyQualifiedName~QualityParserFixture" -p:RunAnalyzers=false