### PR TITLE
Fixed: Improve cache busting for covers using a hash instead of file modification time

### DIFF
--- a/src/NzbDrone.Core.Test/MediaCoverTests/MediaCoverServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaCoverTests/MediaCoverServiceFixture.cs
@@ -26,37 +26,29 @@ namespace NzbDrone.Core.Test.MediaCoverTests
 
             _movie = Builder<Movie>.CreateNew()
                 .With(v => v.Id = 2)
-                .With(v => v.MovieMetadata.Value.Images = new List<MediaCover.MediaCover> { new MediaCover.MediaCover(MediaCoverTypes.Poster, "") })
+                .With(v => v.MovieMetadata.Value.Images = new List<MediaCover.MediaCover> { new(MediaCoverTypes.Poster, "") })
                 .Build();
-
-            Mocker.GetMock<IMovieService>().Setup(m => m.GetMovie(It.Is<int>(id => id == _movie.Id))).Returns(_movie);
         }
 
         [Test]
         public void should_convert_cover_urls_to_local()
         {
             var covers = new List<MediaCover.MediaCover>
-                {
-                    new MediaCover.MediaCover { CoverType = MediaCoverTypes.Banner }
-                };
-
-            Mocker.GetMock<IDiskProvider>().Setup(c => c.FileGetLastWrite(It.IsAny<string>()))
-                .Returns(new DateTime(1234));
-
-            Mocker.GetMock<IDiskProvider>().Setup(c => c.FileExists(It.IsAny<string>()))
-                .Returns(true);
+            {
+                new() { CoverType = MediaCoverTypes.Banner, RemoteUrl = "https://artworks.examples.com/banners/1.jpg" }
+            };
 
             Subject.ConvertToLocalUrls(12, covers);
 
-            covers.Single().Url.Should().Be("/MediaCover/12/banner.jpg?lastWrite=1234");
+            covers.Single().Url.Should().Be("/MediaCover/12/banner.jpg?h=a6210a45e2b93963ad9e");
         }
 
         [Test]
