### PR TITLE
Fix: Bump FFProbe to 5.1.10

### DIFF
--- a/src/NzbDrone.Core/Radarr.Core.csproj
+++ b/src/NzbDrone.Core/Radarr.Core.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Npgsql" Version="9.0.5" />
     <PackageReference Include="Polly" Version="8.6.6" />
     <PackageReference Include="Servarr.FFMpegCore" Version="4.7.0-26" />
-    <PackageReference Include="Servarr.FFprobe" Version="5.1.4.112" />
+    <PackageReference Include="Servarr.FFprobe" Version="5.1.10.124" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.27" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Bumps FFProbe due to a recent security vulnerability. 

Once approved I will push this fix direct to master as well

#### Issues Fixed or Closed by this PR

* Fixes #11527 
* Fixes #11524