### PR TITLE
New: Enhance email notification for added movies

### DIFF
--- a/src/NzbDrone.Core/Notifications/Email/Email.cs
+++ b/src/NzbDrone.Core/Notifications/Email/Email.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using FluentValidation.Results;
 using MailKit.Net.Smtp;
 using MailKit.Security;
@@ -44,12 +45,18 @@ namespace NzbDrone.Core.Notifications.Email
             SendEmail(Settings, MOVIE_DOWNLOADED_TITLE_BRANDED, body);
         }
 
-        public override void OnMovieAdded(Movie movie)
-        {
-            var body = $"{movie.Title} added to library.";
+public override void OnMovieAdded(Movie movie)
+{
+    var encodedTitle = WebUtility.HtmlEncode(movie.Title);
 
-            SendEmail(Settings, MOVIE_ADDED_TITLE_BRANDED, body);
-        }
+    var movieTitle = !string.IsNullOrWhiteSpace(movie.ImdbId)
+        ? $"<a href=\"https://www.imdb.com/title/{movie.ImdbId}/\">{encodedTitle}</a>"
+        : encodedTitle;
+
+    var body = $"<p>{movieTitle} added to library.</p>";
+
+    SendEmail(Settings, MOVIE_ADDED_TITLE_BRANDED, body, htmlBody: true);
+}
 
         public override void OnMovieFileDelete(MovieFileDeleteMessage deleteMessage)
         {


### PR DESCRIPTION
Add a clickable IMDb hyperlink to the movie-added email notification.

#### Database Migration
NO

#### Description
Updates the movie-added email notification to include a hyperlink to the movie's IMDb page when an IMDb ID is available.

The movie title remains displayed without a hyperlink when the movie does not have an IMDb ID.

#### Screenshot (if UI related)
Not applicable. This change only affects the content of email notifications.

#### Todos
- [ ] Tests
- [ ] Translation Keys (`/src/NzbDrone.Core/Localization/Core/en.json`)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
None