### PR TITLE
Load movie catalog on demand

### DIFF
--- a/frontend/src/Activity/Blocklist/BlocklistRow.tsx
+++ b/frontend/src/Activity/Blocklist/BlocklistRow.tsx
@@ -11,7 +11,6 @@ import MovieFormats from 'Movie/MovieFormats';
 import MovieLanguages from 'Movie/MovieLanguages';
 import MovieQuality from 'Movie/MovieQuality';
 import MovieTitleLink from 'Movie/MovieTitleLink';
-import useMovie from 'Movie/useMovie';
 import { removeBlocklistItem } from 'Store/Actions/blocklistActions';
 import Blocklist from 'typings/Blocklist';
 import { SelectStateInputProps } from 'typings/props';
@@ -28,7 +27,7 @@ interface BlocklistRowProps extends Blocklist {
 function BlocklistRow(props: BlocklistRowProps) {
   const {
     id,
-    movieId,
+    movie,
     sourceTitle,
     languages,
     quality,
@@ -42,7 +41,6 @@ function BlocklistRow(props: BlocklistRowProps) {
     onSelectedChange,
   } = props;
 
-  const movie = useMovie(movieId);
   const dispatch = useDispatch();
   const [isDetailsModalOpen, setIsDetailsModalOpen] = useState(false);
 
@@ -57,10 +55,6 @@ function BlocklistRow(props: BlocklistRowProps) {
   const handleRemovePress = useCallback(() => {
     dispatch(removeBlocklistItem({ id }));
   }, [id, dispatch]);
-
-  if (!movie) {
-    return null;
-  }
 
   return (
     <TableRow>

--- a/frontend/src/Activity/History/History.tsx
+++ b/frontend/src/Activity/History/History.tsx
@@ -16,7 +16,6 @@ import TablePager from 'Components/Table/TablePager';
 import usePaging from 'Components/Table/usePaging';
 import useCurrentPage from 'Helpers/Hooks/useCurrentPage';
 import { align, icons, kinds } from 'Helpers/Props';
-import createMoviesFetchingSelector from 'Movie/createMoviesFetchingSelector';
 import {
   clearHistory,
   fetchHistory,
@@ -54,15 +53,12 @@ function History() {
     totalRecords,
   } = useSelector((state: AppState) => state.history);
 
-  const { isMoviesFetching, isMoviesPopulated, moviesError } = useSelector(
-    createMoviesFetchingSelector()
-  );
   const customFilters = useSelector(createCustomFiltersSelector('history'));
   const dispatch = useDispatch();
 
-  const isFetchingAny = isFetching || isMoviesFetching;
-  const isAllPopulated = isPopulated && (isMoviesPopulated || !items.length);
-  const hasError = error || moviesError;
+  const isFetchingAny = isFetching;
+  const isAllPopulated = isPopulated;
+  const hasError = error;
 
   const {
     handleFirstPagePress,

--- a/frontend/src/Activity/History/HistoryRow.tsx
+++ b/frontend/src/Activity/History/HistoryRow.tsx
@@ -9,11 +9,11 @@ import Tooltip from 'Components/Tooltip/Tooltip';
 import usePrevious from 'Helpers/Hooks/usePrevious';
 import { icons, tooltipPositions } from 'Helpers/Props';
 import Language from 'Language/Language';
+import Movie from 'Movie/Movie';
 import MovieFormats from 'Movie/MovieFormats';
 import MovieLanguages from 'Movie/MovieLanguages';
 import MovieQuality from 'Movie/MovieQuality';
 import MovieTitleLink from 'Movie/MovieTitleLink';
-import useMovie from 'Movie/useMovie';
 import { QualityModel } from 'Quality/Quality';
 import { fetchHistory, markAsFailed } from 'Store/Actions/historyActions';
 import CustomFormat from 'typings/CustomFormat';
@@ -26,6 +26,7 @@ import styles from './HistoryRow.css';
 interface HistoryRowProps {
   id: number;
   movieId: number;
+  movie?: Movie;
   languages: Language[];
   quality: QualityModel;
   customFormats?: CustomFormat[];
@@ -44,7 +45,7 @@ interface HistoryRowProps {
 function HistoryRow(props: HistoryRowProps) {
   const {
     id,
-    movieId,
+    movie,
     languages,
     quality,
     customFormats = [],
@@ -62,8 +63,6 @@ function HistoryRow(props: HistoryRowProps) {
 
   const wasMarkingAsFailed = usePrevious(isMarkingAsFailed);
   const dispatch = useDispatch();
-  const movie = useMovie(movieId);
-
   const [isDetailsModalOpen, setIsDetailsModalOpen] = useState(false);
 
   const handleDetailsPress = useCallback(() => {

--- a/frontend/src/Activity/Queue/Queue.tsx
+++ b/frontend/src/Activity/Queue/Queue.tsx
@@ -26,7 +26,6 @@ import usePaging from 'Components/Table/usePaging';
 import useCurrentPage from 'Helpers/Hooks/useCurrentPage';
 import useSelectState from 'Helpers/Hooks/useSelectState';
 import { align, icons, kinds } from 'Helpers/Props';
-import createMoviesFetchingSelector from 'Movie/createMoviesFetchingSelector';
 import { executeCommand } from 'Store/Actions/commandActions';
 import {
   clearQueue,
@@ -78,9 +77,6 @@ function Queue() {
   } = useSelector((state: AppState) => state.queue.paged);
 
   const { count } = useSelector(createQueueStatusSelector());
-  const { isMoviesFetching, isMoviesPopulated, moviesError } = useSelector(
-    createMoviesFetchingSelector()
-  );
   const customFilters = useSelector(createCustomFiltersSelector('queue'));
 
   const isRefreshMonitoredDownloadsExecuting = useSelector(
@@ -106,12 +102,9 @@ function Queue() {
   const [isConfirmRemoveModalOpen, setIsConfirmRemoveModalOpen] =
     useState(false);
 
-  const isRefreshing =
-    isFetching || isMoviesFetching || isRefreshMonitoredDownloadsExecuting;
-  const isAllPopulated =
-    isPopulated &&
-    (isMoviesPopulated || !items.length || items.every((m) => !m.movieId));
-  const hasError = error || moviesError;
+  const isRefreshing = isFetching || isRefreshMonitoredDownloadsExecuting;
+  const isAllPopulated = isPopulated;
+  const hasError = error;
   const selectedCount = selectedIds.length;
   const disableSelectedActions = selectedCount === 0;
 
@@ -268,7 +261,6 @@ function Queue() {
                   return (
                     <QueueRow
                       key={item.id}
-                      movieId={item.movieId}
                       isSelected={selectedState[item.id]}
                       columns={columns}
                       {...item}

--- a/frontend/src/Activity/Queue/QueueRow.tsx
+++ b/frontend/src/Activity/Queue/QueueRow.tsx
@@ -15,11 +15,11 @@ import DownloadProtocol from 'DownloadClient/DownloadProtocol';
 import { icons, kinds, tooltipPositions } from 'Helpers/Props';
 import InteractiveImportModal from 'InteractiveImport/InteractiveImportModal';
 import Language from 'Language/Language';
+import Movie from 'Movie/Movie';
 import MovieFormats from 'Movie/MovieFormats';
 import MovieLanguages from 'Movie/MovieLanguages';
 import MovieQuality from 'Movie/MovieQuality';
 import MovieTitleLink from 'Movie/MovieTitleLink';
-import useMovie from 'Movie/useMovie';
 import { QualityModel } from 'Quality/Quality';
 import { grabQueueItem, removeQueueItem } from 'Store/Actions/queueActions';
 import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
@@ -40,7 +40,7 @@ import styles from './QueueRow.css';
 
 interface QueueRowProps {
   id: number;
-  movieId?: number;
+  movie?: Movie;
   downloadId?: string;
   title: string;
   status: string;
@@ -74,7 +74,7 @@ interface QueueRowProps {
 function QueueRow(props: QueueRowProps) {
   const {
     id,
-    movieId,
+    movie,
     downloadId,
     title,
     status,
@@ -106,7 +106,6 @@ function QueueRow(props: QueueRowProps) {
   } = props;
 
   const dispatch = useDispatch();
-  const movie = useMovie(movieId);
   const { showRelativeDates, shortDateFormat, timeFormat } = useSelector(
     createUISettingsSelector()
   );

--- a/frontend/src/AddMovie/AddNewMovie/AddNewMovieConnector.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewMovieConnector.js
@@ -14,7 +14,7 @@ import AddNewMovie from './AddNewMovie';
 function createMapStateToProps() {
   return createSelector(
     (state) => state.addMovie,
-    (state) => state.movies.items.length,
+    (state) => state.movies.totalRecords,
     (state) => state.router.location,
     (addMovie, existingMoviesCount, location) => {
       const { params } = parseUrl(location.search);

--- a/frontend/src/AddMovie/ImportMovie/Import/ImportMovieTable.js
+++ b/frontend/src/AddMovie/ImportMovie/Import/ImportMovieTable.js
@@ -66,8 +66,7 @@ class ImportMovieTable extends Component {
       const selectedMovie = item.selectedMovie;
       const isSelected = selectedState[id];
 
-      const isExistingMovie = !!selectedMovie &&
-        _.some(prevProps.allMovies, { tmdbId: selectedMovie.tmdbId });
+      const isExistingMovie = !!selectedMovie?.id;
 
       // Props doesn't have a selected movie or
       // the selected movie is an existing movie.
@@ -173,7 +172,6 @@ ImportMovieTable.propTypes = {
   allUnselected: PropTypes.bool.isRequired,
   selectedState: PropTypes.object.isRequired,
   isSmallScreen: PropTypes.bool.isRequired,
-  allMovies: PropTypes.arrayOf(PropTypes.object),
   scroller: PropTypes.instanceOf(Element).isRequired,
   onSelectAllChange: PropTypes.func.isRequired,
   onSelectedChange: PropTypes.func.isRequired,

--- a/frontend/src/AddMovie/ImportMovie/Import/ImportMovieTableConnector.js
+++ b/frontend/src/AddMovie/ImportMovie/Import/ImportMovieTableConnector.js
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { queueLookupMovie, setImportMovieValue } from 'Store/Actions/importMovieActions';
-import createAllMoviesSelector from 'Store/Selectors/createAllMoviesSelector';
 import ImportMovieTable from './ImportMovieTable';
 
 function createMapStateToProps() {
@@ -9,15 +8,13 @@ function createMapStateToProps() {
     (state) => state.addMovie,
     (state) => state.importMovie,
     (state) => state.app.dimensions,
-    createAllMoviesSelector(),
-    (addMovie, importMovie, dimensions, allMovies) => {
+    (addMovie, importMovie, dimensions) => {
       return {
         defaultMonitor: addMovie.defaults.monitor,
         defaultQualityProfileId: addMovie.defaults.qualityProfileId,
         defaultMinimumAvailability: addMovie.defaults.minimumAvailability,
         items: importMovie.items,
-        isSmallScreen: dimensions.isSmallScreen,
-        allMovies
+        isSmallScreen: dimensions.isSmallScreen
       };
     }
   );

--- a/frontend/src/AddMovie/ImportMovie/Import/SelectMovie/ImportMovieSearchResultConnector.js
+++ b/frontend/src/AddMovie/ImportMovie/Import/SelectMovie/ImportMovieSearchResultConnector.js
@@ -1,11 +1,10 @@
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import createExistingMovieSelector from 'Store/Selectors/createExistingMovieSelector';
 import ImportMovieSearchResult from './ImportMovieSearchResult';
 
 function createMapStateToProps() {
   return createSelector(
-    createExistingMovieSelector(),
+    (state, { id }) => !!id,
     (isExistingMovie) => {
       return {
         isExistingMovie

--- a/frontend/src/App/State/MoviesAppState.ts
+++ b/frontend/src/App/State/MoviesAppState.ts
@@ -60,6 +60,23 @@ interface MoviesAppState
     AppSectionDeleteState,
     AppSectionSaveState {
   itemMap: Record<number, number>;
+  page: number;
+  pageSize: number;
+  totalRecords: number;
+  allIds: number[];
+  facets: {
+    certifications?: string[];
+    collections?: string[];
+    genres?: string[];
+    keywords?: string[];
+    originalLanguages?: string[];
+    releaseGroups?: string[];
+    studios?: string[];
+    qualityProfileIds?: number[];
+    tmdbIds?: number[];
+    totalRecords?: number;
+  };
+  jumpBar: Record<string, { count: number; page: number }>;
 
   deleteOptions: {
     addImportExclusion: boolean;

--- a/frontend/src/Calendar/CalendarPage.tsx
+++ b/frontend/src/Calendar/CalendarPage.tsx
@@ -13,7 +13,6 @@ import PageToolbarSection from 'Components/Page/Toolbar/PageToolbarSection';
 import PageToolbarSeparator from 'Components/Page/Toolbar/PageToolbarSeparator';
 import useMeasure from 'Helpers/Hooks/useMeasure';
 import { align, icons } from 'Helpers/Props';
-import NoMovie from 'Movie/NoMovie';
 import {
   searchMissing,
   setCalendarDaysCount,
@@ -23,7 +22,6 @@ import { executeCommand } from 'Store/Actions/commandActions';
 import { createCustomFiltersSelector } from 'Store/Selectors/createClientSideCollectionSelector';
 import createCommandExecutingSelector from 'Store/Selectors/createCommandExecutingSelector';
 import createCommandsSelector from 'Store/Selectors/createCommandsSelector';
-import createMovieCountSelector from 'Store/Selectors/createMovieCountSelector';
 import { isCommandExecuting } from 'Utilities/Command';
 import isBefore from 'Utilities/Date/isBefore';
 import translate from 'Utilities/String/translate';
@@ -95,15 +93,12 @@ function CalendarPage() {
     createCommandExecutingSelector(commandNames.RSS_SYNC)
   );
   const customFilters = useSelector(createCustomFiltersSelector('calendar'));
-  const hasMovies = !!useSelector(createMovieCountSelector());
 
   const [pageContentRef, { width }] = useMeasure();
   const [isCalendarLinkModalOpen, setIsCalendarLinkModalOpen] = useState(false);
   const [isOptionsModalOpen, setIsOptionsModalOpen] = useState(false);
 
   const isMeasured = width > 0;
-  const PageComponent = hasMovies ? Calendar : NoMovie;
-
   const handleGetCalendarLinkPress = useCallback(() => {
     setIsCalendarLinkModalOpen(true);
   }, []);
@@ -189,7 +184,7 @@ function CalendarPage() {
 
           <FilterMenu
             alignMenu={align.RIGHT}
-            isDisabled={!hasMovies}
+            isDisabled={false}
             selectedFilterKey={selectedFilterKey}
             filters={filters}
             customFilters={customFilters}
@@ -204,8 +199,8 @@ function CalendarPage() {
         className={styles.calendarPageBody}
         innerClassName={styles.calendarInnerPageBody}
       >
-        {isMeasured ? <PageComponent totalItems={0} /> : <div />}
-        {hasMovies && <Legend />}
+        {isMeasured ? <Calendar /> : <div />}
+        <Legend />
       </PageContentBody>
 
       <CalendarLinkModal

--- a/frontend/src/Components/Filter/Builder/FilterBuilderRowValue.js
+++ b/frontend/src/Components/Filter/Builder/FilterBuilderRowValue.js
@@ -109,7 +109,8 @@ class FilterBuilderRowValue extends Component {
     const {
       filterValue,
       selectedFilterBuilderProp,
-      tagList
+      tagList,
+      onQueryChange
     } = this.props;
 
     const hasItems = !!tagList.length;
@@ -141,6 +142,7 @@ class FilterBuilderRowValue extends Component {
         maxSuggestionsLength={100}
         minQueryLength={0}
         tagComponent={FilterBuilderRowValueTag}
+        onQueryChange={onQueryChange}
         onTagAdd={this.onTagAdd}
         onTagDelete={this.onTagDelete}
       />
@@ -152,6 +154,7 @@ FilterBuilderRowValue.propTypes = {
   filterValue: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.number])).isRequired,
   selectedFilterBuilderProp: PropTypes.object.isRequired,
   tagList: PropTypes.arrayOf(PropTypes.shape(tagShape)).isRequired,
+  onQueryChange: PropTypes.func,
   onChange: PropTypes.func.isRequired
 };
 

--- a/frontend/src/Components/Filter/Builder/MovieFilterBuilderRowValue.tsx
+++ b/frontend/src/Components/Filter/Builder/MovieFilterBuilderRowValue.tsx
@@ -1,19 +1,61 @@
-import React from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useDebouncedCallback } from 'use-debounce';
 import Movie from 'Movie/Movie';
 import createAllMoviesSelector from 'Store/Selectors/createAllMoviesSelector';
 import sortByProp from 'Utilities/Array/sortByProp';
+import createAjaxRequest from 'Utilities/createAjaxRequest';
 import FilterBuilderRowValue from './FilterBuilderRowValue';
 import FilterBuilderRowValueProps from './FilterBuilderRowValueProps';
 
 function MovieFilterBuilderRowValue(props: FilterBuilderRowValueProps) {
   const allMovies: Movie[] = useSelector(createAllMoviesSelector());
+  const [remoteMovies, setRemoteMovies] = useState<Movie[]>([]);
+  const abortRequest = useRef<(() => void) | null>(null);
 
-  const tagList = allMovies
-    .map((movie) => ({ id: movie.id, name: movie.title }))
-    .sort(sortByProp('name'));
+  const tagList = useMemo(() => {
+    const movies = new Map<number, Movie>();
 
-  return <FilterBuilderRowValue {...props} tagList={tagList} />;
+    [...allMovies, ...remoteMovies].forEach((movie) =>
+      movies.set(movie.id, movie)
+    );
+
+    return Array.from(movies.values())
+      .map((movie) => ({ id: movie.id, name: movie.title }))
+      .sort(sortByProp('name'));
+  }, [allMovies, remoteMovies]);
+
+  const onQueryChange = useDebouncedCallback((term: string) => {
+    abortRequest.current?.();
+
+    if (!term.trim()) {
+      setRemoteMovies([]);
+      return;
+    }
+
+    const ajaxRequest = createAjaxRequest({
+      url: '/movie/search',
+      data: { term, limit: 20 },
+    });
+
+    abortRequest.current = ajaxRequest.abortRequest;
+    ajaxRequest.request.done((movies: Movie[]) => setRemoteMovies(movies));
+  }, 250);
+
+  useEffect(() => {
+    return () => {
+      abortRequest.current?.();
+      onQueryChange.cancel();
+    };
+  }, [onQueryChange]);
+
+  return (
+    <FilterBuilderRowValue
+      {...props}
+      tagList={tagList}
+      onQueryChange={onQueryChange}
+    />
+  );
 }
 
 export default MovieFilterBuilderRowValue;

--- a/frontend/src/Components/Form/Tag/TagInput.tsx
+++ b/frontend/src/Components/Form/Tag/TagInput.tsx
@@ -76,6 +76,7 @@ export interface TagInputProps<T extends TagBase> {
   hasWarning?: boolean;
   tagComponent?: React.ElementType;
   onChange?: (change: InputChanged<T['id'][]>) => void;
+  onQueryChange?: (value: string) => void;
   onTagAdd: (newTag: T) => void;
   onTagDelete: TagInputTagProps<T>['onDelete'];
   onTagReplace?: (
@@ -100,6 +101,7 @@ function TagInput<T extends TagBase>({
   hasError,
   hasWarning,
   onChange,
+  onQueryChange,
   onTagAdd,
   onTagDelete,
   onTagReplace,
@@ -161,6 +163,7 @@ function TagInput<T extends TagBase>({
 
   const handleSuggestionsFetchRequested = useCallback(
     ({ value: newValue }: SuggestionsFetchRequestedParams) => {
+      onQueryChange?.(newValue);
       const lowerCaseValue = newValue.toLowerCase();
 
       const suggestions = tagList.filter((tag) => {
@@ -172,8 +175,22 @@ function TagInput<T extends TagBase>({
 
       setSuggestions(suggestions);
     },
-    [tags, tagList, setSuggestions]
+    [onQueryChange, tags, tagList, setSuggestions]
   );
+
+  useEffect(() => {
+    if (isFocused) {
+      const lowerCaseValue = value.toLowerCase();
+
+      setSuggestions(
+        tagList.filter(
+          (tag) =>
+            String(tag.name).toLowerCase().includes(lowerCaseValue) &&
+            !tags.some((selectedTag) => selectedTag.id === tag.id)
+        )
+      );
+    }
+  }, [isFocused, tagList, tags, value]);
 
   const handleInputKeyDown = useCallback(
     (event: KeyboardEvent<HTMLElement>) => {

--- a/frontend/src/Components/Page/Header/MovieSearchInput.tsx
+++ b/frontend/src/Components/Page/Header/MovieSearchInput.tsx
@@ -11,8 +11,7 @@ import React, {
   useState,
 } from 'react';
 import Autosuggest from 'react-autosuggest';
-import { useDispatch, useSelector } from 'react-redux';
-import { createSelector } from 'reselect';
+import { useDispatch } from 'react-redux';
 import { useDebouncedCallback } from 'use-debounce';
 import { Tag } from 'App/State/TagsAppState';
 import Icon from 'Components/Icon';
@@ -20,9 +19,7 @@ import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import useKeyboardShortcuts from 'Helpers/Hooks/useKeyboardShortcuts';
 import { icons } from 'Helpers/Props';
 import Movie from 'Movie/Movie';
-import createAllMoviesSelector from 'Store/Selectors/createAllMoviesSelector';
-import createDeepEqualSelector from 'Store/Selectors/createDeepEqualSelector';
-import createTagsSelector from 'Store/Selectors/createTagsSelector';
+import createAjaxRequest from 'Utilities/createAjaxRequest';
 import translate from 'Utilities/String/translate';
 import MovieSearchResult from './MovieSearchResult';
 import styles from './MovieSearchInput.css';
@@ -70,60 +67,7 @@ interface Section {
   suggestions: MovieSuggestion[] | AddNewMovieSuggestion[];
 }
 
-function createUnoptimizedSelector() {
-  return createSelector(
-    createAllMoviesSelector(),
-    createTagsSelector(),
-    (allMovies, allTags) => {
-      return allMovies.map((movie): SuggestedMovie => {
-        const {
-          title,
-          originalTitle,
-          year,
-          titleSlug,
-          sortTitle,
-          images,
-          alternateTitles = [],
-          tmdbId,
-          imdbId,
-          tags = [],
-        } = movie;
-
-        return {
-          title,
-          originalTitle,
-          year,
-          titleSlug,
-          sortTitle,
-          images,
-          alternateTitles,
-          tmdbId,
-          imdbId,
-          firstCharacter: title.charAt(0).toLowerCase(),
-          tags: tags.reduce<Tag[]>((acc, id) => {
-            const matchingTag = allTags.find((tag) => tag.id === id);
-
-            if (matchingTag) {
-              acc.push(matchingTag);
-            }
-
-            return acc;
-          }, []),
-        };
-      });
-    }
-  );
-}
-
-function createMoviesSelector() {
-  return createDeepEqualSelector(
-    createUnoptimizedSelector(),
-    (movies) => movies
-  );
-}
-
 function MovieSearchInput() {
-  const movies = useSelector(createMoviesSelector());
   const dispatch = useDispatch();
   const { bindShortcut, unbindShortcut } = useKeyboardShortcuts();
 
@@ -133,17 +77,17 @@ function MovieSearchInput() {
 
   const autosuggestRef = useRef<Autosuggest>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const worker = useRef<Worker | null>(null);
+  const abortRequest = useRef<(() => void) | null>(null);
   const isLoading = useRef(false);
   const requestValue = useRef<string | null>(null);
 
   const suggestionGroups = useMemo(() => {
     const result: Section[] = [];
 
-    if (suggestions.length || isLoading.current) {
+    if (suggestions.length || requestLoading) {
       result.push({
         title: translate('ExistingMovies'),
-        loading: isLoading.current,
+        loading: requestLoading,
         suggestions,
       });
     }
@@ -159,35 +103,7 @@ function MovieSearchInput() {
     });
 
     return result;
-  }, [suggestions, value]);
-
-  const handleSuggestionsReceived = useCallback(
-    (message: { data: { value: string; suggestions: MovieSuggestion[] } }) => {
-      const { value, suggestions } = message.data;
-
-      if (!isLoading.current) {
-        requestValue.current = null;
-        setRequestLoading(false);
-      } else if (value === requestValue.current) {
-        setSuggestions(suggestions);
-        requestValue.current = null;
-        setRequestLoading(false);
-        isLoading.current = false;
-        // setLoading(false);
-      } else {
-        setSuggestions(suggestions);
-        setRequestLoading(true);
-
-        const payload = {
-          value: requestValue,
-          movies,
-        };
-
-        worker.current?.postMessage(payload);
-      }
-    },
-    [movies]
-  );
+  }, [requestLoading, suggestions, value]);
 
   const requestSuggestions = useDebouncedCallback((value: string) => {
     if (!isLoading.current) {
@@ -197,14 +113,45 @@ function MovieSearchInput() {
     requestValue.current = value;
     setRequestLoading(true);
 
-    if (!requestLoading) {
-      const payload = {
-        value,
-        movies,
-      };
+    abortRequest.current?.();
 
-      worker.current?.postMessage(payload);
-    }
+    const ajaxRequest = createAjaxRequest({
+      url: '/movie/search',
+      data: { term: value, limit: 10 },
+    });
+
+    abortRequest.current = ajaxRequest.abortRequest;
+    ajaxRequest.request.done((movies: Movie[]) => {
+      if (value !== requestValue.current) {
+        return;
+      }
+
+      setSuggestions(
+        movies.map((movie) => ({
+          title: movie.title,
+          item: {
+            ...movie,
+            firstCharacter: movie.title.charAt(0).toLowerCase(),
+            tags: [],
+          },
+          indices: [],
+          matches: [{ key: 'title', refIndex: 0 }],
+          refIndex: 0,
+        }))
+      );
+      requestValue.current = null;
+      setRequestLoading(false);
+      isLoading.current = false;
+    });
+
+    ajaxRequest.request.fail(() => {
+      if (value === requestValue.current) {
+        setSuggestions([]);
+        requestValue.current = null;
+        setRequestLoading(false);
+        isLoading.current = false;
+      }
+    });
   }, 250);
 
   const reset = useCallback(() => {
@@ -397,34 +344,7 @@ function MovieSearchInput() {
     suggestionHighlighted: styles.highlighted,
   };
 
-  useEffect(() => {
-    worker.current = new Worker(new URL('./fuse.worker.ts', import.meta.url));
-
-    return () => {
-      if (worker.current) {
-        worker.current.terminate();
-        worker.current = null;
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    worker.current?.addEventListener(
-      'message',
-      handleSuggestionsReceived,
-      false
-    );
-
-    return () => {
-      if (worker.current) {
-        worker.current.removeEventListener(
-          'message',
-          handleSuggestionsReceived,
-          false
-        );
-      }
-    };
-  }, [handleSuggestionsReceived]);
+  useEffect(() => () => abortRequest.current?.(), []);
 
   useEffect(() => {
     bindShortcut('focusMovieSearchInput', focusInput);

--- a/frontend/src/Components/SignalRConnector.js
+++ b/frontend/src/Components/SignalRConnector.js
@@ -6,7 +6,7 @@ import { createSelector } from 'reselect';
 import { setAppValue, setVersion } from 'Store/Actions/appActions';
 import { removeItem, update, updateItem } from 'Store/Actions/baseActions';
 import { fetchCommands, finishCommand, updateCommand } from 'Store/Actions/commandActions';
-import { fetchMovies } from 'Store/Actions/movieActions';
+import { fetchMovieFacets } from 'Store/Actions/movieActions';
 import { fetchQueue, fetchQueueDetails } from 'Store/Actions/queueActions';
 import { fetchRootFolders } from 'Store/Actions/rootFolderActions';
 import { fetchQualityDefinitions } from 'Store/Actions/settingsActions';
@@ -51,7 +51,7 @@ const mapDispatchToProps = {
   dispatchFetchQueue: fetchQueue,
   dispatchFetchQueueDetails: fetchQueueDetails,
   dispatchFetchRootFolders: fetchRootFolders,
-  dispatchFetchMovies: fetchMovies,
+  dispatchFetchMovieFacets: fetchMovieFacets,
   dispatchFetchTags: fetchTags,
   dispatchFetchTagDetails: fetchTagDetails
 };
@@ -248,13 +248,15 @@ class SignalRConnector extends Component {
     const action = body.action;
     const section = 'movies';
 
-    if (action === 'updated') {
+    if (action === 'created' || action === 'updated') {
       this.props.dispatchUpdateItem({ section, ...body.resource });
 
       repopulatePage('movieUpdated');
     } else if (action === 'deleted') {
       this.props.dispatchRemoveItem({ section, id: body.resource.id });
     }
+
+    this.props.dispatchFetchMovieFacets();
   };
 
   handleCollection = (body) => {
@@ -364,7 +366,6 @@ class SignalRConnector extends Component {
 
     const {
       dispatchFetchCommands,
-      dispatchFetchMovies,
       dispatchSetAppValue
     } = this.props;
 
@@ -377,7 +378,6 @@ class SignalRConnector extends Component {
 
     // Repopulate the page (if a repopulator is set) to ensure things
     // are in sync after reconnecting.
-    dispatchFetchMovies();
     dispatchFetchCommands();
     repopulatePage();
   };
@@ -417,7 +417,7 @@ SignalRConnector.propTypes = {
   dispatchFetchQueue: PropTypes.func.isRequired,
   dispatchFetchQueueDetails: PropTypes.func.isRequired,
   dispatchFetchRootFolders: PropTypes.func.isRequired,
-  dispatchFetchMovies: PropTypes.func.isRequired,
+  dispatchFetchMovieFacets: PropTypes.func.isRequired,
   dispatchFetchTags: PropTypes.func.isRequired,
   dispatchFetchTagDetails: PropTypes.func.isRequired
 };

--- a/frontend/src/Helpers/Hooks/useAppPage.ts
+++ b/frontend/src/Helpers/Hooks/useAppPage.ts
@@ -5,7 +5,7 @@ import AppState from 'App/State/AppState';
 import { useInitializeLanguage } from 'Language/useLanguageName';
 import { fetchTranslations } from 'Store/Actions/appActions';
 import { fetchCustomFilters } from 'Store/Actions/customFilterActions';
-import { fetchMovies } from 'Store/Actions/movieActions';
+import { fetchMovieFacets } from 'Store/Actions/movieActions';
 import { fetchMovieCollections } from 'Store/Actions/movieCollectionActions';
 import {
   fetchImportLists,
@@ -19,7 +19,6 @@ import { fetchTags } from 'Store/Actions/tagActions';
 
 const createErrorsSelector = () =>
   createSelector(
-    (state: AppState) => state.movies.error,
     (state: AppState) => state.movieCollections.error,
     (state: AppState) => state.customFilters.error,
     (state: AppState) => state.tags.error,
@@ -31,7 +30,6 @@ const createErrorsSelector = () =>
     (state: AppState) => state.system.status.error,
     (state: AppState) => state.app.translations.error,
     (
-      moviesError,
       movieCollectionsError,
       customFiltersError,
       tagsError,
@@ -44,7 +42,6 @@ const createErrorsSelector = () =>
       translationsError
     ) => {
       const hasError = !!(
-        moviesError ||
         movieCollectionsError ||
         customFiltersError ||
         tagsError ||
@@ -60,7 +57,6 @@ const createErrorsSelector = () =>
       return {
         hasError,
         errors: {
-          moviesError,
           movieCollectionsError,
           customFiltersError,
           tagsError,
@@ -83,7 +79,6 @@ const useAppPage = () => {
 
   const isPopulated = useSelector(
     (state: AppState) =>
-      state.movies.isPopulated &&
       state.movieCollections.isPopulated &&
       state.customFilters.isPopulated &&
       state.tags.isPopulated &&
@@ -112,8 +107,8 @@ const useAppPage = () => {
   }, []);
 
   useEffect(() => {
-    dispatch(fetchMovies());
     dispatch(fetchMovieCollections());
+    dispatch(fetchMovieFacets());
     dispatch(fetchCustomFilters());
     dispatch(fetchTags());
     dispatch(fetchQualityProfiles());

--- a/frontend/src/InteractiveImport/Movie/SelectMovieModalContent.tsx
+++ b/frontend/src/InteractiveImport/Movie/SelectMovieModalContent.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import { useSelector } from 'react-redux';
 import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
+import { useDebouncedCallback } from 'use-debounce';
 import TextInput from 'Components/Form/TextInput';
 import Button from 'Components/Link/Button';
 import ModalBody from 'Components/Modal/ModalBody';
@@ -23,6 +24,7 @@ import createAllMoviesSelector from 'Store/Selectors/createAllMoviesSelector';
 import dimensions from 'Styles/Variables/dimensions';
 import { InputChanged } from 'typings/inputs';
 import sortByProp from 'Utilities/Array/sortByProp';
+import createAjaxRequest from 'Utilities/createAjaxRequest';
 import translate from 'Utilities/String/translate';
 import SelectMovieModalTableHeader from './SelectMovieModalTableHeader';
 import SelectMovieRow from './SelectMovieRow';
@@ -105,6 +107,8 @@ function SelectMovieModalContent(props: SelectMovieModalContentProps) {
   const listRef = useRef<List<RowItemData>>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
   const allMovies: Movie[] = useSelector(createAllMoviesSelector());
+  const [remoteMovies, setRemoteMovies] = useState<Movie[]>([]);
+  const abortRequest = useRef<(() => void) | null>(null);
   const [filter, setFilter] = useState('');
   const [size, setSize] = useState({ width: 0, height: 0 });
   const windowHeight = window.innerHeight;
@@ -146,25 +150,56 @@ function SelectMovieModalContent(props: SelectMovieModalContentProps) {
     };
   }, [listRef, scrollerRef]);
 
+  const searchMovies = useDebouncedCallback((term: string) => {
+    abortRequest.current?.();
+
+    const ajaxRequest = createAjaxRequest({
+      url: term.trim() ? '/movie/search' : '/movie/page',
+      data: term.trim()
+        ? { term, limit: 20 }
+        : { page: 1, pageSize: 100, sortKey: 'sortTitle' },
+    });
+
+    abortRequest.current = ajaxRequest.abortRequest;
+    ajaxRequest.request.done((response: Movie[] | { records: Movie[] }) => {
+      setRemoteMovies(Array.isArray(response) ? response : response.records);
+    });
+  }, 250);
+
+  useEffect(() => {
+    searchMovies('');
+
+    return () => {
+      abortRequest.current?.();
+      searchMovies.cancel();
+    };
+  }, [searchMovies]);
+
   const onFilterChange = useCallback(
     ({ value }: InputChanged<string>) => {
       setFilter(value);
+      searchMovies(value);
     },
-    [setFilter]
+    [searchMovies]
   );
+
+  const sortedMovies = useMemo(() => {
+    const movies = new Map<number, Movie>();
+
+    [...allMovies, ...remoteMovies].forEach((movie) => {
+      movies.set(movie.id, movie);
+    });
+
+    return Array.from(movies.values()).sort(sortByProp('sortTitle'));
+  }, [allMovies, remoteMovies]);
 
   const onMovieSelectWrapper = useCallback(
     (movieId: number) => {
-      const movie = allMovies.find((s) => s.id === movieId) as Movie;
+      const movie = sortedMovies.find((item) => item.id === movieId) as Movie;
 
       onMovieSelect(movie);
     },
-    [allMovies, onMovieSelect]
-  );
-
-  const sortedMovies = useMemo(
-    () => [...allMovies].sort(sortByProp('sortTitle')),
-    [allMovies]
+    [sortedMovies, onMovieSelect]
   );
 
   const items = useMemo(

--- a/frontend/src/Movie/Details/MovieDetails.tsx
+++ b/frontend/src/Movie/Details/MovieDetails.tsx
@@ -153,9 +153,21 @@ function createMovieCreditsSelector() {
 
 interface MovieDetailsProps {
   movieId: number;
+  previousMovie?: {
+    title: string;
+    titleSlug: string;
+  };
+  nextMovie?: {
+    title: string;
+    titleSlug: string;
+  };
 }
 
-function MovieDetails({ movieId }: MovieDetailsProps) {
+function MovieDetails({
+  movieId,
+  previousMovie: requestedPreviousMovie,
+  nextMovie: requestedNextMovie,
+}: MovieDetailsProps) {
   const dispatch = useDispatch();
   const history = useHistory();
 
@@ -226,6 +238,13 @@ function MovieDetails({ movieId }: MovieDetailsProps) {
   }, [movieId, commands]);
 
   const { nextMovie, previousMovie } = useMemo(() => {
+    if (requestedNextMovie && requestedPreviousMovie) {
+      return {
+        nextMovie: requestedNextMovie,
+        previousMovie: requestedPreviousMovie,
+      };
+    }
+
     const sortedMovies = [...allMovies].sort(sortByProp('sortTitle'));
     const movieIndex = sortedMovies.findIndex((movie) => movie.id === movieId);
 
@@ -250,7 +269,7 @@ function MovieDetails({ movieId }: MovieDetailsProps) {
         titleSlug: previousMovie.titleSlug,
       },
     };
-  }, [movieId, allMovies]);
+  }, [movieId, allMovies, requestedNextMovie, requestedPreviousMovie]);
 
   const touchStart = useRef<number | null>(null);
   const [isOrganizeModalOpen, setIsOrganizeModalOpen] = useState(false);

--- a/frontend/src/Movie/Details/MovieDetailsPage.tsx
+++ b/frontend/src/Movie/Details/MovieDetailsPage.tsx
@@ -1,16 +1,35 @@
 import React, { useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useParams } from 'react-router';
+import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import NotFound from 'Components/NotFound';
+import useApiQuery from 'Helpers/Hooks/useApiQuery';
 import usePrevious from 'Helpers/Hooks/usePrevious';
+import Movie from 'Movie/Movie';
+import { updateItem } from 'Store/Actions/baseActions';
 import createAllMoviesSelector from 'Store/Selectors/createAllMoviesSelector';
 import translate from 'Utilities/String/translate';
 import MovieDetails from './MovieDetails';
+
+interface MovieLink {
+  title: string;
+  titleSlug: string;
+}
+
+interface MovieDetailsResponse {
+  movie: Movie;
+  previousMovie: MovieLink;
+  nextMovie: MovieLink;
+}
 
 function MovieDetailsPage() {
   const allMovies = useSelector(createAllMoviesSelector());
   const { titleSlug } = useParams<{ titleSlug: string }>();
   const history = useHistory();
+  const dispatch = useDispatch();
+  const { data, isLoading, isError } = useApiQuery<MovieDetailsResponse>({
+    path: `/movie/slug/${encodeURIComponent(titleSlug)}`,
+  });
 
   const movieIndex = allMovies.findIndex(
     (movie) => movie.titleSlug === titleSlug
@@ -19,20 +38,37 @@ function MovieDetailsPage() {
   const previousIndex = usePrevious(movieIndex);
 
   useEffect(() => {
+    if (data) {
+      dispatch(updateItem({ section: 'movies', ...data.movie }));
+    }
+  }, [data, dispatch]);
+
+  useEffect(() => {
     if (
+      isError &&
       movieIndex === -1 &&
       previousIndex !== -1 &&
       previousIndex !== undefined
     ) {
       history.push(`${window.Radarr.urlBase}/`);
     }
-  }, [movieIndex, previousIndex, history]);
+  }, [isError, movieIndex, previousIndex, history]);
 
-  if (movieIndex === -1) {
+  if (isError && movieIndex === -1) {
     return <NotFound message={translate('MovieCannotBeFound')} />;
   }
 
-  return <MovieDetails movieId={allMovies[movieIndex].id} />;
+  if (isLoading || movieIndex === -1) {
+    return <LoadingIndicator />;
+  }
+
+  return (
+    <MovieDetails
+      movieId={allMovies[movieIndex].id}
+      previousMovie={data?.previousMovie}
+      nextMovie={data?.nextMovie}
+    />
+  );
 }
 
 export default MovieDetailsPage;

--- a/frontend/src/Movie/Index/MovieIndex.tsx
+++ b/frontend/src/Movie/Index/MovieIndex.tsx
@@ -6,7 +6,6 @@ import React, {
   useState,
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router';
 import { SelectProvider } from 'App/SelectContext';
 import ClientSideCollectionAppState from 'App/State/ClientSideCollectionAppState';
 import MoviesAppState, { MovieIndexAppState } from 'App/State/MoviesAppState';
@@ -39,6 +38,10 @@ import scrollPositions from 'Store/scrollPositions';
 import createCommandExecutingSelector from 'Store/Selectors/createCommandExecutingSelector';
 import createDimensionsSelector from 'Store/Selectors/createDimensionsSelector';
 import createMovieClientSideCollectionItemsSelector from 'Store/Selectors/createMovieClientSideCollectionItemsSelector';
+import {
+  registerPagePopulator,
+  unregisterPagePopulator,
+} from 'Utilities/pagePopulator';
 import translate from 'Utilities/String/translate';
 import MovieIndexFilterMenu from './Menus/MovieIndexFilterMenu';
 import MovieIndexSortMenu from './Menus/MovieIndexSortMenu';
@@ -77,13 +80,15 @@ interface MovieIndexProps {
 }
 
 const MovieIndex = withScrollPosition((props: MovieIndexProps) => {
-  const history = useHistory();
-
   const {
     isFetching,
     isPopulated,
     error,
     totalItems,
+    page,
+    totalRecords,
+    allIds,
+    jumpBar,
     items,
     columns,
     selectedFilterKey,
@@ -110,13 +115,19 @@ const MovieIndex = withScrollPosition((props: MovieIndexProps) => {
   const [isSelectMode, setIsSelectMode] = useState(false);
 
   useEffect(() => {
-    if (history.action === 'PUSH') {
-      dispatch(fetchMovies());
-    }
-  }, [history, dispatch]);
+    dispatch(fetchMovies({ page: 1 }));
+  }, [dispatch]);
 
   useEffect(() => {
     dispatch(fetchQueueDetails({ all: true }));
+  }, [dispatch]);
+
+  useEffect(() => {
+    const populate = () => dispatch(fetchMovies({ page: 1 }));
+
+    registerPagePopulator(populate, ['movieUpdated']);
+
+    return () => unregisterPagePopulator(populate);
   }, [dispatch]);
 
   const onRssSyncPress = useCallback(() => {
@@ -152,6 +163,7 @@ const MovieIndex = withScrollPosition((props: MovieIndexProps) => {
   const onSortSelect = useCallback(
     (value: string) => {
       dispatch(setMovieSort({ sortKey: value }));
+      dispatch(fetchMovies({ page: 1 }));
     },
     [dispatch]
   );
@@ -159,6 +171,7 @@ const MovieIndex = withScrollPosition((props: MovieIndexProps) => {
   const onFilterSelect = useCallback(
     (value: string | number) => {
       dispatch(setMovieFilter({ selectedFilterKey: value }));
+      dispatch(fetchMovies({ page: 1 }));
     },
     [dispatch]
   );
@@ -182,16 +195,47 @@ const MovieIndex = withScrollPosition((props: MovieIndexProps) => {
   const onJumpBarItemPress = useCallback(
     (character: string) => {
       setJumpToCharacter(character);
+      const targetPage = jumpBar[character]?.page;
+
+      if (targetPage) {
+        dispatch(fetchMovies({ page: targetPage }));
+      }
     },
-    [setJumpToCharacter]
+    [dispatch, jumpBar]
   );
+
+  const loadNextPageIfNeeded = useCallback(
+    (scrollTop: number) => {
+      const scroller = scrollerRef.current;
+
+      if (
+        scroller &&
+        !isFetching &&
+        items.length < totalRecords &&
+        scrollTop >= (scroller.scrollHeight - scroller.clientHeight) / 2
+      ) {
+        dispatch(fetchMovies({ page: page + 1 }));
+      }
+    },
+    [dispatch, isFetching, items.length, page, totalRecords]
+  );
+
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+
+    if (scroller) {
+      loadNextPageIfNeeded(scroller.scrollTop);
+    }
+  }, [items.length, loadNextPageIfNeeded]);
 
   const onScroll = useCallback(
     ({ scrollTop }: { scrollTop: number }) => {
       setJumpToCharacter(undefined);
       scrollPositions.movieIndex = scrollTop;
+
+      loadNextPageIfNeeded(scrollTop);
     },
-    [setJumpToCharacter]
+    [loadNextPageIfNeeded]
   );
 
   const jumpBarItems: PageJumpBarItems = useMemo(() => {
@@ -203,21 +247,13 @@ const MovieIndex = withScrollPosition((props: MovieIndexProps) => {
       };
     }
 
-    const characters = items.reduce((acc: Record<string, number>, item) => {
-      let char = item.sortTitle.charAt(0);
-
-      if (!isNaN(Number(char))) {
-        char = '#';
-      }
-
-      if (char in acc) {
-        acc[char] = acc[char] + 1;
-      } else {
-        acc[char] = 1;
-      }
-
-      return acc;
-    }, {});
+    const characters = Object.entries(jumpBar).reduce(
+      (acc: Record<string, number>, [character, value]) => {
+        acc[character] = value.count;
+        return acc;
+      },
+      {}
+    );
 
     const order = Object.keys(characters).sort();
 
@@ -230,14 +266,15 @@ const MovieIndex = withScrollPosition((props: MovieIndexProps) => {
       characters,
       order,
     };
-  }, [items, sortKey, sortDirection]);
+  }, [jumpBar, sortKey, sortDirection]);
   const ViewComponent = useMemo(() => getViewComponent(view), [view]);
+  const selectionItems = useMemo(() => allIds.map((id) => ({ id })), [allIds]);
 
   const isLoaded = !!(!error && isPopulated && items.length);
   const hasNoMovie = !totalItems;
 
   return (
-    <SelectProvider items={items}>
+    <SelectProvider items={selectionItems}>
       <PageContent>
         <PageToolbar>
           <PageToolbarSection>

--- a/frontend/src/Movie/Index/MovieIndexFilterModal.tsx
+++ b/frontend/src/Movie/Index/MovieIndexFilterModal.tsx
@@ -3,13 +3,33 @@ import { useDispatch, useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import AppState from 'App/State/AppState';
 import FilterModal from 'Components/Filter/FilterModal';
+import Movie from 'Movie/Movie';
 import { setMovieFilter } from 'Store/Actions/movieIndexActions';
 
 function createMovieSelector() {
   return createSelector(
     (state: AppState) => state.movies.items,
-    (movies) => {
-      return movies;
+    (state: AppState) => state.movies.facets,
+    (movies, facets) => {
+      const facetMovies = [
+        ...(facets.certifications ?? []).map((certification) => ({
+          certification,
+        })),
+        ...(facets.collections ?? []).map((title) => ({
+          collection: { title },
+        })),
+        ...(facets.genres ?? []).map((genre) => ({ genres: [genre] })),
+        ...(facets.keywords ?? []).map((keyword) => ({ keywords: [keyword] })),
+        ...(facets.originalLanguages ?? []).map((name) => ({
+          originalLanguage: { name },
+        })),
+        ...(facets.releaseGroups ?? []).map((releaseGroup) => ({
+          statistics: { releaseGroups: [releaseGroup] },
+        })),
+        ...(facets.studios ?? []).map((studio) => ({ studio })),
+      ] as Movie[];
+
+      return [...movies, ...facetMovies];
     }
   );
 }

--- a/frontend/src/Movie/Index/MovieIndexRefreshMovieButton.tsx
+++ b/frontend/src/Movie/Index/MovieIndexRefreshMovieButton.tsx
@@ -24,7 +24,7 @@ function MovieIndexRefreshMovieButton(
     createCommandExecutingSelector(REFRESH_MOVIE)
   );
   const {
-    items,
+    allIds,
     totalItems,
   }: MoviesAppState & MovieIndexAppState & ClientSideCollectionAppState =
     useSelector(createMovieClientSideCollectionItemsSelector('movieIndex'));
@@ -39,9 +39,7 @@ function MovieIndexRefreshMovieButton(
   }, [selectedState]);
 
   const moviesToRefresh =
-    isSelectMode && selectedMovieIds.length > 0
-      ? selectedMovieIds
-      : items.map((m) => m.id);
+    isSelectMode && selectedMovieIds.length > 0 ? selectedMovieIds : allIds;
 
   const refreshIndexLabel =
     selectedFilterKey === 'all'

--- a/frontend/src/Movie/Index/MovieIndexSearchButton.tsx
+++ b/frontend/src/Movie/Index/MovieIndexSearchButton.tsx
@@ -22,7 +22,7 @@ interface MovieIndexSearchButtonProps {
 function MovieIndexSearchButton(props: MovieIndexSearchButtonProps) {
   const isSearching = useSelector(createCommandExecutingSelector(MOVIE_SEARCH));
   const {
-    items,
+    allIds,
   }: MoviesAppState & MovieIndexAppState & ClientSideCollectionAppState =
     useSelector(createMovieClientSideCollectionItemsSelector('movieIndex'));
 
@@ -38,9 +38,7 @@ function MovieIndexSearchButton(props: MovieIndexSearchButtonProps) {
   }, [selectedState]);
 
   const moviesToSearch =
-    isSelectMode && selectedMovieIds.length > 0
-      ? selectedMovieIds
-      : items.map((m) => m.id);
+    isSelectMode && selectedMovieIds.length > 0 ? selectedMovieIds : allIds;
 
   const searchIndexLabel =
     selectedFilterKey === 'all'
@@ -76,7 +74,7 @@ function MovieIndexSearchButton(props: MovieIndexSearchButtonProps) {
       <PageToolbarButton
         label={isSelectMode ? searchSelectLabel : searchIndexLabel}
         isSpinning={isSearching}
-        isDisabled={!items.length}
+        isDisabled={!allIds.length}
         iconName={icons.SEARCH}
         onPress={moviesToSearch.length > 5 ? onConfirmPress : onPress}
       />

--- a/frontend/src/Movie/Index/Select/Delete/DeleteMovieModalContent.tsx
+++ b/frontend/src/Movie/Index/Select/Delete/DeleteMovieModalContent.tsx
@@ -40,9 +40,9 @@ function DeleteMovieModalContent(props: DeleteMovieModalContentProps) {
   const [deleteFiles, setDeleteFiles] = useState(false);
 
   const movies = useMemo((): Movie[] => {
-    const movies = movieIds.map((id) => {
-      return allMovies.find((s) => s.id === id);
-    }) as Movie[];
+    const movies = movieIds
+      .map((id) => allMovies.find((movie) => movie.id === id))
+      .filter((movie): movie is Movie => movie != null);
 
     return orderBy(movies, ['sortTitle']);
   }, [movieIds, allMovies]);
@@ -106,7 +106,7 @@ function DeleteMovieModalContent(props: DeleteMovieModalContentProps) {
   return (
     <ModalContent onModalClose={onModalClose}>
       <ModalHeader>
-        {movies.length > 1
+        {movieIds.length > 1
           ? translate('DeleteSelectedMovies')
           : translate('DeleteSelectedMovie')}
       </ModalHeader>
@@ -127,7 +127,7 @@ function DeleteMovieModalContent(props: DeleteMovieModalContentProps) {
 
           <FormGroup>
             <FormLabel>
-              {movies.length > 1
+              {movieIds.length > 1
                 ? translate('DeleteMovieFolders')
                 : translate('DeleteMovieFolder')}
             </FormLabel>
@@ -137,7 +137,7 @@ function DeleteMovieModalContent(props: DeleteMovieModalContentProps) {
               name="deleteFiles"
               value={deleteFiles}
               helpText={
-                movies.length > 1
+                movieIds.length > 1
                   ? translate('DeleteMovieFoldersHelpText')
                   : translate('DeleteMovieFolderHelpText')
               }
@@ -150,10 +150,10 @@ function DeleteMovieModalContent(props: DeleteMovieModalContentProps) {
         <div className={styles.message}>
           {deleteFiles
             ? translate('DeleteMovieFolderCountWithFilesConfirmation', {
-                count: movies.length,
+                count: movieIds.length,
               })
             : translate('DeleteMovieFolderCountConfirmation', {
-                count: movies.length,
+                count: movieIds.length,
               })}
         </div>
 

--- a/frontend/src/Movie/Index/Select/Organize/OrganizeMoviesModalContent.tsx
+++ b/frontend/src/Movie/Index/Select/Organize/OrganizeMoviesModalContent.tsx
@@ -65,7 +65,7 @@ function OrganizeMoviesModalContent(props: OrganizeMoviesModalContentProps) {
         </Alert>
 
         <div className={styles.message}>
-          {translate('OrganizeConfirm', { count: movieTitles.length })}
+          {translate('OrganizeConfirm', { count: movieIds.length })}
         </div>
 
         <ul>

--- a/frontend/src/Store/Actions/historyActions.js
+++ b/frontend/src/Store/Actions/historyActions.js
@@ -263,7 +263,11 @@ export const actionHandlers = handleThunks({
       [serverSideCollectionHandlers.EXACT_PAGE]: GOTO_HISTORY_PAGE,
       [serverSideCollectionHandlers.SORT]: SET_HISTORY_SORT,
       [serverSideCollectionHandlers.FILTER]: SET_HISTORY_FILTER
-    }),
+    },
+    (_getState, _payload, data) => {
+      data.includeMovie = true;
+    }
+  ),
 
   [MARK_AS_FAILED]: function(getState, payload, dispatch) {
     const id = payload.id;

--- a/frontend/src/Store/Actions/movieActions.js
+++ b/frontend/src/Store/Actions/movieActions.js
@@ -7,10 +7,10 @@ import { createThunk, handleThunks } from 'Store/thunks';
 // import { batchActions } from 'redux-batched-actions';
 import createAjaxRequest from 'Utilities/createAjaxRequest';
 import dateFilterPredicate from 'Utilities/Date/dateFilterPredicate';
+import findSelectedFilters from 'Utilities/Filter/findSelectedFilters';
 import padNumber from 'Utilities/Number/padNumber';
 import translate from 'Utilities/String/translate';
-import { set, updateItem } from './baseActions';
-import createFetchHandler from './Creators/createFetchHandler';
+import { set, update, updateItem } from './baseActions';
 import createHandleActions from './Creators/createHandleActions';
 import createRemoveItemHandler from './Creators/createRemoveItemHandler';
 import createSaveProviderHandler from './Creators/createSaveProviderHandler';
@@ -352,6 +352,12 @@ export const defaultState = {
   isDeleting: false,
   deleteError: null,
   items: [],
+  page: 0,
+  pageSize: 100,
+  totalRecords: 0,
+  allIds: [],
+  facets: {},
+  jumpBar: {},
   sortKey: 'sortTitle',
   sortDirection: sortDirections.ASCENDING,
   pendingChanges: {},
@@ -368,6 +374,7 @@ export const persistState = [
 // Actions Types
 
 export const FETCH_MOVIES = 'movies/fetchMovies';
+export const FETCH_MOVIE_FACETS = 'movies/fetchMovieFacets';
 export const SET_MOVIE_VALUE = 'movies/setMovieValue';
 export const SAVE_MOVIE = 'movies/saveMovie';
 export const DELETE_MOVIE = 'movies/deleteMovie';
@@ -382,6 +389,7 @@ export const TOGGLE_MOVIE_MONITORED = 'movies/toggleMovieMonitored';
 // Action Creators
 
 export const fetchMovies = createThunk(FETCH_MOVIES);
+export const fetchMovieFacets = createThunk(FETCH_MOVIE_FACETS);
 export const saveMovie = createThunk(SAVE_MOVIE, (payload) => {
   const newPayload = {
     ...payload
@@ -437,7 +445,100 @@ function getSaveAjaxOptions({ ajaxOptions, payload }) {
 
 export const actionHandlers = handleThunks({
 
-  [FETCH_MOVIES]: createFetchHandler(section, '/movie'),
+  [FETCH_MOVIE_FACETS]: (getState, _payload, dispatch) => {
+    const { request, abortRequest } = createAjaxRequest({ url: '/movie/facets' });
+
+    request.done((facets) => {
+      dispatch(set({
+        section,
+        facets,
+        totalRecords: facets.totalRecords,
+        error: null
+      }));
+    });
+
+    request.fail((xhr) => {
+      dispatch(set({ section, error: xhr.aborted ? null : xhr }));
+    });
+
+    return abortRequest;
+  },
+
+  [FETCH_MOVIES]: (getState, payload = {}, dispatch) => {
+    const state = getState();
+    const movieIndex = state.movieIndex;
+    const page = payload.page || 1;
+    const pageSize = 100;
+    const customFilters = state.customFilters.items.filter((filter) =>
+      filter.type === 'movies' || filter.type === 'movieIndex'
+    );
+    const selectedFilters = findSelectedFilters(
+      movieIndex.selectedFilterKey,
+      movieIndex.filters,
+      customFilters
+    );
+    const query = {
+      page,
+      pageSize,
+      sortKey: movieIndex.sortKey,
+      sortDirection: movieIndex.sortDirection,
+      filters: JSON.stringify(selectedFilters)
+    };
+    const queryKey = JSON.stringify({
+      sortKey: query.sortKey,
+      sortDirection: query.sortDirection,
+      filters: query.filters
+    });
+
+    dispatch(set({ section, isFetching: true, queryKey }));
+
+    const { request, abortRequest } = createAjaxRequest({
+      url: '/movie/page',
+      data: query
+    });
+
+    request.done((data) => {
+      if (getState().movies.queryKey !== queryKey) {
+        return;
+      }
+
+      const existingItems = page === 1 ? [] : getState().movies.items;
+      const itemMap = new Map(existingItems.map((movie) => [movie.id, movie]));
+
+      data.records.forEach((movie) => itemMap.set(movie.id, movie));
+
+      dispatch(batchActions([
+        update({ section, data: Array.from(itemMap.values()) }),
+        set({
+          section,
+          page: data.page,
+          pageSize: data.pageSize,
+          totalRecords: data.totalRecords,
+          allIds: data.movieIds,
+          facets: data.facets,
+          jumpBar: data.jumpBar,
+          isFetching: false,
+          isPopulated: true,
+          error: null
+        })
+      ]));
+    });
+
+    request.fail((xhr) => {
+      if (getState().movies.queryKey !== queryKey) {
+        return;
+      }
+
+      dispatch(set({
+        section,
+        isFetching: false,
+        isPopulated: false,
+        error: xhr.aborted ? null : xhr
+      }));
+    });
+
+    return abortRequest;
+  },
   [SAVE_MOVIE]: createSaveProviderHandler(section, '/movie', { getAjaxOptions: getSaveAjaxOptions }),
   [DELETE_MOVIE]: (getState, payload, dispatch) => {
     createRemoveItemHandler(section, '/movie')(getState, payload, dispatch);
@@ -467,7 +568,7 @@ export const actionHandlers = handleThunks({
       monitored
     } = payload;
 
-    const movie = _.find(getState().movies.items, { id });
+    const cachedMovie = _.find(getState().movies.items, { id });
 
     dispatch(updateItem({
       id,
@@ -475,7 +576,7 @@ export const actionHandlers = handleThunks({
       isSaving: true
     }));
 
-    const promise = createAjaxRequest({
+    const save = (movie) => createAjaxRequest({
       url: `/movie/${id}`,
       method: 'PUT',
       data: JSON.stringify({
@@ -484,6 +585,10 @@ export const actionHandlers = handleThunks({
       }),
       dataType: 'json'
     }).request;
+
+    const promise = cachedMovie ?
+      save(cachedMovie) :
+      createAjaxRequest({ url: `/movie/${id}` }).request.then(save);
 
     promise.done((data) => {
       dispatch(updateItem({

--- a/frontend/src/Store/Actions/queueActions.js
+++ b/frontend/src/Store/Actions/queueActions.js
@@ -231,6 +231,7 @@ export const persistState = [
 
 function fetchDataAugmenter(getState, payload, data) {
   data.includeUnknownMovieItems = getState().queue.options.includeUnknownMovieItems;
+  data.includeMovie = true;
 }
 
 //

--- a/frontend/src/Store/Selectors/createClientSideCollectionSelector.js
+++ b/frontend/src/Store/Selectors/createClientSideCollectionSelector.js
@@ -135,7 +135,7 @@ function createClientSideCollectionSelector(section, uiSection) {
         ...uiSectionState,
         customFilters,
         items: sorted,
-        totalItems: state.items.length
+        totalItems: sectionState.totalRecords ?? state.items.length
       };
     }
   );

--- a/frontend/src/Store/Selectors/createCollectionExistingMovieSelector.js
+++ b/frontend/src/Store/Selectors/createCollectionExistingMovieSelector.js
@@ -4,9 +4,11 @@ import createAllMoviesSelector from './createAllMoviesSelector';
 function createCollectionExistingMovieSelector() {
   return createSelector(
     (state, { tmdbId }) => tmdbId,
+    (state, props) => props,
     createAllMoviesSelector(),
-    (tmdbId, allMovies) => {
-      return allMovies.find((movie) => movie.tmdbId === tmdbId);
+    (tmdbId, props, allMovies) => {
+      return allMovies.find((movie) => movie.tmdbId === tmdbId) ||
+        (props.id ? props : undefined);
     }
   );
 }

--- a/frontend/src/Store/Selectors/createExistingMovieSelector.ts
+++ b/frontend/src/Store/Selectors/createExistingMovieSelector.ts
@@ -6,9 +6,13 @@ import createAllMoviesSelector from './createAllMoviesSelector';
 function createExistingMovieSelector() {
   return createSelector(
     (_: AppState, { tmdbId }: { tmdbId: number }) => tmdbId,
+    (_: AppState, { internalId }: { internalId?: number }) => internalId,
+    (state: AppState) => state.movies.facets.tmdbIds,
     createAllMoviesSelector(),
-    (tmdbId, movies) => {
-      return some(movies, { tmdbId });
+    (tmdbId, internalId, tmdbIds = [], movies) => {
+      return (
+        !!internalId || tmdbIds.includes(tmdbId) || some(movies, { tmdbId })
+      );
     }
   );
 }

--- a/frontend/src/Store/Selectors/createImportMovieItemSelector.js
+++ b/frontend/src/Store/Selectors/createImportMovieItemSelector.js
@@ -1,17 +1,15 @@
 import _ from 'lodash';
 import { createSelector } from 'reselect';
-import createAllMoviesSelector from './createAllMoviesSelector';
 
 function createImportMovieItemSelector() {
   return createSelector(
     (state, { id }) => id,
     (state) => state.addMovie,
     (state) => state.importMovie,
-    createAllMoviesSelector(),
-    (id, addMovie, importMovie, movies) => {
+    (id, addMovie, importMovie) => {
       const item = _.find(importMovie.items, { id }) || {};
       const selectedMovie = item && item.selectedMovie;
-      const isExistingMovie = !!selectedMovie && _.some(movies, { tmdbId: selectedMovie.tmdbId });
+      const isExistingMovie = !!selectedMovie?.id;
 
       return {
         defaultMonitor: addMovie.defaults.monitor,

--- a/frontend/src/Store/Selectors/createMovieCountSelector.ts
+++ b/frontend/src/Store/Selectors/createMovieCountSelector.ts
@@ -8,9 +8,10 @@ function createMovieCountSelector() {
     (state: AppState) => state.movies.error,
     (state: AppState) => state.movies.isFetching,
     (state: AppState) => state.movies.isPopulated,
-    (movies, error, isFetching, isPopulated) => {
+    (state: AppState) => state.movies.totalRecords,
+    (movies, error, isFetching, isPopulated, totalRecords) => {
       return {
-        count: movies.length,
+        count: totalRecords || movies.length,
         error,
         isFetching,
         isPopulated,

--- a/frontend/src/Store/Selectors/createProfileInUseSelector.ts
+++ b/frontend/src/Store/Selectors/createProfileInUseSelector.ts
@@ -9,14 +9,17 @@ function createProfileInUseSelector(profileProp: string) {
   return createSelector(
     (_: AppState, { id }: { id: number }) => id,
     createAllMoviesSelector(),
+    (state: AppState) => state.movies.facets.qualityProfileIds,
     (state: AppState) => state.settings.importLists.items,
     (state: AppState) => state.movieCollections.items,
-    (id, movies, lists, collections) => {
+    (id, movies, qualityProfileIds = [], lists, collections) => {
       if (!id) {
         return false;
       }
 
       return (
+        (profileProp === 'qualityProfileId' &&
+          qualityProfileIds.includes(id)) ||
         movies.some((m) => m[profileProp as keyof Movie] === id) ||
         lists.some((list) => list[profileProp as keyof ImportList] === id) ||
         collections.some(

--- a/frontend/src/typings/Blocklist.ts
+++ b/frontend/src/typings/Blocklist.ts
@@ -1,10 +1,12 @@
 import ModelBase from 'App/ModelBase';
 import DownloadProtocol from 'DownloadClient/DownloadProtocol';
 import Language from 'Language/Language';
+import Movie from 'Movie/Movie';
 import { QualityModel } from 'Quality/Quality';
 import CustomFormat from 'typings/CustomFormat';
 
 interface Blocklist extends ModelBase {
+  movie: Movie;
   languages: Language[];
   quality: QualityModel;
   customFormats: CustomFormat[];

--- a/frontend/src/typings/History.ts
+++ b/frontend/src/typings/History.ts
@@ -1,4 +1,5 @@
 import Language from 'Language/Language';
+import Movie from 'Movie/Movie';
 import { QualityModel } from 'Quality/Quality';
 import CustomFormat from './CustomFormat';
 
@@ -73,6 +74,7 @@ export type HistoryData =
   | DownloadIgnoredHistory;
 
 export default interface History {
+  movie?: Movie;
   movieId: number;
   sourceTitle: string;
   languages: Language[];

--- a/src/NzbDrone.Integration.Test/ApiTests/MovieFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/MovieFixture.cs
@@ -140,6 +140,31 @@ namespace NzbDrone.Integration.Test.ApiTests
 
         [Test]
         [Order(2)]
+        public void get_paged_movies_without_changing_the_existing_contract()
+        {
+            EnsureMovie(680, "Pulp Fiction");
+            EnsureMovie(155, "The Dark Knight");
+
+            var page = Movies.Page(1, 1);
+
+            page.Records.Should().HaveCount(1);
+            page.PageSize.Should().Be(1);
+            page.TotalRecords.Should().BeGreaterThanOrEqualTo(2);
+            Movies.All().Should().Contain(v => v.TmdbId == 680).And.Contain(v => v.TmdbId == 155);
+        }
+
+        [Test]
+        [Order(2)]
+        public void search_and_slug_lookup_should_return_existing_movies()
+        {
+            var movie = EnsureMovie(680, "Pulp Fiction");
+
+            Movies.SearchExisting("Pulp").Should().ContainSingle(v => v.Id == movie.Id);
+            Movies.GetBySlug(movie.TitleSlug).Movie.Id.Should().Be(movie.Id);
+        }
+
+        [Test]
+        [Order(2)]
         public void get_movie_by_tmdbid()
         {
             EnsureMovie(680, "Pulp Fiction");

--- a/src/NzbDrone.Integration.Test/Client/MovieClient.cs
+++ b/src/NzbDrone.Integration.Test/Client/MovieClient.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Net;
 using Radarr.Api.V3.Movies;
+using Radarr.Http;
 using RestSharp;
 
 namespace NzbDrone.Integration.Test.Client
@@ -17,6 +18,29 @@ namespace NzbDrone.Integration.Test.Client
             var request = BuildRequest("lookup");
             request.AddQueryParameter("term", term);
             return Get<List<MovieResource>>(request);
+        }
+
+        public PagingResource<MovieResource> Page(int page, int pageSize = 100, string sortKey = "sortTitle", string sortDirection = "ascending")
+        {
+            var request = BuildRequest("page");
+            request.AddQueryParameter("page", page.ToString());
+            request.AddQueryParameter("pageSize", pageSize.ToString());
+            request.AddQueryParameter("sortKey", sortKey);
+            request.AddQueryParameter("sortDirection", sortDirection);
+            return Get<PagingResource<MovieResource>>(request);
+        }
+
+        public List<MovieResource> SearchExisting(string term)
+        {
+            var request = BuildRequest("search");
+            request.AddQueryParameter("term", term);
+            return Get<List<MovieResource>>(request);
+        }
+
+        public MovieDetailsResource GetBySlug(string slug)
+        {
+            var request = BuildRequest($"slug/{slug}");
+            return Get<MovieDetailsResource>(request);
         }
 
         public List<MovieResource> Editor(MovieEditorResource movie)

--- a/src/Radarr.Api.V3/Movies/MovieController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -165,6 +166,108 @@ namespace Radarr.Api.V3.Movies
             }
 
             return moviesResources;
+        }
+
+        [HttpGet("page")]
+        [Produces("application/json")]
+        public MoviePagingResource GetMoviePage([FromQuery] PagingRequestResource paging, [FromQuery] string filters = null, int? languageId = null)
+        {
+            return MovieQueryService.Page(AllMovie(null, false, languageId), paging, filters);
+        }
+
+        [HttpGet("facets")]
+        [Produces("application/json")]
+        public MovieFacetResource GetMovieFacets(int? languageId = null)
+        {
+            return MovieQueryService.CreateFacets(AllMovie(null, true, languageId));
+        }
+
+        [HttpGet("slug/{titleSlug}")]
+        [Produces("application/json")]
+        public ActionResult<MovieDetailsResource> GetMovieBySlug(string titleSlug)
+        {
+            if (!int.TryParse(titleSlug, out var tmdbId))
+            {
+                return NotFound();
+            }
+
+            var movie = _moviesService.FindByTmdbId(tmdbId);
+
+            if (movie == null)
+            {
+                return NotFound();
+            }
+
+            var movies = AllMovie(null).OrderBy(item => item.SortTitle).ThenBy(item => item.Id).ToList();
+            var index = movies.FindIndex(item => item.Id == movie.Id);
+            var previous = movies[(index - 1 + movies.Count) % movies.Count];
+            var next = movies[(index + 1) % movies.Count];
+
+            return new MovieDetailsResource
+            {
+                Movie = movies[index],
+                PreviousMovie = new MovieLinkResource { Title = previous.Title, TitleSlug = previous.TitleSlug },
+                NextMovie = new MovieLinkResource { Title = next.Title, TitleSlug = next.TitleSlug }
+            };
+        }
+
+        [HttpGet("search")]
+        [Produces("application/json")]
+        public List<MovieResource> SearchMovies([FromQuery] string term, [FromQuery] int limit = 10)
+        {
+            if (term.IsNullOrWhiteSpace())
+            {
+                return new List<MovieResource>();
+            }
+
+            limit = Math.Clamp(limit, 1, 20);
+            var normalized = term.Trim();
+
+            return AllMovie(null, false)
+                .Select(movie => new
+                {
+                    Movie = movie,
+                    Score = GetSearchScore(movie, normalized)
+                })
+                .Where(result => result.Score > 0)
+                .OrderByDescending(result => result.Score)
+                .ThenBy(result => result.Movie.SortTitle)
+                .Take(limit)
+                .Select(result => result.Movie)
+                .ToList();
+        }
+
+        private static int GetSearchScore(MovieResource movie, string term)
+        {
+            var candidates = new[]
+                {
+                    movie.Title,
+                    movie.OriginalTitle,
+                    movie.Year.ToString(),
+                    movie.TmdbId.ToString(),
+                    movie.ImdbId
+                }
+                .Concat(movie.AlternateTitles?.Select(title => title.Title) ?? Enumerable.Empty<string>());
+
+            var score = 0;
+
+            foreach (var candidate in candidates.Where(candidate => candidate.IsNotNullOrWhiteSpace()))
+            {
+                if (candidate.Equals(term, StringComparison.OrdinalIgnoreCase))
+                {
+                    score = Math.Max(score, 100);
+                }
+                else if (candidate.StartsWith(term, StringComparison.OrdinalIgnoreCase))
+                {
+                    score = Math.Max(score, 75);
+                }
+                else if (candidate.Contains(term, StringComparison.OrdinalIgnoreCase))
+                {
+                    score = Math.Max(score, 50);
+                }
+            }
+
+            return score;
         }
 
         protected override MovieResource GetResourceById(int id)

--- a/src/Radarr.Api.V3/Movies/MovieLookupController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieLookupController.cs
@@ -24,6 +24,7 @@ namespace Radarr.Api.V3.Movies
         private readonly IMapCoversToLocal _coverMapper;
         private readonly IConfigService _configService;
         private readonly IImportListExclusionService _importListExclusionService;
+        private readonly IMovieService _movieService;
 
         public MovieLookupController(ISearchForNewMovie searchProxy,
                                  IProvideMovieInfo movieInfo,
@@ -31,7 +32,8 @@ namespace Radarr.Api.V3.Movies
                                  INamingConfigService namingService,
                                  IMapCoversToLocal coverMapper,
                                  IConfigService configService,
-                                 IImportListExclusionService importListExclusionService)
+                                 IImportListExclusionService importListExclusionService,
+                                 IMovieService movieService)
         {
             _movieInfo = movieInfo;
             _searchProxy = searchProxy;
@@ -40,6 +42,7 @@ namespace Radarr.Api.V3.Movies
             _coverMapper = coverMapper;
             _configService = configService;
             _importListExclusionService = importListExclusionService;
+            _movieService = movieService;
         }
 
         [NonAction]
@@ -60,7 +63,7 @@ namespace Radarr.Api.V3.Movies
             var availDelay = _configService.AvailabilityDelay;
             var result = new Movie { MovieMetadata = _movieInfo.GetMovieInfo(tmdbId).Item1 };
             var translation = result.MovieMetadata.Value.Translations.FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
-            return result.ToResource(availDelay, translation);
+            return MapExistingMovie(result.ToResource(availDelay, translation));
         }
 
         [HttpGet("imdb")]
@@ -71,7 +74,7 @@ namespace Radarr.Api.V3.Movies
 
             var availDelay = _configService.AvailabilityDelay;
             var translation = result.MovieMetadata.Value.Translations.FirstOrDefault(t => t.Language == (Language)_configService.MovieInfoLanguage);
-            return result.ToResource(availDelay, translation);
+            return MapExistingMovie(result.ToResource(availDelay, translation));
         }
 
         [HttpGet]
@@ -95,6 +98,7 @@ namespace Radarr.Api.V3.Movies
             {
                 var translation = currentMovie.MovieMetadata.Value.Translations.FirstOrDefault(t => t.Language == movieInfoLanguage);
                 var resource = currentMovie.ToResource(availDelay, translation);
+                MapExistingMovie(resource);
 
                 _coverMapper.ConvertToLocalUrls(resource.Id, resource.Images);
 
@@ -110,6 +114,18 @@ namespace Radarr.Api.V3.Movies
 
                 yield return resource;
             }
+        }
+
+        private MovieResource MapExistingMovie(MovieResource resource)
+        {
+            var existingMovie = _movieService.FindByTmdbId(resource.TmdbId);
+
+            if (existingMovie != null)
+            {
+                resource.Id = existingMovie.Id;
+            }
+
+            return resource;
         }
     }
 }

--- a/src/Radarr.Api.V3/Movies/MovieQueryService.cs
+++ b/src/Radarr.Api.V3/Movies/MovieQueryService.cs
@@ -1,0 +1,370 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using NzbDrone.Core.Datastore;
+using Radarr.Http;
+
+namespace Radarr.Api.V3.Movies
+{
+    public class MovieFilterResource
+    {
+        public string Key { get; set; }
+        public string Type { get; set; }
+        public JsonElement Value { get; set; }
+    }
+
+    public class MoviePagingResource : PagingResource<MovieResource>
+    {
+        public List<int> MovieIds { get; set; } = new();
+        public MovieFacetResource Facets { get; set; }
+        public Dictionary<string, MovieJumpResource> JumpBar { get; set; } = new();
+    }
+
+    public class MovieJumpResource
+    {
+        public int Count { get; set; }
+        public int Page { get; set; }
+    }
+
+    public class MovieFacetResource
+    {
+        public List<string> Certifications { get; set; } = new();
+        public List<string> Collections { get; set; } = new();
+        public List<string> Genres { get; set; } = new();
+        public List<string> Keywords { get; set; } = new();
+        public List<string> OriginalLanguages { get; set; } = new();
+        public List<string> ReleaseGroups { get; set; } = new();
+        public List<string> Studios { get; set; } = new();
+        public List<int> QualityProfileIds { get; set; } = new();
+        public List<int> TmdbIds { get; set; } = new();
+        public int TotalRecords { get; set; }
+    }
+
+    public class MovieLinkResource
+    {
+        public string Title { get; set; }
+        public string TitleSlug { get; set; }
+    }
+
+    public class MovieDetailsResource
+    {
+        public MovieResource Movie { get; set; }
+        public MovieLinkResource PreviousMovie { get; set; }
+        public MovieLinkResource NextMovie { get; set; }
+    }
+
+    public static class MovieQueryService
+    {
+        public const int PageSize = 100;
+
+        public static MoviePagingResource Page(IEnumerable<MovieResource> source, PagingRequestResource request, string serializedFilters)
+        {
+            var page = Math.Max(request.Page ?? 1, 1);
+            var pageSize = Math.Clamp(request.PageSize ?? PageSize, 1, PageSize);
+            var sortKey = request.SortKey ?? "sortTitle";
+            var sortDirection = request.SortDirection ?? SortDirection.Ascending;
+            var filters = DeserializeFilters(serializedFilters);
+            var sourceItems = source.ToList();
+            var records = sourceItems.Where(movie => filters.All(filter => Matches(movie, filter)));
+            var comparer = Comparer<object>.Create(CompareValues);
+
+            records = sortDirection == SortDirection.Descending
+                ? records.OrderByDescending(movie => GetSortValue(movie, sortKey), comparer).ThenByDescending(movie => movie.SortTitle).ThenByDescending(movie => movie.Id)
+                : records.OrderBy(movie => GetSortValue(movie, sortKey), comparer).ThenBy(movie => movie.SortTitle).ThenBy(movie => movie.Id);
+
+            var materialized = records.ToList();
+
+            return new MoviePagingResource
+            {
+                Page = page,
+                PageSize = pageSize,
+                SortKey = sortKey,
+                SortDirection = sortDirection,
+                TotalRecords = materialized.Count,
+                Records = materialized.Skip((page - 1) * pageSize).Take(pageSize).ToList(),
+                MovieIds = materialized.Select(movie => movie.Id).ToList(),
+                Facets = CreateFacets(sourceItems),
+                JumpBar = CreateJumpBar(materialized, pageSize)
+            };
+        }
+
+        private static Dictionary<string, MovieJumpResource> CreateJumpBar(List<MovieResource> movies, int pageSize)
+        {
+            var result = new Dictionary<string, MovieJumpResource>(StringComparer.OrdinalIgnoreCase);
+
+            for (var index = 0; index < movies.Count; index++)
+            {
+                var title = movies[index].SortTitle;
+                var character = string.IsNullOrWhiteSpace(title) || char.IsDigit(title[0]) ? "#" : char.ToUpperInvariant(title[0]).ToString();
+
+                if (!result.TryGetValue(character, out var jump))
+                {
+                    jump = new MovieJumpResource { Page = (index / pageSize) + 1 };
+                    result.Add(character, jump);
+                }
+
+                jump.Count++;
+            }
+
+            return result;
+        }
+
+        public static MovieFacetResource CreateFacets(List<MovieResource> movies)
+        {
+            return new MovieFacetResource
+            {
+                Certifications = Distinct(movies.Select(movie => movie.Certification)),
+                Collections = Distinct(movies.Select(movie => movie.Collection?.Title)),
+                Genres = Distinct(movies.SelectMany(movie => movie.Genres ?? new List<string>())),
+                Keywords = Distinct(movies.SelectMany(movie => movie.Keywords ?? new List<string>())),
+                OriginalLanguages = Distinct(movies.Select(movie => movie.OriginalLanguage?.Name)),
+                ReleaseGroups = Distinct(movies.SelectMany(movie => movie.Statistics?.ReleaseGroups ?? new List<string>())),
+                Studios = Distinct(movies.Select(movie => movie.Studio)),
+                QualityProfileIds = movies.Select(movie => movie.QualityProfileId).Distinct().OrderBy(id => id).ToList(),
+                TmdbIds = movies.Select(movie => movie.TmdbId).Distinct().OrderBy(id => id).ToList(),
+                TotalRecords = movies.Count
+            };
+        }
+
+        private static List<string> Distinct(IEnumerable<string> values)
+        {
+            return values.Where(value => !string.IsNullOrWhiteSpace(value)).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(value => value).ToList();
+        }
+
+        private static List<MovieFilterResource> DeserializeFilters(string serializedFilters)
+        {
+            if (string.IsNullOrWhiteSpace(serializedFilters))
+            {
+                return new List<MovieFilterResource>();
+            }
+
+            try
+            {
+                return JsonSerializer.Deserialize<List<MovieFilterResource>>(serializedFilters, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                }) ?? new List<MovieFilterResource>();
+            }
+            catch (JsonException)
+            {
+                return new List<MovieFilterResource>();
+            }
+        }
+
+        private static bool Matches(MovieResource movie, MovieFilterResource filter)
+        {
+            var itemValue = GetValue(movie, filter.Key);
+            var filterValues = filter.Value.ValueKind == JsonValueKind.Array
+                ? filter.Value.EnumerateArray().ToList()
+                : new List<JsonElement> { filter.Value };
+            var isNegative = filter.Type is "notContains" or "notEqual" or "notStartsWith" or "notEndsWith";
+
+            return isNegative
+                ? filterValues.All(value => Compare(itemValue, value, filter.Type))
+                : filterValues.Any(value => Compare(itemValue, value, filter.Type));
+        }
+
+        private static bool Compare(object itemValue, JsonElement filterValue, string type)
+        {
+            if (itemValue == null)
+            {
+                return false;
+            }
+
+            if (itemValue is DateTime dateTime)
+            {
+                return CompareDate(dateTime, filterValue, type);
+            }
+
+            if (itemValue is IEnumerable enumerable && itemValue is not string)
+            {
+                var values = enumerable.Cast<object>().ToList();
+                var contains = values.Any(value => CompareScalar(value, filterValue) == 0);
+                return type is "notContains" or "notEqual" ? !contains : contains;
+            }
+
+            var comparison = CompareScalar(itemValue, filterValue);
+
+            return type switch
+            {
+                "contains" => Convert.ToString(itemValue, CultureInfo.InvariantCulture)?.Contains(GetString(filterValue), StringComparison.OrdinalIgnoreCase) == true,
+                "notContains" => Convert.ToString(itemValue, CultureInfo.InvariantCulture)?.Contains(GetString(filterValue), StringComparison.OrdinalIgnoreCase) != true,
+                "startsWith" => Convert.ToString(itemValue, CultureInfo.InvariantCulture)?.StartsWith(GetString(filterValue), StringComparison.OrdinalIgnoreCase) == true,
+                "notStartsWith" => Convert.ToString(itemValue, CultureInfo.InvariantCulture)?.StartsWith(GetString(filterValue), StringComparison.OrdinalIgnoreCase) != true,
+                "endsWith" => Convert.ToString(itemValue, CultureInfo.InvariantCulture)?.EndsWith(GetString(filterValue), StringComparison.OrdinalIgnoreCase) == true,
+                "notEndsWith" => Convert.ToString(itemValue, CultureInfo.InvariantCulture)?.EndsWith(GetString(filterValue), StringComparison.OrdinalIgnoreCase) != true,
+                "notEqual" => comparison != 0,
+                "greaterThan" => comparison > 0,
+                "greaterThanOrEqual" => comparison >= 0,
+                "lessThan" => comparison < 0,
+                "lessThanOrEqual" => comparison <= 0,
+                _ => comparison == 0
+            };
+        }
+
+        private static bool CompareDate(DateTime itemValue, JsonElement filterValue, string type)
+        {
+            if (filterValue.ValueKind == JsonValueKind.Object && filterValue.TryGetProperty("value", out var value) && filterValue.TryGetProperty("time", out var time))
+            {
+                var amount = value.GetInt32();
+                var boundary = AddTime(DateTime.UtcNow, time.GetString(), type is "inLast" or "notInLast" ? -amount : amount);
+                return type switch
+                {
+                    "inLast" => itemValue > boundary && itemValue < DateTime.UtcNow,
+                    "notInLast" => itemValue < boundary,
+                    "inNext" => itemValue > DateTime.UtcNow && itemValue < boundary,
+                    "notInNext" => itemValue > boundary,
+                    _ => false
+                };
+            }
+
+            if (!DateTime.TryParse(GetString(filterValue), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var date))
+            {
+                return false;
+            }
+
+            return type switch
+            {
+                "lessThan" => itemValue < date,
+                "greaterThan" => itemValue > date,
+                _ => itemValue == date
+            };
+        }
+
+        private static DateTime AddTime(DateTime date, string unit, int amount)
+        {
+            return unit switch
+            {
+                "years" => date.AddYears(amount),
+                "months" => date.AddMonths(amount),
+                "weeks" => date.AddDays(amount * 7),
+                "days" => date.AddDays(amount),
+                "hours" => date.AddHours(amount),
+                _ => date.AddDays(amount)
+            };
+        }
+
+        private static int CompareScalar(object itemValue, JsonElement filterValue)
+        {
+            if (itemValue is bool boolean && filterValue.ValueKind is JsonValueKind.True or JsonValueKind.False)
+            {
+                return boolean.CompareTo(filterValue.GetBoolean());
+            }
+
+            if (IsNumber(itemValue) && filterValue.TryGetDouble(out var number))
+            {
+                return Convert.ToDouble(itemValue, CultureInfo.InvariantCulture).CompareTo(number);
+            }
+
+            return string.Compare(Convert.ToString(itemValue, CultureInfo.InvariantCulture), GetString(filterValue), StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static int CompareValues(object left, object right)
+        {
+            if (ReferenceEquals(left, right))
+            {
+                return 0;
+            }
+
+            if (left == null)
+            {
+                return 1;
+            }
+
+            if (right == null)
+            {
+                return -1;
+            }
+
+            if (IsNumber(left) && IsNumber(right))
+            {
+                return Convert.ToDouble(left, CultureInfo.InvariantCulture).CompareTo(Convert.ToDouble(right, CultureInfo.InvariantCulture));
+            }
+
+            return left is IComparable comparable ? comparable.CompareTo(right) : string.Compare(left.ToString(), right.ToString(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsNumber(object value) => value is byte or short or int or long or float or double or decimal;
+
+        private static string GetString(JsonElement value) => value.ValueKind == JsonValueKind.String ? value.GetString() : value.ToString();
+
+        private static object GetValue(MovieResource movie, string key)
+        {
+            return key switch
+            {
+                "added" => movie.Added,
+                "certification" => movie.Certification,
+                "collection" => movie.Collection?.Title,
+                "digitalRelease" => movie.DigitalRelease,
+                "genres" => movie.Genres,
+                "hasFile" => movie.HasFile,
+                "imdbRating" => movie.Ratings?.Imdb?.Value ?? 0,
+                "imdbVotes" => movie.Ratings?.Imdb?.Votes ?? 0,
+                "inCinemas" => movie.InCinemas,
+                "isAvailable" => movie.IsAvailable,
+                "keywords" => movie.Keywords,
+                "minimumAvailability" => movie.MinimumAvailability.ToString(),
+                "monitored" => movie.Monitored,
+                "movieStatus" => GetMovieStatus(movie),
+                "originalLanguage" => movie.OriginalLanguage?.Name,
+                "originalTitle" => movie.OriginalTitle,
+                "path" => movie.Path,
+                "physicalRelease" => movie.PhysicalRelease,
+                "popularity" => movie.Popularity,
+                "qualityProfileId" => movie.QualityProfileId,
+                "qualityCutoffNotMet" => movie.MovieFile?.QualityCutoffNotMet ?? false,
+                "releaseDate" => movie.ReleaseDate,
+                "releaseGroups" => movie.Statistics?.ReleaseGroups,
+                "rottenTomatoesRating" => movie.Ratings?.RottenTomatoes?.Value ?? -1,
+                "runtime" => movie.Runtime,
+                "sizeOnDisk" => movie.Statistics?.SizeOnDisk ?? 0,
+                "sortTitle" => movie.SortTitle,
+                "status" => movie.Status.ToString(),
+                "studio" => movie.Studio,
+                "tags" => movie.Tags,
+                "title" => movie.Title,
+                "tmdbRating" => movie.Ratings?.Tmdb?.Value ?? 0,
+                "tmdbVotes" => movie.Ratings?.Tmdb?.Votes ?? 0,
+                "traktRating" => movie.Ratings?.Trakt?.Value ?? 0,
+                "traktVotes" => movie.Ratings?.Trakt?.Votes ?? 0,
+                "year" => movie.Year,
+                _ => movie.SortTitle
+            };
+        }
+
+        private static object GetSortValue(MovieResource movie, string key)
+        {
+            return key switch
+            {
+                "status" => (movie.Monitored ? 4 : 0) + (movie.Status.ToString() == "Announced" ? 1 : movie.Status.ToString() == "InCinemas" ? 2 : 3),
+                "movieStatus" => GetMovieStatus(movie) switch
+                {
+                    "downloaded" => 4,
+                    "cutoffNotMet" => 3,
+                    "missing" => 2,
+                    "notAvailable" => 1,
+                    _ => 0
+                },
+                _ => GetValue(movie, key)
+            };
+        }
+
+        private static string GetMovieStatus(MovieResource movie)
+        {
+            if (!movie.Monitored)
+            {
+                return "unmonitored";
+            }
+
+            if (movie.HasFile != true)
+            {
+                return movie.IsAvailable ? "missing" : "notAvailable";
+            }
+
+            return movie.MovieFile?.QualityCutoffNotMet == true ? "cutoffNotMet" : "downloaded";
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Load the movie catalog on demand instead of downloading every movie during application startup.

This adds a paged movie API capped at 100 records per response, server-side sorting and filtering, facets, jump-bar metadata, targeted search, and slug-based detail loading while preserving the existing `GET /movie` contract. The movie index requests the first 100 records and prefetches the next page at the halfway point. If a fast scroll remains beyond the new halfway point after a page is appended, it continues fetching 100-record pages until the buffer is restored.

Activity history and queue requests now include their related movie resources, so Activity pages render without loading the movie catalog. Other consumers that previously depended on the global catalog use targeted lookups or the embedded movie instead.

Production verification used an existing 1,341-movie library:

- Startup catalog payload: 8,135,967 bytes before; 885,084 bytes for the first 100-record page after (about 89% smaller).
- Movie index: exactly 100 initial records and zero legacy `GET /movie` requests.
- Infinite loading: page 2 requested at halfway; a simulated fast scroll automatically chained pages 3 and 4 until the half-list buffer was restored.
- Activity history: 20/20 rows contained embedded movies, with zero movie catalog or movie-page requests.
- Playwright console errors: 0.
- Cold LAN browser timing with the production bundle: about 2.4 seconds to the first movie page and 1.4 seconds to Activity history.
- Container verification: `linux-musl-x64` image running healthy with zero Radarr health warnings.

#### Screenshot (if UI related)

Initial movie page (100 of 1,341; no full-catalog request):

![Initial 100 movies](https://raw.githubusercontent.com/EasyAsABC123/Radarr/f6ca7743d66b7df02a5d65954cac90515430d4a6/pr-evidence/paged-movie-catalog/movies-first-100.png)

Buffer restored after a fast scroll automatically requested additional pages:

![Buffered infinite scroll](https://raw.githubusercontent.com/EasyAsABC123/Radarr/f6ca7743d66b7df02a5d65954cac90515430d4a6/pr-evidence/paged-movie-catalog/movies-buffer-restored-after-fast-scroll.png)

Activity history rendered from embedded movie data without a catalog request:

![Activity without catalog download](https://raw.githubusercontent.com/EasyAsABC123/Radarr/f6ca7743d66b7df02a5d65954cac90515430d4a6/pr-evidence/paged-movie-catalog/activity-without-catalog-download.png)

#### Todos
- [x] Tests
- [x] Translation Keys (no new strings)
- [x] Wiki Updates (not required)

Validation performed:

- Analyzer-enabled .NET build: 0 warnings, 0 errors
- Movie integration fixture: 15 passed
- `yarn lint`
- `tsc --noEmit --skipLibCheck`
- Production webpack build
- Playwright request assertions and screenshots

#### Issues Fixed or Closed by this PR

None.
