### PR TITLE
Improve mobile responsiveness and add a resilient OLED theme

### DIFF
--- a/frontend/src/App/ApplyTheme.tsx
+++ b/frontend/src/App/ApplyTheme.tsx
@@ -4,28 +4,94 @@ import { createSelector } from 'reselect';
 import themes from 'Styles/Themes';
 import AppState from './State/AppState';
 
-function createThemeSelector() {
-  return createSelector(
-    (state: AppState) => state.settings.ui.item.theme || window.Radarr.theme,
-    (theme) => {
-      return theme;
-    }
-  );
+const THEME_STORAGE_KEY = 'radarr-ui-theme';
+const SYSTEM_THEME_QUERY = '(prefers-color-scheme: dark)';
+const themeNames = ['auto', 'light', 'dark', 'oled'] as const;
+
+type ThemeName = (typeof themeNames)[number];
+type ResolvedThemeName = Exclude<ThemeName, 'auto'>;
+
+const themeSelector = createSelector(
+  (state: AppState) => state.settings.ui.item.theme || window.Radarr.theme,
+  (theme) => theme
+);
+
+function isThemeName(theme: unknown): theme is ThemeName {
+  return themeNames.includes(theme as ThemeName);
+}
+
+function resolveTheme(theme: ThemeName): ResolvedThemeName {
+  if (theme !== 'auto') {
+    return theme;
+  }
+
+  return window.matchMedia?.(SYSTEM_THEME_QUERY).matches ? 'dark' : 'light';
 }
 
 function ApplyTheme() {
-  const theme = useSelector(createThemeSelector());
+  const selectedTheme = useSelector(themeSelector);
+  const theme: ThemeName = isThemeName(selectedTheme) ? selectedTheme : 'auto';
 
   const updateCSSVariables = useCallback(() => {
-    Object.entries(themes[theme]).forEach(([key, value]) => {
-      document.documentElement.style.setProperty(`--${key}`, value);
+    const resolvedTheme = resolveTheme(theme);
+    const themeVariables = themes[resolvedTheme] as Record<string, string>;
+    const documentElement = document.documentElement;
+
+    Object.entries(themeVariables).forEach(([key, value]) => {
+      documentElement.style.setProperty(`--${key}`, value);
     });
+
+    documentElement.dataset.theme = theme;
+    documentElement.dataset.resolvedTheme = resolvedTheme.toLowerCase();
+    documentElement.style.colorScheme =
+      resolvedTheme === 'light' ? 'light' : 'dark';
+    documentElement.style.backgroundColor = themeVariables.pageBackground;
+
+    document
+      .querySelector<HTMLMetaElement>('meta[name="theme-color"]')
+      ?.setAttribute('content', themeVariables.pageBackground);
+    document
+      .querySelector<HTMLMetaElement>(
+        'meta[name="msapplication-navbutton-color"]'
+      )
+      ?.setAttribute('content', themeVariables.pageHeaderBackgroundColor);
+
+    window.Radarr.theme = theme;
+
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      // Theme application must continue when storage is blocked or unavailable.
+    }
   }, [theme]);
 
-  // On Component Mount and Component Update
   useEffect(() => {
     updateCSSVariables();
-  }, [updateCSSVariables, theme]);
+
+    if (theme !== 'auto') {
+      return undefined;
+    }
+
+    const systemTheme = window.matchMedia?.(SYSTEM_THEME_QUERY);
+
+    if (!systemTheme) {
+      return undefined;
+    }
+
+    if (systemTheme.addEventListener) {
+      systemTheme.addEventListener('change', updateCSSVariables);
+
+      return () => {
+        systemTheme.removeEventListener('change', updateCSSVariables);
+      };
+    }
+
+    systemTheme.addListener(updateCSSVariables);
+
+    return () => {
+      systemTheme.removeListener(updateCSSVariables);
+    };
+  }, [theme, updateCSSVariables]);
 
   return null;
 }

--- a/frontend/src/Calendar/CalendarPage.css
+++ b/frontend/src/Calendar/CalendarPage.css
@@ -2,6 +2,8 @@
   composes: contentBody from '~Components/Page/PageContentBody.css';
 
   display: flex;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .calendarInnerPageBody {
@@ -10,6 +12,8 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  min-width: 0;
+  max-width: 100%;
   width: 100%;
 }
 
@@ -17,4 +21,5 @@
   margin-top: 20px;
   text-align: center;
   font-size: 20px;
+  overflow-wrap: anywhere;
 }

--- a/frontend/src/Calendar/Header/CalendarHeader.css
+++ b/frontend/src/Calendar/Header/CalendarHeader.css
@@ -1,32 +1,53 @@
 .header {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  min-width: 0;
+  max-width: 100%;
+  gap: 8px;
 }
 
 .navigationButtons {
+  display: flex;
+  align-items: center;
   flex: 1 1 33%;
+  flex-wrap: wrap;
+  min-width: 0;
   text-align: left;
+  gap: 5px;
 }
 
 .todayButton {
   composes: button from '~Components/Link/Button.css';
 
-  margin-left: 5px;
+  margin-left: 0;
 }
 
 .titleDesktop,
 .titleMobile {
+  min-width: 0;
   text-align: center;
   font-size: 18px;
+  overflow-wrap: anywhere;
+}
+
+.titleDesktop {
+  flex: 1 1 33%;
 }
 
 .titleMobile {
+  flex: 1 1 100%;
   margin-bottom: 5px;
 }
 
 .viewButtonsContainer {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
   flex: 1 1 33%;
+  flex-wrap: wrap;
+  min-width: 0;
+  gap: 5px;
 }
 
 .viewMenu {
@@ -43,11 +64,35 @@
 }
 
 @media only screen and (max-width: $breakpointSmall) {
+  .header {
+    align-items: stretch;
+  }
+
   .navigationButtons {
-    flex: 1 0 50%;
+    flex: 1 1 calc(100% - 108px);
+  }
+
+  .todayButton {
+    min-height: 44px;
   }
 
   .viewButtonsContainer {
-    flex: 0 0 100px;
+    flex: 0 1 100px;
+  }
+
+  .viewMenu {
+    min-height: 44px;
+    line-height: 44px;
+  }
+}
+
+@media only screen and (max-width: $breakpointExtraSmall) {
+  .navigationButtons,
+  .viewButtonsContainer {
+    flex-basis: 100%;
+  }
+
+  .viewButtonsContainer {
+    justify-content: flex-start;
   }
 }

--- a/frontend/src/Components/Form/FormGroup.css
+++ b/frontend/src/Components/Form/FormGroup.css
@@ -1,6 +1,9 @@
 .group {
   display: flex;
   margin-bottom: 20px;
+  min-width: 0;
+  max-width: 100%;
+  width: 100%;
 }
 
 /* Sizes */
@@ -24,5 +27,15 @@
 @media only screen and (max-width: $breakpointLarge) {
   .group {
     display: block;
+  }
+}
+
+@media only screen and (max-width: $breakpointSmall) {
+  .extraSmall,
+  .small,
+  .medium,
+  .large {
+    max-width: none;
+    width: 100%;
   }
 }

