### PR TITLE
Avoid rebuilding the pending queue for each bulk removal

### DIFF
--- a/src/Radarr.Api.V3/Queue/QueueController.cs
+++ b/src/Radarr.Api.V3/Queue/QueueController.cs
@@ -99,10 +99,11 @@ namespace Radarr.Api.V3.Queue
             var trackedDownloadIds = new List<string>();
             var pendingToRemove = new List<NzbDrone.Core.Queue.Queue>();
             var trackedToRemove = new List<TrackedDownload>();
+            var pendingById = _pendingReleaseService.GetPendingQueue().ToDictionary(p => p.Id);
 
             foreach (var id in resource.Ids)
             {
-                var pendingRelease = _pendingReleaseService.FindPendingQueueItem(id);
+                pendingById.TryGetValue(id, out var pendingRelease);
 
                 if (pendingRelease != null)
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Bulk queue removal called `FindPendingQueueItem` for every selected ID. That method rebuilds and hydrates the complete pending queue each time. This change builds one request-scoped snapshot, indexes it by queue ID, and preserves the existing resolve-before-remove ordering.

#### Screenshot (if UI related)
Not applicable.

#### Todos
- [x] Tests
- [x] Translation Keys (not applicable)
- [x] Wiki Updates (not applicable)

Focused verification passed:

```text
dotnet build src/Radarr.Api.V3/Radarr.Api.V3.csproj -p:RunAnalyzers=false
Build succeeded.

dotnet test src/NzbDrone.Core.Test/Radarr.Core.Test.csproj --filter FullyQualifiedName~PendingReleaseServiceFixture -p:RunAnalyzers=false
Passed: 2, Failed: 0, Skipped: 0

dotnet test src/NzbDrone.Integration.Test/Radarr.Integration.Test.csproj -c Debug --filter FullyQualifiedName~QueueFixture --no-restore -p:RunAnalyzers=false
Passed: 2, Failed: 0, Skipped: 0
```

The integration target was built in Debug together with `Radarr.Mono` before running the fixture. The changed file has no `git diff --check` findings.

#### Controlled Benchmark

A .NET 8.0.29 Release microbenchmark used three warmups and 15 interleaved samples on the isolated pending-item classification step.

- Workload: 1,000 synthetic pending items and 250 selected IDs.
- Median elapsed time: 8.2230 ms before and 0.0691 ms after, a 99.16% reduction.
- Median current-thread managed allocations: 48,048,136 bytes before and 225,208 bytes after, a 99.53% reduction.
- Correctness guardrail: both implementations produced checksum `62750`.
- Baseline/candidate elapsed-time coefficients of variation: 6.00% and 4.79%.

The benchmark passed the predefined 20% meaningful-improvement threshold. It excludes real `PendingReleaseService` hydration and removal, including the remaining per-pending-item rebuild in `RemovePendingQueueItems`, so it does not establish request or production latency.

#### Issues Fixed or Closed by this PR
None.

### Disclosure

Investigated thoroughly with GPT-5.6 Codex (high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.
