### PR TITLE
Fixed: Label Add Movie search result buttons

### DIFF
--- a/frontend/src/AddMovie/AddNewMovie/AddNewMovieSearchResult.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewMovieSearchResult.js
@@ -101,6 +101,11 @@ class AddNewMovieSearchResult extends Component {
       <div className={styles.searchResult}>
         <Link
           className={styles.underlay}
+          aria-label={
+            isExistingMovie ?
+              title :
+              translate('AddMovieWithTitle', { title })
+          }
           {...linkProps}
         />
 

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -31,6 +31,7 @@
   "AddListExclusion": "Add List Exclusion",
   "AddListExclusionMovieHelpText": "Prevent movie from being added to {appName} by lists",
   "AddMovie": "Add Movie",
+  "AddMovieWithTitle": "Add {title}",
   "AddMovies": "Add Movies",
   "AddNew": "Add New",
   "AddNewMessage": "It's easy to add a new movie, just start typing the name of the movie you want to add",


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The full Add Movie search result acts as a button, but it does not have an accessible name. Screen readers announce a button without identifying which movie it will add.

This labels new movie results as “Add {title}”. Results for movies already in the library use the movie title as the link name.

The existing visual layout and interaction behavior are unchanged.

#### Testing

- Ran frontend lint
- Ran stylelint
- Built the frontend

#### Screenshot (if UI related)

#### Todos

- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
