### PR TITLE
Fixed: NullReferenceException in VerifyImport when the tracked download is no longer linked to a movie

### DIFF
--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ImportFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ImportFixture.cs
@@ -209,6 +209,26 @@ namespace NzbDrone.Core.Test.Download
             AssertImported();
         }
 
+        [Test]
+        public void should_use_movie_from_import_results_when_tracked_download_is_no_longer_linked_to_a_movie()
+        {
+            var movie = new Movie { Id = 7 };
+
+            _trackedDownload.RemoteMovie.Movie = null;
+
+            var importResults = new List<ImportResult>
+                                {
+                                    new ImportResult(new ImportDecision(new LocalMovie { Path = @"C:\TestPath\Droned.1998.mkv".AsOsAgnostic(), Movie = movie }))
+                                };
+
+            Subject.VerifyImport(_trackedDownload, importResults).Should().BeTrue();
+
+            _trackedDownload.State.Should().Be(TrackedDownloadState.Imported);
+
+            Mocker.GetMock<IEventAggregator>()
+                  .Verify(v => v.PublishEvent(It.Is<DownloadCompletedEvent>(c => c.MovieId == movie.Id)), Times.Once());
+        }
+
         private void AssertNotImported()
         {
             Mocker.GetMock<IEventAggregator>()

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -201,7 +201,7 @@ namespace NzbDrone.Core.Download
             {
                 _logger.Debug("All movies were imported for {0}", trackedDownload.DownloadItem.Title);
                 trackedDownload.State = TrackedDownloadState.Imported;
-                _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload, trackedDownload.RemoteMovie.Movie.Id));
+                PublishDownloadCompleted(trackedDownload, GetMovieId(trackedDownload, importResults, null));
                 return true;
             }
 
@@ -218,6 +218,8 @@ namespace NzbDrone.Core.Download
 
             if (allMoviesImportedInHistory)
             {
+                var movieId = GetMovieId(trackedDownload, importResults, historyItems);
+
                 // Log different error messages depending on the circumstances, but treat both as fully imported, because that's the reality.
                 // The second message shouldn't be logged in most cases, but continued reporting would indicate an ongoing issue.
                 if (atLeastOneMovieImported)
@@ -228,7 +230,7 @@ namespace NzbDrone.Core.Download
                 {
                     _logger.ForDebugEvent()
                            .Message("No Movies were just imported, but all movies were previously imported, possible issue with download history.")
-                           .Property("MovieId", trackedDownload.RemoteMovie.Movie.Id)
+                           .Property("MovieId", movieId)
                            .Property("DownloadId", trackedDownload.DownloadItem.DownloadId)
                            .Property("Title", trackedDownload.DownloadItem.Title)
                            .Property("Path", trackedDownload.ImportItem.OutputPath.ToString())
@@ -237,13 +239,48 @@ namespace NzbDrone.Core.Download
                 }
 
                 trackedDownload.State = TrackedDownloadState.Imported;
-                _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload, trackedDownload.RemoteMovie.Movie.Id));
+                PublishDownloadCompleted(trackedDownload, movieId);
 
                 return true;
             }
 
             _logger.Debug("Not all movies have been imported for {0}", trackedDownload.DownloadItem.Title);
             return false;
+        }
+
+        private void PublishDownloadCompleted(TrackedDownload trackedDownload, int movieId)
+        {
+            if (movieId <= 0)
+            {
+                _logger.Warn("Unable to determine which movie was imported for {0}, skipping download completed event", trackedDownload.DownloadItem.Title);
+
+                return;
+            }
+
+            _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload, movieId));
+        }
+
+        private int GetMovieId(TrackedDownload trackedDownload, List<ImportResult> importResults, List<MovieHistory> historyItems)
+        {
+            // The tracked download can lose its movie link while it's being processed, the cached
+            // item is rebuilt from the download title alone when the movie is refreshed or edited.
+            var movieId = trackedDownload.RemoteMovie?.Movie?.Id ?? 0;
+
+            if (movieId > 0)
+            {
+                return movieId;
+            }
+
+            movieId = importResults.Where(c => c.Result == ImportResultType.Imported)
+                                   .Select(c => c.ImportDecision?.LocalMovie?.Movie?.Id ?? 0)
+                                   .FirstOrDefault(id => id > 0);
+
+            if (movieId > 0 || historyItems == null)
+            {
+                return movieId;
+            }
+
+            return historyItems.Select(h => h.MovieId).FirstOrDefault(id => id > 0);
         }
 
         private void SetStateToImportBlocked(TrackedDownload trackedDownload)

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -201,7 +201,7 @@ namespace NzbDrone.Core.Download
             {
                 _logger.Debug("All movies were imported for {0}", trackedDownload.DownloadItem.Title);
                 trackedDownload.State = TrackedDownloadState.Imported;
-                PublishDownloadCompleted(trackedDownload, GetMovieId(trackedDownload, importResults, null));
+                _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload, GetMovieId(trackedDownload, importResults, null)));
                 return true;
             }
 
