### PR TITLE
fix(ui): localize Moment date formatting

### DIFF
--- a/frontend/src/Settings/UI/UISettings.js
+++ b/frontend/src/Settings/UI/UISettings.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Alert from 'Components/Alert';
@@ -31,24 +32,94 @@ export const firstDayOfWeekOptions = [
 ];
 
 export const weekColumnOptions = [
-  { key: 'ddd M/D', value: 'Tue 3/25', hint: 'ddd M/D' },
-  { key: 'ddd MM/DD', value: 'Tue 03/25', hint: 'ddd MM/DD' },
-  { key: 'ddd D/M', value: 'Tue 25/3', hint: 'ddd D/M' },
-  { key: 'ddd DD/MM', value: 'Tue 25/03', hint: 'ddd DD/MM' }
+  {
+    key: 'ddd M/D',
+    get value() {
+      return moment('2014-03-25').format(this.key);
+    },
+    hint: 'ddd M/D'
+  },
+  {
+    key: 'ddd MM/DD',
+    get value() {
+      return moment('2014-03-25').format(this.key);
+    },
+    hint: 'ddd MM/DD'
+  },
+  {
+    key: 'ddd D/M',
+    get value() {
+      return moment('2014-03-25').format(this.key);
+    },
+    hint: 'ddd D/M'
+  },
+  {
+    key: 'ddd DD/MM',
+    get value() {
+      return moment('2014-03-25').format(this.key);
+    },
+    hint: 'ddd DD/MM'
+  }
 ];
 
 const shortDateFormatOptions = [
-  { key: 'MMM D YYYY', value: 'Mar 25 2014', hint: 'MMM D YYYY' },
-  { key: 'DD MMM YYYY', value: '25 Mar 2014', hint: 'DD MMM YYYY' },
-  { key: 'MM/D/YYYY', value: '03/25/2014', hint: 'MM/D/YYYY' },
-  { key: 'MM/DD/YYYY', value: '03/25/2014', hint: 'MM/DD/YYYY' },
-  { key: 'DD/MM/YYYY', value: '25/03/2014', hint: 'DD/MM/YYYY' },
-  { key: 'YYYY-MM-DD', value: '2014-03-25', hint: 'YYYY-MM-DD' }
+  {
+    key: 'MMM D YYYY',
+    get value() {
+      return moment('2014-03-25').format(this.key);
+    },
+    hint: 'MMM D YYYY'
+  },
+  {
+    key: 'DD MMM YYYY',
+    get value() {
+      return moment('2014-03-25').format(this.key);
+    },
+    hint: 'DD MMM YYYY'
+  },
+  {
+    key: 'MM/D/YYYY',
+    get value() {
+      return moment('2014-03-25').format(this.key);
+    },
+    hint: 'MM/D/YYYY'
+  },
+  {
+    key: 'MM/DD/YYYY',
+    get value() {
+      return moment('2014-03-25').format(this.key);
+    },
+    hint: 'MM/DD/YYYY'
+  },
+  {
+    key: 'DD/MM/YYYY',
+    get value() {
+      return moment('2014-03-25').format(this.key);
+    },
+    hint: 'DD/MM/YYYY'
+  },
+  {
+    key: 'YYYY-MM-DD',
+    get value() {
+      return moment('2014-03-25').format(this.key);
+    },
+    hint: 'YYYY-MM-DD'
+  }
 ];
 
 const longDateFormatOptions = [
-  { key: 'dddd, MMMM D YYYY', value: 'Tuesday, March 25, 2014' },
-  { key: 'dddd, D MMMM YYYY', value: 'Tuesday, 25 March, 2014' }
+  {
+    key: 'dddd, MMMM D YYYY',
+    get value() {
+      return moment('2014-03-25').format(this.key);
+    }
+  },
+  {
+    key: 'dddd, D MMMM YYYY',
+    get value() {
+      return moment('2014-03-25').format(this.key);
+    }
+  }
 ];
 
 export const timeFormatOptions = [

--- a/frontend/src/Utilities/String/translate.ts
+++ b/frontend/src/Utilities/String/translate.ts
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import createAjaxRequest from 'Utilities/createAjaxRequest';
 
 function getTranslations() {
@@ -8,12 +9,51 @@ function getTranslations() {
   }).request;
 }
 
+interface LanguageResponse {
+  identifier: string;
+}
+
+function getLanguage() {
+  return createAjaxRequest({
+    global: false,
+    dataType: 'json',
+    url: '/localization/language',
+  }).request;
+}
+
+async function setMomentLocale() {
+  const { identifier } = (await getLanguage()) as LanguageResponse;
+  const locale = identifier.toLowerCase();
+
+  if (locale === 'en') {
+    moment.locale(locale);
+    return;
+  }
+
+  try {
+    await import(`moment/locale/${locale}`);
+    moment.locale(locale);
+  } catch {
+    const language = locale.split('-')[0];
+
+    try {
+      await import(`moment/locale/${language}`);
+      moment.locale(language);
+    } catch {
+      moment.locale('en');
+    }
+  }
+}
+
 let translations: Record<string, string> = {};
 
 export async function fetchTranslations(): Promise<boolean> {
   return new Promise(async (resolve) => {
     try {
-      const data = await getTranslations();
+      const [data] = await Promise.all([
+        getTranslations(),
+        setMomentLocale().catch(() => moment.locale('en')),
+      ]);
       translations = data.Strings;
 
       resolve(true);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Load Moment's locale from the configured UI language and generate date-format previews dynamically instead of using English examples.

#### Screenshot
<img width="353" height="120" alt="Capture d’écran du 2026-08-20 18-08-49" src="https://github.com/user-attachments/assets/a7f6097b-e87a-4976-96e0-02287c0c3f08" />
<br />
<img width="353" height="120" alt="Capture d’écran du 2026-08-20 18-08-34" src="https://github.com/user-attachments/assets/2d091966-648f-4248-b43e-e17b7da8b7ba" />

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
I don't know