### PR TITLE
Fixed: Match year custom formats after import

### DIFF
--- a/src/NzbDrone.Core.Test/CustomFormats/CustomFormatCalculationServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/CustomFormatCalculationServiceFixture.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.CustomFormats
+{
+    [TestFixture]
+    public class CustomFormatCalculationServiceFixture : CoreTest<CustomFormatCalculationService>
+    {
+        private CustomFormat _yearFormat;
+        private Movie _movie;
+
+        [SetUp]
+        public void Setup()
+        {
+            _yearFormat = new CustomFormat("2020s",
+                new YearSpecification
+                {
+                    Min = 2020,
+                    Max = 2029
+                });
+
+            _movie = new Movie
+            {
+                Title = "Test Movie",
+                Year = 2025
+            };
+
+            Mocker.GetMock<ICustomFormatService>()
+                .Setup(s => s.All())
+                .Returns(new List<CustomFormat> { _yearFormat });
+        }
+
+        [Test]
+        public void should_match_year_condition_when_parsing_remote_movie()
+        {
+            var remoteMovie = new RemoteMovie
+            {
+                Movie = _movie,
+                ParsedMovieInfo = new ParsedMovieInfo
+                {
+                    Year = 2025
+                }
+            };
+
+            Subject.ParseCustomFormat(remoteMovie, 0).Should().Contain(_yearFormat);
+        }
+
+        [Test]
+        public void should_match_year_condition_when_parsing_imported_movie_file()
+        {
+            var movieFile = new MovieFile
+            {
+                RelativePath = "Test.Movie.2025.mkv"
+            };
+
+            Subject.ParseCustomFormat(movieFile, _movie).Should().Contain(_yearFormat);
+        }
+    }
+}

--- a/src/NzbDrone.Core/CustomFormats/Specifications/YearSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/YearSpecification.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.CustomFormats
 
         protected override bool IsSatisfiedByWithoutNegate(CustomFormatInput input)
         {
-            var year = input.MovieInfo?.Year ?? input.Movie?.MovieMetadata?.Value?.Year;
+            var year = input.MovieInfo?.Year > 0 ? input.MovieInfo.Year : input.Movie?.MovieMetadata?.Value?.Year;
 
             return year >= Min && year <= Max;
         }


### PR DESCRIPTION
### Summary
- Treat parsed year 0 as absent for year custom format matching
- Fall back to the movie metadata year when calculating formats for imported movie files
- Add regression coverage for grab-time and imported-file custom format calculation

Closes #11306

### Tests
- DOTNET_ROOT=/tmp/dotnet-8.0.421 PATH=/tmp/dotnet-8.0.421:$PATH dotnet test src/NzbDrone.Core.Test/Radarr.Core.Test.csproj --filter "FullyQualifiedName~CustomFormatCalculationServiceFixture" -p:RunAnalyzers=false