### PR TITLE
New: Treat stalled torrents as failed after a configurable timeout

### DIFF
--- a/frontend/src/Settings/DownloadClients/Options/DownloadClientOptions.js
+++ b/frontend/src/Settings/DownloadClients/Options/DownloadClientOptions.js
@@ -116,6 +116,24 @@ function DownloadClientOptions(props) {
                     </FormGroup> :
                     null
                 }
+
+                <FormGroup
+                  advancedSettings={advancedSettings}
+                  isAdvanced={true}
+                  size={sizes.MEDIUM}
+                >
+                  <FormLabel>{translate('StalledTorrentTimeout')}</FormLabel>
+
+                  <FormInputGroup
+                    type={inputTypes.NUMBER}
+                    name="stalledTorrentTimeout"
+                    min={0}
+                    unit="minutes"
+                    helpText={translate('StalledTorrentTimeoutHelpText')}
+                    onChange={onInputChange}
+                    {...settings.stalledTorrentTimeout}
+                  />
+                </FormGroup>
               </Form>
 
               <Alert kind={kinds.INFO}>

--- a/src/NzbDrone.Core.Test/Download/FailedDownloadServiceTests/ProcessFailedFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/FailedDownloadServiceTests/ProcessFailedFixture.cs
@@ -69,6 +69,19 @@ namespace NzbDrone.Core.Test.Download.FailedDownloadServiceTests
         }
 
         [Test]
+        public void should_mark_failed_with_stalled_message_if_stalled()
+        {
+            _trackedDownload.IsStalled = true;
+
+            Subject.ProcessFailed(_trackedDownload);
+
+            Mocker.GetMock<IEventAggregator>()
+                  .Verify(v => v.PublishEvent(It.Is<DownloadFailedEvent>(c => c.Message == "Download stalled with no progress")), Times.Once());
+
+            _trackedDownload.State.Should().Be(TrackedDownloadState.Failed);
+        }
+
+        [Test]
         public void should_include_tracked_download_in_message()
         {
             _trackedDownload.DownloadItem.Status = DownloadItemStatus.Failed;

--- a/src/NzbDrone.Core.Test/Download/FailedDownloadServiceTests/ProcessFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/FailedDownloadServiceTests/ProcessFixture.cs
@@ -1,12 +1,15 @@
+using System;
 using System.Collections.Generic;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Disk;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.History;
+using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
@@ -55,6 +58,21 @@ namespace NzbDrone.Core.Test.Download.FailedDownloadServiceTests
                 .Returns(new List<MovieHistory>());
         }
 
