### PR TITLE
Remove unused package references

### DIFF
--- a/src/NzbDrone.Common/Radarr.Common.csproj
+++ b/src/NzbDrone.Common/Radarr.Common.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="System.Data.SQLite" Version="2.0.4" />
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
     <PackageReference Include="System.ValueTuple" Version="4.6.2" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.1" />

--- a/src/NzbDrone.Core/Radarr.Core.csproj
+++ b/src/NzbDrone.Core/Radarr.Core.csproj
@@ -8,13 +8,11 @@
     <PackageReference Include="Equ" Version="2.3.0" />
     <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="8.0.27" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.5" />
     <PackageReference Include="Npgsql" Version="9.0.5" />
     <PackageReference Include="Polly" Version="8.6.6" />
     <PackageReference Include="Servarr.FFMpegCore" Version="4.7.0-26" />
     <PackageReference Include="Servarr.FFprobe" Version="5.1.10.124" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.27" />
-    <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
`Microsoft.Data.SqlClient`, `System.Configuration.ConfigurationManager` and `System.Memory` are not referenced anywhere.

Radarr only talks to SQLite and PostgreSQL: the referenced migration runners are `FluentMigrator.Runner.SQLite` and `FluentMigrator.Runner.Postgres`, with `System.Data.SQLite` and `Npgsql` as the providers. There is no `using Microsoft.Data`, no `SqlConnection/SqlCommand`, and no use of `ConfigurationManager` in the tree. `System.Memory` is a no-op on .NET 8.0, the package resolves to zero runtime files and nothing else in the graph depends on it.

`System.Configuration.ConfigurationManager` is also a transitive dependency of `Microsoft.Data.SqlClient`, so once the latter is gone nothing else requires it.

Dropping the three removes **32** files from the build output: the SqlClient assemblies, the `Azure.Identity/MSAL` stack it drags in (`Azure.Core`, `Azure.Identity`, `Microsoft.Identity.Client`, `Microsoft.Identity.Client.Extensions.Msal`, `System.ClientModel`, `System.Memory.Data`), the whole `Microsoft.IdentityModel` stack, `System.IdentityModel.Tokens.Jwt`, `System.Security.Cryptography.ProtectedData` and 13 localized resource directories.

Everything, including the Windows and test projects, still builds fine.

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
N.A.
