### PR TITLE
Fixed: Propagate test failures from test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -76,9 +76,4 @@ else
   exit 3
 fi
 
-if [ "$EXIT_CODE" -ge 0 ]; then
-  echo "Failed tests: $EXIT_CODE"
-  exit 0
-else
-  exit $EXIT_CODE
-fi
+exit "$EXIT_CODE"


### PR DESCRIPTION
#### Database Migration

NO

#### Description

`test.sh` currently treats every `dotnet test` result as success because all process exit codes satisfy `-ge 0`.
Return the captured status directly so failed tests propagate to callers and successful runs still return zero.

Verification:

- Stubbed `dotnet` to return `7`; `test.sh Linux Unit Test` returned `7`.
- Stubbed `dotnet` to return `0`; `test.sh Linux Unit Test` returned `0`.

#### Screenshot (if UI related)

Not applicable.

#### Todos

- [x] Tests
- [x] Translation Keys (not applicable)
- [x] Wiki Updates (not applicable)

#### Issues Fixed or Closed by this PR

None. No matching issue or pull request was found.

### Disclosure

Investigated thoroughly with OpenAI GPT-5.6 (high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.