### PR TITLE
New: Preserve original file date when replacing movie files

### DIFF
--- a/frontend/src/Settings/MediaManagement/MediaManagement.tsx
+++ b/frontend/src/Settings/MediaManagement/MediaManagement.tsx
@@ -93,6 +93,12 @@ const fileDateOptions: EnhancedSelectInputValue<string>[] = [
       return translate('PhysicalReleaseDate');
     },
   },
+  {
+    key: 'preserveOriginal',
+    get value() {
+      return translate('PreserveOriginalFileDate');
+    },
+  },
 ];
 
 function MediaManagement() {

--- a/src/NzbDrone.Core.Test/MediaFiles/UpdateMovieFileServiceTests.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/UpdateMovieFileServiceTests.cs
@@ -1,0 +1,149 @@
+using System;
+using FizzWare.NBuilder;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Disk;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.MediaFiles
+{
+    public class UpdateMovieFileServiceTests : CoreTest<UpdateMovieFileService>
+    {
+        private MovieFile _movieFile;
+        private Movie _movie;
+
+        [SetUp]
+        public void Setup()
+        {
+            _movie = Builder<Movie>
+                .CreateNew()
+                .With(m => m.Path = @"C:\Test\Movies\Movie".AsOsAgnostic())
+                .With(m => m.MovieMetadata = new LazyLoaded<MovieMetadata>(Builder<MovieMetadata>
+                    .CreateNew()
+                    .With(mm => mm.PhysicalRelease = new DateTime(2025, 1, 15))
+                    .With(mm => mm.DigitalRelease = new DateTime(2025, 2, 15))
+                    .With(mm => mm.InCinemas = new DateTime(2024, 12, 15))
+                    .Build()))
+                .Build();
+
+            _movieFile = Builder<MovieFile>
+                .CreateNew()
+                .With(mf => mf.RelativePath = "Movie.2025.mkv")
+                .With(mf => mf.Movie = _movie)
+                .Build();
+
+            Mocker.GetMock<IDiskProvider>()
+                .Setup(c => c.FileGetLastWrite(It.IsAny<string>()))
+                .Returns(DateTime.Now);
+
+            Mocker.GetMock<IConfigService>()
+                .Setup(c => c.FileDate)
+                .Returns(FileDateType.None);
+        }
+
+        [Test]
+        public void should_set_file_date_to_physical_release_when_filedate_is_release()
+        {
+            Mocker.GetMock<IConfigService>()
+                .Setup(c => c.FileDate)
+                .Returns(FileDateType.Release);
+
+            Subject.ChangeFileDateForFile(_movieFile, _movie);
+
+            var expectedDate = _movie.MovieMetadata.Value.PhysicalRelease.Value;
+            Mocker.GetMock<IDiskProvider>()
+                .Verify(v => v.FileSetLastWriteTime(It.IsAny<string>(), It.Is<DateTime>(d => d.Date == expectedDate.Date)), Times.Once());
+        }
+
+        [Test]
+        public void should_set_file_date_to_cinemas_when_filedate_is_cinemas()
+        {
+            Mocker.GetMock<IConfigService>()
+                .Setup(c => c.FileDate)
+                .Returns(FileDateType.Cinemas);
+
+            Subject.ChangeFileDateForFile(_movieFile, _movie);
+
+            var expectedDate = _movie.MovieMetadata.Value.InCinemas.Value;
+            Mocker.GetMock<IDiskProvider>()
+                .Verify(v => v.FileSetLastWriteTime(It.IsAny<string>(), It.Is<DateTime>(d => d.Date == expectedDate.Date)), Times.Once());
+        }
+
+        [Test]
+        public void should_preserve_original_file_date_when_filedate_is_preserve_original()
+        {
+            Mocker.GetMock<IConfigService>()
+                .Setup(c => c.FileDate)
+                .Returns(FileDateType.PreserveOriginal);
+
+            var preservedDate = new DateTime(2025, 11, 25);
+
+            Subject.ChangeFileDateForFile(_movieFile, _movie, preservedDate);
+
+            Mocker.GetMock<IDiskProvider>()
+                .Verify(v => v.FileSetLastWriteTime(It.IsAny<string>(), It.Is<DateTime>(d => d.Date == preservedDate.Date)), Times.Once());
+        }
+
+        [Test]
+        public void should_not_set_date_when_filedate_is_preserve_original_and_no_preserved_date()
+        {
+            Mocker.GetMock<IConfigService>()
+                .Setup(c => c.FileDate)
+                .Returns(FileDateType.PreserveOriginal);
+
+            Subject.ChangeFileDateForFile(_movieFile, _movie, null);
+
+            Mocker.GetMock<IDiskProvider>()
+                .Verify(v => v.FileSetLastWriteTime(It.IsAny<string>(), It.IsAny<DateTime>()), Times.Never());
+        }
+
+        [Test]
+        public void should_not_set_date_when_filedate_is_none()
+        {
+            Mocker.GetMock<IConfigService>()
+                .Setup(c => c.FileDate)
+                .Returns(FileDateType.None);
+
+            Subject.ChangeFileDateForFile(_movieFile, _movie);
+
+            Mocker.GetMock<IDiskProvider>()
+                .Verify(v => v.FileSetLastWriteTime(It.IsAny<string>(), It.IsAny<DateTime>()), Times.Never());
+        }
+
+        [Test]
+        public void should_not_set_date_when_release_date_is_missing()
+        {
+            Mocker.GetMock<IConfigService>()
+                .Setup(c => c.FileDate)
+                .Returns(FileDateType.Release);
+
+            _movie.MovieMetadata.Value.PhysicalRelease = null;
+            _movie.MovieMetadata.Value.DigitalRelease = null;
+
+            Subject.ChangeFileDateForFile(_movieFile, _movie);
+
+            Mocker.GetMock<IDiskProvider>()
+                .Verify(v => v.FileSetLastWriteTime(It.IsAny<string>(), It.IsAny<DateTime>()), Times.Never());
+        }
+
+        [Test]
+        public void should_not_set_date_when_cinemas_date_is_missing()
+        {
+            Mocker.GetMock<IConfigService>()
+                .Setup(c => c.FileDate)
+                .Returns(FileDateType.Cinemas);
+
+            _movie.MovieMetadata.Value.InCinemas = null;
+
+            Subject.ChangeFileDateForFile(_movieFile, _movie);
+
+            Mocker.GetMock<IDiskProvider>()
+                .Verify(v => v.FileSetLastWriteTime(It.IsAny<string>(), It.IsAny<DateTime>()), Times.Never());
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using FizzWare.NBuilder;
 using FluentAssertions;
@@ -123,6 +124,36 @@ namespace NzbDrone.Core.Test.MediaFiles
             Assert.Throws<RootFolderNotFoundException>(() => Subject.UpgradeMovieFile(_movieFile, _localMovie));
 
             Mocker.GetMock<IMediaFileService>().Verify(v => v.Delete(_localMovie.Movie.MovieFile, DeleteMediaFileReason.Upgrade), Times.Never());
+        }
+
+        [Test]
+        public void should_capture_existing_file_date_for_preservation()
+        {
+            GivenSingleMovieWithSingleMovieFile();
+            var originalDate = new DateTime(2025, 11, 25);
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(c => c.FileGetLastWrite(It.IsAny<string>()))
+                  .Returns(originalDate);
+
+            Subject.UpgradeMovieFile(_movieFile, _localMovie);
+
+            _localMovie.PreservedFileDate.Should().Be(originalDate);
+        }
+
+        [Test]
+        public void should_not_fail_if_cannot_read_existing_file_date()
+        {
+            GivenSingleMovieWithSingleMovieFile();
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(c => c.FileGetLastWrite(It.IsAny<string>()))
+                  .Throws<Exception>();
+
+            Subject.UpgradeMovieFile(_movieFile, _localMovie);
+
+            _localMovie.PreservedFileDate.Should().BeNull();
+            Mocker.GetMock<IRecycleBinProvider>().Verify(v => v.DeleteFile(It.IsAny<string>(), It.IsAny<string>()), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -196,6 +196,8 @@
   "ChangeCategoryMultipleHint": "Changes downloads to the 'Post-Import Category' from Download Client",
   "ChangeFileDate": "Change File Date",
   "ChangeFileDateHelpText": "Change file date on import/rescan",
+  "PreserveOriginalFileDate": "Preserve Original File Date",
+  "PreserveOriginalFileDateHelpText": "Do not change file date during import/upgrade/rescan",
   "ChangeHasNotBeenSavedYet": "Change has not been saved yet",
   "CheckDownloadClientForDetails": "check download client for more details",
   "CheckForFinishedDownloadsInterval": "Check For Finished Downloads Interval",

--- a/src/NzbDrone.Core/MediaFiles/FileDateType.cs
+++ b/src/NzbDrone.Core/MediaFiles/FileDateType.cs
@@ -4,6 +4,7 @@
     {
         None = 0,
         Cinemas = 1,
-        Release = 2
+        Release = 2,
+        PreserveOriginal = 3
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MovieFileMovingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieFileMovingService.cs
@@ -143,7 +143,14 @@ namespace NzbDrone.Core.MediaFiles
                 _diskTransferService.TransferFile(movieFilePath, destinationFilePath, mode);
             }
 
-            _updateMovieFileService.ChangeFileDateForFile(movieFile, movie);
+            if (localMovie?.PreservedFileDate.HasValue == true)
+            {
+                _updateMovieFileService.ChangeFileDateForFile(movieFile, movie, localMovie.PreservedFileDate);
+            }
+            else
+            {
+                _updateMovieFileService.ChangeFileDateForFile(movieFile, movie);
+            }
 
             try
             {

--- a/src/NzbDrone.Core/MediaFiles/UpdateMovieFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpdateMovieFileService.cs
@@ -15,6 +15,7 @@ namespace NzbDrone.Core.MediaFiles
     public interface IUpdateMovieFileService
     {
         void ChangeFileDateForFile(MovieFile movieFile, Movie movie);
+        void ChangeFileDateForFile(MovieFile movieFile, Movie movie, DateTime? preservedFileDate);
     }
 
     public class UpdateMovieFileService : IUpdateMovieFileService,
@@ -38,15 +39,31 @@ namespace NzbDrone.Core.MediaFiles
 
         public void ChangeFileDateForFile(MovieFile movieFile, Movie movie)
         {
-            ChangeFileDate(movieFile, movie);
+            ChangeFileDate(movieFile, movie, null);
         }
 
-        private bool ChangeFileDate(MovieFile movieFile, Movie movie)
+        public void ChangeFileDateForFile(MovieFile movieFile, Movie movie, DateTime? preservedFileDate)
+        {
+            ChangeFileDate(movieFile, movie, preservedFileDate);
+        }
+
+        private bool ChangeFileDate(MovieFile movieFile, Movie movie, DateTime? preservedFileDate = null)
         {
             var movieFilePath = Path.Combine(movie.Path, movieFile.RelativePath);
 
             switch (_configService.FileDate)
             {
+                case FileDateType.PreserveOriginal:
+                    {
+                        if (preservedFileDate.HasValue == false)
+                        {
+                            _logger.Debug("Preserve original file date is enabled but no preserved date available for [{0}]", movieFilePath);
+                            return false;
+                        }
+
+                        return ChangeFileDate(movieFilePath, preservedFileDate.Value);
+                    }
+
                 case FileDateType.Release:
                     {
                         var releaseDate = movie.MovieMetadata.Value.PhysicalRelease ?? movie.MovieMetadata.Value.DigitalRelease;

--- a/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using NLog;
 using NzbDrone.Common.Disk;
@@ -58,6 +59,18 @@ namespace NzbDrone.Core.MediaFiles
                 if (_diskProvider.FileExists(movieFilePath))
                 {
                     _logger.Debug("Removing existing movie file: {0}", existingFile);
+
+                    // Capture original file date before deletion for potential preservation
+                    try
+                    {
+                        localMovie.PreservedFileDate = _diskProvider.FileGetLastWrite(movieFilePath);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Debug(ex, "Failed to read file date for preservation: {0}", movieFilePath);
+                        localMovie.PreservedFileDate = null;
+                    }
+
                     recycleBinPath = _recycleBinProvider.DeleteFile(movieFilePath, subfolder);
                 }
                 else

--- a/src/NzbDrone.Core/Parser/Model/LocalMovie.cs
+++ b/src/NzbDrone.Core/Parser/Model/LocalMovie.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Download;
@@ -38,6 +39,7 @@ namespace NzbDrone.Core.Parser.Model
         public int CustomFormatScore { get; set; }
         public GrabbedReleaseInfo Release { get; set; }
         public bool ScriptImported { get; set; }
+        public DateTime? PreservedFileDate { get; set; }
         public string FileNameBeforeRename { get; set; }
         public bool ShouldImportExtras { get; set; }
         public List<string> PossibleExtraFiles { get; set; }


### PR DESCRIPTION
### Database Migration
NO

### Description
#### Why
When Radarr replaces/upgrades an existing movie file, the file system modified date is reset.
This can make external players detect the movie as recently added, even if it was already in the library.

#### What Changed
Added a new file date mode: PreserveOriginal.
During replacement/upgrade, Radarr now reads and keeps the timestamp of the existing destination file before deletion.
The preserved timestamp is propagated through the import/upgrade flow and applied to the final file when PreserveOriginal is selected.
Added the PreserveOriginal option in Media Management settings (UI).
Added/updated unit tests for file date behavior and preservation flow.
Added English localization key/value for the new option.
#### Scope
This PR includes one feature only: preserving original file date on file replacement/upgrade.

#### Screenshot (if UI related)
<img width="1122" height="865" alt="Capture d’écran 2026-07-27 à 21 47 30" src="https://github.com/user-attachments/assets/2a557df0-ecc9-49a5-b091-f5213d59ef6e" />

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)