### PR TITLE
Fixed: Label table selection checkboxes

### DIFF
--- a/frontend/src/Components/Form/CheckInput.tsx
+++ b/frontend/src/Components/Form/CheckInput.tsx
@@ -12,6 +12,7 @@ interface ChangeEvent<T = Element> extends SyntheticEvent<T, MouseEvent> {
 }
 
 export interface CheckInputProps {
+  ariaLabel?: string;
   className?: string;
   containerClassName?: string;
   name: string;
@@ -27,6 +28,7 @@ export interface CheckInputProps {
 
 function CheckInput(props: CheckInputProps) {
   const {
+    ariaLabel,
     className = styles.input,
     containerClassName = styles.container,
     name,
@@ -103,6 +105,7 @@ function CheckInput(props: CheckInputProps) {
           className={styles.checkbox}
           type="checkbox"
           name={name}
+          aria-label={ariaLabel}
           checked={isChecked}
           disabled={isDisabled}
           onChange={handleChange}

--- a/frontend/src/Components/Table/Cells/TableSelectCell.tsx
+++ b/frontend/src/Components/Table/Cells/TableSelectCell.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import CheckInput from 'Components/Form/CheckInput';
 import { CheckInputChanged } from 'typings/inputs';
 import { SelectStateInputProps } from 'typings/props';
+import translate from 'Utilities/String/translate';
 import TableRowCell, { TableRowCellProps } from './TableRowCell';
 import styles from './TableSelectCell.css';
 
@@ -48,6 +49,7 @@ function TableSelectCell({
       <CheckInput
         className={styles.input}
         name={id.toString()}
+        ariaLabel={translate('SelectRow')}
         value={isSelected}
         {...otherProps}
         onChange={handleChange}

--- a/frontend/src/Components/Table/Cells/VirtualTableSelectCell.tsx
+++ b/frontend/src/Components/Table/Cells/VirtualTableSelectCell.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import CheckInput from 'Components/Form/CheckInput';
 import { CheckInputChanged } from 'typings/inputs';
 import { SelectStateInputProps } from 'typings/props';
+import translate from 'Utilities/String/translate';
 import VirtualTableRowCell, {
   VirtualTableRowCellProps,
 } from './VirtualTableRowCell';
@@ -35,6 +36,7 @@ function VirtualTableSelectCell({
       <CheckInput
         className={inputClassName}
         name={id.toString()}
+        ariaLabel={translate('SelectRow')}
         value={isSelected}
         isDisabled={isDisabled}
         onChange={handleChange}

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1768,6 +1768,7 @@
   "SelectMovieModalTitle": "{modalTitle} - Select Movie",
   "SelectQuality": "Select Quality",
   "SelectReleaseGroup": "Select Release Group",
+  "SelectRow": "Select row",
   "SendAnonymousUsageData": "Send Anonymous Usage Data",
   "SetIndexerFlags": "Set Indexer Flags",
   "SetIndexerFlagsModalTitle": "{modalTitle} - Set Indexer Flags",


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Table row selection checkboxes do not have an accessible name, leaving screen readers to announce them as unnamed checkboxes.

This adds an optional accessible label to the shared CheckInput component and uses the localized “Select row” label for both regular and virtual table selection cells.

#### Testing

- Ran frontend lint
- Ran stylelint
- Built the frontend

#### Screenshot (if UI related)

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
