### PR TITLE
Bump NUnit to 4.5.1

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -125,9 +125,9 @@
   <ItemGroup Condition="'$(TestProject)'=='true'">
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
-    <PackageReference Include="NunitXml.TestLogger" Version="3.1.20" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.3.0" />
+    <PackageReference Include="NunitXml.TestLogger" Version="8.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(RadarrProject)'=='true' and '$(EnableAnalyzers)'=='false'">

--- a/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
@@ -927,7 +927,7 @@ namespace NzbDrone.Common.Test.DiskTests
             var sourceFiles = Directory.GetFileSystemEntries(source, "*", SearchOption.AllDirectories).Select(v => v.Substring(source.Length + 1)).ToArray();
             var destFiles = Directory.GetFileSystemEntries(destination, "*", SearchOption.AllDirectories).Select(v => v.Substring(destination.Length + 1)).ToArray();
 
-            CollectionAssert.AreEquivalent(sourceFiles, destFiles);
+            Assert.That(sourceFiles, Is.EquivalentTo(destFiles));
         }
 
         private void VerifyMoveFolder(string source, string from, string destination)
@@ -937,7 +937,7 @@ namespace NzbDrone.Common.Test.DiskTests
             var sourceFiles = Directory.GetFileSystemEntries(source, "*", SearchOption.AllDirectories).Select(v => v.Substring(source.Length + 1)).ToArray();
             var destFiles = Directory.GetFileSystemEntries(destination, "*", SearchOption.AllDirectories).Select(v => v.Substring(destination.Length + 1)).ToArray();
 
-            CollectionAssert.AreEquivalent(sourceFiles, destFiles);
+            Assert.That(sourceFiles, Is.EquivalentTo(destFiles));
         }
 
         private void VerifyDeletedFile(string filePath)

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/HadoukenTests/HadoukenFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/HadoukenTests/HadoukenFixture.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Download.Clients.Hadouken;
 using NzbDrone.Core.Download.Clients.Hadouken.Models;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
 using NzbDrone.Test.Common;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace NzbDrone.Core.Test.Download.DownloadClientTests.HadoukenTests
 {

--- a/src/NzbDrone.Core.Test/ParserTests/RomanNumeralTests/RomanNumeralConversionFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/RomanNumeralTests/RomanNumeralConversionFixture.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using NzbDrone.Core.Parser.RomanNumerals;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace NzbDrone.Core.Test.ParserTests.RomanNumeralTests
 {

--- a/src/NzbDrone.Test.Common/Radarr.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/Radarr.Test.Common.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NLog" Version="5.5.1" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Bumping NUnit to v4 for better async support.

https://docs.nunit.org/articles/nunit/Towards-NUnit4.html

`using Assert = NUnit.Framework.Legacy.ClassicAssert;` can be removed with the .NET 10 bump, as NUnit added them in the new version as an extension which are supported since C14/.NET10. 