### PR TITLE
Client schema: reuse common property-name casing

### DIFF
--- a/src/Radarr.Http/ClientSchema/SchemaBuilder.cs
+++ b/src/Radarr.Http/ClientSchema/SchemaBuilder.cs
@@ -131,7 +131,7 @@ namespace Radarr.Http.ClientSchema
 
                     var field = new Field
                     {
-                        Name = prefix + GetCamelCaseName(propertyInfo.Name),
+                        Name = prefix + propertyInfo.Name.FirstCharToLower(),
                         Label = label,
                         Unit = fieldAttribute.Unit,
                         HelpText = helpText,
@@ -179,7 +179,7 @@ namespace Radarr.Http.ClientSchema
                 }
                 else
                 {
-                    result.AddRange(GetFieldMapping(propertyInfo.PropertyType, GetCamelCaseName(propertyInfo.Name) + ".", t => propertyInfo.GetValue(targetSelector(t), null)));
+                    result.AddRange(GetFieldMapping(propertyInfo.PropertyType, propertyInfo.Name.FirstCharToLower() + ".", t => propertyInfo.GetValue(targetSelector(t), null)));
                 }
             }
 
@@ -339,11 +339,6 @@ namespace Radarr.Http.ClientSchema
                     return STJson.Deserialize(json, propertyType);
                 };
             }
-        }
-
-        private static string GetCamelCaseName(string name)
-        {
-            return char.ToLowerInvariant(name[0]) + name.Substring(1);
         }
     }
 }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

##### Summary

`SchemaBuilder` maintained a private `GetCamelCaseName` implementation even though the same class already uses the common `FirstCharToLower` extension for the identical invariant first-character transformation.
This pull request routes flat and nested schema property names through the common extension and removes the duplicate helper without changing generated names.

##### Evidence

- [`SchemaBuilder.cs`](https://github.com/Radarr/Radarr/blob/c6fef4309de3ffdd5e0e9607ad30beb12d791333/src/Radarr.Http/ClientSchema/SchemaBuilder.cs#L132-L146) used the private helper for flat property names while using `FirstCharToLower` for adjacent schema values.
- [`SchemaBuilder.cs`](https://github.com/Radarr/Radarr/blob/c6fef4309de3ffdd5e0e9607ad30beb12d791333/src/Radarr.Http/ClientSchema/SchemaBuilder.cs#L180-L182) used the same private helper for nested prefixes.
- [`StringExtensions.cs`](https://github.com/Radarr/Radarr/blob/c6fef4309de3ffdd5e0e9607ad30beb12d791333/src/NzbDrone.Common/Extensions/StringExtensions.cs#L31-L39) owns the tested common transformation.

##### Changes

- Replace both `GetCamelCaseName(propertyInfo.Name)` calls with `propertyInfo.Name.FirstCharToLower()`.
- Delete the private duplicate helper.
- Preserve the existing mapping cache, localization, conversion, and recursion behavior.

##### Risks and boundaries

- CLR property names are non-empty, so the extension's null and empty handling does not change these callsites.
- Flat and nested field names remain unchanged; this does not alter other client-schema mappings or casing rules.

##### Verification

- `SchemaBuilderFixture` — 3 passed.
- `FirstCharacterToLowerFixture` — 6 passed.
- `git diff --check` — passed.

I checked all relevant issues, comments, pull requests, and support discussions; this pull request is not a duplicate.

#### Screenshot (if UI related)

Not applicable; generated schema names and UI behavior are unchanged.

#### Todos

- [x] Tests — existing focused fixtures passed.
- [x] Translation Keys — not applicable; no user-facing strings changed.
- [x] [Wiki Updates](https://wiki.servarr.com) — not applicable; no user-facing behavior changed.

#### Issues Fixed or Closed by this PR

* None.

#### Disclosure

Investigated thoroughly with GPT-5.6 (high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.