### PR TITLE
Fixed: Stop processing releases from indexers returning invalid files

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadApprovedReportsTests/DownloadApprovedFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadApprovedReportsTests/DownloadApprovedFixture.cs
@@ -286,5 +286,40 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
 
             ExceptionVerification.ExpectedWarns(1);
         }
+
+        [Test]
+        public async Task should_skip_remaining_releases_from_indexer_after_invalid_download_file()
+        {
+            var failedRelease = GetRemoteMovie(new QualityModel(Quality.HDTV720p), GetMovie(1));
+            var skippedRelease = GetRemoteMovie(new QualityModel(Quality.HDTV720p), GetMovie(2));
+            var otherIndexerRelease = GetRemoteMovie(new QualityModel(Quality.HDTV720p), GetMovie(3));
+
+            failedRelease.Release.IndexerId = 1;
+            skippedRelease.Release.IndexerId = 1;
+            otherIndexerRelease.Release.IndexerId = 2;
+
+            var decisions = new List<DownloadDecision>
+            {
+                new DownloadDecision(failedRelease),
+                new DownloadDecision(skippedRelease),
+                new DownloadDecision(otherIndexerRelease)
+            };
+
+            Mocker.GetMock<IDownloadService>()
+                  .Setup(s => s.DownloadReport(It.Is<RemoteMovie>(r => r.Release.IndexerId == 1), null))
+                  .Throws(new InvalidDownloadFileException(failedRelease.Release, "Invalid NZB", new InvalidNzbException("Invalid NZB")));
+
+            var result = await Subject.ProcessDecisions(decisions);
+
+            Mocker.GetMock<IDownloadService>()
+                  .Verify(v => v.DownloadReport(It.Is<RemoteMovie>(r => r.Release.IndexerId == 1), null), Times.Once());
+            Mocker.GetMock<IDownloadService>()
+                  .Verify(v => v.DownloadReport(It.Is<RemoteMovie>(r => r.Release.IndexerId == 2), null), Times.Once());
+
+            result.Grabbed.Should().ContainSingle();
+            result.Rejected.Should().HaveCount(2);
+
+            ExceptionVerification.ExpectedWarns(1);
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/Blackhole/TorrentBlackholeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/Blackhole/TorrentBlackholeFixture.cs
@@ -157,6 +157,21 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.Blackhole
         }
 
         [Test]
