### PR TITLE
Fixed: Reject import of files that don't match the movie being imported

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Specifications/MatchesFolderSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Specifications/MatchesFolderSpecificationFixture.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
 using FizzWare.NBuilder;
 using FluentAssertions;
+using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.MediaFiles.MovieImport.Specifications;
 using NzbDrone.Core.Movies;
-using NzbDrone.Core.Movies.AlternativeTitles;
+using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Test.Common;
@@ -15,25 +16,28 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieImport.Specifications
     public class MatchesFolderSpecificationFixture : CoreTest<MatchesFolderSpecification>
     {
         private Movie _movie;
+        private Movie _otherMovie;
         private LocalMovie _localMovie;
 
         [SetUp]
         public void Setup()
         {
             _movie = Builder<Movie>.CreateNew()
-                .With(m => m.MovieMetadata = new MovieMetadata
-                {
-                    Title = "Movie Title",
-                    CleanTitle = "movietitle",
-                    Year = 2011,
-                    TmdbId = 50000,
-                    ImdbId = "tt1111111"
-                })
+                .With(m => m.Id = 1)
+                .Build();
+
+            _otherMovie = Builder<Movie>.CreateNew()
+                .With(m => m.Id = 2)
                 .Build();
 
             _localMovie = Builder<LocalMovie>.CreateNew()
                 .With(l => l.Path = @"C:\Test\Unsorted\Movie.Title.2011.720p.BluRay-Radarr\Movie.Title.2011.720p.BluRay-Radarr.mkv".AsOsAgnostic())
                 .With(l => l.Movie = _movie)
+                .With(l => l.FolderMovieInfo = new ParsedMovieInfo
+                {
+                    MovieTitles = new List<string> { "Movie Title" },
+                    Year = 2011
+                })
                 .With(l => l.FileMovieInfo = new ParsedMovieInfo
                 {
                     MovieTitles = new List<string> { "Movie Title" },
@@ -42,11 +46,27 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieImport.Specifications
                 .Build();
         }
 
+        private void GivenFileMapsTo(Movie movie)
+        {
+            Mocker.GetMock<IParsingService>()
+                .Setup(s => s.Map(_localMovie.FileMovieInfo, It.IsAny<string>(), It.IsAny<int>(), null))
+                .Returns(new RemoteMovie { Movie = movie });
+        }
+
         [Test]
         public void should_be_accepted_for_existing_file()
         {
             _localMovie.ExistingFile = true;
-            _localMovie.FileMovieInfo.Year = 2008;
+            GivenFileMapsTo(_otherMovie);
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_be_accepted_if_folder_name_is_not_parseable()
+        {
+            _localMovie.FolderMovieInfo = null;
+            GivenFileMapsTo(_otherMovie);
 
             Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
         }
@@ -68,118 +88,41 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieImport.Specifications
         }
 
         [Test]
-        public void should_be_accepted_if_file_year_matches_movie()
+        public void should_be_accepted_if_file_does_not_map_to_a_movie()
         {
-            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
-        }
-
-        [Test]
-        public void should_be_accepted_if_file_year_matches_secondary_year()
-        {
-            _movie.MovieMetadata.Value.Year = 2012;
-            _movie.MovieMetadata.Value.SecondaryYear = 2011;
+            GivenFileMapsTo(null);
 
             Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
         }
 
         [Test]
-        public void should_be_accepted_if_file_has_no_year()
+        public void should_be_accepted_if_file_maps_to_the_same_movie()
         {
-            _localMovie.FileMovieInfo.MovieTitles = new List<string> { "Another Movie" };
-            _localMovie.FileMovieInfo.Year = 0;
+            GivenFileMapsTo(_movie);
 
             Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
         }
 
         [Test]
-        public void should_be_accepted_if_movie_has_no_year()
+        public void should_be_rejected_if_file_maps_to_a_different_movie()
         {
-            _movie.MovieMetadata.Value.Year = 0;
-            _localMovie.FileMovieInfo.Year = 2008;
-
-            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
-        }
-
-        [Test]
-        public void should_be_accepted_if_file_year_is_part_of_the_title()
-        {
-            _movie.MovieMetadata.Value.Title = "Movie Title 2049";
-            _movie.MovieMetadata.Value.CleanTitle = "movietitle2049";
-            _movie.MovieMetadata.Value.Year = 2017;
-
-            _localMovie.FileMovieInfo.MovieTitles = new List<string> { "Movie Title" };
-            _localMovie.FileMovieInfo.Year = 2049;
-
-            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
-        }
-
-        [Test]
-        public void should_be_accepted_if_file_year_is_part_of_an_alternative_title()
-        {
-            _movie.MovieMetadata.Value.Year = 2017;
-            _movie.MovieMetadata.Value.AlternativeTitles = new List<AlternativeTitle>
-            {
-                new AlternativeTitle
-                {
-                    Title = "Movie Title 2049",
-                    CleanTitle = "movietitle2049"
-                }
-            };
-
-            _localMovie.FileMovieInfo.Year = 2049;
-
-            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
-        }
-
-        [Test]
-        public void should_be_rejected_if_file_year_does_not_match_movie()
-        {
-            _localMovie.FileMovieInfo.Year = 2008;
+            GivenFileMapsTo(_otherMovie);
 
             Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeFalse();
         }
 
         [Test]
-        public void should_be_rejected_if_file_is_a_different_movie_with_a_different_year()
-        {
-            _localMovie.FileMovieInfo.MovieTitles = new List<string> { "Another Movie" };
-            _localMovie.FileMovieInfo.Year = 2008;
-
-            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeFalse();
-        }
-
-        [Test]
-        public void should_be_accepted_if_file_tmdb_id_matches_movie()
-        {
-            _localMovie.FileMovieInfo.TmdbId = 50000;
-            _localMovie.FileMovieInfo.Year = 2008;
-
-            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
-        }
-
-        [Test]
-        public void should_be_rejected_if_file_tmdb_id_does_not_match_movie()
-        {
-            _localMovie.FileMovieInfo.TmdbId = 60000;
-
-            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeFalse();
-        }
-
-        [Test]
-        public void should_be_accepted_if_file_imdb_id_matches_movie()
+        public void should_pass_ids_from_file_to_the_parsing_service()
         {
             _localMovie.FileMovieInfo.ImdbId = "tt1111111";
-            _localMovie.FileMovieInfo.Year = 2008;
+            _localMovie.FileMovieInfo.TmdbId = 50000;
 
-            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
-        }
+            GivenFileMapsTo(_movie);
 
-        [Test]
-        public void should_be_rejected_if_file_imdb_id_does_not_match_movie()
-        {
-            _localMovie.FileMovieInfo.ImdbId = "tt2222222";
+            Subject.IsSatisfiedBy(_localMovie, null);
 
-            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeFalse();
+            Mocker.GetMock<IParsingService>()
+                .Verify(s => s.Map(_localMovie.FileMovieInfo, "tt1111111", 50000, null), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Specifications/MatchesFolderSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Specifications/MatchesFolderSpecificationFixture.cs
@@ -1,6 +1,10 @@
+using System.Collections.Generic;
 using FizzWare.NBuilder;
+using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.MediaFiles.MovieImport.Specifications;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.AlternativeTitles;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Test.Common;
@@ -10,58 +14,172 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieImport.Specifications
     [TestFixture]
     public class MatchesFolderSpecificationFixture : CoreTest<MatchesFolderSpecification>
     {
+        private Movie _movie;
         private LocalMovie _localMovie;
 
         [SetUp]
         public void Setup()
         {
+            _movie = Builder<Movie>.CreateNew()
+                .With(m => m.MovieMetadata = new MovieMetadata
+                {
+                    Title = "Movie Title",
+                    CleanTitle = "movietitle",
+                    Year = 2011,
+                    TmdbId = 50000,
+                    ImdbId = "tt1111111"
+                })
+                .Build();
+
             _localMovie = Builder<LocalMovie>.CreateNew()
-                                                 .With(l => l.Path = @"C:\Test\Unsorted\Series.Title.S01E01.720p.HDTV-Sonarr\S01E05.mkv".AsOsAgnostic())
-                                                 .With(l => l.FileMovieInfo =
-                                                     Builder<ParsedMovieInfo>.CreateNew()
-                                                                               .Build())
-                                                 .Build();
+                .With(l => l.Path = @"C:\Test\Unsorted\Movie.Title.2011.720p.BluRay-Radarr\Movie.Title.2011.720p.BluRay-Radarr.mkv".AsOsAgnostic())
+                .With(l => l.Movie = _movie)
+                .With(l => l.FileMovieInfo = new ParsedMovieInfo
+                {
+                    MovieTitles = new List<string> { "Movie Title" },
+                    Year = 2011
+                })
+                .Build();
         }
 
-        // TODO: Decide whether to reimplement this!
-
-        /*[Test]
+        [Test]
         public void should_be_accepted_for_existing_file()
         {
             _localMovie.ExistingFile = true;
+            _localMovie.FileMovieInfo.Year = 2008;
 
             Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
         }
 
         [Test]
-        public void should_be_accepted_if_folder_name_is_not_parseable()
+        public void should_be_accepted_if_file_name_is_not_parseable()
         {
-            _localMovie.Path = @"C:\Test\Unsorted\Series.Title\S01E01.mkv".AsOsAgnostic();
+            _localMovie.FileMovieInfo = null;
 
             Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
         }
 
         [Test]
-        public void should_should_be_accepted_for_full_season()
+        public void should_be_accepted_if_file_title_is_empty()
         {
-            _localMovie.Path = @"C:\Test\Unsorted\Series.Title.S01\S01E01.mkv".AsOsAgnostic();
+            _localMovie.FileMovieInfo = new ParsedMovieInfo();
 
             Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
         }
 
         [Test]
-        public void should_be_accepted_if_file_and_folder_have_the_same_episode()
+        public void should_be_accepted_if_file_year_matches_movie()
         {
-            _localMovie.Path = @"C:\Test\Unsorted\Series.Title.S01E01.720p.HDTV-Sonarr\S01E01.mkv".AsOsAgnostic();
             Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
         }
 
+        [Test]
+        public void should_be_accepted_if_file_year_matches_secondary_year()
+        {
+            _movie.MovieMetadata.Value.Year = 2012;
+            _movie.MovieMetadata.Value.SecondaryYear = 2011;
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
+        }
 
         [Test]
-        public void should_be_rejected_if_file_and_folder_do_not_have_same_episode()
+        public void should_be_accepted_if_file_has_no_year()
         {
-            _localMovie.Path = @"C:\Test\Unsorted\Series.Title.S01E01.720p.HDTV-Sonarr\S01E05.mkv".AsOsAgnostic();
+            _localMovie.FileMovieInfo.MovieTitles = new List<string> { "Another Movie" };
+            _localMovie.FileMovieInfo.Year = 0;
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_be_accepted_if_movie_has_no_year()
+        {
+            _movie.MovieMetadata.Value.Year = 0;
+            _localMovie.FileMovieInfo.Year = 2008;
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_be_accepted_if_file_year_is_part_of_the_title()
+        {
+            _movie.MovieMetadata.Value.Title = "Movie Title 2049";
+            _movie.MovieMetadata.Value.CleanTitle = "movietitle2049";
+            _movie.MovieMetadata.Value.Year = 2017;
+
+            _localMovie.FileMovieInfo.MovieTitles = new List<string> { "Movie Title" };
+            _localMovie.FileMovieInfo.Year = 2049;
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_be_accepted_if_file_year_is_part_of_an_alternative_title()
+        {
+            _movie.MovieMetadata.Value.Year = 2017;
+            _movie.MovieMetadata.Value.AlternativeTitles = new List<AlternativeTitle>
+            {
+                new AlternativeTitle
+                {
+                    Title = "Movie Title 2049",
+                    CleanTitle = "movietitle2049"
+                }
+            };
+
+            _localMovie.FileMovieInfo.Year = 2049;
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_be_rejected_if_file_year_does_not_match_movie()
+        {
+            _localMovie.FileMovieInfo.Year = 2008;
+
             Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeFalse();
-        }*/
+        }
+
+        [Test]
+        public void should_be_rejected_if_file_is_a_different_movie_with_a_different_year()
+        {
+            _localMovie.FileMovieInfo.MovieTitles = new List<string> { "Another Movie" };
+            _localMovie.FileMovieInfo.Year = 2008;
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_be_accepted_if_file_tmdb_id_matches_movie()
+        {
+            _localMovie.FileMovieInfo.TmdbId = 50000;
+            _localMovie.FileMovieInfo.Year = 2008;
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_be_rejected_if_file_tmdb_id_does_not_match_movie()
+        {
+            _localMovie.FileMovieInfo.TmdbId = 60000;
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_be_accepted_if_file_imdb_id_matches_movie()
+        {
+            _localMovie.FileMovieInfo.ImdbId = "tt1111111";
+            _localMovie.FileMovieInfo.Year = 2008;
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_be_rejected_if_file_imdb_id_does_not_match_movie()
+        {
+            _localMovie.FileMovieInfo.ImdbId = "tt2222222";
+
+            Subject.IsSatisfiedBy(_localMovie, null).Accepted.Should().BeFalse();
+        }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportRejectionReason.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportRejectionReason.cs
@@ -25,5 +25,6 @@ public enum ImportRejectionReason
     MultiPartMovie,
     NotQualityUpgrade,
     NotRevisionUpgrade,
-    NotCustomFormatUpgrade
+    NotCustomFormatUpgrade,
+    MovieDoesNotMatch
 }

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Specifications/MatchesFolderSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Specifications/MatchesFolderSpecification.cs
@@ -1,6 +1,9 @@
-using System.IO;
+using System.Collections.Generic;
+using System.Linq;
 using NLog;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Download;
+using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.MediaFiles.MovieImport.Specifications
@@ -21,22 +24,64 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Specifications
                 return ImportSpecDecision.Accept();
             }
 
-            var dirInfo = new FileInfo(localMovie.Path).Directory;
+            var fileInfo = localMovie.FileMovieInfo;
 
-            if (dirInfo == null)
+            if (fileInfo == null || fileInfo.PrimaryMovieTitle.IsNullOrWhiteSpace())
             {
                 return ImportSpecDecision.Accept();
             }
 
-            // TODO: Actually implement this!!!!
-            /*var folderInfo = Parser.Parser.ParseMovieTitle(dirInfo.Name, false);
+            var movie = localMovie.Movie;
+            var movieMetadata = movie.MovieMetadata.Value;
 
-            if (folderInfo == null)
+            if (fileInfo.TmdbId > 0 && movie.TmdbId > 0)
             {
-                return Decision.Accept();
-            }*/
+                if (fileInfo.TmdbId != movie.TmdbId)
+                {
+                    _logger.Debug("TMDB ID {0} in file {1} does not match movie being imported: {2}", fileInfo.TmdbId, localMovie.Path, movie);
 
-            return ImportSpecDecision.Accept();
+                    return ImportSpecDecision.Reject(ImportRejectionReason.MovieDoesNotMatch, "TMDB ID {0} in file does not match movie: {1}", fileInfo.TmdbId, movie.Title);
+                }
+
+                return ImportSpecDecision.Accept();
+            }
+
+            if (fileInfo.ImdbId.IsNotNullOrWhiteSpace() && movie.ImdbId.IsNotNullOrWhiteSpace())
+            {
+                if (fileInfo.ImdbId != movie.ImdbId)
+                {
+                    _logger.Debug("IMDb ID {0} in file {1} does not match movie being imported: {2}", fileInfo.ImdbId, localMovie.Path, movie);
+
+                    return ImportSpecDecision.Reject(ImportRejectionReason.MovieDoesNotMatch, "IMDb ID {0} in file does not match movie: {1}", fileInfo.ImdbId, movie.Title);
+                }
+
+                return ImportSpecDecision.Accept();
+            }
+
+            if (fileInfo.Year <= 1800 || movieMetadata.Year == 0)
+            {
+                return ImportSpecDecision.Accept();
+            }
+
+            if (fileInfo.Year == movieMetadata.Year || fileInfo.Year == movieMetadata.SecondaryYear)
+            {
+                return ImportSpecDecision.Accept();
+            }
+
+            // The parsed year may be part of the title itself (e.g. Blade Runner 2049)
+            var movieTitles = new List<string> { movieMetadata.CleanTitle };
+            movieTitles.AddIfNotNull(movieMetadata.CleanOriginalTitle);
+            movieTitles.AddRange(movieMetadata.AlternativeTitles.Select(t => t.CleanTitle));
+            movieTitles.AddRange(movieMetadata.Translations.Select(t => t.CleanTitle));
+
+            if (fileInfo.MovieTitles.Any(t => movieTitles.Contains($"{t} {fileInfo.Year}".CleanMovieTitle())))
+            {
+                return ImportSpecDecision.Accept();
+            }
+
+            _logger.Debug("Year {0} in file {1} does not match movie being imported: {2}", fileInfo.Year, localMovie.Path, movie);
+
+            return ImportSpecDecision.Reject(ImportRejectionReason.MovieDoesNotMatch, "Year {0} in file does not match movie: {1} ({2})", fileInfo.Year, movie.Title, movieMetadata.Year);
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Specifications/MatchesFolderSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Specifications/MatchesFolderSpecification.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Download;
@@ -10,16 +8,23 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Specifications
 {
     public class MatchesFolderSpecification : IImportDecisionEngineSpecification
     {
+        private readonly IParsingService _parsingService;
         private readonly Logger _logger;
 
-        public MatchesFolderSpecification(Logger logger)
+        public MatchesFolderSpecification(IParsingService parsingService, Logger logger)
         {
+            _parsingService = parsingService;
             _logger = logger;
         }
 
         public ImportSpecDecision IsSatisfiedBy(LocalMovie localMovie, DownloadClientItem downloadClientItem)
         {
             if (localMovie.ExistingFile)
+            {
+                return ImportSpecDecision.Accept();
+            }
+
+            if (localMovie.FolderMovieInfo == null)
             {
                 return ImportSpecDecision.Accept();
             }
@@ -31,57 +36,16 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Specifications
                 return ImportSpecDecision.Accept();
             }
 
-            var movie = localMovie.Movie;
-            var movieMetadata = movie.MovieMetadata.Value;
+            var fileMovie = _parsingService.Map(fileInfo, fileInfo.ImdbId, fileInfo.TmdbId)?.Movie;
 
-            if (fileInfo.TmdbId > 0 && movie.TmdbId > 0)
-            {
-                if (fileInfo.TmdbId != movie.TmdbId)
-                {
-                    _logger.Debug("TMDB ID {0} in file {1} does not match movie being imported: {2}", fileInfo.TmdbId, localMovie.Path, movie);
-
-                    return ImportSpecDecision.Reject(ImportRejectionReason.MovieDoesNotMatch, "TMDB ID {0} in file does not match movie: {1}", fileInfo.TmdbId, movie.Title);
-                }
-
-                return ImportSpecDecision.Accept();
-            }
-
-            if (fileInfo.ImdbId.IsNotNullOrWhiteSpace() && movie.ImdbId.IsNotNullOrWhiteSpace())
-            {
-                if (fileInfo.ImdbId != movie.ImdbId)
-                {
-                    _logger.Debug("IMDb ID {0} in file {1} does not match movie being imported: {2}", fileInfo.ImdbId, localMovie.Path, movie);
-
-                    return ImportSpecDecision.Reject(ImportRejectionReason.MovieDoesNotMatch, "IMDb ID {0} in file does not match movie: {1}", fileInfo.ImdbId, movie.Title);
-                }
-
-                return ImportSpecDecision.Accept();
-            }
-
-            if (fileInfo.Year <= 1800 || movieMetadata.Year == 0)
+            if (fileMovie == null || fileMovie.Id == localMovie.Movie.Id)
             {
                 return ImportSpecDecision.Accept();
             }
 
-            if (fileInfo.Year == movieMetadata.Year || fileInfo.Year == movieMetadata.SecondaryYear)
-            {
-                return ImportSpecDecision.Accept();
-            }
+            _logger.Debug("File {0} mapped to movie {1}, which does not match the movie being imported: {2}", localMovie.Path, fileMovie, localMovie.Movie);
 
-            // The parsed year may be part of the title itself (e.g. Blade Runner 2049)
-            var movieTitles = new List<string> { movieMetadata.CleanTitle };
-            movieTitles.AddIfNotNull(movieMetadata.CleanOriginalTitle);
-            movieTitles.AddRange(movieMetadata.AlternativeTitles.Select(t => t.CleanTitle));
-            movieTitles.AddRange(movieMetadata.Translations.Select(t => t.CleanTitle));
-
-            if (fileInfo.MovieTitles.Any(t => movieTitles.Contains($"{t} {fileInfo.Year}".CleanMovieTitle())))
-            {
-                return ImportSpecDecision.Accept();
-            }
-
-            _logger.Debug("Year {0} in file {1} does not match movie being imported: {2}", fileInfo.Year, localMovie.Path, movie);
-
-            return ImportSpecDecision.Reject(ImportRejectionReason.MovieDoesNotMatch, "Year {0} in file does not match movie: {1} ({2})", fileInfo.Year, movie.Title, movieMetadata.Year);
+            return ImportSpecDecision.Reject(ImportRejectionReason.MovieDoesNotMatch, "Movie in file ({0}) does not match the movie being imported: {1}", fileMovie.Title, localMovie.Movie.Title);
         }
     }
 }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`MatchesFolderSpecification` has been a stub since the fork (`// TODO: Actually implement this!!!!`) — it accepts everything. Sonarr's equivalent rejects files whose episodes conflict with the folder name; this is the movie analogue.

During automatic import every video file in a download folder is assigned the same movie, so a folder containing more than one movie (multi movie packs, bonus features, a bad file in the torrent) can silently import the wrong content as the target movie.

Following review feedback, this now mirrors the Sonarr spec's shape rather than doing its own matching: when a file sits in a parseable release folder, its parsed name (including any IMDb/TMDB ids present) is resolved through `ParsingService.Map`, and the file is only rejected when it resolves to a different movie in the library than the one being imported. If the folder isn't parseable, the file's name can't be parsed, or it doesn't resolve to a known movie, the file is accepted as before — no title or year heuristics involved.

Manual import is unaffected: `ManualImportService.Execute` doesn't evaluate import specs, so a rejected file can still be imported interactively; the rejection just shows up in the interactive import list.

Replaced the commented out Sonarr tests in the fixture with cases covering each branch, with the parsing service mocked.

#### Todos

- [x] Tests
- [ ] Translation Keys (rejection messages aren't localised in the other import specs either)
- [ ] Wiki Updates
