### PR TITLE
Fixed: Kodi Metadata Files Issues

### DIFF
--- a/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFormatterTests/FormatAudioCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFormatterTests/FormatAudioCodecFixture.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Extras.Metadata.Consumers.Xbmc;
+using NzbDrone.Core.MediaFiles.MediaInfo;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.Xbmc.XbmcMetadataFormatterTests
+{
+    [TestFixture]
+    public class FormatAudioCodecFixture : TestBase
+    {
+        [TestCase(new[] { "dts", "", "DTS-HD MA" }, "dtshd_ma")]
+        [TestCase(new[] { "dts", "", "DTS:X" }, "dtshd_ma_x")]
+        [TestCase(new[] { "dts", "", "DTS" }, "dts")]
+        [TestCase(new[] { "truehd", "thd+", "" }, "truehd_atmos")]
+        [TestCase(new[] { "truehd", "", "" }, "truehd")]
+        [TestCase(new[] { "eac3", "ec+3", "" }, "eac3_ddp_atmos")]
+        [TestCase(new[] { "eac3", "", "" }, "eac3")]
+        [TestCase(new[] { "aac", "", "" }, "aac")]
+        [TestCase(new[] { "aac", "", "HE-AAC" }, "he_aac")]
+        public void should_format_audio_format(string[] audioFormat, string expectedFormat)
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                AudioFormat = audioFormat[0],
+                AudioCodecID = audioFormat[1],
+                AudioProfile = audioFormat[2]
+            };
+
+            XbmcMetadataFormatter.FormatAudioCodec(mediaInfoModel).Should().Be(expectedFormat);
+        }
+
+        [Test]
+        public void should_return_audio_format_by_default()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                AudioFormat = "Other Audio Format",
+            };
+
+            XbmcMetadataFormatter.FormatAudioCodec(mediaInfoModel).Should().Be(mediaInfoModel.AudioFormat);
+        }
+
+        [Test]
+        public void should_return_empty_if_audio_stream_is_null()
+        {
+            XbmcMetadataFormatter.FormatAudioCodec(null).Should().Be(string.Empty);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -374,7 +374,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                     audio.Add(new XElement("bitrate", movieFile.MediaInfo.AudioBitrate));
                     audio.Add(new XElement("channels", audioChannelCount));
                     audio.Add(new XElement("codec", XbmcMetadataFormatter.FormatAudioCodec(movieFile.MediaInfo)));
-                    audio.Add(new XElement("language", movieFile.MediaInfo.AudioLanguages));
+                    audio.Add(new XElement("language", movieFile.MediaInfo.AudioLanguages.FirstOrDefault()));
                     streamDetails.Add(audio);
 
                     if (movieFile.MediaInfo.Subtitles is { Count: > 0 })

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -338,7 +338,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                     var video = new XElement("video");
                     video.Add(new XElement("aspect", (float)movieFile.MediaInfo.Width / (float)movieFile.MediaInfo.Height));
                     video.Add(new XElement("bitrate", movieFile.MediaInfo.VideoBitrate));
-                    video.Add(new XElement("codec", MediaInfoFormatter.FormatVideoCodec(movieFile.MediaInfo, sceneName)));
+                    video.Add(new XElement("codec", movieFile.MediaInfo.VideoFormat));
                     video.Add(new XElement("framerate", movieFile.MediaInfo.VideoFps.ToString("0.###")));
                     video.Add(new XElement("height", movieFile.MediaInfo.Height));
                     video.Add(new XElement("scantype", movieFile.MediaInfo.ScanType));
@@ -373,7 +373,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                     var audioChannelCount = movieFile.MediaInfo.AudioChannels;
                     audio.Add(new XElement("bitrate", movieFile.MediaInfo.AudioBitrate));
                     audio.Add(new XElement("channels", audioChannelCount));
-                    audio.Add(new XElement("codec", MediaInfoFormatter.FormatAudioCodec(movieFile.MediaInfo, sceneName)));
+                    audio.Add(new XElement("codec", XbmcMetadataFormatter.FormatAudioCodec(movieFile.MediaInfo)));
                     audio.Add(new XElement("language", movieFile.MediaInfo.AudioLanguages));
                     streamDetails.Add(audio);
 

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -339,7 +339,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                     video.Add(new XElement("aspect", (float)movieFile.MediaInfo.Width / (float)movieFile.MediaInfo.Height));
                     video.Add(new XElement("bitrate", movieFile.MediaInfo.VideoBitrate));
                     video.Add(new XElement("codec", MediaInfoFormatter.FormatVideoCodec(movieFile.MediaInfo, sceneName)));
-                    video.Add(new XElement("framerate", movieFile.MediaInfo.VideoFps));
+                    video.Add(new XElement("framerate", movieFile.MediaInfo.VideoFps.ToString("0.###")));
                     video.Add(new XElement("height", movieFile.MediaInfo.Height));
                     video.Add(new XElement("scantype", movieFile.MediaInfo.ScanType));
                     video.Add(new XElement("width", movieFile.MediaInfo.Width));

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFormatter.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFormatter.cs
@@ -1,0 +1,53 @@
+using NzbDrone.Core.MediaFiles.MediaInfo;
+
+namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
+{
+    public static class XbmcMetadataFormatter
+    {
+        public static string FormatAudioCodec(MediaInfoModel mediaInfo)
+        {
+            if (mediaInfo == null)
+            {
+                return string.Empty;
+            }
+
+            var audioFormat = mediaInfo.AudioFormat;
+            var audioCodecID = mediaInfo.AudioCodecID ?? string.Empty;
+            var audioProfile = mediaInfo.AudioProfile ?? string.Empty;
+
+            // profile name definitions here https://github.com/FFmpeg/FFmpeg/blob/n5.1.4/libavcodec/profiles.c
+            // ffmpeg 5.1.4 doesn't support the profiles "Dolby Digital Plus + Dolby Atmos" and "Dolby TrueHD + Dolby Atmos"
+            // A custom ffmpeg patch maps them as codec_tag_string values "ec+3" and "thd+" respectively.
+            return audioCodecID switch
+            {
+                "thd+" => "truehd_atmos",
+                "ec+3" => "eac3_ddp_atmos",
+                _ => audioFormat switch
+                {
+                    // Missing Kodi dedicated codes for "DTS-ES" "DTS Express" "DTS 96/24"
+                    // ffmpeg 5.1.4 doesn't support "DTS-HD MA + DTS:X" and "DTS-HD MA + DTS:X IMAX" for dtshd_ma_x and dtshd_ma_x_imax
+                    // A custom ffmpeg patch identifies both as profile "DTS:X"
+                    "dts" => audioProfile switch
+                    {
+                        "DTS:X" => "dtshd_ma_x",
+                        "DTS-HD HRA" => "dtshd_hra",
+                        "DTS-HD MA" => "dtshd_ma",
+                        _ => audioFormat,
+                    },
+
+                    // Missing Kodi dedicated codes for "LD", "ELD", "Main", "xHE-AAC"
+                    "aac" => audioProfile switch
+                    {
+                        "LC" => "aac_lc",
+                        "HE-AAC" => "he_aac",
+                        "HE-AACv2" => "he_aac_v2",
+                        "SSR" => "aac_ssr",
+                        "LTP" => "aac_ltp",
+                        _ => audioFormat,
+                    },
+                    _ => audioFormat
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description

A discussion was started in #11516.

Fix a few issues in the `<streamdetails>` section of the generated Kodi .nfo files. Individual commit for each.
- `<codec>` is supposed to be the ffmpeg codec name or Kodi specific codes when profiles are involved
- `<framerate>` had an excessive number of decimals. Reduced to 3.
- The audio `<language>` is not supposed to be a concatenation of languages

The codec has been visible in Kodi's GUI for many versions.
The audio language will be visible by default in the upcoming v22 (in alpha) but was already visible in 3rd party skins.
Kodi doesn't probe the media stream details when information is provided via nfo file.

See the NFO spec https://kodi.wiki/view/NFO_files/Movies, https://kodi.wiki/view/NFO_files/Episodes
More up to date lists of codec strings: https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d5/d11/modules__infolabels_boolean_conditions.html#ListItem_VideoCodec and https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d5/d11/modules__infolabels_boolean_conditions.html#ListItem_AudioCodec

I hadn't coded in C# for many years and tried my best to follow the style of the code base and the new-to-me C# idioms, let me know.

The audio stream language solution here is just a quick fix for a bigger issue: MediaInfoModel only has information about the audio stream chosen as primary. However the NFO should contain one `<audio>` tag and its subtags per audio track.
It's a much bigger change in Radarr though. I don't mind removing the audio language commit if you don't want temporary solutions.
I have a change for the complete solution except for the unit tests, I don't know how the existing should be adapted or new ones created.

#### Screenshots

extract of .nfo before:
```
    <streamdetails>
      <video>
        <aspect>1.7777778</aspect>
        <bitrate>0</bitrate>
>>>     <codec>x265</codec>
>>>     <framerate>23.976023976023976023976023976</framerate>
        <height>1080</height>
        <scantype>Progressive</scantype>
        <width>1920</width>
        <duration>24.19145</duration>
        <durationinseconds>1451</durationinseconds>
        <hdrtype></hdrtype>
      </video>
      <audio>
        <bitrate>0</bitrate>
        <channels>2</channels>
>>>     <codec>AAC</codec>
>>>     <language>jpneng</language>
      </audio>
      <subtitle>
        <language>eng</language>
      </subtitle>
    </streamdetails>

```

extract of .nfo after:
```
    <streamdetails>
      <video>
        <aspect>1.7777778</aspect>
        <bitrate>0</bitrate>
>>>     <codec>hevc</codec>
>>>     <framerate>23.976</framerate>
        <height>1080</height>
        <scantype>Progressive</scantype>
        <width>1920</width>
        <duration>24.19145</duration>
        <durationinseconds>1451</durationinseconds>
        <hdrtype></hdrtype>
      </video>
      <audio>
        <bitrate>0</bitrate>
        <channels>2</channels>
>>>     <codec>aac_lc</codec>
>>>     <language>jpn</language>
      </audio>
      <subtitle>
        <language>eng</language>
      </subtitle>
    </streamdetails>
```


#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #11516