### PR TITLE
Fix: Defer movie path update until file move actually completes

### DIFF
--- a/src/NzbDrone.Core.Test/MovieTests/MoveMovieServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MoveMovieServiceFixture.cs
@@ -87,6 +87,18 @@ namespace NzbDrone.Core.Test.MovieTests
         }
 
         [Test]
+        public void should_update_movie_path_only_after_successful_move()
+        {
+            Subject.Execute(_command);
+
+            Mocker.GetMock<IDiskTransferService>()
+                  .Verify(v => v.TransferFolder(_command.SourcePath, _command.DestinationPath, TransferMode.Move), Times.Once());
+
+            Mocker.GetMock<IMovieService>()
+                  .Verify(v => v.UpdateMovie(It.Is<Movie>(m => m.Path == _command.DestinationPath)), Times.Once());
+        }
+
+        [Test]
         public void should_use_destination_path()
         {
             Subject.Execute(_command);

--- a/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/UpdateMultipleMoviesFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/UpdateMultipleMoviesFixture.cs
@@ -76,15 +76,10 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
                 .Returns<Movie, bool>((s, u) => Path.Combine(s.RootFolderPath, s.Title));
 
             var originalPaths = _movies.ToDictionary(s => s.Id, s => s.Path);
-            var pendingMoveMovieIds = new HashSet<int> { _movies[0].Id, _movies[1].Id };
 
-            var result = Subject.UpdateMovie(_movies, false, pendingMoveMovieIds);
+            var result = Subject.UpdateMovie(_movies, false, true);
 
-            result.Where(s => pendingMoveMovieIds.Contains(s.Id))
-                  .Should().OnlyContain(s => s.Path == originalPaths[s.Id]);
-
-            result.Where(s => !pendingMoveMovieIds.Contains(s.Id))
-                  .Should().OnlyContain(s => s.Path.StartsWith(newRoot));
+            result.Should().OnlyContain(s => s.Path == originalPaths[s.Id]);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/UpdateMultipleMoviesFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/UpdateMultipleMoviesFixture.cs
@@ -66,6 +66,28 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
         }
 
         [Test]
+        public void should_not_update_path_for_movies_pending_a_file_move()
+        {
+            var newRoot = @"C:\Test\Movies2".AsOsAgnostic();
+            _movies.ForEach(s => s.RootFolderPath = newRoot);
+
+            Mocker.GetMock<IBuildMoviePaths>()
+                .Setup(s => s.BuildPath(It.IsAny<Movie>(), false))
+                .Returns<Movie, bool>((s, u) => Path.Combine(s.RootFolderPath, s.Title));
+
+            var originalPaths = _movies.ToDictionary(s => s.Id, s => s.Path);
+            var pendingMoveMovieIds = new HashSet<int> { _movies[0].Id, _movies[1].Id };
+
+            var result = Subject.UpdateMovie(_movies, false, pendingMoveMovieIds);
+
+            result.Where(s => pendingMoveMovieIds.Contains(s.Id))
+                  .Should().OnlyContain(s => s.Path == originalPaths[s.Id]);
+
+            result.Where(s => !pendingMoveMovieIds.Contains(s.Id))
+                  .Should().OnlyContain(s => s.Path.StartsWith(newRoot));
+        }
+
+        [Test]
         public void should_be_able_to_update_many_movies()
         {
             var movies = Builder<Movie>.CreateListOfSize(50)

--- a/src/NzbDrone.Core/Movies/MoveMovieService.cs
+++ b/src/NzbDrone.Core/Movies/MoveMovieService.cs
@@ -71,17 +71,19 @@ namespace NzbDrone.Core.Movies
 
                 _logger.ProgressInfo("{0} moved successfully to {1}", movie.Title, destinationPath);
 
+                UpdatePath(movie.Id, destinationPath);
+
                 _eventAggregator.PublishEvent(new MovieMovedEvent(movie, sourcePath, destinationPath));
             }
             catch (IOException ex)
             {
                 _logger.Error(ex, "Unable to move movie from '{0}' to '{1}'. Try moving files manually", sourcePath, destinationPath);
 
-                RevertPath(movie.Id, sourcePath);
+                UpdatePath(movie.Id, sourcePath);
             }
         }
 
