### PR TITLE
Remove offensive joke about a sensitive topic

### DIFF
--- a/frontend/src/Components/Loading/LoadingMessage.tsx
+++ b/frontend/src/Components/Loading/LoadingMessage.tsx
@@ -14,7 +14,6 @@ const messages = [
   "I could've been faster in Python",
   "Don't forget to rewind your movies",
   'Congratulations! You are the 1000th visitor.',
-  "HELP! I'm being held hostage and forced to write these stupid lines!",
   'RE-calibrating the internet...',
   "I'll be here all week",
   "Don't forget to tip your waitress",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Removed the offensive 'Hostage & Slavery' joke from loading message. The other messages are lighthearted or technical in nature, so this particular message stands out quite noticeably from the rest. 

I understand that this is an older [reference](https://www.stackprinter.com/export?linktohome=true&printer=false&question=182112&service=stackoverflow), but given today’s climate, the humor doesn’t land nearly as well. 