+        private void GivenStalledTorrentTimeout(int minutes)
+        {
+            Mocker.GetMock<IConfigService>()
+                .SetupGet(s => s.StalledTorrentTimeout)
+                .Returns(minutes);
+        }
+
+        private void GivenStalledDownload(int minutesSinceProgress)
+        {
+            _trackedDownload.Protocol = DownloadProtocol.Torrent;
+            _trackedDownload.IsStalled = false;
+            _trackedDownload.LastProgressDate = DateTime.UtcNow.AddMinutes(-minutesSinceProgress);
+            _trackedDownload.DownloadItem.Status = DownloadItemStatus.Warning;
+        }
+
         [Test]
         public void should_not_fail_if_matching_history_is_not_found()
         {
@@ -85,6 +103,94 @@ namespace NzbDrone.Core.Test.Download.FailedDownloadServiceTests
             Subject.Check(_trackedDownload);
 
             _trackedDownload.StatusMessages.Should().NotBeEmpty();
+        }
+
+        [Test]
+        public void should_not_mark_stalled_download_as_failed_pending_if_timeout_is_disabled()
+        {
+            GivenStalledDownload(120);
+
+            Subject.Check(_trackedDownload);
+
+            _trackedDownload.State.Should().Be(TrackedDownloadState.Downloading);
+            _trackedDownload.IsStalled.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_mark_stalled_download_as_failed_pending_after_timeout()
+        {
+            GivenStalledTorrentTimeout(60);
+            GivenStalledDownload(120);
+
+            Subject.Check(_trackedDownload);
+
+            _trackedDownload.State.Should().Be(TrackedDownloadState.FailedPending);
+            _trackedDownload.IsStalled.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_mark_stalled_download_as_failed_pending_if_downloading_without_progress()
+        {
+            GivenStalledTorrentTimeout(60);
+            GivenStalledDownload(120);
+            _trackedDownload.DownloadItem.Status = DownloadItemStatus.Downloading;
+
+            Subject.Check(_trackedDownload);
+
+            _trackedDownload.State.Should().Be(TrackedDownloadState.FailedPending);
+            _trackedDownload.IsStalled.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_not_mark_stalled_download_as_failed_pending_before_timeout()
+        {
+            GivenStalledTorrentTimeout(60);
+            GivenStalledDownload(30);
+
+            Subject.Check(_trackedDownload);
+
+            _trackedDownload.State.Should().Be(TrackedDownloadState.Downloading);
+            _trackedDownload.IsStalled.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_not_mark_stalled_download_as_failed_pending_for_usenet()
+        {
+            GivenStalledTorrentTimeout(60);
+            GivenStalledDownload(120);
+            _trackedDownload.Protocol = DownloadProtocol.Usenet;
+
+            Subject.Check(_trackedDownload);
+
+            _trackedDownload.State.Should().Be(TrackedDownloadState.Downloading);
+            _trackedDownload.IsStalled.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_not_mark_paused_download_as_failed_pending()
+        {
+            GivenStalledTorrentTimeout(60);
+            GivenStalledDownload(120);
+            _trackedDownload.DownloadItem.Status = DownloadItemStatus.Paused;
+
+            Subject.Check(_trackedDownload);
+
+            _trackedDownload.State.Should().Be(TrackedDownloadState.Downloading);
+            _trackedDownload.IsStalled.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_warn_if_stalled_download_was_not_grabbed()
+        {
+            GivenStalledTorrentTimeout(60);
+            GivenStalledDownload(120);
+            GivenNoGrabbedHistory();
+
+            Subject.Check(_trackedDownload);
+
+            _trackedDownload.StatusMessages.Should().NotBeEmpty();
+            _trackedDownload.State.Should().Be(TrackedDownloadState.Downloading);
+            _trackedDownload.IsStalled.Should().BeFalse();
         }
 
         private void AssertDownloadNotFailed()

--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common.Cache;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.History;
@@ -84,6 +86,54 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
             trackedDownload.RemoteMovie.Should().NotBeNull();
             trackedDownload.RemoteMovie.Movie.Should().NotBeNull();
             trackedDownload.RemoteMovie.Movie.Id.Should().Be(3);
+        }
+
+        [Test]
+        public void should_only_reset_last_progress_date_when_download_progresses()
+        {
+            Mocker.GetMock<ICacheManager>()
+                  .Setup(s => s.GetCache<TrackedDownload>(It.IsAny<Type>()))
+                  .Returns(new Cached<TrackedDownload>());
+
+            GivenDownloadHistory();
+
+            var client = new DownloadClientDefinition()
+            {
+                Id = 1,
+                Protocol = DownloadProtocol.Torrent
+            };
+
+            DownloadClientItem BuildItem(long remainingSize)
+            {
+                return new DownloadClientItem()
+                {
+                    Title = "A Movie 1998",
+                    DownloadId = "35238",
+                    Status = DownloadItemStatus.Downloading,
+                    RemainingSize = remainingSize,
+                    DownloadClientInfo = new DownloadClientItemClientInfo
+                    {
+                        Protocol = client.Protocol,
+                        Id = client.Id,
+                        Name = client.Name
+                    }
+                };
+            }
+
+            var trackedDownload = Subject.TrackDownload(client, BuildItem(100));
+
+            trackedDownload.LastProgressDate.Should().HaveValue();
+
+            var lastProgressDate = DateTime.UtcNow.AddHours(-1);
+            trackedDownload.LastProgressDate = lastProgressDate;
+
+            var stalledDownload = Subject.TrackDownload(client, BuildItem(100));
+
+            stalledDownload.LastProgressDate.Should().Be(lastProgressDate);
+
+            var progressedDownload = Subject.TrackDownload(client, BuildItem(50));
+
+            progressedDownload.LastProgressDate.Should().NotBe(lastProgressDate);
         }
 
         [Test]

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -197,6 +197,13 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("AutoRedownloadFailedFromInteractiveSearch", value); }
         }
 
+        public int StalledTorrentTimeout
+        {
+            get { return GetValueInt("StalledTorrentTimeout", 0); }
+
+            set { SetValue("StalledTorrentTimeout", value); }
+        }
+
         public bool CreateEmptyMovieFolders
         {
             get { return GetValueBoolean("CreateEmptyMovieFolders", false); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -23,6 +23,7 @@ namespace NzbDrone.Core.Configuration
 
         bool AutoRedownloadFailed { get; set; }
         bool AutoRedownloadFailedFromInteractiveSearch { get; set; }
+        int StalledTorrentTimeout { get; set; }
 
         // Media Management
         bool AutoUnmonitorPreviouslyDownloadedMovies { get; set; }

--- a/src/NzbDrone.Core/Download/FailedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/FailedDownloadService.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.History;
+using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser.Model;
 
@@ -21,12 +23,15 @@ namespace NzbDrone.Core.Download
     {
         private readonly IHistoryService _historyService;
         private readonly IEventAggregator _eventAggregator;
+        private readonly IConfigService _configService;
 
         public FailedDownloadService(IHistoryService historyService,
-                                     IEventAggregator eventAggregator)
+                                     IEventAggregator eventAggregator,
+                                     IConfigService configService)
         {
             _historyService = historyService;
             _eventAggregator = eventAggregator;
+            _configService = configService;
         }
 
         public void MarkAsFailed(int historyId, bool skipRedownload = false)
@@ -75,7 +80,10 @@ namespace NzbDrone.Core.Download
                 }
 
                 trackedDownload.State = TrackedDownloadState.FailedPending;
+                return;
             }
+
+            CheckStalled(trackedDownload);
         }
 
         public void ProcessFailed(TrackedDownload trackedDownload)
@@ -98,6 +106,10 @@ namespace NzbDrone.Core.Download
             {
                 failure = "Encrypted download detected";
             }
+            else if (trackedDownload.IsStalled)
+            {
+                failure = "Download stalled with no progress";
+            }
             else if (trackedDownload.DownloadItem.Status == DownloadItemStatus.Failed && trackedDownload.DownloadItem.Message.IsNotNullOrWhiteSpace())
             {
                 failure = trackedDownload.DownloadItem.Message;
@@ -105,6 +117,41 @@ namespace NzbDrone.Core.Download
 
             trackedDownload.State = TrackedDownloadState.Failed;
             PublishDownloadFailedEvent(grabbedItems.First(), failure, trackedDownload);
+        }
+
+        private void CheckStalled(TrackedDownload trackedDownload)
+        {
+            var stalledTorrentTimeout = _configService.StalledTorrentTimeout;
+
+            if (stalledTorrentTimeout == 0 || trackedDownload.Protocol != DownloadProtocol.Torrent)
+            {
+                return;
+            }
+
+            // Paused and queued downloads aren't making progress by design, only consider
+            // downloads the client is actively trying to get data for.
+            if (trackedDownload.DownloadItem.Status != DownloadItemStatus.Downloading &&
+                trackedDownload.DownloadItem.Status != DownloadItemStatus.Warning)
+            {
+                return;
+            }
+
+            if (!trackedDownload.LastProgressDate.HasValue ||
+                trackedDownload.LastProgressDate.Value.AddMinutes(stalledTorrentTimeout) > DateTime.UtcNow)
+            {
+                return;
+            }
+
+            var grabbedItems = GetGrabbedHistory(trackedDownload.DownloadItem.DownloadId);
+
+            if (grabbedItems.Empty())
+            {
+                trackedDownload.Warn("Download is stalled and wasn't grabbed by Radarr, skipping automatic download handling");
+                return;
+            }
+
+            trackedDownload.IsStalled = true;
+            trackedDownload.State = TrackedDownloadState.FailedPending;
         }
 
         private void PublishDownloadFailedEvent(MovieHistory historyItem, string message, TrackedDownload trackedDownload = null, bool skipRedownload = false)

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
@@ -18,6 +18,8 @@ namespace NzbDrone.Core.Download.TrackedDownloads
         public DateTime? Added { get; set; }
         public bool IsTrackable { get; set; }
         public bool HasNotifiedManualInteractionRequired { get; set; }
+        public DateTime? LastProgressDate { get; set; }
+        public bool IsStalled { get; set; }
 
         public TrackedDownload()
         {

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -115,6 +115,17 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                 HasNotifiedManualInteractionRequired = existingItem?.HasNotifiedManualInteractionRequired ?? false
             };
 
+            if (existingItem != null &&
+                existingItem.DownloadItem.Status == downloadItem.Status &&
+                existingItem.DownloadItem.RemainingSize == downloadItem.RemainingSize)
+            {
+                trackedDownload.LastProgressDate = existingItem.LastProgressDate;
+            }
+            else
+            {
+                trackedDownload.LastProgressDate = DateTime.UtcNow;
+            }
+
             try
             {
                 var historyItems = _historyService.FindByDownloadId(downloadItem.DownloadId)

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1856,6 +1856,8 @@
   "SslCertPath": "SSL Cert Path",
   "SslCertPathHelpText": "Path to pfx file",
   "SslPort": "SSL Port",
+  "StalledTorrentTimeout": "Stalled Torrent Timeout",
+  "StalledTorrentTimeoutHelpText": "How long a torrent can make no progress before it is treated as failed and blocklisted, in minutes. 0 to disable",
   "StandardMovieFormat": "Standard Movie Format",
   "StartImport": "Start Import",
   "StartProcessing": "Start Processing",

--- a/src/Radarr.Api.V3/Config/DownloadClientConfigResource.cs
+++ b/src/Radarr.Api.V3/Config/DownloadClientConfigResource.cs
@@ -12,6 +12,7 @@ namespace Radarr.Api.V3.Config
 
         public bool AutoRedownloadFailed { get; set; }
         public bool AutoRedownloadFailedFromInteractiveSearch { get; set; }
+        public int StalledTorrentTimeout { get; set; }
     }
 
     public static class DownloadClientConfigResourceMapper
@@ -26,7 +27,8 @@ namespace Radarr.Api.V3.Config
                 CheckForFinishedDownloadInterval = model.CheckForFinishedDownloadInterval,
 
                 AutoRedownloadFailed = model.AutoRedownloadFailed,
-                AutoRedownloadFailedFromInteractiveSearch = model.AutoRedownloadFailedFromInteractiveSearch
+                AutoRedownloadFailedFromInteractiveSearch = model.AutoRedownloadFailedFromInteractiveSearch,
+                StalledTorrentTimeout = model.StalledTorrentTimeout
             };
         }
     }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

