### PR TITLE
Fixed: Trakt import list crash on watchlist entry with null TMDB ID

### DIFF
--- a/src/NzbDrone.Core.Test/ImportListTests/Trakt/TraktParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/Trakt/TraktParserFixture.cs
@@ -1,0 +1,65 @@
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.ImportLists;
+using NzbDrone.Core.ImportLists.Trakt;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.ImportListTests.Trakt
+{
+    public class TraktParserFixture : CoreTest<TraktParser>
+    {
+        private ImportListResponse CreateResponse(string url, string content)
+        {
+            var httpRequest = new HttpRequest(url);
+            var httpResponse = new HttpResponse(httpRequest, new HttpHeader(), Encoding.UTF8.GetBytes(content));
+
+            return new ImportListResponse(new ImportListRequest(httpRequest), httpResponse);
+        }
+
+        [Test]
+        public void should_parse_movie_with_valid_tmdb_id()
+        {
+            var json = @"[
+              {
+                ""type"": ""movie"",
+                ""movie"": {
+                  ""title"": ""Rogue One: A Star Wars Story"",
+                  ""year"": 2016,
+                  ""ids"": { ""trakt"": 190420, ""slug"": ""rogue-one"", ""imdb"": ""tt3748528"", ""tmdb"": 330459 }
+                }
+              }
+            ]";
+
+            var result = Subject.ParseResponse(CreateResponse("http://api.trakt.tv/users/me/watchlist/movies", json));
+
+            result.Should().HaveCount(1);
+            result.First().Title.Should().Be("Rogue One: A Star Wars Story");
+            result.First().TmdbId.Should().Be(330459);
+            result.First().ImdbId.Should().Be("tt3748528");
+            result.First().Year.Should().Be(2016);
+        }
+
+        [Test]
+        public void should_not_throw_when_entry_has_null_tmdb_id()
+        {
+            var json = @"[
+              {
+                ""type"": ""movie"",
+                ""movie"": {
+                  ""title"": ""Nosferatu"",
+                  ""year"": null,
+                  ""ids"": { ""trakt"": 287264, ""slug"": ""nosferatu"", ""imdb"": null, ""tmdb"": null }
+                }
+              }
+            ]";
+
+            var result = Subject.ParseResponse(CreateResponse("http://api.trakt.tv/users/me/watchlist/movies", json));
+
+            result.Should().HaveCount(1);
+            result.First().TmdbId.Should().Be(0);
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularParser.cs
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
                 {
                     Title = movie.Title,
                     ImdbId = movie.Ids.Imdb,
-                    TmdbId = movie.Ids.Tmdb,
+                    TmdbId = movie.Ids.Tmdb ?? 0,
                     Year = movie.Year ?? 0
                 });
             }

--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktParser.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.ImportLists.Trakt
                 {
                     Title = movie.Movie.Title,
                     ImdbId = movie.Movie.Ids.Imdb,
-                    TmdbId = movie.Movie.Ids.Tmdb,
+                    TmdbId = movie.Movie.Ids.Tmdb ?? 0,
                     Year = movie.Movie.Year ?? 0
                 });
             }

--- a/src/NzbDrone.Core/Notifications/Trakt/Resource/TraktMovieIdsResource.cs
+++ b/src/NzbDrone.Core/Notifications/Trakt/Resource/TraktMovieIdsResource.cs
@@ -5,6 +5,6 @@ namespace NzbDrone.Core.Notifications.Trakt.Resource
         public int Trakt { get; set; }
         public string Slug { get; set; }
         public string Imdb { get; set; }
-        public int Tmdb { get; set; }
+        public int? Tmdb { get; set; }
     }
 }


### PR DESCRIPTION
**FULL DISCLOSURE**: Filing my own bug report with Claude Code!

_It didn't seem to be picked up by anyone involved in the project 🤷_

I'm not fluent in C# at all, only fluent in Rails, Java, Node, Deno, Angular, Vue, etc.

On the other hand, I was certain the bug I'd reported wasn't a complicated fix.

It turns out the fix Claude produced was only a three-line code change.

I hope you'll forgive me for doing that — I'll understand if you decline it. Since I'm being honest about it, I guess I'm not too bad a criminal, right?

---

#### Database Migration
YES - XXXX | NO

#### Description
Trakt returns orphaned watchlist entries (movie deleted from Trakt's DB) with all external ids, including tmdb, set to null. TraktMovieIdsResource.Tmdb was a non-nullable int, so deserializing such an entry threw a JsonException and aborted the entire sync/test.

Make Tmdb nullable and coalesce to 0 in the Trakt parsers, matching the existing convention where downstream import list processing already filters out TmdbId == 0 entries instead of crashing.


#### Todos
- [x] Tests (It is generated, as disclosed)
- [ ] ~Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)~ (not applicable)
- [ ] ~[Wiki Updates](https://wiki.servarr.com)~ (not applicable)

#### Issues Fixed or Closed by this PR

* Fixes #11519