-        public void should_convert_media_urls_to_local_without_time_if_file_doesnt_exist()
+        public void should_convert_media_urls_to_local_without_hash_if_remote_url_is_empty()
         {
             var covers = new List<MediaCover.MediaCover>
                 {
-                    new MediaCover.MediaCover { CoverType = MediaCoverTypes.Banner }
+                    new() { CoverType = MediaCoverTypes.Banner }
                 };
 
             Subject.ConvertToLocalUrls(12, covers);

--- a/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
+++ b/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using NLog;
-using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
@@ -19,9 +17,7 @@ namespace NzbDrone.Core.MediaCover
 {
     public interface IMapCoversToLocal
     {
-        Dictionary<string, FileInfo> GetCoverFileInfos();
-        void ConvertToLocalUrls(int movieId, IEnumerable<MediaCover> covers, Dictionary<string, FileInfo> fileInfos = null);
-        void ConvertToLocalUrls(IEnumerable<Tuple<int, IEnumerable<MediaCover>>> items, Dictionary<string, FileInfo> coverFileInfos);
+        void ConvertToLocalUrls(int movieId, IEnumerable<MediaCover> covers);
         string GetCoverPath(int movieId, MediaCoverTypes coverType, int? height = null);
     }
 
@@ -43,7 +39,7 @@ namespace NzbDrone.Core.MediaCover
 
         // ImageSharp is slow on ARM (no hardware acceleration on mono yet)
         // So limit the number of concurrent resizing tasks
-        private static SemaphoreSlim _semaphore = new SemaphoreSlim((int)Math.Ceiling(Environment.ProcessorCount / 2.0));
+        private static readonly SemaphoreSlim Semaphore = new((int)Math.Ceiling(Environment.ProcessorCount / 2.0));
 
         public MediaCoverService(IMediaCoverProxy mediaCoverProxy,
                                  IImageResizer resizer,
@@ -69,28 +65,16 @@ namespace NzbDrone.Core.MediaCover
 
         public string GetCoverPath(int movieId, MediaCoverTypes coverType, int? height = null)
         {
-            var heightSuffix = height.HasValue ? "-" + height.ToString() : "";
+            var heightSuffix = height.HasValue ? $"-{height}" : "";
 
-            return Path.Combine(GetMovieCoverPath(movieId), coverType.ToString().ToLower() + heightSuffix + GetExtension(coverType));
+            return Path.Combine(GetMovieCoverPath(movieId), coverType.ToString().ToLowerInvariant() + heightSuffix + GetExtension(coverType));
         }
 
-        public Dictionary<string, FileInfo> GetCoverFileInfos()
-        {
-            if (!_diskProvider.FolderExists(_coverRootFolder))
-            {
-                return new Dictionary<string, FileInfo>();
-            }
-
-            return _diskProvider
-                .GetFileInfos(_coverRootFolder, true)
-                .ToDictionary(x => x.FullName, PathEqualityComparer.Instance);
-        }
-
-        public void ConvertToLocalUrls(int movieId, IEnumerable<MediaCover> covers, Dictionary<string, FileInfo> fileInfos = null)
+        public void ConvertToLocalUrls(int movieId, IEnumerable<MediaCover> covers)
         {
             if (movieId == 0)
             {
-                // Movie isn't in Radarr yet, map via a proxy to circument referrer issues
+                // Movie isn't in Radarr yet, map via a proxy to circumvent referrer issues
                 foreach (var mediaCover in covers)
                 {
                     mediaCover.Url = _mediaCoverProxy.RegisterUrl(mediaCover.RemoteUrl);
@@ -105,34 +89,13 @@ namespace NzbDrone.Core.MediaCover
                         continue;
                     }
 
-                    var filePath = GetCoverPath(movieId, mediaCover.CoverType);
+                    mediaCover.Url = _configFileProvider.UrlBase + @"/MediaCover/" + movieId + "/" + mediaCover.CoverType.ToString().ToLowerInvariant() + GetExtension(mediaCover.CoverType);
 
-                    mediaCover.Url = _configFileProvider.UrlBase + @"/MediaCover/" + movieId + "/" + mediaCover.CoverType.ToString().ToLower() + GetExtension(mediaCover.CoverType);
-
-                    DateTime? lastWrite = null;
-
-                    if (fileInfos != null && fileInfos.TryGetValue(filePath, out var file))
+                    if (mediaCover.RemoteUrl.IsNotNullOrWhiteSpace())
                     {
-                        lastWrite = file.LastWriteTimeUtc;
-                    }
-                    else if (_diskProvider.FileExists(filePath))
-                    {
-                        lastWrite = _diskProvider.FileGetLastWrite(filePath);
-                    }
-
-                    if (lastWrite.HasValue)
-                    {
-                        mediaCover.Url += "?lastWrite=" + lastWrite.Value.Ticks;
+                        mediaCover.Url += "?h=" + mediaCover.RemoteUrl.SHA256Hash()[..20];
                     }
                 }
-            }
-        }
-
-        public void ConvertToLocalUrls(IEnumerable<Tuple<int, IEnumerable<MediaCover>>> items, Dictionary<string, FileInfo> coverFileInfos)
-        {
-            foreach (var movie in items)
-            {
-                ConvertToLocalUrls(movie.Item1, movie.Item2, coverFileInfos);
             }
         }
 
@@ -184,7 +147,7 @@ namespace NzbDrone.Core.MediaCover
 
             try
             {
-                _semaphore.Wait();
+                Semaphore.Wait();
 
                 foreach (var tuple in toResize)
                 {
@@ -193,7 +156,7 @@ namespace NzbDrone.Core.MediaCover
             }
             finally
             {
-                _semaphore.Release();
+                Semaphore.Release();
             }
 
             return updated;
@@ -252,7 +215,7 @@ namespace NzbDrone.Core.MediaCover
             }
         }
 
-        private string GetExtension(MediaCoverTypes coverType)
+        private static string GetExtension(MediaCoverTypes coverType)
         {
             return coverType switch
             {

--- a/src/Radarr.Api.V3/Movies/MovieController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieController.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentValidation;
@@ -156,9 +154,7 @@ namespace Radarr.Api.V3.Movies
 
                 if (!excludeLocalCovers)
                 {
-                    var coverFileInfos = _coverMapper.GetCoverFileInfos();
-
-                    MapCoversToLocal(moviesResources, coverFileInfos);
+                    MapCoversToLocal(moviesResources.ToArray());
                 }
 
                 LinkMovieStatistics(moviesResources, sdict);
@@ -283,14 +279,12 @@ namespace Radarr.Api.V3.Movies
             _moviesService.DeleteMovie(id, deleteFiles, addImportExclusion);
         }
 
-        private void MapCoversToLocal(MovieResource movie)
+        private void MapCoversToLocal(params MovieResource[] movies)
         {
-            _coverMapper.ConvertToLocalUrls(movie.Id, movie.Images);
-        }
-
-        private void MapCoversToLocal(IEnumerable<MovieResource> movies, Dictionary<string, FileInfo> coverFileInfos)
-        {
-            _coverMapper.ConvertToLocalUrls(movies.Select(x => Tuple.Create(x.Id, x.Images.AsEnumerable())), coverFileInfos);
+            foreach (var movieResource in movies)
+            {
+                _coverMapper.ConvertToLocalUrls(movieResource.Id, movieResource.Images);
+            }
         }
 
         private void FetchAndLinkMovieStatistics(MovieResource resource)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Improve loading times for series endpoint by skipping the last modification time fetching for covers to be used as argument for cache busting. Instead switching to generating a hash based on `RemoteUrl`.
#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #11558