--- a/frontend/src/Components/Form/FormInputGroup.css
+++ b/frontend/src/Components/Form/FormInputGroup.css
@@ -1,18 +1,22 @@
 .inputGroupContainer {
   flex: 1 1 auto;
   min-width: 0;
+  max-width: 100%;
 }
 
 .inputGroup {
   display: flex;
   flex: 1 1 auto;
   flex-wrap: wrap;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .inputContainer {
   position: relative;
   flex: 1 1 auto;
   min-width: 0;
+  max-width: 100%;
 }
 
 .inputUnit {
@@ -21,7 +25,7 @@
   right: 20px;
   margin-top: 7px;
   width: 75px;
-  color: #c6c6c6;
+  color: var(--helpTextColor);
   text-align: right;
   pointer-events: none;
   user-select: none;
@@ -35,7 +39,9 @@
 
 .pendingChangesContainer {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
+  flex: 0 0 30px;
   width: 30px;
 }
 
@@ -48,4 +54,25 @@
 .helpLink {
   margin-top: 5px;
   line-height: 20px;
+  overflow-wrap: anywhere;
+}
+
+@media only screen and (max-width: $breakpointSmall) {
+  .inputGroup {
+    row-gap: 5px;
+  }
+
+  .inputUnit {
+    margin-top: 11px;
+  }
+
+  .pendingChangesContainer {
+    flex-basis: 44px;
+    min-height: 44px;
+    width: 44px;
+  }
+
+  .pendingChangesIcon {
+    line-height: 44px;
+  }
 }

--- a/frontend/src/Components/Form/FormLabel.css
+++ b/frontend/src/Components/Form/FormLabel.css
@@ -3,9 +3,12 @@
   justify-content: flex-end;
   margin-right: $formLabelRightMarginWidth;
   padding-top: 8px;
+  min-width: 0;
   min-height: 35px;
+  max-width: 100%;
   text-align: end;
   font-weight: bold;
+  overflow-wrap: anywhere;
 }
 
 .hasError {
@@ -19,6 +22,11 @@
 @media only screen and (max-width: $breakpointLarge) {
   .label {
     justify-content: flex-start;
+    margin-right: 0;
+    padding-top: 0;
+    padding-bottom: 6px;
+    min-height: 0;
+    text-align: start;
   }
 }
 

--- a/frontend/src/Components/Form/Input.css
+++ b/frontend/src/Components/Form/Input.css
@@ -1,5 +1,7 @@
 .input {
   padding: 6px 16px;
+  min-width: 0;
+  max-width: 100%;
   width: 100%;
   height: 35px;
   border: 1px solid var(--inputBorderColor);
@@ -7,11 +9,17 @@
   background-color: var(--inputBackgroundColor);
   box-shadow: inset 0 1px 1px var(--inputBoxShadowColor);
   color: var(--textColor);
+  scroll-margin-block: 80px;
 
   &:focus {
     outline: 0;
     border-color: var(--inputFocusBorderColor);
     box-shadow: inset 0 1px 1px var(--inputBoxShadowColor), 0 0 8px var(--inputFocusBoxShadowColor);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--themeBlue);
+    outline-offset: 1px;
   }
 }
 
@@ -28,4 +36,12 @@
 .hasButton {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
+}
+
+@media only screen and (max-width: $breakpointSmall) {
+  .input {
+    min-height: 44px;
+    height: 44px;
+    font-size: 16px;
+  }
 }

--- a/frontend/src/Components/Form/SelectInput.css
+++ b/frontend/src/Components/Form/SelectInput.css
@@ -2,6 +2,7 @@
   composes: input from '~Components/Form/Input.css';
 
   padding: 0 11px;
+  max-width: 100%;
 }
 
 .hasError {
@@ -15,4 +16,11 @@
 .isDisabled {
   opacity: 0.7;
   cursor: not-allowed;
+}
+
+@media only screen and (max-width: $breakpointSmall) {
+  .select {
+    min-height: 44px;
+    height: 44px;
+  }
 }

--- a/frontend/src/Components/Link/Button.css
+++ b/frontend/src/Components/Link/Button.css
@@ -1,13 +1,15 @@
 .button {
   composes: link from '~./Link.css';
 
-  overflow: hidden;
+  min-width: 0;
+  max-width: 100%;
   border: 1px solid;
   border-radius: 4px;
   vertical-align: middle;
   text-align: center;
-  white-space: nowrap;
+  white-space: normal;
   line-height: normal;
+  overflow-wrap: anywhere;
 
   &:global(.isDisabled) {
     opacity: 0.65;
@@ -116,4 +118,15 @@
   margin-left: -1px;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
+}
+
+@media only screen and (max-width: $breakpointSmall) {
+  .button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    min-height: 44px;
+  }
 }

--- a/frontend/src/Components/Link/IconButton.css
+++ b/frontend/src/Components/Link/IconButton.css
@@ -1,8 +1,12 @@
 .button {
   composes: link from '~Components/Link/Link.css';
 
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   margin: 0 2px;
+  min-width: 22px;
+  min-height: 22px;
   width: 22px;
   border-radius: 4px;
   background-color: transparent;
@@ -17,5 +21,21 @@
 
   &.isDisabled {
     color: var(--iconButtonDisabledColor);
+  }
+}
+
+@media only screen and (max-width: $breakpointSmall) {
+  .button {
+    min-width: 44px;
+    min-height: 44px;
+    width: 44px;
+  }
+}
+
+@media (pointer: coarse) {
+  .button {
+    min-width: 44px;
+    min-height: 44px;
+    width: 44px;
   }
 }

--- a/frontend/src/Components/Menu/MenuContent.css
+++ b/frontend/src/Components/Menu/MenuContent.css
@@ -2,11 +2,24 @@
   z-index: $popperZIndex;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+  max-width: calc(100vw - 16px - env(safe-area-inset-left) - env(safe-area-inset-right));
+  max-height: calc(100svh - 16px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
   background-color: var(--toolbarMenuItemBackgroundColor);
   line-height: 20px;
+}
+
+@supports (max-height: 100dvh) {
+  .menuContent {
+    max-height: calc(100dvh - 16px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+  }
 }
 
 .scroller {
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
+  overflow-y: auto;
+  max-height: inherit;
+  overscroll-behavior: contain;
 }

--- a/frontend/src/Components/Menu/MenuItem.css
+++ b/frontend/src/Components/Menu/MenuItem.css
@@ -1,10 +1,12 @@
 .menuItem {
   @add-mixin truncate;
-  display: block;
+  display: flex;
+  align-items: center;
   flex-shrink: 0;
   padding: 10px 20px;
   min-width: 150px;
-  max-width: 250px;
+  min-height: 44px;
+  max-width: min(250px, calc(100vw - 16px));
   background-color: var(--toolbarMenuItemBackgroundColor);
   color: var(--menuItemColor);
   line-height: 20px;
@@ -20,4 +22,15 @@
 .isDisabled {
   color: var(--disabledColor);
   pointer-events: none;
+}
+
+@media only screen and (max-width: $breakpointSmall) {
+  .menuItem {
+    overflow: visible;
+    min-width: min(240px, calc(100vw - 16px));
+    max-width: calc(100vw - 16px);
+    text-overflow: clip;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
 }

--- a/frontend/src/Components/Modal/Modal.css
+++ b/frontend/src/Components/Modal/Modal.css
@@ -1,17 +1,20 @@
 .modalContainer {
-  position: absolute;
-  top: 0;
+  position: fixed;
+  inset: 0;
   z-index: $modalZIndex;
-  width: 100%;
-  height: 100%;
 }
 
 .modalBackdrop {
   display: flex;
   align-items: center;
   justify-content: center;
+  padding:
+    calc(12px + env(safe-area-inset-top))
+    calc(12px + env(safe-area-inset-right))
+    calc(12px + env(safe-area-inset-bottom))
+    calc(12px + env(safe-area-inset-left));
+  min-height: 100vh;
   width: 100%;
-  height: 100%;
   background-color: var(--modalBackdropBackgroundColor);
   opacity: 1;
 }
@@ -19,15 +22,29 @@
 .modal {
   position: relative;
   display: flex;
-  max-width: 90%;
-  max-height: 90%;
+  overflow: hidden;
+  min-width: 0;
+  min-height: 0;
+  max-width: calc(100% - 24px);
+  max-height: calc(100svh - 24px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
   border-radius: 6px;
   opacity: 1;
+}
+
+@supports (min-height: 100dvh) {
+  .modalBackdrop {
+    min-height: 100dvh;
+  }
+
+  .modal {
+    max-height: calc(100dvh - 24px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+  }
 }
 
 .modalOpen {
   /* Prevent the body from scrolling when the modal is open */
   overflow: hidden !important;
+  overscroll-behavior: none;
 }
 
 .modalOpenIOS {
@@ -89,17 +106,37 @@
 }
 
 @media only screen and (max-width: $breakpointMedium) {
-  .modalContainer {
-    position: fixed;
+  .modalBackdrop {
+    align-items: stretch;
+    padding: 0;
   }
 
+  .modal.extraSmall,
   .modal.small,
   .modal.medium,
   .modal.large,
   .modal.extraLarge,
   .modal.extraExtraLarge {
-    max-height: 100%;
+    min-height: 0;
+    max-width: none;
+    max-height: none;
     width: 100%;
-    height: 100% !important;
+    height: 100%;
+    border-radius: 0;
+  }
+}
+
+@media only screen and (max-height: 500px) and (orientation: landscape) {
+  .modalBackdrop {
+    align-items: stretch;
+    padding: 0;
+  }
+
+  .modal {
+    max-width: none;
+    max-height: none;
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
   }
 }

--- a/frontend/src/Components/Modal/ModalBody.css
+++ b/frontend/src/Components/Modal/ModalBody.css
@@ -1,12 +1,31 @@
 .modalBody {
   flex: 1 0 1px;
   padding: $modalBodyPadding;
+  min-width: 0;
+  min-height: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .modalScroller {
   flex-grow: 1;
+  min-width: 0;
+  min-height: 0;
+  max-width: 100%;
 }
 
 .innerModalBody {
   padding: $modalBodyPadding;
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+@media only screen and (max-width: $breakpointSmall) {
+  .modalBody,
+  .innerModalBody {
+    padding: 15px;
+    padding-right: calc(15px + env(safe-area-inset-right));
+    padding-left: calc(15px + env(safe-area-inset-left));
+  }
 }

--- a/frontend/src/Components/Modal/ModalContent.css
+++ b/frontend/src/Components/Modal/ModalContent.css
@@ -3,15 +3,24 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  overflow: hidden;
+  min-width: 0;
+  min-height: 0;
+  max-width: 100%;
   width: 100%;
   background-color: var(--modalBackgroundColor);
 }
 
 .closeButton {
   position: absolute;
-  top: 0;
-  right: 0;
+  top: env(safe-area-inset-top);
+  right: env(safe-area-inset-right);
   z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
   width: 60px;
   height: 60px;
   text-align: center;

--- a/frontend/src/Components/Modal/ModalFooter.css
+++ b/frontend/src/Components/Modal/ModalFooter.css
@@ -3,21 +3,29 @@
   align-items: center;
   justify-content: flex-end;
   flex-shrink: 0;
+  flex-wrap: wrap;
   padding: 15px 30px;
+  min-width: 0;
   border-top: 1px solid var(--borderColor);
+  gap: 10px;
 
   a,
   button {
-    margin-left: 10px;
-
-    &:first-child {
-      margin-left: 0;
-    }
+    margin-left: 0;
   }
 }
 
 @media only screen and (max-width: $breakpointSmall) {
   .modalFooter {
     padding: 15px;
+    padding-right: calc(15px + env(safe-area-inset-right));
+    padding-bottom: calc(15px + env(safe-area-inset-bottom));
+    padding-left: calc(15px + env(safe-area-inset-left));
+  }
+
+  .modalFooter a,
+  .modalFooter button {
+    flex: 1 1 120px;
+    min-height: 44px;
   }
 }

--- a/frontend/src/Components/Modal/ModalHeader.css
+++ b/frontend/src/Components/Modal/ModalHeader.css
@@ -2,7 +2,21 @@
   @add-mixin truncate;
 
   flex-shrink: 0;
-  padding: 15px 50px 15px 30px;
+  padding: 15px 60px 15px 30px;
+  padding-top: calc(15px + env(safe-area-inset-top));
+  min-width: 0;
   border-bottom: 1px solid var(--borderColor);
   font-size: 18px;
+}
+
+@media only screen and (max-width: $breakpointSmall) {
+  .modalHeader {
+    overflow: visible;
+    padding-right: calc(60px + env(safe-area-inset-right));
+    padding-left: calc(15px + env(safe-area-inset-left));
+    min-height: calc(60px + env(safe-area-inset-top));
+    text-overflow: clip;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
 }

--- a/frontend/src/Components/Page/Header/PageHeader.css
+++ b/frontend/src/Components/Page/Header/PageHeader.css
@@ -3,7 +3,9 @@
   display: flex;
   align-items: center;
   flex: 0 0 auto;
-  height: $headerHeight;
+  padding-top: env(safe-area-inset-top);
+  min-width: 0;
+  height: calc($headerHeight + env(safe-area-inset-top));
   background-color: var(--pageHeaderBackgroundColor);
   color: var(--white);
 }
@@ -12,7 +14,8 @@
   display: flex;
   align-items: center;
   flex: 0 0 $sidebarWidth;
-  padding-left: 20px;
+  padding-left: calc(20px + env(safe-area-inset-left));
+  min-width: 0;
 }
 
 .logoLink {
@@ -37,15 +40,20 @@
 
 .sidebarToggleContainer {
   display: none;
+  align-items: center;
   justify-content: center;
   flex: 0 0 45px;
   margin-right: 14px;
+  min-width: 44px;
+  min-height: 44px;
 }
 
 .right {
   display: flex;
   justify-content: flex-end;
   flex-grow: 1;
+  padding-right: env(safe-area-inset-right);
+  min-width: 0;
 }
 
 .translate {
@@ -54,10 +62,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 35px;
-  color: #fff;
+  min-width: 44px;
+  min-height: 44px;
+  width: 44px;
+  color: var(--white);
   text-align: center;
-  line-height: 60px;
+  line-height: $headerHeight;
 
   &:hover {
     color: var(--toobarButtonHoverColor);
@@ -70,19 +80,22 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
+  min-width: 44px;
+  min-height: 44px;
+  width: 44px;
   color: var(--themeRed);
   text-align: center;
-  line-height: 60px;
+  line-height: $headerHeight;
 
   &:hover {
-    color: #9c1f30;
+    color: var(--dangerHoverBackgroundColor);
   }
 }
 
 @media only screen and (max-width: $breakpointSmall) {
   .logoContainer {
     flex: 0 0 60px;
+    padding-left: calc(14px + env(safe-area-inset-left));
   }
 
   .sidebarToggleContainer {
@@ -91,8 +104,16 @@
 }
 
 @media only screen and (max-width: $breakpointExtraSmall) {
-  .donate,
-  .translate {
-    display: none;
+  .logoContainer {
+    flex-basis: 52px;
+    padding-left: calc(10px + env(safe-area-inset-left));
+  }
+
+  .sidebarToggleContainer {
+    margin-right: 4px;
+  }
+
+  .right {
+    flex-wrap: wrap;
   }
 }

--- a/frontend/src/Components/Page/Page.css
+++ b/frontend/src/Components/Page/Page.css
@@ -1,6 +1,8 @@
 .page {
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  min-height: 100vh;
   height: 100%;
 }
 
@@ -8,11 +10,19 @@
   position: relative; /* need this to position inner content - is this really needed? */
   display: flex;
   flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+}
+
+@supports (min-height: 100dvh) {
+  .page {
+    min-height: 100dvh;
+  }
 }
 
 @media only screen and (max-width: $breakpointSmall) {
   .page {
     flex-grow: 1;
-    height: initial;
+    height: auto;
   }
 }

--- a/frontend/src/Components/Page/PageContent.css
+++ b/frontend/src/Components/Page/PageContent.css
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  overflow-x: hidden;
+  min-width: 0;
+  max-width: 100%;
   width: 100%;
 }

--- a/frontend/src/Components/Page/PageContentBody.css
+++ b/frontend/src/Components/Page/PageContentBody.css
@@ -1,16 +1,19 @@
 .contentBody {
   /* 1px for flex-basis so the div grows correctly in Edge/Firefox */
   flex: 1 0 1px;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .innerContentBody {
   padding: $pageContentBodyPadding;
+  min-width: 0;
+  max-width: 100%;
 }
 
 @media only screen and (max-width: $breakpointSmall) {
   .contentBody {
     flex-basis: auto;
-    overflow-y: hidden !important;
   }
 
   .innerContentBody {

--- a/frontend/src/Components/Page/PageContentFooter.css
+++ b/frontend/src/Components/Page/PageContentFooter.css
@@ -1,13 +1,26 @@
 .contentFooter {
   display: flex;
   flex: 0 0 auto;
+  flex-wrap: wrap;
   padding: 20px;
+  max-width: 100%;
   background-color: var(--pageFooterBackground);
+  gap: 10px;
 }
 
 @media only screen and (max-width: $breakpointSmall) {
   .contentFooter {
-    display: block;
+    position: sticky;
+    bottom: 0;
+    z-index: 2;
+    display: flex;
+    overflow-y: auto;
+    padding: 15px;
+    padding-right: calc(15px + env(safe-area-inset-right));
+    padding-bottom: calc(15px + env(safe-area-inset-bottom));
+    padding-left: calc(15px + env(safe-area-inset-left));
+    max-height: 50svh;
+    overscroll-behavior: contain;
   }
 }
 

--- a/frontend/src/Components/Page/Sidebar/PageSidebar.css
+++ b/frontend/src/Components/Page/Sidebar/PageSidebar.css
@@ -11,6 +11,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  min-width: 0;
   background-color: var(--sidebarBackgroundColor);
   color: var(--white);
 }
@@ -18,16 +19,22 @@
 @media only screen and (max-width: $breakpointSmall) {
   .sidebarContainer {
     position: fixed;
-    top: 0;
+    top: env(safe-area-inset-top);
+    bottom: 0;
     z-index: 2;
-    height: 100vh;
+    max-width: calc(100% - 44px - env(safe-area-inset-right));
+    height: auto;
   }
 
   .sidebar {
-    position: fixed;
+    position: absolute;
+    inset: 0;
     z-index: 2;
+    overflow-x: hidden;
     overflow-y: auto;
+    padding-bottom: env(safe-area-inset-bottom);
     width: 100%;
     height: 100%;
+    overscroll-behavior: contain;
   }
 }

--- a/frontend/src/Components/Page/Sidebar/PageSidebarItem.css
+++ b/frontend/src/Components/Page/Sidebar/PageSidebarItem.css
@@ -9,9 +9,12 @@
 }
 
 .link {
-  display: block;
-  padding: 12px 24px;
+  display: flex;
+  align-items: center;
+  padding: 10px 24px;
+  min-height: 44px;
   color: var(--sidebarColor);
+  overflow-wrap: anywhere;
 
   &:hover,
   &:focus {
@@ -37,11 +40,14 @@
 
 .iconContainer {
   display: inline-block;
+  flex: 0 0 18px;
   margin-right: 7px;
   width: 18px;
   text-align: center;
 }
 
 .status {
-  float: right;
+  flex-shrink: 0;
+  float: none;
+  margin-left: auto;
 }

--- a/frontend/src/Components/Page/Toolbar/PageToolbar.css
+++ b/frontend/src/Components/Page/Toolbar/PageToolbar.css
@@ -3,14 +3,24 @@
   justify-content: space-between;
   flex: 0 0 auto;
   padding: 0 20px;
+  min-width: 0;
+  min-height: $toolbarHeight;
   height: $toolbarHeight;
   background-color: var(--toolbarBackgroundColor);
   color: var(--toolbarColor);
-  line-height: 60px;
+  line-height: $toolbarHeight;
 }
 
 @media only screen and (max-width: $breakpointSmall) {
   .toolbar {
-    padding: 0 10px;
+    align-items: center;
+    flex-wrap: wrap;
+    padding: 5px 10px;
+    padding-right: calc(10px + env(safe-area-inset-right));
+    padding-left: calc(10px + env(safe-area-inset-left));
+    min-height: $toolbarHeight;
+    height: auto;
+    line-height: normal;
+    gap: 4px;
   }
 }

--- a/frontend/src/Components/Page/Toolbar/PageToolbarButton.css
+++ b/frontend/src/Components/Page/Toolbar/PageToolbarButton.css
@@ -1,9 +1,16 @@
 .toolbarButton {
   composes: link from '~Components/Link/Link.css';
 
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 1 auto;
+  flex-direction: column;
   padding-top: 4px;
   min-width: $toolbarButtonWidth;
-  width: min-content;
+  min-height: 44px;
+  max-width: 100%;
+  width: max-content;
   text-align: center;
 
   &:hover {
@@ -23,15 +30,24 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  overflow: hidden;
-  height: 24px;
+  min-height: 24px;
+  height: auto;
 }
 
 .label {
   padding: 0 3px;
   max-width: 100%;
-  max-height: 100%;
   color: var(--toolbarLabelColor);
   font-size: $extraSmallFontSize;
   line-height: calc($extraSmallFontSize + 1px);
+  overflow-wrap: anywhere;
+}
+
+@media only screen and (max-width: $breakpointMedium) {
+  .toolbarButton {
+    padding: 4px;
+    min-width: 52px;
+    width: auto;
+    white-space: normal;
+  }
 }

--- a/frontend/src/Components/Page/Toolbar/PageToolbarSection.css
+++ b/frontend/src/Components/Page/Toolbar/PageToolbarSection.css
@@ -1,13 +1,14 @@
 .sectionContainer {
   display: flex;
   flex: 1 1 auto;
-  overflow: hidden;
+  min-width: 0;
 }
 
 .section {
   display: flex;
   align-items: stretch;
   flex-grow: 1;
+  min-width: 0;
 }
 
 .left {
@@ -30,8 +31,21 @@
   margin-right: 8px;
 }
 
-@media only screen and (max-width: $breakpointSmall) {
+@media only screen and (max-width: $breakpointMedium) {
+  .sectionContainer,
+  .section {
+    flex-wrap: wrap;
+    overflow: visible;
+  }
+
+  .sectionContainer {
+    flex: 1 1 auto;
+  }
+
   .overflowMenuButton {
+    min-width: 44px;
+    min-height: 44px;
+
     &::after {
       margin-left: 0;
       content: '\25BE';

--- a/frontend/src/Components/Table/Cells/TableRowCell.css
+++ b/frontend/src/Components/Table/Cells/TableRowCell.css
@@ -1,11 +1,14 @@
 .cell {
   padding: 8px;
+  min-width: 0;
   border-top: 1px solid var(--borderColor);
   line-height: 1.52857143;
 }
 
 @media only screen and (max-width: $breakpointMedium) {
   .cell {
-    white-space: nowrap;
+    white-space: normal;
+    word-break: normal;
+    overflow-wrap: anywhere;
   }
 }

--- a/frontend/src/Components/Table/Table.css
+++ b/frontend/src/Components/Table/Table.css
@@ -1,10 +1,16 @@
 .tableContainer {
+  min-width: 0;
+  max-width: 100%;
+  width: 100%;
+
   &.horizontalScroll {
     overflow-x: auto;
+    overscroll-behavior-inline: contain;
   }
 }
 
 .table {
+  min-width: 100%;
   max-width: 100%;
   width: 100%;
   border-collapse: collapse;
@@ -12,12 +18,15 @@
 
 @media only screen and (max-width: $breakpointMedium) {
   .tableContainer {
-    min-width: 100%;
-    width: fit-content;
+    overflow-x: auto;
+    overflow-y: hidden;
+    min-width: 0;
+    max-width: 100%;
+    width: 100%;
+    overscroll-behavior-inline: contain;
+  }
 
-    &.horizontalScroll {
-      overflow-y: hidden;
-      width: 100%;
-    }
+  .table {
+    min-width: 100%;
   }
 }

--- a/frontend/src/Components/Table/TablePager.css
+++ b/frontend/src/Components/Table/TablePager.css
@@ -2,12 +2,15 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  min-width: 0;
+  gap: 10px;
 }
 
 .loadingContainer,
 .controlsContainer,
 .recordsContainer {
   flex: 0 1 33%;
+  min-width: 0;
 }
 
 .controlsContainer {
@@ -31,7 +34,10 @@
 .controls {
   display: flex;
   align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
   text-align: center;
+  gap: 2px;
 }
 
 .pageNumber {
@@ -39,6 +45,9 @@
 }
 
 .pageLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 0;
   width: 30px;
   height: 30px;
@@ -47,6 +56,7 @@
 
 .records {
   color: var(--disabledColor);
+  overflow-wrap: anywhere;
 }
 
 .disabledPageButton {
@@ -67,11 +77,33 @@
 
   .loadingContainer,
   .recordsContainer {
-    flex: 0 1 50%;
+    flex: 1 1 calc(50% - 5px);
   }
 
   .controlsContainer {
-    flex: 0 1 100%;
+    flex: 1 1 100%;
     order: -1;
+  }
+
+  .pageLink {
+    min-width: 44px;
+    min-height: 44px;
+    width: 44px;
+    height: 44px;
+    line-height: 44px;
+  }
+
+  .pageSelect {
+    min-height: 44px;
+    height: 44px;
+  }
+}
+
+@media only screen and (max-width: $breakpointExtraSmall) {
+  .loadingContainer,
+  .recordsContainer {
+    justify-content: center;
+    flex-basis: 100%;
+    text-align: center;
   }
 }

--- a/frontend/src/InteractiveSearch/InteractiveSearch.css
+++ b/frontend/src/InteractiveSearch/InteractiveSearch.css
@@ -1,11 +1,91 @@
 .filterMenuContainer {
   display: flex;
   justify-content: flex-end;
+  flex-wrap: wrap;
   margin-bottom: 10px;
+  min-width: 0;
+  max-width: 100%;
+  gap: 8px;
+}
+
+.mobileSort {
+  display: none;
+}
+
+.results {
+  min-width: 0;
+  max-width: 100%;
 }
 
 .alert {
   composes: alert from '~Components/Alert.css';
 
   margin-top: 10px;
+  overflow-wrap: anywhere;
+}
+
+@media only screen and (max-width: $breakpointMedium) {
+  .mobileSort {
+    display: flex;
+    align-items: center;
+    margin-bottom: 10px;
+    min-width: 0;
+    max-width: 100%;
+    gap: 8px;
+  }
+
+  .mobileSortLabel {
+    flex: 0 0 auto;
+    font-weight: bold;
+  }
+
+  .mobileSortSelect {
+    flex: 1 1 auto;
+    padding: 0 11px;
+    min-width: 0;
+    min-height: 44px;
+    max-width: 100%;
+    height: 44px;
+    border: 1px solid var(--inputBorderColor);
+    border-radius: 4px;
+    background-color: var(--inputBackgroundColor);
+    color: var(--textColor);
+    font-size: 16px;
+  }
+
+  .results > div {
+    overflow: visible;
+  }
+
+  .results table,
+  .results tbody {
+    display: block;
+    min-width: 0;
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .results thead {
+    position: absolute;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    margin: -1px;
+    padding: 0;
+    width: 1px;
+    height: 1px;
+    border: 0;
+    white-space: nowrap;
+  }
+}
+
+@media only screen and (max-width: $breakpointSmall) {
+  .filterMenuContainer {
+    justify-content: stretch;
+  }
+
+  .mobileSort {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 4px;
+  }
 }

--- a/frontend/src/InteractiveSearch/InteractiveSearch.css.d.ts
+++ b/frontend/src/InteractiveSearch/InteractiveSearch.css.d.ts
@@ -3,6 +3,10 @@
 interface CssExports {
   'alert': string;
   'filterMenuContainer': string;
+  'mobileSort': string;
+  'mobileSortLabel': string;
+  'mobileSortSelect': string;
+  'results': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/frontend/src/InteractiveSearch/InteractiveSearch.tsx
+++ b/frontend/src/InteractiveSearch/InteractiveSearch.tsx
@@ -121,6 +121,85 @@ const columns: Column[] = [
   },
 ];
 
+const reversibleSortDirections: SortDirection[] = [
+  sortDirections.ASCENDING,
+  sortDirections.DESCENDING,
+];
+
+interface MobileSortOption {
+  name: string;
+  label: () => string;
+  directions: SortDirection[];
+}
+
+const mobileSortOptions: MobileSortOption[] = [
+  {
+    name: 'protocol',
+    label: () => translate('Source'),
+    directions: reversibleSortDirections,
+  },
+  {
+    name: 'age',
+    label: () => translate('Age'),
+    directions: reversibleSortDirections,
+  },
+  {
+    name: 'title',
+    label: () => translate('Title'),
+    directions: reversibleSortDirections,
+  },
+  {
+    name: 'indexer',
+    label: () => translate('Indexer'),
+    directions: reversibleSortDirections,
+  },
+  {
+    name: 'history',
+    label: () => translate('History'),
+    directions: [sortDirections.ASCENDING],
+  },
+  {
+    name: 'size',
+    label: () => translate('Size'),
+    directions: reversibleSortDirections,
+  },
+  {
+    name: 'peers',
+    label: () => translate('Peers'),
+    directions: reversibleSortDirections,
+  },
+  {
+    name: 'languages',
+    label: () => translate('Language'),
+    directions: reversibleSortDirections,
+  },
+  {
+    name: 'qualityWeight',
+    label: () => translate('Quality'),
+    directions: reversibleSortDirections,
+  },
+  {
+    name: 'customFormatScore',
+    label: () => translate('CustomFormatScore'),
+    directions: reversibleSortDirections,
+  },
+  {
+    name: 'indexerFlags',
+    label: () => translate('IndexerFlags'),
+    directions: reversibleSortDirections,
+  },
+  {
+    name: 'rejections',
+    label: () => translate('Rejections'),
+    directions: [sortDirections.ASCENDING],
+  },
+  {
+    name: 'releaseWeight',
+    label: () => translate('AddToDownloadQueue'),
+    directions: [sortDirections.ASCENDING],
+  },
+];
+
 interface InteractiveSearchProps {
   searchPayload: InteractiveSearchPayload;
 }
@@ -155,6 +234,15 @@ function InteractiveSearch({ searchPayload }: InteractiveSearchProps) {
       dispatch(setReleasesSort({ sortKey, sortDirection }));
     },
     [dispatch]
+  );
+
+  const handleMobileSortChange = useCallback(
+    ({ currentTarget }: React.ChangeEvent<HTMLSelectElement>) => {
+      const [nextSortKey, nextSortDirection] = currentTarget.value.split('|');
+
+      handleSortPress(nextSortKey, nextSortDirection as SortDirection);
+    },
+    [handleSortPress]
   );
 
   const handleGrabPress = useCallback(
@@ -200,6 +288,39 @@ function InteractiveSearch({ searchPayload }: InteractiveSearchProps) {
         />
       </div>
 
+      <div className={styles.mobileSort}>
+        <label
+          className={styles.mobileSortLabel}
+          htmlFor="interactive-search-sort"
+        >
+          {translate('Sort')}
+        </label>
+        <select
+          id="interactive-search-sort"
+          className={styles.mobileSortSelect}
+          value={`${sortKey}|${sortDirection || sortDirections.ASCENDING}`}
+          onChange={handleMobileSortChange}
+        >
+          {mobileSortOptions.flatMap((option) => {
+            const label = option.label();
+
+            return option.directions.map((direction) => {
+              const directionIndicator =
+                direction === sortDirections.ASCENDING ? '↑' : '↓';
+
+              return (
+                <option
+                  key={`${option.name}-${direction}`}
+                  value={`${option.name}|${direction}`}
+                >
+                  {label} {directionIndicator}
+                </option>
+              );
+            });
+          })}
+        </select>
+      </div>
+
       {isFetching ? <LoadingIndicator /> : null}
 
       {!isFetching && error ? (
@@ -230,25 +351,27 @@ function InteractiveSearch({ searchPayload }: InteractiveSearchProps) {
       ) : null}
 
       {isPopulated && !!items.length ? (
-        <Table
-          columns={columns}
-          sortKey={sortKey}
-          sortDirection={sortDirection}
-          onSortPress={handleSortPress}
-        >
-          <TableBody>
-            {items.map((item) => {
-              return (
-                <InteractiveSearchRow
-                  key={`${item.indexerId}-${item.guid}`}
-                  {...item}
-                  searchPayload={searchPayload}
-                  onGrabPress={handleGrabPress}
-                />
-              );
-            })}
-          </TableBody>
-        </Table>
+        <div className={styles.results}>
+          <Table
+            columns={columns}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            onSortPress={handleSortPress}
+          >
+            <TableBody>
+              {items.map((item) => {
+                return (
+                  <InteractiveSearchRow
+                    key={`${item.indexerId}-${item.guid}`}
+                    {...item}
+                    searchPayload={searchPayload}
+                    onGrabPress={handleGrabPress}
+                  />
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
       ) : null}
 
       {totalItems !== items.length && !!items.length ? (

--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.css
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.css
@@ -1,14 +1,25 @@
+.releaseRow {
+  min-width: 0;
+}
+
 .protocol {
   composes: cell from '~Components/Table/Cells/TableRowCell.css';
 
   width: 80px;
 }
 
+.title {
+  composes: cell from '~Components/Table/Cells/TableRowCell.css';
+}
+
 .titleContent {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  word-break: break-all;
+  min-width: 0;
+  word-break: normal;
+  gap: 8px;
+  overflow-wrap: anywhere;
 }
 
 .indexer {
@@ -92,7 +103,6 @@
   position: absolute;
   top: 4px;
   left: 0;
-  /* width: 100%; */
   text-align: center;
 }
 
@@ -100,6 +110,137 @@
   position: absolute;
   top: 7px;
   left: 8px;
-  /* width: 100%; */
   text-align: center;
+}
+
+@media only screen and (max-width: $breakpointMedium) {
+  .releaseRow {
+    display: grid;
+    margin-bottom: 12px;
+    min-width: 0;
+    max-width: 100%;
+    width: 100%;
+    border: 1px solid var(--borderColor);
+    border-radius: 6px;
+    background-color: var(--cardBackgroundColor);
+    box-shadow: 0 1px 3px var(--cardShadowColor);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .releaseRow > td {
+    display: flex;
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 8px 10px;
+    min-width: 0;
+    width: auto;
+    border-top: 0;
+    border-bottom: 1px solid var(--borderColor);
+    white-space: normal;
+    gap: 2px;
+    overflow-wrap: anywhere;
+  }
+
+  .releaseRow > td::before {
+    color: var(--helpTextColor);
+    content: attr(data-label);
+    font-weight: bold;
+    font-size: $smallFontSize;
+    line-height: 1.25;
+  }
+
+  .releaseRow .title,
+  .releaseRow .download {
+    grid-column: 1 / -1;
+  }
+
+  .releaseRow .title {
+    grid-row: 1;
+  }
+
+  .releaseRow .download {
+    grid-row: 2;
+  }
+
+  .releaseRow .title {
+    padding-top: 12px;
+    padding-bottom: 12px;
+    background-color: var(--cardAlternateBackgroundColor);
+    font-size: $defaultFontSize;
+  }
+
+  .titleContent {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .quality,
+  .age,
+  .size {
+    white-space: normal;
+  }
+
+  .download {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-direction: row;
+    min-width: 0;
+    width: auto;
+    border-bottom: 0;
+    background-color: var(--cardAlternateBackgroundColor);
+    text-align: end;
+    gap: 4px;
+  }
+
+  .download::before {
+    flex: 1 1 auto;
+    margin-right: auto;
+    text-align: start;
+  }
+
+  .download > button,
+  .download > a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .manualDownloadContent {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    min-width: 44px;
+    min-height: 44px;
+    width: 44px;
+    height: 44px;
+    line-height: 44px;
+  }
+
+  .interactiveIcon {
+    top: 50%;
+    left: 6px;
+    transform: translateY(-50%);
+  }
+
+  .downloadIcon {
+    top: 50%;
+    left: 22px;
+    transform: translateY(-50%);
+  }
+}
+
+@media only screen and (max-width: 340px) {
+  .releaseRow {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .releaseRow .title,
+  .releaseRow .download {
+    grid-column: 1;
+  }
 }

--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.css.d.ts
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.css.d.ts
@@ -16,7 +16,9 @@ interface CssExports {
   'protocol': string;
   'quality': string;
   'rejected': string;
+  'releaseRow': string;
   'size': string;
+  'title': string;
   'titleContent': string;
 }
 export const cssExports: CssExports;

--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.tsx
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.tsx
@@ -192,13 +192,17 @@ function InteractiveSearchRow(props: InteractiveSearchRowProps) {
   }, [setIsOverrideModalOpen]);
 
   return (
-    <TableRow>
-      <TableRowCell className={styles.protocol}>
+    <TableRow className={styles.releaseRow}>
+      <TableRowCell
+        className={styles.protocol}
+        data-label={translate('Source')}
+      >
         <ProtocolLabel protocol={protocol} />
       </TableRowCell>
 
       <TableRowCell
         className={styles.age}
+        data-label={translate('Age')}
         title={formatDateTime(publishDate, longDateFormat, timeFormat, {
           includeSeconds: true,
         })}
@@ -206,7 +210,7 @@ function InteractiveSearchRow(props: InteractiveSearchRowProps) {
         {formatAge(age, ageHours, ageMinutes)}
       </TableRowCell>
 
-      <TableRowCell>
+      <TableRowCell className={styles.title} data-label={translate('Title')}>
         <div className={styles.titleContent}>
           <Link to={infoUrl} title={title}>
             {title}
@@ -214,9 +218,17 @@ function InteractiveSearchRow(props: InteractiveSearchRowProps) {
         </div>
       </TableRowCell>
 
-      <TableRowCell className={styles.indexer}>{indexer}</TableRowCell>
+      <TableRowCell
+        className={styles.indexer}
+        data-label={translate('Indexer')}
+      >
+        {indexer}
+      </TableRowCell>
 
-      <TableRowCell className={styles.history}>
+      <TableRowCell
+        className={styles.history}
+        data-label={translate('History')}
+      >
         {historyGrabbedData?.date && !historyFailedData?.date ? (
           <Tooltip
             anchor={<Icon name={icons.DOWNLOADING} kind={kinds.DEFAULT} />}
@@ -268,23 +280,34 @@ function InteractiveSearchRow(props: InteractiveSearchRowProps) {
         ) : null}
       </TableRowCell>
 
-      <TableRowCell className={styles.size}>{formatBytes(size)}</TableRowCell>
+      <TableRowCell className={styles.size} data-label={translate('Size')}>
+        {formatBytes(size)}
+      </TableRowCell>
 
-      <TableRowCell className={styles.peers}>
+      <TableRowCell className={styles.peers} data-label={translate('Peers')}>
         {protocol === 'torrent' ? (
           <Peers seeders={seeders} leechers={leechers} />
         ) : null}
       </TableRowCell>
 
-      <TableRowCell className={styles.languages}>
+      <TableRowCell
+        className={styles.languages}
+        data-label={translate('Language')}
+      >
         <MovieLanguages languages={languages} />
       </TableRowCell>
 
-      <TableRowCell className={styles.quality}>
+      <TableRowCell
+        className={styles.quality}
+        data-label={translate('Quality')}
+      >
         <MovieQuality quality={quality} showRevision={true} />
       </TableRowCell>
 
-      <TableRowCell className={styles.customFormatScore}>
+      <TableRowCell
+        className={styles.customFormatScore}
+        data-label={translate('CustomFormatScore')}
+      >
         <Tooltip
           anchor={formatCustomFormatScore(
             customFormatScore,
@@ -295,7 +318,10 @@ function InteractiveSearchRow(props: InteractiveSearchRowProps) {
         />
       </TableRowCell>
 
-      <TableRowCell className={styles.indexerFlags}>
+      <TableRowCell
+        className={styles.indexerFlags}
+        data-label={translate('IndexerFlags')}
+      >
         {indexerFlags.length ? (
           <Popover
             anchor={<Icon name={icons.FLAG} />}
@@ -312,7 +338,10 @@ function InteractiveSearchRow(props: InteractiveSearchRowProps) {
         ) : null}
       </TableRowCell>
 
-      <TableRowCell className={styles.rejected}>
+      <TableRowCell
+        className={styles.rejected}
+        data-label={translate('Rejections')}
+      >
         {rejections.length ? (
           <Popover
             anchor={<Icon name={icons.DANGER} kind={kinds.DANGER} />}
@@ -329,7 +358,10 @@ function InteractiveSearchRow(props: InteractiveSearchRowProps) {
         ) : null}
       </TableRowCell>
 
-      <TableRowCell className={styles.download}>
+      <TableRowCell
+        className={styles.download}
+        data-label={translate('AddToDownloadQueue')}
+      >
         <SpinnerIconButton
           name={getDownloadIcon(isGrabbing, isGrabbed, grabError)}
           kind={getDownloadKind(isGrabbed, grabError)}

--- a/frontend/src/Movie/Details/MovieDetails.css
+++ b/frontend/src/Movie/Details/MovieDetails.css
@@ -1,5 +1,7 @@
 .innerContentBody {
   padding: 0;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .header {
@@ -12,6 +14,7 @@
   margin-top: 20px;
   text-align: center;
   font-size: 20px;
+  overflow-wrap: anywhere;
 }
 
 .backdrop {
@@ -19,6 +22,7 @@
   z-index: -1;
   width: 100%;
   height: 100%;
+  background-position: center;
   background-size: cover;
 }
 
@@ -33,6 +37,7 @@
 .headerContent {
   display: flex;
   padding: 30px;
+  min-width: 0;
   width: 100%;
   height: 100%;
   color: var(--white);
@@ -51,6 +56,7 @@
   flex-direction: column;
   flex-grow: 1;
   overflow: hidden;
+  min-width: 0;
 }
 
 .titleRow {
@@ -58,21 +64,28 @@
   display: flex;
   justify-content: space-between;
   flex: 0 0 auto;
+  min-width: 0;
+  gap: 10px;
 }
 
 .titleContainer {
   display: flex;
+  flex-wrap: wrap;
   margin-bottom: 5px;
+  min-width: 0;
 }
 
 .title {
+  min-width: 0;
   font-weight: 300;
   font-size: 50px;
   line-height: 60px;
+  overflow-wrap: anywhere;
 }
 
 .toggleMonitoredContainer {
   align-self: center;
+  flex-shrink: 0;
   margin-right: 10px;
 }
 
@@ -98,7 +111,12 @@
 .movieNavigationButtons {
   position: absolute;
   right: 0;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  white-space: normal;
+  gap: 4px;
 }
 
 .movieNavigationButton {
@@ -106,7 +124,7 @@
 
   margin-left: 5px;
   width: 30px;
-  color: #e1e2e3;
+  color: var(--sidebarColor);
   white-space: nowrap;
 
   &:hover {
@@ -115,8 +133,12 @@
 }
 
 .details {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   margin-bottom: 8px;
   padding-left: 7px;
+  min-width: 0;
   font-weight: 300;
   font-size: 20px;
 }
@@ -155,33 +177,48 @@
 .studio,
 .collection,
 .genres {
+  min-width: 0;
+  max-width: 100%;
+  word-break: break-word;
   font-weight: 300;
   font-size: 17px;
+  overflow-wrap: anywhere;
 }
 
 .overview {
   flex: 1 0 0;
   margin-top: 8px;
+  min-width: 0;
   min-height: 0;
   text-wrap: balance;
   font-size: $intermediateFontSize;
+  overflow-wrap: anywhere;
 }
 
 .contentContainer {
   padding: 20px;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .tabList {
+  display: flex;
+  overflow-x: auto;
   margin: 0;
   padding: 0;
+  max-width: 100%;
   border-bottom: 1px solid var(--lightGray);
+  overscroll-behavior-inline: contain;
 }
 
 .tab {
   position: relative;
   bottom: -1px;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
   padding: 6px 12px;
+  min-height: 44px;
   border: 1px solid transparent;
   border-top: none;
   list-style: none;
@@ -194,28 +231,44 @@
 
 .tabContent {
   margin-top: 20px;
-}
-
-@media only screen and (max-width: $breakpointSmall) {
-  .contentContainer {
-    padding: 20px 0;
-  }
-
-  .headerContent {
-    padding: 15px;
-  }
-
-  .title {
-    font-weight: 300;
-    font-size: 30px;
-    line-height: 30px;
-  }
+  min-width: 0;
+  max-width: 100%;
 }
 
 @media only screen and (max-width: $breakpointLarge) {
-  .poster,
-  .movieNavigationButtons {
+  .header {
+    min-height: 300px;
+    height: auto;
+  }
+
+  .headerContent {
+    min-height: 300px;
+    height: auto;
+  }
+
+  .poster {
     display: none;
+  }
+
+  .info {
+    overflow: visible;
+  }
+
+  .titleRow {
+    flex-wrap: wrap;
+  }
+
+  .movieNavigationButtons {
+    position: static;
+    flex: 0 0 auto;
+    margin-left: auto;
+  }
+
+  .movieNavigationButton {
+    margin-left: 0;
+    min-width: 44px;
+    min-height: 44px;
+    width: 44px;
   }
 
   .certification,
@@ -227,6 +280,71 @@
   }
 
   .details {
+    padding-left: 0;
     font-size: 19px;
+  }
+}
+
+@media only screen and (max-width: $breakpointSmall) {
+  .header {
+    min-height: 0;
+  }
+
+  .headerContent {
+    padding: 15px;
+    padding-right: calc(15px + env(safe-area-inset-right));
+    padding-left: calc(15px + env(safe-area-inset-left));
+    min-height: 0;
+  }
+
+  .titleRow {
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .titleContainer {
+    flex: 1 1 100%;
+  }
+
+  .title {
+    font-weight: 300;
+    font-size: clamp(28px, 9vw, 38px);
+    line-height: 1.1;
+  }
+
+  .movieNavigationButtons {
+    justify-content: flex-start;
+    margin-left: 0;
+    width: 100%;
+  }
+
+  .details {
+    font-size: 17px;
+    gap: 2px 0;
+  }
+
+  .path,
+  .sizeOnDisk,
+  .qualityProfileName,
+  .statusName,
+  .originalLanguage,
+  .studio,
+  .collection,
+  .genres {
+    font-size: 16px;
+  }
+
+  .overview {
+    flex: 0 0 auto;
+    text-wrap: pretty;
+  }
+
+  .contentContainer {
+    padding: 15px 0;
+  }
+
+  .tabContent {
+    padding-right: 10px;
+    padding-left: 10px;
   }
 }

--- a/frontend/src/Movie/Details/MovieDetailsLinks.css
+++ b/frontend/src/Movie/Details/MovieDetailsLinks.css
@@ -1,11 +1,20 @@
 .links {
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
   margin: 0;
+  min-width: 0;
+  max-width: 100%;
+  gap: 4px 8px;
 }
 
 .link {
-  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .linkLabel {
@@ -16,7 +25,11 @@
 
 @media only screen and (max-width: $breakpointExtraSmall) {
   .links {
-    display: flex;
-    flex-flow: column wrap;
+    align-items: flex-start;
+    flex-flow: column nowrap;
+  }
+
+  .link {
+    width: 100%;
   }
 }

--- a/frontend/src/Movie/Index/MovieIndex.css
+++ b/frontend/src/Movie/Index/MovieIndex.css
@@ -2,12 +2,15 @@
   display: flex;
   flex: 1 0 1px;
   overflow: hidden;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .errorMessage {
   margin-top: 20px;
   text-align: center;
   font-size: 20px;
+  overflow-wrap: anywhere;
 }
 
 .contentBody {
@@ -16,6 +19,8 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .postersInnerContentBody {
@@ -27,6 +32,8 @@
 
   /* 5px less padding than normal to handle poster's 5px margin */
   padding: calc($pageContentBodyPadding - 5px);
+  min-width: 0;
+  max-width: 100%;
 }
 
 .tableInnerContentBody {
@@ -35,12 +42,16 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .contentBodyContainer {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  min-width: 0;
+  max-width: 100%;
 }
 
 @media only screen and (max-width: $breakpointSmall) {

--- a/frontend/src/Movie/Index/MovieIndexFooter.css
+++ b/frontend/src/Movie/Index/MovieIndexFooter.css
@@ -2,16 +2,22 @@
   display: flex;
   flex-wrap: wrap;
   margin-top: 20px;
+  min-width: 0;
   font-size: $smallFontSize;
+  gap: 4px 16px;
 }
 
 .legendItem {
   display: flex;
+  align-items: center;
   margin-bottom: 4px;
+  min-width: 0;
   line-height: 16px;
+  overflow-wrap: anywhere;
 }
 
 .legendItemColor {
+  flex-shrink: 0;
   margin-right: 8px;
   width: 30px;
   height: 16px;
@@ -66,6 +72,8 @@
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
+  min-width: 0;
+  gap: 8px 16px;
 }
 
 @media (max-width: $breakpointLarge) {

--- a/frontend/src/Movie/Index/Overview/MovieIndexOverview.css
+++ b/frontend/src/Movie/Index/Overview/MovieIndexOverview.css
@@ -3,10 +3,13 @@ $hoverScale: 1.05;
 .content {
   display: flex;
   flex-grow: 1;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .poster {
   position: relative;
+  flex-shrink: 0;
 }
 
 .editorSelect {
@@ -51,6 +54,7 @@ $hoverScale: 1.05;
   flex-direction: column;
   overflow: hidden;
   padding-left: 10px;
+  min-width: 0;
 }
 
 .titleRow {
@@ -58,7 +62,9 @@ $hoverScale: 1.05;
   justify-content: space-between;
   flex: 0 0 auto;
   margin-bottom: 10px;
+  min-width: 0;
   line-height: 32px;
+  gap: 8px;
 }
 
 .title {
@@ -66,18 +72,27 @@ $hoverScale: 1.05;
   composes: link;
 
   flex: 1 0 1px;
+  min-width: 0;
   font-weight: 300;
   font-size: 30px;
 }
 
 .actions {
-  white-space: nowrap;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  white-space: normal;
 }
 
 .details {
   display: flex;
   justify-content: space-between;
   flex: 1 0 auto;
+  flex-wrap: wrap;
+  min-width: 0;
+  gap: 8px;
 }
 
 .overviewContainer {
@@ -85,24 +100,58 @@ $hoverScale: 1.05;
   justify-content: space-between;
   flex: 0 1 1000px;
   flex-direction: column;
+  min-width: 0;
 }
 
 .overview {
   composes: link;
 
   overflow: hidden;
+  min-width: 0;
   min-height: 0;
+  overflow-wrap: anywhere;
 }
 
 .tags {
   display: flex;
   justify-content: space-around;
+  flex-wrap: wrap;
   overflow: hidden;
+  min-width: 0;
 }
 
 @media only screen and (max-width: $breakpointSmall) {
+  .content {
+    align-items: flex-start;
+  }
+
+  .info {
+    padding-left: 8px;
+  }
+
+  .titleRow {
+    flex-wrap: wrap;
+    margin-bottom: 6px;
+    line-height: 1.2;
+  }
+
+  .title {
+    flex-basis: 100%;
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+    font-size: 22px;
+    overflow-wrap: anywhere;
+  }
+
+  .actions {
+    justify-content: flex-start;
+    width: 100%;
+  }
+
   .overview {
-    display: none;
+    display: block;
+    margin-top: 8px;
   }
 }
 

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.css
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.css
@@ -1,12 +1,13 @@
 $hoverScale: 1.05;
 
 .content {
-  transition: all 200ms ease-in;
+  transition: box-shadow 200ms ease-in;
 
-  &:hover {
+  &:hover,
+  &:focus-within {
     z-index: 2;
     box-shadow: 0 0 12px var(--black);
-    transition: all 200ms ease-in;
+    transition: box-shadow 200ms ease-in;
 
     .controls {
       opacity: 0.9;
@@ -38,6 +39,7 @@ $hoverScale: 1.05;
   color: var(--offWhite);
   text-align: center;
   font-size: 20px;
+  overflow-wrap: anywhere;
 }
 
 .title {
@@ -53,8 +55,9 @@ $hoverScale: 1.05;
   bottom: 10px;
   left: 10px;
   z-index: 3;
+  display: flex;
   border-radius: 4px;
-  background-color: #707070;
+  background-color: var(--toolbarBackgroundColor);
   color: var(--white);
   font-size: $smallFontSize;
   opacity: 0;
@@ -73,6 +76,33 @@ $hoverScale: 1.05;
   .container {
     padding: 5px;
   }
+
+  .title {
+    overflow: visible;
+    padding: 4px;
+    min-height: 34px;
+    text-overflow: clip;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .controls {
+    bottom: 6px;
+    left: 6px;
+    opacity: 0.92;
+  }
+
+  .action {
+    min-width: 44px;
+    min-height: 44px;
+    width: 44px;
+  }
+}
+
+@media (hover: none) {
+  .controls {
+    opacity: 0.92;
+  }
 }
 
 .tags {
@@ -80,6 +110,7 @@ $hoverScale: 1.05;
   align-items: center;
   justify-content: space-around;
   padding: 0 3px;
+  min-width: 0;
   height: 21px;
   background-color: var(--movieBackgroundColor);
 }
@@ -87,6 +118,7 @@ $hoverScale: 1.05;
 .tagsList {
   display: flex;
   overflow: hidden;
+  min-width: 0;
 }
 
 .deleted {
@@ -122,7 +154,7 @@ $hoverScale: 1.05;
 }
 
 .nextAiring {
-  background-color: #fafbfc;
+  background-color: var(--cardAlternateBackgroundColor);
   text-align: center;
   font-size: $smallFontSize;
 }

--- a/frontend/src/Movie/Index/Posters/MovieIndexPosterInfo.css
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPosterInfo.css
@@ -1,4 +1,5 @@
 .info {
+  min-width: 0;
   background-color: var(--movieBackgroundColor);
   text-align: center;
   font-size: $smallFontSize;
@@ -16,4 +17,15 @@
 
 .tagsList {
   composes: tagsList from '~./MovieIndexPoster.css';
+}
+
+@media only screen and (max-width: $breakpointSmall) {
+  .title {
+    overflow: visible;
+    padding: 4px;
+    min-height: 34px;
+    text-overflow: clip;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
 }

--- a/frontend/src/Movie/Index/Select/MovieIndexSelectFooter.css
+++ b/frontend/src/Movie/Index/Select/MovieIndexSelectFooter.css
@@ -2,27 +2,35 @@
   composes: contentFooter from '~Components/Page/PageContentFooter.css';
 
   align-items: center;
+  min-width: 0;
 }
 
 .buttons {
   display: flex;
+  flex-wrap: wrap;
+  min-width: 0;
+  gap: 10px;
 }
 
 .actionButtons,
 .deleteButtons {
   display: flex;
+  flex-wrap: wrap;
+  min-width: 0;
   gap: 10px;
 }
 
 .deleteButtons {
-  margin-left: 50px;
+  margin-left: 40px;
 }
 
 .selected {
   display: flex;
   justify-content: flex-end;
   flex-grow: 1;
+  min-width: 0;
   font-weight: bold;
+  overflow-wrap: anywhere;
 }
 
 @media only screen and (max-width: $breakpointMedium) {
@@ -33,7 +41,7 @@
 
   .selected {
     justify-content: center;
-    margin-bottom: 20px;
+    margin-bottom: 10px;
     width: 100%;
     order: -1;
   }
@@ -42,31 +50,33 @@
 @media only screen and (max-width: $breakpointSmall) {
   .footer {
     display: flex;
+    align-items: stretch;
     flex-direction: column;
   }
 
   .buttons {
     flex-direction: column;
-    margin-top: 20px;
-    gap: 20px;
-  }
-
-  .actionButtons {
-    flex-wrap: wrap;
+    margin-top: 0;
+    gap: 12px;
   }
 
   .actionButtons,
   .deleteButtons {
     display: flex;
-    justify-content: center;
+    justify-content: stretch;
+    margin-left: 0;
+    width: 100%;
   }
 
-  .deleteButtons {
-    margin-left: 0;
+  .actionButtons > button,
+  .deleteButtons > button {
+    flex: 1 1 120px;
+    min-height: 44px;
   }
 
   .selected {
     justify-content: center;
+    margin-bottom: 0;
     order: -1;
   }
 }

--- a/frontend/src/Styles/Themes/dark.js
+++ b/frontend/src/Styles/Themes/dark.js
@@ -42,6 +42,7 @@ module.exports = {
   themeDarkColor: '#494949',
   themeLightColor: '#595959',
   pageBackground: '#202020',
+  pageFooterBackground: 'rgba(0, 0, 0, .25)',
   pageFooterBackgroud: 'rgba(0, 0, 0, .25)',
 
   torrentColor: '#00853d',

--- a/frontend/src/Styles/Themes/index.js
+++ b/frontend/src/Styles/Themes/index.js
@@ -1,11 +1,13 @@
 import * as dark from './dark';
 import * as light from './light';
+import * as oled from './oled';
 
-const defaultDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-const auto = defaultDark ? dark : light;
+// ApplyTheme resolves Auto at runtime so it can react to system-theme changes.
+const auto = light;
 
 export default {
   auto,
   light,
-  dark
+  dark,
+  oled
 };

--- a/frontend/src/Styles/Themes/light.js
+++ b/frontend/src/Styles/Themes/light.js
@@ -43,6 +43,7 @@ module.exports = {
   themeDarkColor: '#595959',
   themeLightColor: '#707070',
   pageBackground: '#f5f7fa',
+  pageFooterBackground: '#f1f1f1',
   pageFooterBackgroud: '#f1f1f1',
 
   torrentColor: '#00853d',

--- a/frontend/src/Styles/Themes/oled.js
+++ b/frontend/src/Styles/Themes/oled.js
@@ -1,0 +1,82 @@
+const dark = require('./dark');
+
+module.exports = {
+  ...dark,
+
+  // Theme Colors
+  textColor: '#d2d2d2',
+  defaultColor: '#d2d2d2',
+  disabledColor: '#999',
+  dimColor: '#777',
+  helpTextColor: '#a4a6a7',
+  pageBackground: '#000000',
+  pageFooterBackground: '#050505',
+  pageFooterBackgroud: '#050505',
+
+  // Header
+  pageHeaderBackgroundColor: '#050505',
+
+  // Sidebar
+  sidebarBackgroundColor: '#050505',
+  sidebarActiveBackgroundColor: '#171717',
+
+  // Toolbar
+  toolbarBackgroundColor: '#080808',
+  toolbarMenuItemBackgroundColor: '#101010',
+  toolbarMenuItemHoverBackgroundColor: '#1b1b1b',
+
+  // Accents
+  borderColor: '#606060',
+  inputBorderColor: '#606060',
+
+  // Buttons
+  defaultBackgroundColor: '#151515',
+  defaultBorderColor: '#606060',
+  defaultHoverBackgroundColor: '#202020',
+  defaultHoverBorderColor: '#777777',
+
+  // Modal
+  modalBackgroundColor: '#080808',
+
+  // Menu
+  menuItemHoverBackgroundColor: '#1c1c1c',
+
+  // Scroller
+  scrollbarBackgroundColor: '#3d3d3d',
+  scrollbarHoverBackgroundColor: '#575757',
+
+  // Card
+  cardBackgroundColor: '#080808',
+  cardShadowColor: '#000000',
+  cardAlternateBackgroundColor: '#111111',
+  cardCenterBackgroundColor: '#080808',
+
+  // Form
+  inputBackgroundColor: '#0d0d0d',
+  inputReadOnlyBackgroundColor: '#050505',
+  inputHoverBackgroundColor: '#181818',
+  inputSelectedBackgroundColor: '#202020',
+
+  // Popover
+  popoverTitleBackgroundColor: '#111111',
+  popoverTitleBorderColor: '#606060',
+  popoverBodyBackgroundColor: '#080808',
+  popoverArrowBorderColor: '#606060',
+
+  // Calendar
+  calendarTodayBackgroundColor: '#171717',
+  calendarBackgroundColor: '#050505',
+  calendarBorderColor: '#606060',
+
+  // Table
+  tableRowHoverBackgroundColor: '#151515',
+
+  // Movie
+  addMovieBackgroundColor: '#050505',
+  movieBackgroundColor: '#080808',
+  searchIconContainerBackgroundColor: '#0d0d0d',
+
+  // Misc
+  progressBarBackgroundColor: '#292929',
+  logEventsBackgroundColor: '#050505'
+};

--- a/frontend/src/Styles/scaffolding.css
+++ b/frontend/src/Styles/scaffolding.css
@@ -8,20 +8,44 @@
   box-sizing: border-box;
 }
 
-*:focus {
+*:focus-visible {
+  outline: 2px solid var(--inputFocusBorderColor);
+  outline-offset: 2px;
+}
+
+[tabindex='-1']:focus-visible {
   outline: none;
+}
+
+::selection {
+  background-color: var(--selectedColor);
+  color: var(--black);
 }
 /* stylelint-enable */
 
 html,
 body {
+  min-width: 0;
+  width: 100%;
   color: var(--textColor);
   font-family: 'Roboto', 'open sans', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
 }
 
+html {
+  background-color: var(--pageBackground);
+}
+
 body {
+  min-height: 100vh;
+  background-color: var(--pageBackground);
   font-size: 14px;
   line-height: 1.528571429; /* 20/14 */
+}
+
+@supports (min-height: 100dvh) {
+  body {
+    min-height: 100dvh;
+  }
 }
 
 /* Override normalize */
@@ -37,6 +61,11 @@ textarea {
   line-height: 1.528571429; /* 20/14 */
 }
 
+button,
+a {
+  touch-action: manipulation;
+}
+
 /* Better defaults for unordererd lists */
 
 ul {
@@ -44,11 +73,32 @@ ul {
   padding-left: 20px;
 }
 
-@media only screen and (min-device-width: 375px) and (max-device-width: 812px) {
+@media only screen and (max-width: $breakpointSmall), (pointer: coarse) {
   input,
   optgroup,
   select,
   textarea {
     font-size: 16px;
+  }
+}
+
+/* stylelint-disable selector-max-universal, time-min-milliseconds */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* stylelint-enable selector-max-universal, time-min-milliseconds */
+
+@media (forced-colors: active) {
+  :focus-visible {
+    outline-color: Highlight;
   }
 }

--- a/frontend/src/Utilities/String/titleCase.js
+++ b/frontend/src/Utilities/String/titleCase.js
@@ -6,6 +6,10 @@ function titleCase(input) {
   }
 
   return input.replace(regex, (match) => {
+    if (match.toLowerCase() === 'oled') {
+      return 'OLED';
+    }
+
     return match.charAt(0).toUpperCase() + match.substr(1).toLowerCase();
   });
 }

--- a/frontend/src/index.ejs
+++ b/frontend/src/index.ejs
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
+    <meta name="color-scheme" content="light dark" />
     <!-- Chrome, Safari, Opera, and Firefox OS -->
     <meta name="theme-color" content="#595959" />
     <!-- Windows Phone -->
@@ -13,9 +13,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="format-detection" content="telephone=no">
-
     <meta name="description" content="Radarr" />
-
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -49,27 +47,81 @@
       name="msapplication-config"
       content="/Content/browserconfig.xml"
     />
-
     <link rel="stylesheet" type="text/css" href="/Content/Fonts/fonts.css">
 
     <script>
-      window.Radarr = {
-        urlBase: '__URL_BASE__'
-      };
+      (function () {
+        var storageKey = 'radarr-ui-theme';
+        var supportedThemes = ['auto', 'light', 'dark', 'oled'];
+        var selectedTheme = 'auto';
+
+        try {
+          var storedTheme = window.localStorage.getItem(storageKey);
+
+          if (supportedThemes.indexOf(storedTheme) !== -1) {
+            selectedTheme = storedTheme;
+          }
+        } catch (error) {
+          // Storage can be unavailable in private or hardened browsing modes.
+        }
+
+        var prefersDark = window.matchMedia &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var resolvedTheme = selectedTheme === 'auto' ?
+          (prefersDark ? 'dark' : 'light') : selectedTheme;
+        var pageBackgrounds = {
+          light: '#f5f7fa',
+          dark: '#202020',
+          oled: '#000000'
+        };
+        var headerBackgrounds = {
+          light: '#464b51',
+          dark: '#2a2a2a',
+          oled: '#050505'
+        };
+        var documentElement = document.documentElement;
+        var themeColor = pageBackgrounds[resolvedTheme];
+
+        documentElement.dataset.theme = selectedTheme;
+        documentElement.dataset.resolvedTheme = resolvedTheme.toLowerCase();
+        documentElement.style.colorScheme = resolvedTheme === 'light' ?
+          'light' : 'dark';
+        documentElement.style.backgroundColor = themeColor;
+
+        var themeColorMeta = document.querySelector('meta[name="theme-color"]');
+        var navButtonMeta = document.querySelector(
+          'meta[name="msapplication-navbutton-color"]'
+        );
+
+        if (themeColorMeta) {
+          themeColorMeta.setAttribute('content', themeColor);
+        }
+
+        if (navButtonMeta) {
+          navButtonMeta.setAttribute(
+            'content',
+            headerBackgrounds[resolvedTheme]
+          );
+        }
+
+        window.Radarr = {
+          urlBase: '__URL_BASE__',
+          theme: selectedTheme
+        };
+      }());
     </script>
 
     <% for (key in htmlWebpackPlugin.files.js) { %><script type="text/javascript" src="<%= htmlWebpackPlugin.files.js[key] %>" data-no-hash></script><% } %>
     <% for (key in htmlWebpackPlugin.files.css) { %><link href="<%= htmlWebpackPlugin.files.css[key] %>" rel="stylesheet"></link><% } %>
 
     <title>Radarr</title>
-
     <!--
       The super basic styling for .root  will live here,
       saves fighting with CSS Modules for ~10 lines
     -->
     <style>
       .root {
-        overflow: hidden;
+        min-width: 0;
         height: 100%; /* needed for proper layout */
       }
 
@@ -83,7 +135,6 @@
       }
     </style>
   </head>
-
   <body>
     <div id="portal-root"></div>
     <div id="root" class="root"></div>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Improve Radarr on narrow and short viewports without changing established desktop behavior. This change makes shared page, toolbar, form, menu, modal, table, movie, and calendar UI more responsive; presents Interactive Search results as usable mobile cards; and adds a true-black OLED theme with prepaint theme selection.

The change also improves keyboard focus, text selection, reduced-motion behavior, forced-colors behavior, safe-area handling, touch targets, and mobile input sizing.

#### Screenshot (if UI related)
UI change. See **Verification** for the observed runtime viewport checks. No images are embedded in this PR body.

#### Todos
- [ ] Tests — the Radarr automated test suites were not run
- [x] Translation Keys (`./src/NzbDrone.Core/Localization/Core/en.json`) — no catalog changes are required; the UI uses existing keys
- [x] [Wiki Updates](https://wiki.servarr.com) — no wiki change is required

#### Issues Fixed or Closed by this PR
None.

## User impact

- Phone layouts keep primary actions and shared content inside the usable viewport.
- Interactive Search keeps the desktop sortable table and reflows the same rows into labeled mobile cards at medium and smaller widths.
- Mobile search adds a labeled sort control for the existing sort fields and keeps fixed sort directions where the desktop table requires them.
- Dialogs, menus, forms, toolbars, movie pages, and calendar controls better support narrow, short, safe-area, and coarse-pointer viewports.
- OLED provides a distinct true-black canvas with stepped near-black surfaces. Light, Dark, and Auto remain available.

## Implementation

- Update 51 frontend files. The changes are limited to UI theme logic, startup markup, React view markup, CSS, and CSS module declarations.
- Add shared `min-width`, wrapping, viewport-unit, safe-area, overflow, and 44 px touch-target rules at the components that own the layout.
- Preserve one Interactive Search row tree and its existing actions. CSS changes its presentation to a card grid on small screens, while `data-label` values provide visible mobile field labels.
- Add an `oled` token map and apply the selected or resolved theme to CSS variables, document datasets, native `color-scheme`, page background, and browser theme metadata.
- Apply the stored theme before application paint. Invalid or unavailable storage falls back safely, and Auto follows the system color preference.
- Add visible `:focus-visible` treatment, selection colors, reduced-motion handling, forced-colors focus, and 16 px small-screen form text.

## Verification

### Observed checks

- [x] Production Webpack build succeeded.
- [x] .NET Windows x64 package build succeeded.
- [x] The packaged application started and served the real first-run UI on port 7878.
- [x] Chromium showed the real UI at 390×844 and 1440×900 with no horizontal page overflow at either width.
- [x] Auto resolved to Dark under a dark system preference and set the native `color-scheme` to `dark`.
- [x] ESLint completed with no errors.
- [x] Stylelint completed with no errors.

### Package harness evidence

The isolated package harness is supporting evidence, not a substitute for the runtime checks above. Its report records:

- [x] CSS parse and property-order checks: 40/40 files.
- [x] Source contracts: 49/49.
- [x] Changed-code syntax and theme contracts: 18/18.
- [x] Prepaint startup cases: 9/9.
- [x] Responsive and theme cases: 1,116/1,116; interaction contracts: 10/10.

### Not run

- [ ] Unit, integration, and end-to-end test suites.
- [ ] Firefox, WebKit, or Safari checks.
- [ ] Screen-reader or physical-device checks, including real safe areas and virtual keyboards.

## Risk

**Moderate.** Shared CSS changes can affect many routes and viewport combinations. The adaptive Interactive Search layout also depends on the current table row structure. Theme startup now mirrors the selected theme in local storage so it can prevent an incorrect first paint.

Risk is lower outside the UI: there are no database, dependency, backend behavior, API, route, localization catalog, logo, font, or image changes.

## Reviewer focus

1. Check shared page, toolbar, modal, form, menu, table, movie, and calendar behavior near responsive breakpoints and on short landscape viewports.
2. Confirm that Interactive Search card labels, sort choices, download actions, keyboard navigation, and desktop table behavior remain correct.
3. Check Auto, Light, Dark, and OLED during first paint, settings changes, system theme changes, invalid stored values, and blocked storage.
4. Check focus, reduced motion, forced colors, safe areas, long text, portaled content, and coarse-pointer controls.
5. Confirm behavior with authentication and a reverse-proxy URL base.

## Compatibility

- No database migration or data conversion is required.
- Existing backend behavior, routes, API calls, state actions, and desktop table behavior remain unchanged.
- No dependency manifest or lockfile changes are included.
- Existing localization keys are reused. No translation catalog update is required.
- Browser runtime coverage in this change is limited to Chromium; Firefox, WebKit, Safari, and physical devices remain unverified.

## Rollback

Revert this PR as one unit. No database or data rollback is required. If the theme work is reverted separately, remove the OLED tokens, theme export, runtime application logic, prepaint logic, and OLED title handling together so startup and settings stay consistent.
