### PR TITLE
New: Add full release title custom format condition

### DIFF
--- a/src/NzbDrone.Core.Test/CustomFormats/Specifications/FullReleaseTitleSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/Specifications/FullReleaseTitleSpecificationFixture.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.CustomFormats.Specifications
+{
+    [TestFixture]
+    public class FullReleaseTitleSpecificationFixture : CoreTest<FullReleaseTitleSpecification>
+    {
+        private CustomFormatInput _input;
+
+        [SetUp]
+        public void Setup()
+        {
+            _input = new CustomFormatInput
+            {
+                MovieInfo = new ParsedMovieInfo
+                {
+                    ReleaseTitle = "Example.Feature.2026.1080p.WEB-DL",
+                    SimpleReleaseTitle = "A.Movie.2026.1080p.WEB-DL"
+                }
+            };
+        }
+
+        [Test]
+        public void should_match_the_movie_title()
+        {
+            Subject.Value = @"example[ ._-]+feature";
+
+            Subject.IsSatisfiedBy(_input).Should().BeTrue();
+        }
+
+        [Test]
+        public void should_not_change_the_existing_release_title_matching_behavior()
+        {
+            var specification = new ReleaseTitleSpecification
+            {
+                Value = @"example[ ._-]+feature"
+            };
+
+            specification.IsSatisfiedBy(_input).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_match_the_filename_when_the_full_release_title_is_not_available()
+        {
+            _input.MovieInfo.ReleaseTitle = null;
+            _input.Filename = "Example.Feature.2026.1080p.WEB-DL.mkv";
+            Subject.Value = @"example[ ._-]+feature";
+
+            Subject.IsSatisfiedBy(_input).Should().BeTrue();
+        }
+    }
+}

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -196,6 +196,7 @@ namespace NzbDrone.Core.CustomFormats
             {
                 MovieTitles = new List<string> { movie.Title },
                 SimpleReleaseTitle = releaseTitle.SimplifyReleaseTitle(),
+                ReleaseTitle = releaseTitle,
                 Year = movie.Year,
                 Quality = movieFile.Quality,
                 Languages = movieFile.Languages,

--- a/src/NzbDrone.Core/CustomFormats/Specifications/FullReleaseTitleSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/FullReleaseTitleSpecification.cs
@@ -1,0 +1,14 @@
+namespace NzbDrone.Core.CustomFormats
+{
+    public class FullReleaseTitleSpecification : RegexSpecificationBase
+    {
+        public override int Order => 1;
+        public override string ImplementationName => "Full Release Title";
+        public override string InfoLink => "https://wiki.servarr.com/radarr/settings#custom-formats-2";
+
+        protected override bool IsSatisfiedByWithoutNegate(CustomFormatInput input)
+        {
+            return MatchString(input.MovieInfo?.ReleaseTitle) || MatchString(input.Filename);
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds a Full Release Title Custom Format condition that evaluates the original, unmodified release title, including the movie-title portion before the year.

The existing Release Title condition remains unchanged to preserve its current matching behavior. Full release-title data is also retained during movie-file Custom Format evaluation, with filename fallback when no original release title is available.

#### Issues Fixed or Closed by this PR

* Fixes #4859 