### PR TITLE
Fixed: Ignore invalid languages during Manual Import

### DIFF
--- a/src/NzbDrone.Core/Datastore/Converters/LanguageIntConverter.cs
+++ b/src/NzbDrone.Core/Datastore/Converters/LanguageIntConverter.cs
@@ -34,8 +34,15 @@ namespace NzbDrone.Core.Datastore.Converters
 
     public class LanguageIntConverter : JsonConverter<Language>
     {
+        public override bool HandleNull => true;
+
         public override Language Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return Language.Unknown;
+            }
+
             var item = reader.GetInt32();
             return (Language)item;
         }

--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -239,5 +239,15 @@ namespace NzbDrone.Core.Languages
 
             return language;
         }
+
+        public bool IsValid(bool throwOnMissing = true)
+        {
+            return Lookup.ContainsKey(Id) switch
+            {
+                false when throwOnMissing => throw new InvalidOperationException("ID does not match a known language"),
+                false => false,
+                _ => true
+            };
+        }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportFile.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportFile.cs
@@ -10,8 +10,8 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
     {
         public string Path { get; set; }
         public string FolderName { get; set; }
-        public QualityModel Quality { get; set; }
-        public List<Language> Languages { get; set; }
+        public QualityModel Quality { get; set; } = new();
+        public List<Language> Languages { get; set; } = [];
         public string ReleaseGroup { get; set; }
         public int IndexerFlags { get; set; }
         public string DownloadId { get; set; }

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
@@ -452,8 +452,12 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
                 localMovie.Movie = movie;
                 localMovie.ReleaseGroup = file.ReleaseGroup;
                 localMovie.Quality = file.Quality;
-                localMovie.Languages = file.Languages;
                 localMovie.IndexerFlags = (IndexerFlags)file.IndexerFlags;
+
+                if (file.Languages is { Count: > 0 } && file.Languages.All(l => l is not null && l.IsValid()))
+                {
+                    localMovie.Languages = file.Languages;
+                }
 
                 localMovie.CustomFormats = _formatCalculator.ParseCustomFormat(localMovie);
                 localMovie.CustomFormatScore = localMovie.Movie.QualityProfile?.CalculateCustomFormatScore(localMovie.CustomFormats) ?? 0;


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Adding validation for languages for user defined languages on manual imports.

Due to the fact that commands' body isn't validated on POST /command, any invalid language Id will be shown in the logs and not in the response of said endpoint.

This is also a change in behavior, as it's going to treat `[]` or `[null]` as not defined and won't override them thus allowing Radarr to use the aggregate languages from media info instead.

Second commit is related to already imported files with null values saved in the database. https://github.com/Sonarr/Sonarr/pull/8500

