### PR TITLE
Fixed: Use periods as search title separators

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
@@ -13,12 +13,16 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         [TestCase("Star Wars: The Clone Wars", "Star+Wars+The+Clone+Wars")]
         [TestCase("Hawaii Five-0", "Hawaii+Five+0")]
         [TestCase("Franklin & Bash", "Franklin+and+Bash")]
-        [TestCase("Chicago P.D.", "Chicago+PD")]
+        [TestCase("Chicago P.D.", "Chicago+P+D")]
         [TestCase("Kourtney And Khlo\u00E9 Take The Hamptons", "Kourtney+And+Khloe+Take+The+Hamptons")]
         [TestCase("Betty White`s Off Their Rockers", "Betty+Whites+Off+Their+Rockers")]
         [TestCase("Betty White\u00b4s Off Their Rockers", "Betty+Whites+Off+Their+Rockers")]
         [TestCase("Betty White‘s Off Their Rockers", "Betty+Whites+Off+Their+Rockers")]
         [TestCase("Betty White’s Off Their Rockers", "Betty+Whites+Off+Their+Rockers")]
+        [TestCase("Snake Eyes: G.I. Joe Origins", "Snake+Eyes+G+I+Joe+Origins")]
+        [TestCase("Sniper: G.R.I.T. - Global Response & Intelligence Team", "Sniper+G+R+I+T+Global+Response+and+Intelligence+Team")]
+        [TestCase("Ghost in the Shell 2.0", "Ghost+in+the+Shell+2+0")]
+        [TestCase("G.O.A.T", "G+O+A+T")]
         public void should_replace_some_special_characters(string input, string expected)
         {
             Subject.SceneTitles = new List<string> { input };

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -9,8 +9,8 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 {
     public abstract class SearchCriteriaBase
     {
-        private static readonly Regex SpecialCharacter = new Regex(@"['.\u0060\u00B4\u2018\u2019]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex NonWord = new Regex(@"[\W]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex SpecialCharacter = new Regex(@"['\u0060\u00B4\u2018\u2019]+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex NonWord = new Regex(@"[\W]+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex BeginningThe = new Regex(@"^the\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public Movie Movie { get; set; }
@@ -28,6 +28,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
             var cleanTitle = BeginningThe.Replace(title, string.Empty);
 
             cleanTitle = cleanTitle.Replace("&", "and");
+            cleanTitle = cleanTitle.Replace(".", "+");
             cleanTitle = SpecialCharacter.Replace(cleanTitle, "");
             cleanTitle = NonWord.Replace(cleanTitle, "+");
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Treat periods in movie search titles as separators instead of removing them when building cleaned scene-title search terms. This keeps dotted acronyms searchable as separate tokens, such as `G.I. Joe` becoming `G+I+Joe` instead of `GI+Joe`.

Adds regression coverage for dotted acronyms and decimal-style title punctuation.

#### Screenshot (if UI related)
N/A

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) - not required
- [x] [Wiki Updates](https://wiki.servarr.com) - not required

#### Issues Fixed or Closed by this PR

* Fixes #11457

#### Tests
- `git diff --check`
- `docker run --rm --user 501:20 -e HOME=/tmp -e DOTNET_CLI_HOME=/tmp -e NUGET_PACKAGES=/tmp/nuget -v /Volumes/vibecoding/Radarr-codex:/repo -w /repo mcr.microsoft.com/dotnet/sdk:8.0.421 dotnet test src/NzbDrone.Core.Test/Radarr.Core.Test.csproj -c Debug -f net8.0 -p:Platform=Posix -p:EnableAnalyzers=false --filter FullyQualifiedName~SearchDefinitionFixture`

#### Risk / Notes
- Scope is limited to non-raw cleaned search-title generation.
- Host `dotnet` was not available on PATH locally, so the targeted .NET test was run through the pinned SDK Docker image.
- A targeted analyzer-enabled run failed on pre-existing `SA1200` errors in untouched `NzbDrone.Common` files; the targeted fixture passed with analyzers disabled.
