### PR TITLE
Fixed: Importing single files from Freebox

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/FreeboxDownloadTests/TorrentFreeboxDownloadFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/FreeboxDownloadTests/TorrentFreeboxDownloadFixture.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
-using NzbDrone.Common.Disk;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.Clients;
@@ -25,12 +24,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
         protected FreeboxDownloadTask _task;
 
         protected string _defaultDestination = @"/some/path";
-        protected string _encodedDefaultDestination = "L3NvbWUvcGF0aA==";
         protected string _category = "somecat";
-        protected string _encodedDefaultDestinationAndCategory = "L3NvbWUvcGF0aC9zb21lY2F0";
         protected string _destinationDirectory = @"/path/to/media";
-        protected string _encodedDestinationDirectory = "L3BhdGgvdG8vbWVkaWE=";
-        protected OsPath _physicalPath = new OsPath("/mnt/sdb1/mydata");
         protected string _downloadURL => "magnet:?xt=urn:btih:5dee65101db281ac9c46344cd6b175cdcad53426&dn=download";
 
         [SetUp]
@@ -51,7 +46,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
 
             _downloadConfiguration = new FreeboxDownloadConfiguration()
             {
-                DownloadDirectory = _encodedDefaultDestination
+                DownloadDirectory = _defaultDestination.EncodeBase64()
             };
 
             _task = new FreeboxDownloadTask()
@@ -157,7 +152,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
             await Subject.Download(remoteMovie, CreateIndexer());
 
             Mocker.GetMock<IFreeboxDownloadProxy>()
-                  .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), _encodedDestinationDirectory, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
+                  .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), $"{_destinationDirectory}/Droned.1998.1080p.WEB-DL-DRONE".EncodeBase64(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
         }
 
         [Test]
@@ -172,7 +167,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
             await Subject.Download(remoteMovie, CreateIndexer());
 
             Mocker.GetMock<IFreeboxDownloadProxy>()
-                  .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), _encodedDefaultDestinationAndCategory, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
+                  .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), $"{_defaultDestination}/{_category}/Droned.1998.1080p.WEB-DL-DRONE".EncodeBase64(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
         }
 
         [Test]
@@ -186,7 +181,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
             await Subject.Download(remoteMovie, CreateIndexer());
 
             Mocker.GetMock<IFreeboxDownloadProxy>()
-                  .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), _encodedDefaultDestination, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
+                  .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), $"{_defaultDestination}/Droned.1998.1080p.WEB-DL-DRONE".EncodeBase64(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
         }
 
         [TestCase(false, false)]

--- a/src/NzbDrone.Core/Download/Clients/FreeboxDownload/TorrentFreeboxDownload.cs
+++ b/src/NzbDrone.Core/Download/Clients/FreeboxDownload/TorrentFreeboxDownload.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.FreeboxDownload.Responses;
 using NzbDrone.Core.Localization;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 
@@ -130,7 +131,7 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload
         protected override string AddFromMagnetLink(RemoteMovie remoteMovie, string hash, string magnetLink)
         {
             return _proxy.AddTaskFromUrl(magnetLink,
-                                         GetDownloadDirectory().EncodeBase64(),
+                                         GetDownloadDirectory(remoteMovie).EncodeBase64(),
                                          ToBePaused(),
                                          ToBeQueuedFirst(remoteMovie),
                                          GetSeedRatio(remoteMovie),
@@ -141,7 +142,7 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload
         {
             return _proxy.AddTaskFromFile(filename,
                                           fileContent,
-                                          GetDownloadDirectory().EncodeBase64(),
+                                          GetDownloadDirectory(remoteMovie).EncodeBase64(),
                                           ToBePaused(),
                                           ToBeQueuedFirst(remoteMovie),
                                           GetSeedRatio(remoteMovie),
@@ -186,18 +187,28 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload
             }
         }
 
-        private string GetDownloadDirectory()
+        private string GetDownloadDirectory(RemoteMovie remoteMovie = null)
         {
+            string destDir;
+
             if (Settings.DestinationDirectory.IsNotNullOrWhiteSpace())
             {
-                return Settings.DestinationDirectory.TrimEnd('/');
+                destDir = Settings.DestinationDirectory.TrimEnd('/');
+            }
+            else
+            {
+                destDir = _proxy.GetDownloadConfiguration(Settings).DecodedDownloadDirectory.TrimEnd('/');
+
+                if (Settings.Category.IsNotNullOrWhiteSpace())
+                {
+                    destDir = $"{destDir}/{Settings.Category}";
+                }
             }
 
-            var destDir = _proxy.GetDownloadConfiguration(Settings).DecodedDownloadDirectory.TrimEnd('/');
-
-            if (Settings.Category.IsNotNullOrWhiteSpace())
+            if (remoteMovie?.Release?.Title.IsNotNullOrWhiteSpace() ?? false)
             {
-                destDir = $"{destDir}/{Settings.Category}";
+                var folderName = FileNameBuilder.CleanFileName(remoteMovie.Release.Title);
+                destDir = $"{destDir}/{folderName}";
             }
 
             return destDir;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Since movie files usually aren't in a subfolder, freebox uses the output directory to save the files but on import radarr will import the first file that it finds in the downloads folder. So the solution is to create a subfolder based on the release title for every grab to ensure radarr finds the file.

#### Issues Fixed or Closed by this PR

* Fixes #9938
* Fixes #11651
* Closes #11428