-        private void RevertPath(int movieId, string path)
+        private void UpdatePath(int movieId, string path)
         {
             var movie = _movieService.GetMovie(movieId);
 

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.Movies
         Dictionary<int, List<int>> AllMovieTags();
         Movie UpdateMovie(Movie movie);
         List<Movie> UpdateMovie(List<Movie> movies, bool useExistingRelativeFolder);
-        List<Movie> UpdateMovie(List<Movie> movies, bool useExistingRelativeFolder, HashSet<int> pendingMoveMovieIds);
+        List<Movie> UpdateMovie(List<Movie> movies, bool useExistingRelativeFolder, bool deferPathUpdate);
         void UpdateLastSearchTime(Movie movie);
         List<int> GetRecommendedTmdbIds();
         bool MoviePathExists(string folder);
@@ -258,10 +258,10 @@ namespace NzbDrone.Core.Movies
 
         public List<Movie> UpdateMovie(List<Movie> movies, bool useExistingRelativeFolder)
         {
-            return UpdateMovie(movies, useExistingRelativeFolder, null);
+            return UpdateMovie(movies, useExistingRelativeFolder, false);
         }
 
-        public List<Movie> UpdateMovie(List<Movie> movies, bool useExistingRelativeFolder, HashSet<int> pendingMoveMovieIds)
+        public List<Movie> UpdateMovie(List<Movie> movies, bool useExistingRelativeFolder, bool deferPathUpdate)
         {
             _logger.Debug("Updating {0} movies", movies.Count);
 
@@ -269,7 +269,7 @@ namespace NzbDrone.Core.Movies
             {
                 _logger.Trace("Updating: {0}", m.Title);
 
-                if (pendingMoveMovieIds != null && pendingMoveMovieIds.Contains(m.Id))
+                if (deferPathUpdate)
                 {
                     // The file move is queued as a separate, asynchronous command. Path is
                     // updated by MoveMovieService once the move has actually completed, so an

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -271,10 +271,6 @@ namespace NzbDrone.Core.Movies
 
                 if (deferPathUpdate)
                 {
-                    // The file move is queued as a separate, asynchronous command. Path is
-                    // updated by MoveMovieService once the move has actually completed, so an
-                    // interrupted move (crash, full disk) doesn't leave the DB pointing at files
-                    // that were never actually relocated.
                     _logger.Trace("Path update for {0} deferred until file move completes", m.Title);
                 }
                 else if (!m.RootFolderPath.IsNullOrWhiteSpace())

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -42,6 +42,7 @@ namespace NzbDrone.Core.Movies
         Dictionary<int, List<int>> AllMovieTags();
         Movie UpdateMovie(Movie movie);
         List<Movie> UpdateMovie(List<Movie> movies, bool useExistingRelativeFolder);
+        List<Movie> UpdateMovie(List<Movie> movies, bool useExistingRelativeFolder, HashSet<int> pendingMoveMovieIds);
         void UpdateLastSearchTime(Movie movie);
         List<int> GetRecommendedTmdbIds();
         bool MoviePathExists(string folder);
@@ -257,13 +258,26 @@ namespace NzbDrone.Core.Movies
 
         public List<Movie> UpdateMovie(List<Movie> movies, bool useExistingRelativeFolder)
         {
+            return UpdateMovie(movies, useExistingRelativeFolder, null);
+        }
+
+        public List<Movie> UpdateMovie(List<Movie> movies, bool useExistingRelativeFolder, HashSet<int> pendingMoveMovieIds)
+        {
             _logger.Debug("Updating {0} movies", movies.Count);
 
             foreach (var m in movies)
             {
                 _logger.Trace("Updating: {0}", m.Title);
 
-                if (!m.RootFolderPath.IsNullOrWhiteSpace())
+                if (pendingMoveMovieIds != null && pendingMoveMovieIds.Contains(m.Id))
+                {
+                    // The file move is queued as a separate, asynchronous command. Path is
+                    // updated by MoveMovieService once the move has actually completed, so an
+                    // interrupted move (crash, full disk) doesn't leave the DB pointing at files
+                    // that were never actually relocated.
+                    _logger.Trace("Path update for {0} deferred until file move completes", m.Title);
+                }
+                else if (!m.RootFolderPath.IsNullOrWhiteSpace())
                 {
                     m.Path = _moviePathBuilder.BuildPath(m, useExistingRelativeFolder);
 

--- a/src/Radarr.Api.V3/Movies/MovieEditorController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieEditorController.cs
@@ -118,8 +118,7 @@ namespace Radarr.Api.V3.Movies
             var translations = _movieTranslationService.GetAllTranslationsForLanguage(configLanguage);
             var tdict = translations.ToDictionaryIgnoreDuplicates(x => x.MovieMetadataId);
 
-            var pendingMoveMovieIds = resource.MoveFiles ? moviesToMove.Select(m => m.MovieId).ToHashSet() : null;
-            var updatedMovies = _movieService.UpdateMovie(moviesToUpdate, !resource.MoveFiles, pendingMoveMovieIds);
+            var updatedMovies = _movieService.UpdateMovie(moviesToUpdate, !resource.MoveFiles, resource.MoveFiles);
 
             var moviesResources = new List<MovieResource>(updatedMovies.Count);
 

--- a/src/Radarr.Api.V3/Movies/MovieEditorController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieEditorController.cs
@@ -118,7 +118,8 @@ namespace Radarr.Api.V3.Movies
             var translations = _movieTranslationService.GetAllTranslationsForLanguage(configLanguage);
             var tdict = translations.ToDictionaryIgnoreDuplicates(x => x.MovieMetadataId);
 
-            var updatedMovies = _movieService.UpdateMovie(moviesToUpdate, !resource.MoveFiles);
+            var pendingMoveMovieIds = resource.MoveFiles ? moviesToMove.Select(m => m.MovieId).ToHashSet() : null;
+            var updatedMovies = _movieService.UpdateMovie(moviesToUpdate, !resource.MoveFiles, pendingMoveMovieIds);
 
             var moviesResources = new List<MovieResource>(updatedMovies.Count);
 


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`MovieEditorController.SaveAll` writes the new path to the DB synchronously while the actual file move runs async as `BulkMoveMovieCommand`. If Radarr gets interrupted in between (crash, full disk) the DB ends up pointing at a path the files never reached; this matches the repro/root cause discussed in #5857.

`MovieService.UpdateMovie` now takes a `deferPathUpdate` flag that skips the path write for movies pending a move, and `MoveMovieService.MoveSingleMovie` persists the confirmed path itself once the transfer actually succeeds, instead of the controller writing it eagerly for the whole batch. Movies with `MoveFiles=false` aren't touched, no window to guard against there.

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

Related to #5857 (same root cause discussed there)

