### PR TITLE
Fixed: Broken Trakt links

### DIFF
--- a/frontend/src/Movie/Details/MovieDetailsLinks.tsx
+++ b/frontend/src/Movie/Details/MovieDetailsLinks.tsx
@@ -29,18 +29,17 @@ function MovieDetailsLinks(props: MovieDetailsLinksProps) {
         </Label>
       </Link>
 
-      <Link
-        className={styles.link}
-        to={`https://trakt.tv/search/tmdb/${tmdbId}?id_type=movie`}
-      >
-        <Label
-          className={styles.linkLabel}
-          kind={kinds.INFO}
-          size={sizes.LARGE}
-        >
-          {translate('Trakt')}
-        </Label>
-      </Link>
+      {imdbId ? (
+        <Link className={styles.link} to={`https://trakt.tv/movies/${imdbId}`}>
+          <Label
+            className={styles.linkLabel}
+            kind={kinds.INFO}
+            size={sizes.LARGE}
+          >
+            {translate('Trakt')}
+          </Label>
+        </Link>
+      ) : null}
 
       <Link
         className={styles.link}

--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -615,12 +615,12 @@ namespace NzbDrone.Core.Notifications.Discord
 
             var links = new List<string>
             {
-                $"[TMDb](https://themoviedb.org/movie/{movie.MovieMetadata.Value.TmdbId})",
-                $"[Trakt](https://trakt.tv/search/tmdb/{movie.MovieMetadata.Value.TmdbId}?id_type=movie)"
+                $"[TMDb](https://themoviedb.org/movie/{movie.MovieMetadata.Value.TmdbId})"
             };
 
             if (movie.MovieMetadata.Value.ImdbId.IsNotNullOrWhiteSpace())
             {
+                links.Add($"[Trakt](https://trakt.tv/movies/{movie.MovieMetadata.Value.ImdbId})");
                 links.Add($"[IMDb](https://imdb.com/title/{movie.MovieMetadata.Value.ImdbId}/)");
             }
 

--- a/src/NzbDrone.Core/Notifications/Gotify/Gotify.cs
+++ b/src/NzbDrone.Core/Notifications/Gotify/Gotify.cs
@@ -173,10 +173,10 @@ namespace NzbDrone.Core.Notifications.Gotify
                             linkUrl = $"https://www.imdb.com/title/{movie.ImdbId}";
                         }
 
-                        if (linkType == MetadataLinkType.Trakt && movie.TmdbId > 0)
+                        if (linkType == MetadataLinkType.Trakt && movie.ImdbId.IsNotNullOrWhiteSpace())
                         {
                             linkText = "Trakt";
-                            linkUrl = $"https://trakt.tv/search/tmdb/{movie.TmdbId}?id_type=movie";
+                            linkUrl = $"https://trakt.tv/movies/{movie.ImdbId}";
                         }
 
                         sb.AppendLine($"[{linkText}]({linkUrl})");

--- a/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
@@ -141,9 +141,9 @@ namespace NzbDrone.Core.Notifications.Telegram
                     links.Add(new TelegramLink("IMDb", $"https://www.imdb.com/title/{movie.ImdbId}"));
                 }
 
-                if (linkType == MetadataLinkType.Trakt && movie.TmdbId > 0)
+                if (linkType == MetadataLinkType.Trakt && movie.ImdbId.IsNotNullOrWhiteSpace())
                 {
-                    links.Add(new TelegramLink("Trakt", $"https://trakt.tv/search/tmdb/{movie.TmdbId}?id_type=movie"));
+                    links.Add(new TelegramLink("Trakt", $"https://trakt.tv/movies/{movie.ImdbId}"));
                 }
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The `trakt.tv/search/tmdb/{tmdbId}?id_type=movie` route now redirects to app.trakt.tv and returns a 404 for every movie, so every Trakt link Radarr emits is dead.

Replaced all four uses with the direct movie route, which resolves an IMDb ID to the movie page: movie details links, and the Discord, Telegram and Gotify notifications.

The new route needs an IMDb ID rather than a TMDb ID, so each use is guarded on `imdbId` being present, matching the existing guard on the IMDb links alongside them. Movies without an IMDb ID no longer render a Trakt link rather than showing a broken one.

Verified the new URLs against ~25 films spanning 1927-2028, multiple languages, and both 7- and 8-digit IMDb IDs.

#### Screenshot (if UI related)
No visual changes

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #11532