### PR TITLE
Movie details: reuse the modal state hook

### DIFF
--- a/frontend/src/Movie/Details/MovieDetails.tsx
+++ b/frontend/src/Movie/Details/MovieDetails.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 import TextTruncate from 'react-text-truncate';
@@ -31,6 +25,7 @@ import Popover from 'Components/Tooltip/Popover';
 import Tooltip from 'Components/Tooltip/Tooltip';
 import TraktRating from 'Components/TraktRating';
 import useMeasure from 'Helpers/Hooks/useMeasure';
+import useModalOpenState from 'Helpers/Hooks/useModalOpenState';
 import usePrevious from 'Helpers/Hooks/usePrevious';
 import {
   icons,
@@ -253,66 +248,42 @@ function MovieDetails({ movieId }: MovieDetailsProps) {
   }, [movieId, allMovies]);
 
   const touchStart = useRef<number | null>(null);
-  const [isOrganizeModalOpen, setIsOrganizeModalOpen] = useState(false);
-  const [isManageMoviesModalOpen, setIsManageMoviesModalOpen] = useState(false);
-  const [isInteractiveSearchModalOpen, setIsInteractiveSearchModalOpen] =
-    useState(false);
-  const [isEditMovieModalOpen, setIsEditMovieModalOpen] = useState(false);
-  const [isDeleteMovieModalOpen, setIsDeleteMovieModalOpen] = useState(false);
-  const [isMovieHistoryModalOpen, setIsMovieHistoryModalOpen] = useState(false);
+  const [isOrganizeModalOpen, handleOrganizePress, handleOrganizeModalClose] =
+    useModalOpenState(false);
+  const [
+    isManageMoviesModalOpen,
+    handleManageMoviesPress,
+    handleManageMoviesModalClose,
+  ] = useModalOpenState(false);
+  const [
+    isInteractiveSearchModalOpen,
+    handleInteractiveSearchPress,
+    handleInteractiveSearchModalClose,
+  ] = useModalOpenState(false);
+  const [
+    isEditMovieModalOpen,
+    handleEditMoviePress,
+    handleEditMovieModalClose,
+  ] = useModalOpenState(false);
+  const [
+    isDeleteMovieModalOpen,
+    openDeleteMovieModal,
+    handleDeleteMovieModalClose,
+  ] = useModalOpenState(false);
+  const [
+    isMovieHistoryModalOpen,
+    handleMovieHistoryPress,
+    handleMovieHistoryModalClose,
+  ] = useModalOpenState(false);
   const [titleRef, { width: titleWidth }] = useMeasure();
   const [overviewRef, { height: overviewHeight }] = useMeasure();
   const wasRefreshing = usePrevious(isRefreshing);
   const wasRenaming = usePrevious(isRenaming);
 
-  const handleOrganizePress = useCallback(() => {
-    setIsOrganizeModalOpen(true);
-  }, []);
-
-  const handleOrganizeModalClose = useCallback(() => {
-    setIsOrganizeModalOpen(false);
-  }, []);
-
-  const handleManageMoviesPress = useCallback(() => {
-    setIsManageMoviesModalOpen(true);
-  }, []);
-
-  const handleManageMoviesModalClose = useCallback(() => {
-    setIsManageMoviesModalOpen(false);
-  }, []);
-
-  const handleInteractiveSearchPress = useCallback(() => {
-    setIsInteractiveSearchModalOpen(true);
-  }, []);
-
-  const handleInteractiveSearchModalClose = useCallback(() => {
-    setIsInteractiveSearchModalOpen(false);
-  }, []);
-
-  const handleEditMoviePress = useCallback(() => {
-    setIsEditMovieModalOpen(true);
-  }, []);
-
-  const handleEditMovieModalClose = useCallback(() => {
-    setIsEditMovieModalOpen(false);
-  }, []);
-
   const handleDeleteMoviePress = useCallback(() => {
-    setIsEditMovieModalOpen(false);
-    setIsDeleteMovieModalOpen(true);
-  }, []);
-
-  const handleDeleteMovieModalClose = useCallback(() => {
-    setIsDeleteMovieModalOpen(false);
-  }, []);
-
-  const handleMovieHistoryPress = useCallback(() => {
-    setIsMovieHistoryModalOpen(true);
-  }, []);
-
-  const handleMovieHistoryModalClose = useCallback(() => {
-    setIsMovieHistoryModalOpen(false);
-  }, []);
+    handleEditMovieModalClose();
+    openDeleteMovieModal();
+  }, [handleEditMovieModalClose, openDeleteMovieModal]);
 
   const handleMonitorTogglePress = useCallback(
     (value: boolean) => {


### PR DESCRIPTION
#### Database Migration

NO

#### Description

##### Summary

`MovieDetails` repeated six false-initialized modal states and eleven setter-only open or close callbacks even though `useModalOpenState` already owns that lifecycle elsewhere in the frontend.
This pull request replaces the repeated wrappers with six independent hook calls while keeping the edit-to-delete transition and keyboard-navigation policy local to `MovieDetails`.

##### Evidence

- [`MovieDetails.tsx`](https://github.com/Radarr/Radarr/blob/c6fef4309de3ffdd5e0e9607ad30beb12d791333/frontend/src/Movie/Details/MovieDetails.tsx#L255-L315) declared six state pairs and eleven setter-only callbacks.
- [`useModalOpenState.ts`](https://github.com/Radarr/Radarr/blob/c6fef4309de3ffdd5e0e9607ad30beb12d791333/frontend/src/Helpers/Hooks/useModalOpenState.ts#L1-L17) owns the same independent state and stable open or close callbacks.
- [Sonarr pull request #6533](https://github.com/Sonarr/Sonarr/pull/6533) documents the hook's original purpose as replacing this exact repetition pattern; Radarr already uses the hook across ten production components.

##### Changes

- Replace six modal `useState(false)` pairs and eleven setter-only wrappers with six independent `useModalOpenState(false)` calls.
- Keep `handleDeleteMoviePress` as the feature-local edit-close and delete-open transition.
- Preserve the same six modal booleans used to disable keyboard navigation.

##### Risks and boundaries

- Each modal retains independent mount-local state; this does not combine modal lifecycle or move transition policy into the hook.
- The delete transition closes edit before opening delete and declares both stable callbacks as dependencies.
- Poster loading, touch handling, modal options, and rendered modal components are unchanged.

##### Verification

- `yarn run eslint --config frontend/.eslintrc.js --ignore-path frontend/.eslintignore frontend/src/Movie/Details/MovieDetails.tsx` — passed.
- `yarn build` — webpack compiled successfully.
- `git diff --check` — passed.

I checked all relevant issues, comments, pull requests, and support discussions; this pull request is not a duplicate.

#### Screenshot (if UI related)

Not applicable; this refactor does not change rendered UI or modal behavior.

#### Todos

- [x] Tests — targeted ESLint and the frontend build passed.
- [x] Translation Keys — not applicable; no user-facing strings changed.
- [x] [Wiki Updates](https://wiki.servarr.com) — not applicable; no user-facing behavior changed.

#### Issues Fixed or Closed by this PR

* None.

#### Disclosure

Investigated thoroughly with GPT-5.6 (high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.