+        public void Download_should_wrap_invalid_torrent_as_invalid_download_file()
+        {
+            var remoteMovie = CreateRemoteMovie();
+
+            Mocker.GetMock<ITorrentFileInfoReader>()
+                .Setup(c => c.GetHashFromTorrentFile(It.IsAny<byte[]>()))
+                .Throws(new InvalidDataException("Invalid torrent"));
+
+            var exception = Assert.ThrowsAsync<InvalidDownloadFileException>(async () => await Subject.Download(remoteMovie, CreateIndexer()));
+
+            exception.InnerException.Should().BeOfType<InvalidDataException>();
+            Mocker.GetMock<IDiskProvider>().Verify(c => c.OpenWriteStream(It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
         public async Task Download_should_save_magnet_if_enabled()
         {
             GivenMagnetFilePath();

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/Blackhole/UsenetBlackholeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/Blackhole/UsenetBlackholeFixture.cs
@@ -12,6 +12,7 @@ using NzbDrone.Common.Disk;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.Clients.Blackhole;
+using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Test.Common;
 
@@ -125,6 +126,21 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.Blackhole
             Mocker.GetMock<IHttpClient>().Verify(c => c.GetAsync(It.Is<HttpRequest>(v => v.Url.FullUri == _downloadUrl)), Times.Once());
             Mocker.GetMock<IDiskProvider>().Verify(c => c.OpenWriteStream(_filePath), Times.Once());
             Mocker.GetMock<IHttpClient>().Verify(c => c.DownloadFileAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
+        public void Download_should_wrap_invalid_nzb_as_invalid_download_file()
+        {
+            var remoteMovie = CreateRemoteMovie();
+
+            Mocker.GetMock<IValidateNzbs>()
+                .Setup(v => v.Validate(It.IsAny<string>(), It.IsAny<byte[]>()))
+                .Throws(new InvalidNzbException("Invalid NZB"));
+
+            var exception = Assert.ThrowsAsync<InvalidDownloadFileException>(async () => await Subject.Download(remoteMovie, CreateIndexer()));
+
+            exception.InnerException.Should().BeOfType<InvalidNzbException>();
+            Mocker.GetMock<IDiskProvider>().Verify(c => c.OpenWriteStream(It.IsAny<string>()), Times.Never());
         }
 
         [Test]

--- a/src/NzbDrone.Core/Download/ProcessDownloadDecisions.cs
+++ b/src/NzbDrone.Core/Download/ProcessDownloadDecisions.cs
@@ -47,10 +47,12 @@ namespace NzbDrone.Core.Download
 
             var usenetFailed = false;
             var torrentFailed = false;
+            var failedIndexers = new HashSet<int>();
 
             foreach (var report in prioritizedDecisions)
             {
                 var downloadProtocol = report.RemoteMovie.Release.DownloadProtocol;
+                var indexerId = report.RemoteMovie.Release.IndexerId;
 
                 // Skip if already grabbed
                 if (IsMovieProcessed(grabbed, report))
@@ -61,6 +63,12 @@ namespace NzbDrone.Core.Download
                 if (report.TemporarilyRejected)
                 {
                     PreparePending(pendingAddQueue, grabbed, pending, report, PendingReleaseReason.Delay);
+                    continue;
+                }
+
+                if (indexerId > 0 && failedIndexers.Contains(indexerId))
+                {
+                    rejected.Add(report);
                     continue;
                 }
 
@@ -104,6 +112,18 @@ namespace NzbDrone.Core.Download
                             else if (downloadProtocol == DownloadProtocol.Torrent)
                             {
                                 torrentFailed = true;
+                            }
+
+                            break;
+                        }
+
+                    case ProcessedDecisionResult.IndexerFailed:
+                        {
+                            rejected.Add(report);
+
+                            if (indexerId > 0)
+                            {
+                                failedIndexers.Add(indexerId);
                             }
 
                             break;
@@ -207,6 +227,11 @@ namespace NzbDrone.Core.Download
             {
                 _logger.Warn("Failed to download release '{0}' from Indexer {1}. Release not available", remoteMovie, remoteIndexer);
                 return ProcessedDecisionResult.Rejected;
+            }
+            catch (InvalidDownloadFileException ex)
+            {
+                _logger.Warn(ex, "Indexer {0} returned an invalid download file for release '{1}', skipping remaining releases from this indexer.", remoteIndexer, remoteMovie);
+                return ProcessedDecisionResult.IndexerFailed;
             }
             catch (Exception ex)
             {

--- a/src/NzbDrone.Core/Download/ProcessedDecisionResult.cs
+++ b/src/NzbDrone.Core/Download/ProcessedDecisionResult.cs
@@ -6,6 +6,7 @@ namespace NzbDrone.Core.Download
         Pending,
         Rejected,
         Failed,
+        IndexerFailed,
         Skipped
     }
 }

--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -197,7 +197,16 @@ namespace NzbDrone.Core.Download
             }
 
             var filename = string.Format("{0}.torrent", FileNameBuilder.CleanFileName(remoteMovie.Release.Title));
-            var hash = _torrentFileInfoReader.GetHashFromTorrentFile(torrentFile);
+            string hash;
+
+            try
+            {
+                hash = _torrentFileInfoReader.GetHashFromTorrentFile(torrentFile);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidDownloadFileException(remoteMovie.Release, "Indexer returned an invalid torrent file", ex);
+            }
 
             EnsureReleaseIsNotBlocklisted(remoteMovie, indexer, hash);
 

--- a/src/NzbDrone.Core/Download/UsenetClientBase.cs
+++ b/src/NzbDrone.Core/Download/UsenetClientBase.cs
@@ -84,7 +84,14 @@ namespace NzbDrone.Core.Download
                 throw new ReleaseDownloadException(remoteMovie.Release, "Downloading nzb failed", ex);
             }
 
-            _nzbValidationService.Validate(filename, nzbData);
+            try
+            {
+                _nzbValidationService.Validate(filename, nzbData);
+            }
+            catch (InvalidNzbException ex)
+            {
+                throw new InvalidDownloadFileException(remoteMovie.Release, "Indexer returned an invalid NZB file", ex);
+            }
 
             _logger.Info("Adding report [{0}] to the queue.", remoteMovie.Release.Title);
             return AddFromNzbFile(remoteMovie, filename, nzbData);

--- a/src/NzbDrone.Core/Exceptions/InvalidDownloadFileException.cs
+++ b/src/NzbDrone.Core/Exceptions/InvalidDownloadFileException.cs
@@ -1,0 +1,13 @@
+using System;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.Exceptions
+{
+    public class InvalidDownloadFileException : ReleaseDownloadException
+    {
+        public InvalidDownloadFileException(ReleaseInfo release, string message, Exception innerException)
+            : base(release, message, innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When an indexer download endpoint returns an invalid NZB or torrent payload, Radarr currently treats each release as an unrelated generic failure. Automatic searches then continue trying every candidate from the same broken indexer, with the grab rate limit adding two seconds per attempt. A sufficiently large result set can keep a search busy for many minutes and degrade API/UI responsiveness.

This change wraps NZB and torrent validation failures in a dedicated release download exception. During multi-release processing, the first invalid payload trips a circuit breaker for that indexer for the remainder of the current search. Releases from other indexers continue to be evaluated normally.

#### Screenshot (if UI related)
N/A

#### Todos
- [x] Tests
- [x] Translation Keys (not required)
- [x] Wiki Updates (not required)

#### Test Coverage
- Added client tests for invalid NZB and torrent payload classification.
- Added decision-processing coverage confirming remaining releases from the failed indexer are skipped while another indexer is still tried.
- Full `Radarr.Core.Test` suite: 4,072 passed, 26 skipped, 0 failed.

#### Issues Fixed or Closed by this PR

N/A