qBittorrent reports torrents that have stopped making progress (`stalledDL`, `error`, `missingFiles`, `metaDL` with DHT disabled) as a warning rather than a failure, so failed download handling never triggers and a dead torrent sits in the queue indefinitely. The same applies to other torrent clients with equivalent states, and most people end up running an external script to deal with it.

This adds an optional Stalled Torrent Timeout (advanced setting under Failed Download Handling, disabled by default). Radarr already refreshes tracked downloads every minute; this change remembers when each torrent last made progress (a change in remaining size or client status) and, once a torrent the client is actively downloading has made no progress for longer than the timeout, treats it as failed through the existing pipeline: the release is blocklisted, and removal and redownload follow the current Failed Download Handling settings.

It is deliberately conservative:

- Torrent protocol only, and only for downloads grabbed by Radarr (others get the usual queue warning).
- Paused and queued torrents are not counted, so client queue limits and manual pauses are unaffected.
- Any progress resets the clock, leaving slow but healthy torrents alone.
- The timer is kept in memory, so a restart starts the count again rather than failing anything early.

#### Screenshot (if UI related)

![Stalled Torrent Timeout setting](https://raw.githubusercontent.com/Hzoid/Radarr/screenshots/stalled-torrent-timeout.png)

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

* Closes #5407