@@ -239,7 +239,7 @@ namespace NzbDrone.Core.Download
                 }
 
                 trackedDownload.State = TrackedDownloadState.Imported;
-                PublishDownloadCompleted(trackedDownload, movieId);
+                _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload, movieId));
 
                 return true;
             }
@@ -248,39 +248,30 @@ namespace NzbDrone.Core.Download
             return false;
         }
 
-        private void PublishDownloadCompleted(TrackedDownload trackedDownload, int movieId)
-        {
-            if (movieId <= 0)
-            {
-                _logger.Warn("Unable to determine which movie was imported for {0}, skipping download completed event", trackedDownload.DownloadItem.Title);
-
-                return;
-            }
-
-            _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload, movieId));
-        }
-
         private int GetMovieId(TrackedDownload trackedDownload, List<ImportResult> importResults, List<MovieHistory> historyItems)
         {
-            // The tracked download can lose its movie link while it's being processed, the cached
-            // item is rebuilt from the download title alone when the movie is refreshed or edited.
-            var movieId = trackedDownload.RemoteMovie?.Movie?.Id ?? 0;
-
-            if (movieId > 0)
+            // The tracked download can lose its movie link while it's being processed, the cached item
+            // is rebuilt from the download title alone whenever a movie is added, edited or deleted.
+            if (trackedDownload.RemoteMovie?.Movie != null)
             {
-                return movieId;
+                return trackedDownload.RemoteMovie.Movie.Id;
             }
 
-            movieId = importResults.Where(c => c.Result == ImportResultType.Imported)
-                                   .Select(c => c.ImportDecision?.LocalMovie?.Movie?.Id ?? 0)
-                                   .FirstOrDefault(id => id > 0);
+            var movieId = importResults.Where(c => c.Result == ImportResultType.Imported)
+                                       .Select(c => c.ImportDecision?.LocalMovie?.Movie?.Id ?? 0)
+                                       .FirstOrDefault(id => id > 0);
 
-            if (movieId > 0 || historyItems == null)
+            if (movieId == 0 && historyItems != null)
             {
-                return movieId;
+                movieId = historyItems.Select(h => h.MovieId).FirstOrDefault(id => id > 0);
             }
 
-            return historyItems.Select(h => h.MovieId).FirstOrDefault(id => id > 0);
+            if (movieId == 0)
+            {
+                _logger.Warn("Unable to determine which movie was imported for {0}", trackedDownload.DownloadItem.Title);
+            }
+
+            return movieId;
         }
 
         private void SetStateToImportBlocked(TrackedDownload trackedDownload)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
`CompletedDownloadService.VerifyImport` reads `trackedDownload.RemoteMovie.Movie.Id` in three places without a null check, and throws a `NullReferenceException` right after the files have already been imported.

`Import` does guard against a missing movie before it processes anything, but the link can disappear between that guard and `VerifyImport`. `TrackedDownloadService` handles `MovieAddedEvent`, `MovieEditedEvent`, `MoviesBulkEditedEvent` and `MoviesDeletedEvent` by running `UpdateCachedItem` over the cached tracked downloads, and that rebuilds `RemoteMovie` from the download title alone:

```csharp
var parsedMovieInfo = Parser.Parser.ParseMovieTitle(trackedDownload.DownloadItem.Title);

trackedDownload.RemoteMovie = parsedMovieInfo == null ? null : _parsingService.Map(parsedMovieInfo, "", 0, null);
```

If the title doesn't map back to a movie on its own - a transliterated non-English release name does it every time - `RemoteMovie.Movie` comes back null on the very object the import is running on.

What it costs: the files are imported, then `VerifyImport` throws. `DownloadCompletedEvent` is never published, so nothing is written to history and the download is never marked as imported. The queue item stays and is reprocessed every minute forever, and the exception ends the rest of that `ProcessMonitoredDownloads` run. I hit this repeatedly on 6.3.0 while edits were happening in the library and downloads were completing at the same time.

The movie id is now resolved from what was actually imported (`importResults`, plus history for the already-imported-in-history path), and a warning is logged instead of throwing when no id can be determined at all.

The added test reproduces it: on `develop` it fails with the same `NullReferenceException` at `CompletedDownloadService.cs:204`, and it passes with this change.

#### Screenshot (if UI related)
n/a

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) - not needed
- [ ] [Wiki Updates](https://wiki.servarr.com) - not needed

#### Issues Fixed or Closed by this PR
None open that I could find - I searched and #6275 is a different case.
