### PR TITLE
Fixed: Search All to use only movies without files or with upgrades enabled

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/MoviesSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/MoviesSearchService.cs
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.IndexerSearch
             var userInvokedSearch = message.Trigger == CommandTrigger.Manual;
 
             var movies = _movieService.GetMovies(message.MovieIds)
-                .Where(m => (m.Monitored && m.IsAvailable()) || userInvokedSearch)
+                .Where(m => (!m.HasFile || m.QualityProfile.UpgradeAllowed) && ((m.Monitored && m.IsAvailable()) || userInvokedSearch))
                 .ToList();
 
             SearchForBulkMovies(movies, userInvokedSearch).GetAwaiter().GetResult();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixing movie search to search only for eligible movies that have no files or if they're have upgrades enabled.

A mix of https://github.com/Sonarr/Sonarr/blob/818ac70df13c84f0ef41d18e6c45d095b6ea22ae/src/NzbDrone.Core/IndexerSearch/SeriesSearchService.cs#L44-L49 and https://github.com/Sonarr/Sonarr/blob/818ac70df13c84f0ef41d18e6c45d095b6ea22ae/src/NzbDrone.Core/IndexerSearch/SeriesSearchService.cs#L68