### PR TITLE
New: Segment-wise path suggestion search with match highlighting

### DIFF
--- a/frontend/src/Components/Form/PathInput.css
+++ b/frontend/src/Components/Form/PathInput.css
@@ -9,6 +9,9 @@
 
 .pathMatch {
   font-weight: bold;
+  border-radius: 3px;
+  background-color: color-mix(in srgb, var(--radarrYellow) 30%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--radarrYellow) 40%, transparent);
 }
 
 .fileBrowserButton {

--- a/frontend/src/Components/Form/PathInput.css
+++ b/frontend/src/Components/Form/PathInput.css
@@ -8,10 +8,10 @@
 }
 
 .pathMatch {
-  font-weight: bold;
   border-radius: 3px;
   background-color: color-mix(in srgb, var(--radarrYellow) 30%, transparent);
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--radarrYellow) 40%, transparent);
+  font-weight: bold;
 }
 
 .fileBrowserButton {

--- a/frontend/src/Components/Form/PathInput.tsx
+++ b/frontend/src/Components/Form/PathInput.tsx
@@ -77,7 +77,7 @@ function PathInput(props: PathInputProps) {
   );
 
   const handleClearPaths = useCallback(() => {
-    dispatch(clearPaths);
+    dispatch(clearPaths());
   }, [dispatch]);
 
   return (
@@ -110,18 +110,15 @@ export function PathInputInternal(props: PathInputInternalProps) {
   const [value, setValue] = useState(inputValue);
   const [isFileBrowserModalOpen, setIsFileBrowserModalOpen] = useState(false);
   const previousInputValue = usePrevious(inputValue);
-  const dispatch = useDispatch();
-
-  const handleFetchPaths = useCallback(
-    (path: string) => {
-      dispatch(fetchPaths({ path, includeFiles }));
-    },
-    [includeFiles, dispatch]
-  );
 
   // Typing resolves every keystroke server-side; debounce so a pause
   // fetches once instead of once per character.
-  const debouncedFetchPaths = useDebouncedCallback(handleFetchPaths, 150);
+  const handleSuggestionsFetchRequested = useDebouncedCallback(
+    ({ value: newValue }: SuggestionsFetchRequestedParams) => {
+      onFetchPaths(newValue);
+    },
+    150
+  );
 
   const handleInputChange = useCallback(
     (_event: SyntheticEvent, { newValue }: ChangeEvent) => {
@@ -162,6 +159,7 @@ export function PathInputInternal(props: PathInputInternalProps) {
       // otherwise let it move focus to the next field.
       if (path && path.path !== value) {
         event.preventDefault();
+        handleSuggestionsFetchRequested.cancel();
 
         onChange({
           name,
@@ -169,33 +167,36 @@ export function PathInputInternal(props: PathInputInternalProps) {
         });
 
         if (path.type !== 'file') {
-          handleFetchPaths(path.path);
+          onFetchPaths(path.path);
         }
       }
     },
-    [name, value, filteredPaths, handleFetchPaths, onChange]
+    [
+      name,
+      value,
+      filteredPaths,
+      handleSuggestionsFetchRequested,
+      onFetchPaths,
+      onChange,
+    ]
   );
   const handleInputBlur = useCallback(() => {
+    handleSuggestionsFetchRequested.cancel();
+
     onChange({
       name,
       value,
     });
 
     onClearPaths();
-  }, [name, value, onClearPaths, onChange]);
+  }, [name, value, handleSuggestionsFetchRequested, onClearPaths, onChange]);
 
   const handleSuggestionSelected = useCallback(
     (_event: SyntheticEvent, { suggestion }: { suggestion: Path }) => {
-      handleFetchPaths(suggestion.path);
+      handleSuggestionsFetchRequested.cancel();
+      onFetchPaths(suggestion.path);
     },
-    [handleFetchPaths]
-  );
-
-  const handleSuggestionsFetchRequested = useCallback(
-    ({ value: newValue }: SuggestionsFetchRequestedParams) => {
-      debouncedFetchPaths(newValue);
-    },
-    [debouncedFetchPaths]
+    [handleSuggestionsFetchRequested, onFetchPaths]
   );
 
   const handleFileBrowserOpenPress = useCallback(() => {

--- a/frontend/src/Components/Form/PathInput.tsx
+++ b/frontend/src/Components/Form/PathInput.tsx
@@ -125,11 +125,31 @@ export function PathInputInternal(props: PathInputInternalProps) {
     [setValue]
   );
 
+  // Match each typed segment against the candidate's segment at the same
+  // depth, so any contiguous part of any directory name matches its level
+  // (`/down/dbd` matches `/downloads/[DBD-Raws].../`).
+  const searchSegments = value
+    .split(/[\\/]/)
+    .filter((segment) => segment.length)
+    .map((segment) => segment.toLowerCase());
+
+  const filteredPaths = searchSegments.length
+    ? paths.filter(({ path: candidatePath }) => {
+        const candidateSegments = candidatePath
+          .split(/[\\/]/)
+          .filter((segment) => segment.length);
+
+        return searchSegments.every((segment, index) =>
+          candidateSegments[index]?.toLowerCase().includes(segment)
+        );
+      })
+    : paths;
+
   const handleInputKeyDown = useCallback(
     (event: KeyboardEvent<HTMLElement>) => {
       if (event.key === 'Tab') {
         event.preventDefault();
-        const path = paths[0];
+        const path = filteredPaths[0];
 
         if (path) {
           onChange({
@@ -143,7 +163,7 @@ export function PathInputInternal(props: PathInputInternalProps) {
         }
       }
     },
-    [name, paths, handleFetchPaths, onChange]
+    [name, filteredPaths, handleFetchPaths, onChange]
   );
   const handleInputBlur = useCallback(() => {
     onChange({
@@ -187,19 +207,45 @@ export function PathInputInternal(props: PathInputInternalProps) {
 
   const renderSuggestion = useCallback(
     ({ path }: Path, { query }: { query: string }) => {
-      const lastSeparatorIndex =
-        query.lastIndexOf('\\') || query.lastIndexOf('/');
+      // Strip one trailing separator so `/downloads/Kung/` still
+      // highlights `Kung` (the segment being searched).
+      const trimmedQuery = /[\\/]$/.test(query) ? query.slice(0, -1) : query;
+      const searchValue = trimmedQuery
+        .slice(
+          Math.max(
+            trimmedQuery.lastIndexOf('/'),
+            trimmedQuery.lastIndexOf('\\')
+          ) + 1
+        )
+        .toLowerCase();
 
-      if (lastSeparatorIndex === -1) {
+      // Highlight the match within the entry name (after its parent
+      // separator), not the shared parent portion of the path.
+      const parentEnd =
+        path.endsWith('/') || path.endsWith('\\')
+          ? path.length - 1
+          : path.length;
+      const nameStart =
+        Math.max(
+          path.lastIndexOf('/', parentEnd - 1),
+          path.lastIndexOf('\\', parentEnd - 1)
+        ) + 1;
+
+      const matchIndex = searchValue
+        ? path.toLowerCase().indexOf(searchValue, nameStart)
+        : -1;
+
+      if (matchIndex === -1) {
         return <span>{path}</span>;
       }
 
       return (
         <span>
+          {path.substring(0, matchIndex)}
           <span className={styles.pathMatch}>
-            {path.substring(0, lastSeparatorIndex)}
+            {path.substring(matchIndex, matchIndex + searchValue.length)}
           </span>
-          {path.substring(lastSeparatorIndex)}
+          {path.substring(matchIndex + searchValue.length)}
         </span>
       );
     },
@@ -219,7 +265,7 @@ export function PathInputInternal(props: PathInputInternalProps) {
         className={hasFileBrowser ? styles.hasFileBrowser : undefined}
         name={name}
         value={value}
-        suggestions={paths}
+        suggestions={filteredPaths}
         getSuggestionValue={getSuggestionValue}
         renderSuggestion={renderSuggestion}
         onInputKeyDown={handleInputKeyDown}

--- a/frontend/src/Components/Form/PathInput.tsx
+++ b/frontend/src/Components/Form/PathInput.tsx
@@ -141,9 +141,16 @@ export function PathInputInternal(props: PathInputInternalProps) {
           .split(/[\\/]/)
           .filter((segment) => segment.length);
 
-        return searchSegments.every((segment, index) =>
-          candidateSegments[index]?.toLowerCase().includes(segment)
-        );
+        return searchSegments.every((segment, index) => {
+          const candidateSegment = candidateSegments[index];
+
+          // A bounded search can stop at a broad intermediate segment and
+          // return those parent candidates instead of listing every child.
+          return (
+            candidateSegment === undefined ||
+            candidateSegment.toLowerCase().includes(segment)
+          );
+        });
       })
     : paths;
 

--- a/frontend/src/Components/Form/PathInput.tsx
+++ b/frontend/src/Components/Form/PathInput.tsx
@@ -47,6 +47,40 @@ function handleSuggestionsClearRequested() {
   // because we don't want to reset the paths after a path is selected.
 }
 
+function splitPathSegments(path: string) {
+  return path
+    .split(/[\\/]/)
+    .filter((segment) => segment.length)
+    .map((segment) => segment.toLowerCase());
+}
+
+function comparePathMatches(left: Path, right: Path, searchSegments: string[]) {
+  const getRank = (candidate: Path) => {
+    const candidateSegments = splitPathSegments(candidate.path);
+    const segmentIndex = Math.max(candidateSegments.length - 1, 0);
+    const searchValue = searchSegments[segmentIndex] ?? '';
+    const candidateValue = candidate.name.toLowerCase();
+
+    return [
+      candidateValue === searchValue ? 0 : 1,
+      candidateValue.startsWith(searchValue) ? 0 : 1,
+      Math.max(candidateValue.length - searchValue.length, 0),
+      candidate.type === 'file' ? 1 : 0,
+    ];
+  };
+
+  const leftRank = getRank(left);
+  const rightRank = getRank(right);
+
+  for (let i = 0; i < leftRank.length; i++) {
+    if (leftRank[i] !== rightRank[i]) {
+      return leftRank[i] - rightRank[i];
+    }
+  }
+
+  return left.path.toLowerCase().localeCompare(right.path.toLowerCase());
+}
+
 function createPathsSelector() {
   return createSelector(
     (state: AppState) => state.paths,
@@ -130,29 +164,45 @@ export function PathInputInternal(props: PathInputInternalProps) {
   // Match each typed segment against the candidate's segment at the same
   // depth, so any contiguous part of any directory name matches its level
   // (`/down/dbd` matches `/downloads/[DBD-Raws].../`).
-  const searchSegments = value
-    .split(/[\\/]/)
-    .filter((segment) => segment.length)
-    .map((segment) => segment.toLowerCase());
+  const searchSegments = splitPathSegments(value);
 
-  const filteredPaths = searchSegments.length
-    ? paths.filter(({ path: candidatePath }) => {
-        const candidateSegments = candidatePath
-          .split(/[\\/]/)
-          .filter((segment) => segment.length);
+  const filteredPaths = (
+    searchSegments.length
+      ? paths.filter(({ path: candidatePath }) => {
+          const candidateSegments = splitPathSegments(candidatePath);
 
-        return searchSegments.every((segment, index) => {
-          const candidateSegment = candidateSegments[index];
+          return searchSegments.every((segment, index) => {
+            const candidateSegment = candidateSegments[index];
 
-          // A bounded search can stop at a broad intermediate segment and
-          // return those parent candidates instead of listing every child.
-          return (
-            candidateSegment === undefined ||
-            candidateSegment.toLowerCase().includes(segment)
-          );
-        });
-      })
-    : paths;
+            // Exact-prefix resolution can stop before later typed segments and
+            // return the unresolved parent candidate for explicit selection.
+            return (
+              candidateSegment === undefined ||
+              candidateSegment.includes(segment)
+            );
+          });
+        })
+      : paths
+  )
+    .slice()
+    .sort((left, right) => comparePathMatches(left, right, searchSegments));
+
+  const selectPath = useCallback(
+    (path: Path) => {
+      handleSuggestionsFetchRequested.cancel();
+      setValue(path.path);
+
+      onChange({
+        name,
+        value: path.path,
+      });
+
+      if (path.type !== 'file') {
+        onFetchPaths(path.path);
+      }
+    },
+    [name, handleSuggestionsFetchRequested, onFetchPaths, onChange]
+  );
 
   const handleInputKeyDown = useCallback(
     (event: KeyboardEvent<HTMLElement>) => {
@@ -166,26 +216,10 @@ export function PathInputInternal(props: PathInputInternalProps) {
       // otherwise let it move focus to the next field.
       if (path && path.path !== value) {
         event.preventDefault();
-        handleSuggestionsFetchRequested.cancel();
-
-        onChange({
-          name,
-          value: path.path,
-        });
-
-        if (path.type !== 'file') {
-          onFetchPaths(path.path);
-        }
+        selectPath(path);
       }
     },
-    [
-      name,
-      value,
-      filteredPaths,
-      handleSuggestionsFetchRequested,
-      onFetchPaths,
-      onChange,
-    ]
+    [value, filteredPaths, selectPath]
   );
   const handleInputBlur = useCallback(() => {
     handleSuggestionsFetchRequested.cancel();
@@ -200,10 +234,9 @@ export function PathInputInternal(props: PathInputInternalProps) {
 
   const handleSuggestionSelected = useCallback(
     (_event: SyntheticEvent, { suggestion }: { suggestion: Path }) => {
-      handleSuggestionsFetchRequested.cancel();
-      onFetchPaths(suggestion.path);
+      selectPath(suggestion);
     },
-    [handleSuggestionsFetchRequested, onFetchPaths]
+    [selectPath]
   );
 
   const handleFileBrowserOpenPress = useCallback(() => {
@@ -213,13 +246,6 @@ export function PathInputInternal(props: PathInputInternalProps) {
   const handleFileBrowserModalClose = useCallback(() => {
     setIsFileBrowserModalOpen(false);
   }, [setIsFileBrowserModalOpen]);
-
-  const handleChange = useCallback(
-    (change: InputChanged<Path>) => {
-      onChange({ name, value: change.value.path });
-    },
-    [name, onChange]
-  );
 
   const getSuggestionValue = useCallback(({ path }: Path) => path, []);
 
@@ -307,7 +333,6 @@ export function PathInputInternal(props: PathInputInternalProps) {
         onSuggestionSelected={handleSuggestionSelected}
         onSuggestionsFetchRequested={handleSuggestionsFetchRequested}
         onSuggestionsClearRequested={handleSuggestionsClearRequested}
-        onChange={handleChange}
       />
 
       {hasFileBrowser ? (

--- a/frontend/src/Components/Form/PathInput.tsx
+++ b/frontend/src/Components/Form/PathInput.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-autosuggest';
 import { useDispatch, useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
+import { useDebouncedCallback } from 'use-debounce';
 import AppState from 'App/State/AppState';
 import { Path } from 'App/State/PathsAppState';
 import FileBrowserModal from 'Components/FileBrowser/FileBrowserModal';
@@ -118,6 +119,10 @@ export function PathInputInternal(props: PathInputInternalProps) {
     [includeFiles, dispatch]
   );
 
+  // Typing resolves every keystroke server-side; debounce so a pause
+  // fetches once instead of once per character.
+  const debouncedFetchPaths = useDebouncedCallback(handleFetchPaths, 150);
+
   const handleInputChange = useCallback(
     (_event: SyntheticEvent, { newValue }: ChangeEvent) => {
       setValue(newValue);
@@ -183,9 +188,9 @@ export function PathInputInternal(props: PathInputInternalProps) {
 
   const handleSuggestionsFetchRequested = useCallback(
     ({ value: newValue }: SuggestionsFetchRequestedParams) => {
-      handleFetchPaths(newValue);
+      debouncedFetchPaths(newValue);
     },
-    [handleFetchPaths]
+    [debouncedFetchPaths]
   );
 
   const handleFileBrowserOpenPress = useCallback(() => {

--- a/frontend/src/Components/Form/PathInput.tsx
+++ b/frontend/src/Components/Form/PathInput.tsx
@@ -152,23 +152,28 @@ export function PathInputInternal(props: PathInputInternalProps) {
 
   const handleInputKeyDown = useCallback(
     (event: KeyboardEvent<HTMLElement>) => {
-      if (event.key === 'Tab') {
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const path = filteredPaths[0];
+
+      // Only capture Tab when it would complete a different path;
+      // otherwise let it move focus to the next field.
+      if (path && path.path !== value) {
         event.preventDefault();
-        const path = filteredPaths[0];
 
-        if (path) {
-          onChange({
-            name,
-            value: path.path,
-          });
+        onChange({
+          name,
+          value: path.path,
+        });
 
-          if (path.type !== 'file') {
-            handleFetchPaths(path.path);
-          }
+        if (path.type !== 'file') {
+          handleFetchPaths(path.path);
         }
       }
     },
-    [name, filteredPaths, handleFetchPaths, onChange]
+    [name, value, filteredPaths, handleFetchPaths, onChange]
   );
   const handleInputBlur = useCallback(() => {
     onChange({

--- a/frontend/src/Components/Form/PathInput.tsx
+++ b/frontend/src/Components/Form/PathInput.tsx
@@ -217,47 +217,62 @@ export function PathInputInternal(props: PathInputInternalProps) {
 
   const renderSuggestion = useCallback(
     ({ path }: Path, { query }: { query: string }) => {
-      // Strip one trailing separator so `/downloads/Kung/` still
-      // highlights `Kung` (the segment being searched).
-      const trimmedQuery = /[\\/]$/.test(query) ? query.slice(0, -1) : query;
-      const searchValue = trimmedQuery
-        .slice(
-          Math.max(
-            trimmedQuery.lastIndexOf('/'),
-            trimmedQuery.lastIndexOf('\\')
-          ) + 1
-        )
-        .toLowerCase();
+      // Same segment rules as filteredPaths: each typed segment matches
+      // the candidate's segment at the same depth.
+      const searchSegments = query
+        .split(/[\\/]/)
+        .filter((segment) => segment.length)
+        .map((segment) => segment.toLowerCase());
 
-      // Highlight the match within the entry name (after its parent
-      // separator), not the shared parent portion of the path.
-      const parentEnd =
-        path.endsWith('/') || path.endsWith('\\')
-          ? path.length - 1
-          : path.length;
-      const nameStart =
-        Math.max(
-          path.lastIndexOf('/', parentEnd - 1),
-          path.lastIndexOf('\\', parentEnd - 1)
-        ) + 1;
+      // Capture separator runs so every token is re-emitted unchanged
+      // and only candidate segments are matched against.
+      const tokens = path.split(/([\\/]+)/);
+      const rendered: React.ReactNode[] = [];
+      let segmentIndex = -1;
 
-      const matchIndex = searchValue
-        ? path.toLowerCase().indexOf(searchValue, nameStart)
-        : -1;
+      tokens.forEach((token, tokenIndex) => {
+        // Odd indexes are separator runs; render them untouched.
+        // Empty edge tokens consume no search segment.
+        if (tokenIndex % 2 === 1 || token.length === 0) {
+          rendered.push(token);
+          return;
+        }
 
-      if (matchIndex === -1) {
-        return <span>{path}</span>;
-      }
+        segmentIndex += 1;
 
-      return (
-        <span>
-          {path.substring(0, matchIndex)}
-          <span className={styles.pathMatch}>
-            {path.substring(matchIndex, matchIndex + searchValue.length)}
-          </span>
-          {path.substring(matchIndex + searchValue.length)}
-        </span>
-      );
+        const searchValue = searchSegments[segmentIndex];
+
+        if (!searchValue) {
+          rendered.push(token);
+          return;
+        }
+
+        const lowerToken = token.toLowerCase();
+        let offset = 0;
+        let matchIndex = lowerToken.indexOf(searchValue);
+
+        while (matchIndex !== -1) {
+          if (matchIndex > offset) {
+            rendered.push(token.substring(offset, matchIndex));
+          }
+
+          rendered.push(
+            <span
+              key={`${tokenIndex}-${matchIndex}`}
+              className={styles.pathMatch}
+            >
+              {token.substring(matchIndex, matchIndex + searchValue.length)}
+            </span>
+          );
+
+          offset = matchIndex + searchValue.length;
+          matchIndex = lowerToken.indexOf(searchValue, offset);
+        }
+
+        rendered.push(token.substring(offset));
+      });
+
+      return <span>{rendered}</span>;
     },
     []
   );

--- a/frontend/src/Store/Actions/pathActions.js
+++ b/frontend/src/Store/Actions/pathActions.js
@@ -11,13 +11,8 @@ export const section = 'paths';
 
 const LISTING_CACHE_TTL = 5000;
 const LISTING_CACHE_MAX_SIZE = 256;
-const MAX_CONCURRENT_LISTING_REQUESTS = 8;
-const MIN_FUZZY_INTERMEDIATE_SEGMENT_LENGTH = 2;
-const MAX_FUZZY_INTERMEDIATE_MATCHES = 20;
 const listingCache = new Map();
 const inFlightListings = new Map();
-const listingRequestQueue = [];
-let activeListingRequests = 0;
 let latestFetchId = 0;
 
 //
@@ -90,56 +85,6 @@ function cacheListing(cacheKey, data) {
   }
 }
 
-function startListingRequest({ requestFactory, resolve, reject }) {
-  activeListingRequests++;
-
-  Promise.resolve()
-    .then(requestFactory)
-    .then(resolve, reject)
-    .finally(() => {
-      activeListingRequests--;
-      runListingRequestQueue();
-    });
-}
-
-function runListingRequestQueue() {
-  while (
-    activeListingRequests < MAX_CONCURRENT_LISTING_REQUESTS &&
-    listingRequestQueue.length
-  ) {
-    startListingRequest(listingRequestQueue.shift());
-  }
-}
-
-function scheduleListingRequest(requestFactory) {
-  return new Promise((resolve, reject) => {
-    listingRequestQueue.push({ requestFactory, resolve, reject });
-    runListingRequestQueue();
-  });
-}
-
-async function mapWithConcurrency(items, mapper) {
-  const results = new Array(items.length);
-  let nextIndex = 0;
-
-  async function worker() {
-    while (nextIndex < items.length) {
-      const index = nextIndex++;
-
-      results[index] = await mapper(items[index]);
-    }
-  }
-
-  const workers = Array.from(
-    { length: Math.min(MAX_CONCURRENT_LISTING_REQUESTS, items.length) },
-    worker
-  );
-
-  await Promise.all(workers);
-
-  return results;
-}
-
 //
 // Action Handlers
 
@@ -170,16 +115,16 @@ export const actionHandlers = handleThunks({
         return inFlight;
       }
 
-      const listingPromise = scheduleListingRequest(() => {
-        return createAjaxRequest({
+      const listingPromise = Promise.resolve(
+        createAjaxRequest({
           url: '/filesystem',
           data: {
             path: queryPath,
             allowFoldersWithoutTrailingSlashes,
             includeFiles
           }
-        }).request;
-      })
+        }).request
+      )
         .then((data) => {
           cacheListing(cacheKey, data);
 
@@ -198,18 +143,22 @@ export const actionHandlers = handleThunks({
       return listingPromise;
     };
 
-    // Resolve the query segment by segment: each segment is a
-    // case-insensitive containment filter for its directory level, so
-    // `/down/dbd` descends into `/downloads/` and matches `[DBD-Raws]...`.
+    // Resolve one directory level at a time. Intermediate segments must be
+    // exact, so fuzzy input cannot fan out into multiple child listings.
     let rootPath = '/';
+    let pathWithoutRoot = path;
 
     if ((/^[a-zA-Z]:[\\/]/).test(path)) {
       rootPath = path.slice(0, 3);
+      pathWithoutRoot = path.slice(3);
     } else if (path.startsWith('\\')) {
       rootPath = '\\';
+      pathWithoutRoot = path.slice(1);
     }
 
-    const segments = path.split(/[\\/]/).filter((segment) => segment.length);
+    const segments = pathWithoutRoot
+      .split(/[\\/]/)
+      .filter((segment) => segment.length);
     const hasTrailingSeparator = (/[\\/]$/).test(path);
 
     const resolve = async() => {
@@ -217,21 +166,17 @@ export const actionHandlers = handleThunks({
         return fetchChildren(rootPath);
       }
 
-      let parents = [rootPath];
+      let queryPath = rootPath;
       let parent = '';
       let results = [];
-      const limitedResults = [];
 
       for (let i = 0; i < segments.length; i++) {
         const segment = segments[i].toLowerCase();
         const isLast = i === segments.length - 1;
 
-        const listings = await mapWithConcurrency(parents, fetchChildren);
-        const directories = listings.flatMap((data) => data.directories);
-
-        if (listings.length) {
-          parent = listings[listings.length - 1].parent;
-        }
+        const listing = await fetchChildren(queryPath);
+        const { directories, files } = listing;
+        parent = listing.parent;
 
         const matched = directories.filter(({ name }) =>
           name.toLowerCase().includes(segment)
@@ -239,7 +184,6 @@ export const actionHandlers = handleThunks({
 
         if (isLast) {
           if (includeFiles) {
-            const files = listings.flatMap((data) => data.files);
             matched.push(
               ...files.filter(({ name }) => name.toLowerCase().includes(segment))
             );
@@ -250,61 +194,40 @@ export const actionHandlers = handleThunks({
             break;
           }
 
-          // Trailing separator after an exact directory name lists its
-          // children (`/config/`); after a partial name the match itself
-          // stays the suggestion (`/downloads/Kung/`).
+          // A trailing separator lists children only when the directory name
+          // is unambiguous. Partial or ambiguous names remain suggestions.
           const exactDirs = matched.filter(
             ({ name, type }) => type === 'folder' && name.toLowerCase() === segment
           );
-          results = matched.filter((entry) => !exactDirs.includes(entry));
 
-          if (exactDirs.length) {
-            const subListings = await mapWithConcurrency(
-              exactDirs,
-              ({ path: dirPath }) => fetchChildren(dirPath)
-            );
-            parent = subListings[subListings.length - 1].parent;
-            results.push(
-              ...subListings.flatMap((data) =>
-                (includeFiles ? [...data.directories, ...data.files] : data.directories)
-              )
-            );
+          if (exactDirs.length !== 1) {
+            results = matched;
+            break;
           }
+
+          const subListing = await fetchChildren(exactDirs[0].path);
+          parent = subListing.parent;
+          results = includeFiles ?
+            [...subListing.directories, ...subListing.files] :
+            subListing.directories;
         } else {
           const matchedFolders = matched.filter(({ type }) => type === 'folder');
           const exactFolders = matchedFolders.filter(
             ({ name }) => name.toLowerCase() === segment
           );
-          const canFollowFuzzyMatches =
-            segment.length >= MIN_FUZZY_INTERMEDIATE_SEGMENT_LENGTH &&
-            matchedFolders.length <= MAX_FUZZY_INTERMEDIATE_MATCHES;
 
-          // Exact path segments are safe to follow. Fuzzy intermediate
-          // segments must be specific and bounded so a broad match cannot
-          // turn the next segment into hundreds of filesystem requests.
-          if (canFollowFuzzyMatches) {
-            parents = matchedFolders.map(({ path: matchedPath }) => matchedPath);
-          } else {
-            limitedResults.push(
-              ...matchedFolders.filter(
-                ({ name }) => name.toLowerCase() !== segment
-              )
-            );
-
-            if (!exactFolders.length) {
-              break;
-            }
-
-            parents = exactFolders.map(({ path: matchedPath }) => matchedPath);
+          if (exactFolders.length !== 1) {
+            results = matchedFolders;
+            break;
           }
+
+          queryPath = exactFolders[0].path;
         }
       }
 
       return {
         parent,
-        directories: [...limitedResults, ...results].filter(
-          ({ type }) => type === 'folder'
-        ),
+        directories: results.filter(({ type }) => type === 'folder'),
         files: results.filter(({ type }) => type === 'file')
       };
     };

--- a/frontend/src/Store/Actions/pathActions.js
+++ b/frontend/src/Store/Actions/pathActions.js
@@ -9,6 +9,15 @@ import createHandleActions from './Creators/createHandleActions';
 
 export const section = 'paths';
 
+const LISTING_CACHE_TTL = 5000;
+const LISTING_CACHE_MAX_SIZE = 256;
+const MAX_CONCURRENT_LISTING_REQUESTS = 8;
+const listingCache = new Map();
+const inFlightListings = new Map();
+const listingRequestQueue = [];
+let activeListingRequests = 0;
+let latestFetchId = 0;
+
 //
 // State
 
@@ -34,12 +43,100 @@ export const CLEAR_PATHS = 'paths/clearPaths';
 
 export const fetchPaths = createThunk(FETCH_PATHS);
 export const updatePaths = createAction(UPDATE_PATHS);
-export const clearPaths = createAction(CLEAR_PATHS);
+const createClearPathsAction = createAction(CLEAR_PATHS);
 
-// Short-lived listing cache: segment resolution re-fetches the same
-// parent directories on nearly every keystroke.
-const LISTING_CACHE_TTL = 5000;
-const listingCache = new Map();
+export function clearPaths() {
+  latestFetchId++;
+
+  return createClearPathsAction();
+}
+
+function getCachedListing(cacheKey) {
+  const now = Date.now();
+
+  listingCache.forEach(({ expiresAt }, key) => {
+    if (expiresAt <= now) {
+      listingCache.delete(key);
+    }
+  });
+
+  const cached = listingCache.get(cacheKey);
+
+  if (!cached) {
+    return undefined;
+  }
+
+  // Refresh insertion order so the size bound evicts the least recently used
+  // listing first.
+  listingCache.delete(cacheKey);
+  listingCache.set(cacheKey, cached);
+
+  return cached.data;
+}
+
+function cacheListing(cacheKey, data) {
+  listingCache.delete(cacheKey);
+  listingCache.set(cacheKey, {
+    data,
+    expiresAt: Date.now() + LISTING_CACHE_TTL
+  });
+
+  while (listingCache.size > LISTING_CACHE_MAX_SIZE) {
+    const oldestKey = listingCache.keys().next().value;
+
+    listingCache.delete(oldestKey);
+  }
+}
+
+function startListingRequest({ requestFactory, resolve, reject }) {
+  activeListingRequests++;
+
+  Promise.resolve()
+    .then(requestFactory)
+    .then(resolve, reject)
+    .finally(() => {
+      activeListingRequests--;
+      runListingRequestQueue();
+    });
+}
+
+function runListingRequestQueue() {
+  while (
+    activeListingRequests < MAX_CONCURRENT_LISTING_REQUESTS &&
+    listingRequestQueue.length
+  ) {
+    startListingRequest(listingRequestQueue.shift());
+  }
+}
+
+function scheduleListingRequest(requestFactory) {
+  return new Promise((resolve, reject) => {
+    listingRequestQueue.push({ requestFactory, resolve, reject });
+    runListingRequestQueue();
+  });
+}
+
+async function mapWithConcurrency(items, mapper) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+
+      results[index] = await mapper(items[index]);
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(MAX_CONCURRENT_LISTING_REQUESTS, items.length) },
+    worker
+  );
+
+  await Promise.all(workers);
+
+  return results;
+}
 
 //
 // Action Handlers
@@ -47,6 +144,8 @@ const listingCache = new Map();
 export const actionHandlers = handleThunks({
 
   [FETCH_PATHS]: function(getState, payload, dispatch) {
+    const fetchId = ++latestFetchId;
+
     dispatch(set({ section, isFetching: true }));
 
     const {
@@ -57,27 +156,44 @@ export const actionHandlers = handleThunks({
 
     const fetchChildren = (queryPath) => {
       const cacheKey = `${includeFiles}:${allowFoldersWithoutTrailingSlashes}:${queryPath}`;
-      const cached = listingCache.get(cacheKey);
+      const cached = getCachedListing(cacheKey);
 
-      if (cached && Date.now() - cached.timestamp < LISTING_CACHE_TTL) {
-        return Promise.resolve(cached.data);
+      if (cached !== undefined) {
+        return Promise.resolve(cached);
       }
 
-      return createAjaxRequest({
-        url: '/filesystem',
-        data: {
-          path: queryPath,
-          allowFoldersWithoutTrailingSlashes,
-          includeFiles
-        }
-      }).request.then(
-        (data) => {
-          listingCache.set(cacheKey, { data, timestamp: Date.now() });
+      const inFlight = inFlightListings.get(cacheKey);
+
+      if (inFlight) {
+        return inFlight;
+      }
+
+      const listingPromise = scheduleListingRequest(() => {
+        return createAjaxRequest({
+          url: '/filesystem',
+          data: {
+            path: queryPath,
+            allowFoldersWithoutTrailingSlashes,
+            includeFiles
+          }
+        }).request;
+      })
+        .then((data) => {
+          cacheListing(cacheKey, data);
 
           return data;
-        },
-        () => ({ parent: '', directories: [], files: [] })
-      );
+        }, () => {
+          return { parent: '', directories: [], files: [] };
+        })
+        .finally(() => {
+          if (inFlightListings.get(cacheKey) === listingPromise) {
+            inFlightListings.delete(cacheKey);
+          }
+        });
+
+      inFlightListings.set(cacheKey, listingPromise);
+
+      return listingPromise;
     };
 
     // Resolve the query segment by segment: each segment is a
@@ -107,7 +223,7 @@ export const actionHandlers = handleThunks({
         const segment = segments[i].toLowerCase();
         const isLast = i === segments.length - 1;
 
-        const listings = await Promise.all(parents.map(fetchChildren));
+        const listings = await mapWithConcurrency(parents, fetchChildren);
         const directories = listings.flatMap((data) => data.directories);
 
         if (listings.length) {
@@ -140,8 +256,9 @@ export const actionHandlers = handleThunks({
           results = matched.filter((entry) => !exactDirs.includes(entry));
 
           if (exactDirs.length) {
-            const subListings = await Promise.all(
-              exactDirs.map(({ path: dirPath }) => fetchChildren(dirPath))
+            const subListings = await mapWithConcurrency(
+              exactDirs,
+              ({ path: dirPath }) => fetchChildren(dirPath)
             );
             parent = subListings[subListings.length - 1].parent;
             results.push(
@@ -165,6 +282,10 @@ export const actionHandlers = handleThunks({
     };
 
     resolve().then((data) => {
+      if (fetchId !== latestFetchId) {
+        return;
+      }
+
       // `currentPath` stays empty so the prefix-based selectors pass the
       // resolved entries through; matching happens against the typed value.
       dispatch(updatePaths({ path: '', ...data }));
@@ -196,10 +317,13 @@ export const reducers = createHandleActions({
     return newState;
   },
 
-  [CLEAR_PATHS]: (state, { payload }) => {
+  [CLEAR_PATHS]: (state) => {
     const newState = Object.assign({}, state);
 
-    newState.path = '';
+    newState.currentPath = '';
+    newState.isFetching = false;
+    newState.isPopulated = false;
+    newState.error = null;
     newState.directories = [];
     newState.files = [];
     newState.parent = '';

--- a/frontend/src/Store/Actions/pathActions.js
+++ b/frontend/src/Store/Actions/pathActions.js
@@ -12,6 +12,8 @@ export const section = 'paths';
 const LISTING_CACHE_TTL = 5000;
 const LISTING_CACHE_MAX_SIZE = 256;
 const MAX_CONCURRENT_LISTING_REQUESTS = 8;
+const MIN_FUZZY_INTERMEDIATE_SEGMENT_LENGTH = 2;
+const MAX_FUZZY_INTERMEDIATE_MATCHES = 20;
 const listingCache = new Map();
 const inFlightListings = new Map();
 const listingRequestQueue = [];
@@ -218,6 +220,7 @@ export const actionHandlers = handleThunks({
       let parents = [rootPath];
       let parent = '';
       let results = [];
+      const limitedResults = [];
 
       for (let i = 0; i < segments.length; i++) {
         const segment = segments[i].toLowerCase();
@@ -268,15 +271,40 @@ export const actionHandlers = handleThunks({
             );
           }
         } else {
-          parents = matched
-            .filter(({ type }) => type === 'folder')
-            .map(({ path: matchedPath }) => matchedPath);
+          const matchedFolders = matched.filter(({ type }) => type === 'folder');
+          const exactFolders = matchedFolders.filter(
+            ({ name }) => name.toLowerCase() === segment
+          );
+          const canFollowFuzzyMatches =
+            segment.length >= MIN_FUZZY_INTERMEDIATE_SEGMENT_LENGTH &&
+            matchedFolders.length <= MAX_FUZZY_INTERMEDIATE_MATCHES;
+
+          // Exact path segments are safe to follow. Fuzzy intermediate
+          // segments must be specific and bounded so a broad match cannot
+          // turn the next segment into hundreds of filesystem requests.
+          if (canFollowFuzzyMatches) {
+            parents = matchedFolders.map(({ path: matchedPath }) => matchedPath);
+          } else {
+            limitedResults.push(
+              ...matchedFolders.filter(
+                ({ name }) => name.toLowerCase() !== segment
+              )
+            );
+
+            if (!exactFolders.length) {
+              break;
+            }
+
+            parents = exactFolders.map(({ path: matchedPath }) => matchedPath);
+          }
         }
       }
 
       return {
         parent,
-        directories: results.filter(({ type }) => type === 'folder'),
+        directories: [...limitedResults, ...results].filter(
+          ({ type }) => type === 'folder'
+        ),
         files: results.filter(({ type }) => type === 'file')
       };
     };

--- a/frontend/src/Store/Actions/pathActions.js
+++ b/frontend/src/Store/Actions/pathActions.js
@@ -36,6 +36,11 @@ export const fetchPaths = createThunk(FETCH_PATHS);
 export const updatePaths = createAction(UPDATE_PATHS);
 export const clearPaths = createAction(CLEAR_PATHS);
 
+// Short-lived listing cache: segment resolution re-fetches the same
+// parent directories on nearly every keystroke.
+const LISTING_CACHE_TTL = 5000;
+const listingCache = new Map();
+
 //
 // Action Handlers
 
@@ -51,6 +56,13 @@ export const actionHandlers = handleThunks({
     } = payload;
 
     const fetchChildren = (queryPath) => {
+      const cacheKey = `${includeFiles}:${allowFoldersWithoutTrailingSlashes}:${queryPath}`;
+      const cached = listingCache.get(cacheKey);
+
+      if (cached && Date.now() - cached.timestamp < LISTING_CACHE_TTL) {
+        return Promise.resolve(cached.data);
+      }
+
       return createAjaxRequest({
         url: '/filesystem',
         data: {
@@ -59,7 +71,11 @@ export const actionHandlers = handleThunks({
           includeFiles
         }
       }).request.then(
-        (data) => data,
+        (data) => {
+          listingCache.set(cacheKey, { data, timestamp: Date.now() });
+
+          return data;
+        },
         () => ({ parent: '', directories: [], files: [] })
       );
     };
@@ -93,7 +109,10 @@ export const actionHandlers = handleThunks({
 
         const listings = await Promise.all(parents.map(fetchChildren));
         const directories = listings.flatMap((data) => data.directories);
-        parent = listings[listings.length - 1].parent;
+
+        if (listings.length) {
+          parent = listings[listings.length - 1].parent;
+        }
 
         const matched = directories.filter(({ name }) =>
           name.toLowerCase().includes(segment)

--- a/frontend/src/Store/Actions/pathActions.js
+++ b/frontend/src/Store/Actions/pathActions.js
@@ -50,32 +50,111 @@ export const actionHandlers = handleThunks({
       includeFiles = false
     } = payload;
 
-    const promise = createAjaxRequest({
-      url: '/filesystem',
-      data: {
-        path,
-        allowFoldersWithoutTrailingSlashes,
-        includeFiles
-      }
-    }).request;
+    const fetchChildren = (queryPath) => {
+      return createAjaxRequest({
+        url: '/filesystem',
+        data: {
+          path: queryPath,
+          allowFoldersWithoutTrailingSlashes,
+          includeFiles
+        }
+      }).request.then(
+        (data) => data,
+        () => ({ parent: '', directories: [], files: [] })
+      );
+    };
 
-    promise.done((data) => {
-      dispatch(updatePaths({ path, ...data }));
+    // Resolve the query segment by segment: each segment is a
+    // case-insensitive containment filter for its directory level, so
+    // `/down/dbd` descends into `/downloads/` and matches `[DBD-Raws]...`.
+    let rootPath = '/';
+
+    if ((/^[a-zA-Z]:[\\/]/).test(path)) {
+      rootPath = path.slice(0, 3);
+    } else if (path.startsWith('\\')) {
+      rootPath = '\\';
+    }
+
+    const segments = path.split(/[\\/]/).filter((segment) => segment.length);
+    const hasTrailingSeparator = (/[\\/]$/).test(path);
+
+    const resolve = async() => {
+      if (!segments.length) {
+        return fetchChildren(rootPath);
+      }
+
+      let parents = [rootPath];
+      let parent = '';
+      let results = [];
+
+      for (let i = 0; i < segments.length; i++) {
+        const segment = segments[i].toLowerCase();
+        const isLast = i === segments.length - 1;
+
+        const listings = await Promise.all(parents.map(fetchChildren));
+        const directories = listings.flatMap((data) => data.directories);
+        parent = listings[listings.length - 1].parent;
+
+        const matched = directories.filter(({ name }) =>
+          name.toLowerCase().includes(segment)
+        );
+
+        if (isLast) {
+          if (includeFiles) {
+            const files = listings.flatMap((data) => data.files);
+            matched.push(
+              ...files.filter(({ name }) => name.toLowerCase().includes(segment))
+            );
+          }
+
+          if (!hasTrailingSeparator) {
+            results = matched;
+            break;
+          }
+
+          // Trailing separator after an exact directory name lists its
+          // children (`/config/`); after a partial name the match itself
+          // stays the suggestion (`/downloads/Kung/`).
+          const exactDirs = matched.filter(
+            ({ name, type }) => type === 'folder' && name.toLowerCase() === segment
+          );
+          results = matched.filter((entry) => !exactDirs.includes(entry));
+
+          if (exactDirs.length) {
+            const subListings = await Promise.all(
+              exactDirs.map(({ path: dirPath }) => fetchChildren(dirPath))
+            );
+            parent = subListings[subListings.length - 1].parent;
+            results.push(
+              ...subListings.flatMap((data) =>
+                (includeFiles ? [...data.directories, ...data.files] : data.directories)
+              )
+            );
+          }
+        } else {
+          parents = matched
+            .filter(({ type }) => type === 'folder')
+            .map(({ path: matchedPath }) => matchedPath);
+        }
+      }
+
+      return {
+        parent,
+        directories: results.filter(({ type }) => type === 'folder'),
+        files: results.filter(({ type }) => type === 'file')
+      };
+    };
+
+    resolve().then((data) => {
+      // `currentPath` stays empty so the prefix-based selectors pass the
+      // resolved entries through; matching happens against the typed value.
+      dispatch(updatePaths({ path: '', ...data }));
 
       dispatch(set({
         section,
         isFetching: false,
         isPopulated: true,
         error: null
-      }));
-    });
-
-    promise.fail((xhr) => {
-      dispatch(set({
-        section,
-        isFetching: false,
-        isPopulated: false,
-        error: xhr
       }));
     });
   }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Improves the path input's autocomplete: suggestions are now matched segment-by-segment (each typed path fragment matches the candidate's directory at the same depth, so /down/dbd finds /downloads/[DBD-Raws]…/), path listings are cached and fetches debounced to avoid a request per keystroke, `Tab` completion no longer traps focus when there's nothing to complete, and every matching text fragment in a suggestion is highlighted with a theme-aware pill while preserving the path's original case and separators.

The change is in the shared `PathInput` component, so it applies everywhere path suggestions appear:
   - All path-type settings fields (Settings → General → Backups → Folder, and other path fields across settings pages)
   - File Browser modal path input
   - Interactive Import → Select Folder modal

#### Screenshot (if UI related)
<img width="2614" height="939" alt="图片" src="https://github.com/user-attachments/assets/fb553d67-4d29-4bc4-8394-852341fbf0be" />


#### Todos
- None
#### Issues Fixed or Closed by this PR

- None