### PR TITLE
New: Rotten Tomatoes link on movie details

### DIFF
--- a/frontend/src/AddMovie/AddNewMovie/AddNewMovieSearchResult.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewMovieSearchResult.js
@@ -272,6 +272,7 @@ class AddNewMovieSearchResult extends Component {
                     tmdbId={tmdbId}
                     imdbId={imdbId}
                     youTubeTrailerId={youTubeTrailerId}
+                    title={title}
                   />
                 }
                 canFlip={true}

--- a/frontend/src/DiscoverMovie/Overview/DiscoverMovieOverview.js
+++ b/frontend/src/DiscoverMovie/Overview/DiscoverMovieOverview.js
@@ -193,6 +193,7 @@ class DiscoverMovieOverview extends Component {
                         tmdbId={tmdbId}
                         imdbId={imdbId}
                         youTubeTrailerId={youTubeTrailerId}
+                        title={title}
                       />
                     }
                   />

--- a/frontend/src/DiscoverMovie/Posters/DiscoverMoviePoster.js
+++ b/frontend/src/DiscoverMovie/Posters/DiscoverMoviePoster.js
@@ -154,6 +154,7 @@ class DiscoverMoviePoster extends Component {
                     tmdbId={tmdbId}
                     imdbId={imdbId}
                     youTubeTrailerId={youTubeTrailerId}
+                    title={title}
                   />
                 }
               />

--- a/frontend/src/DiscoverMovie/Table/DiscoverMovieRow.js
+++ b/frontend/src/DiscoverMovie/Table/DiscoverMovieRow.js
@@ -423,6 +423,7 @@ class DiscoverMovieRow extends Component {
                           tmdbId={tmdbId}
                           imdbId={imdbId}
                           youTubeTrailerId={youTubeTrailerId}
+                          title={title}
                         />
                       }
                     />

--- a/frontend/src/Movie/Details/MovieDetails.tsx
+++ b/frontend/src/Movie/Details/MovieDetails.tsx
@@ -743,6 +743,7 @@ function MovieDetails({ movieId }: MovieDetailsProps) {
                           tmdbId={tmdbId}
                           imdbId={imdbId}
                           youTubeTrailerId={youTubeTrailerId}
+                          title={title}
                         />
                       }
                       position={tooltipPositions.BOTTOM}

--- a/frontend/src/Movie/Details/MovieDetailsLinks.tsx
+++ b/frontend/src/Movie/Details/MovieDetailsLinks.tsx
@@ -8,11 +8,11 @@ import styles from './MovieDetailsLinks.css';
 
 type MovieDetailsLinksProps = Pick<
   Movie,
-  'tmdbId' | 'imdbId' | 'youTubeTrailerId'
+  'tmdbId' | 'imdbId' | 'youTubeTrailerId' | 'title'
 >;
 
 function MovieDetailsLinks(props: MovieDetailsLinksProps) {
-  const { tmdbId, imdbId, youTubeTrailerId } = props;
+  const { tmdbId, imdbId, youTubeTrailerId, title } = props;
 
   return (
     <div className={styles.links}>
@@ -106,6 +106,23 @@ function MovieDetailsLinks(props: MovieDetailsLinksProps) {
             </Label>
           </Link>
         </>
+      ) : null}
+
+      {title ? (
+        <Link
+          className={styles.link}
+          to={`https://www.rottentomatoes.com/search?search=${encodeURIComponent(
+            title
+          )}`}
+        >
+          <Label
+            className={styles.linkLabel}
+            kind={kinds.INFO}
+            size={sizes.LARGE}
+          >
+            {translate('RottenTomatoes')}
+          </Label>
+        </Link>
       ) : null}
 
       {youTubeTrailerId ? (

--- a/frontend/src/Movie/Index/Overview/MovieIndexOverview.tsx
+++ b/frontend/src/Movie/Index/Overview/MovieIndexOverview.tsx
@@ -191,6 +191,7 @@ function MovieIndexOverview(props: MovieIndexOverviewProps) {
                       tmdbId={tmdbId}
                       imdbId={imdbId}
                       youTubeTrailerId={youTubeTrailerId}
+                      title={title}
                     />
                   }
                 />

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.tsx
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.tsx
@@ -189,6 +189,7 @@ function MovieIndexPoster(props: MovieIndexPosterProps) {
                   tmdbId={tmdbId}
                   imdbId={imdbId}
                   youTubeTrailerId={youTubeTrailerId}
+                  title={title}
                 />
               }
             />

--- a/frontend/src/Movie/Index/Table/MovieIndexRow.tsx
+++ b/frontend/src/Movie/Index/Table/MovieIndexRow.tsx
@@ -456,6 +456,7 @@ function MovieIndexRow(props: MovieIndexRowProps) {
                       tmdbId={tmdbId}
                       imdbId={imdbId}
                       youTubeTrailerId={youTubeTrailerId}
+                      title={title}
                     />
                   }
                   canFlip={true}

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1715,6 +1715,7 @@
   "RootFolderSelectFreeSpace": "{freeSpace} Free",
   "RootFolders": "Root Folders",
   "RootFoldersLoadError": "Unable to load root folders",
+  "RottenTomatoes": "Rotten Tomatoes",
   "RottenTomatoesRating": "Tomato Rating",
   "Rss": "RSS",
   "RssIsNotSupportedWithThisIndexer": "RSS is not supported with this indexer",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds a Rotten Tomatoes link to the movie details link list, alongside the existing TMDb, Trakt, Letterboxd, IMDb, MovieChat, MDBList, Blu-ray and Trailer links.

Rotten Tomatoes has no identifier anywhere in Radarr's movie model, and none are present in the upstream metadata payload either — `RatingItem` carries only `Count`, `Value`, `Origin` and `Type`. There is therefore no way
to build a canonical `/m/` URL, so this links to a title search instead: 

 https://www.rottentomatoes.com/search?search={title}

Titles are passed through `encodeURIComponent`, so colons, accents and apostrophes are handled (verified against "3:10 to Yuma", "Léon: The Professional" as examples).

`MovieDetailsLinks` previously took only `tmdbId`, `imdbId` and `youTubeTrailerId`, so this adds `title` to its props and to all eight call sites. `title` was already in scope at every implementation, so no additional plumbing was required. The link is guarded on `title` being present.

This only touches the Rotten Tomatoes half of #6764, though that feature request is ambiguous due to it's age. Metacritic could be added the same way if wanted — the rating data is already in the model but is not currently rendered anywhere in the UI, so it would need a component as well as a link.

#### Screenshot (if UI related)
<img width="672" height="272" alt="SCR-20260813-mbnp" src="https://github.com/user-attachments/assets/adbb6666-e6aa-4866-98b4-58288deb2214" />

#### Todos
- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
* Partially addresses #6764