### PR TITLE
Fixed: Blank page when selecting search suggestion on mobile devices

### DIFF
--- a/frontend/src/Components/Page/Header/MovieSearchInput.tsx
+++ b/frontend/src/Components/Page/Header/MovieSearchInput.tsx
@@ -219,8 +219,10 @@ function MovieSearchInput() {
     inputRef.current?.focus();
   }, []);
 
-  const getSectionSuggestions = useCallback((section: Section) => {
-    return section.suggestions;
+  // Section can be undefined on mobile tap due to race condition with input blur
+  // https://github.com/moroshko/react-autosuggest/issues/853
+  const getSectionSuggestions = useCallback((section: Section | undefined) => {
+    return section?.suggestions ?? [];
   }, []);
 
   const renderSectionTitle = useCallback((section: Section) => {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
On mobile touchscreen devices, tapping a search suggestion in the header search input triggers a native input blur (virtual keyboard dismissal) before the tap callback resolves. This causes a race condition where the blur handler resets `suggestions` to `[]`, shifting the sections in `suggestionGroups`. When `react-autosuggest` invokes `onSuggestionClick` using the original section index, `getSuggestion` invokes `getSectionSuggestions(undefined)`. Evaluating `section.suggestions` on undefined threw an uncaught TypeError, crashing React and rendering a blank page (see [react-autosuggest#853](https://github.com/moroshko/react-autosuggest/issues/853)).

Safely handle `Section | undefined` in `getSectionSuggestions` by returning `[]`.

#### Screenshot (if UI related)
N/A

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
