### PR TITLE
Fixed: Custom formats with year for imported files

### DIFF
--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -64,9 +64,10 @@ namespace NzbDrone.Core.CustomFormats
 
             var movieInfo = new ParsedMovieInfo
             {
-                MovieTitles = new List<string>() { movie.Title },
+                MovieTitles = new List<string> { movie.Title },
                 SimpleReleaseTitle = parsed?.SimpleReleaseTitle ?? blocklist.SourceTitle.SimplifyReleaseTitle(),
                 ReleaseTitle = parsed?.ReleaseTitle ?? blocklist.SourceTitle,
+                Year = movie.Year,
                 Edition = parsed?.Edition,
                 Quality = blocklist.Quality,
                 Languages = blocklist.Languages,
@@ -94,9 +95,10 @@ namespace NzbDrone.Core.CustomFormats
 
             var movieInfo = new ParsedMovieInfo
             {
-                MovieTitles = new List<string>() { movie.Title },
+                MovieTitles = new List<string> { movie.Title },
                 SimpleReleaseTitle = parsed?.SimpleReleaseTitle ?? history.SourceTitle.SimplifyReleaseTitle(),
                 ReleaseTitle = parsed?.ReleaseTitle ?? history.SourceTitle,
+                Year = movie.Year,
                 Edition = parsed?.Edition,
                 Quality = history.Quality,
                 Languages = history.Languages,
@@ -119,9 +121,10 @@ namespace NzbDrone.Core.CustomFormats
         {
             var movieInfo = new ParsedMovieInfo
             {
-                MovieTitles = new List<string>() { localMovie.Movie.Title },
+                MovieTitles = new List<string> { localMovie.Movie.Title },
                 SimpleReleaseTitle = localMovie.SceneName.IsNotNullOrWhiteSpace() ? localMovie.SceneName.SimplifyReleaseTitle() : Path.GetFileName(localMovie.Path).SimplifyReleaseTitle(),
                 ReleaseTitle = localMovie.SceneName,
+                Year = localMovie.Movie.Year,
                 Quality = localMovie.Quality,
                 Edition = localMovie.Edition,
                 Languages = localMovie.Languages,
@@ -191,8 +194,9 @@ namespace NzbDrone.Core.CustomFormats
 
             var movieInfo = new ParsedMovieInfo
             {
-                MovieTitles = new List<string>() { movie.Title },
+                MovieTitles = new List<string> { movie.Title },
                 SimpleReleaseTitle = releaseTitle.SimplifyReleaseTitle(),
+                Year = movie.Year,
                 Quality = movieFile.Quality,
                 Languages = movieFile.Languages,
                 ReleaseGroup = movieFile.ReleaseGroup,

--- a/src/NzbDrone.Core/CustomFormats/Specifications/YearSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/YearSpecification.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.CustomFormats
 
         protected override bool IsSatisfiedByWithoutNegate(CustomFormatInput input)
         {
-            var year = input.MovieInfo?.Year ?? input.Movie?.MovieMetadata?.Value?.Year;
+            var year = input.MovieInfo?.Year is > 0 ? input.MovieInfo.Year : input.Movie?.MovieMetadata?.Value?.Year;
 
             return year >= Min && year <= Max;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Pass movie year in `CustomFormatCalculationService` for already imported files needed for the year specification.

#### Issues Fixed or Closed by this PR

* Fixes #11306
* Closing #11503