### PR TITLE
Update API docs

### DIFF
--- a/src/Radarr.Api.V3/openapi.json
+++ b/src/Radarr.Api.V3/openapi.json
@@ -9572,6 +9572,10 @@
           "authenticationRequired": {
             "$ref": "#/components/schemas/AuthenticationRequiredType"
           },
+          "allowedHosts": {
+            "type": "string",
+            "nullable": true
+          },
           "analyticsEnabled": {
             "type": "boolean"
           },
@@ -9616,6 +9620,10 @@
             "nullable": true
           },
           "urlBase": {
+            "type": "string",
+            "nullable": true
+          },
+          "trustedNetworks": {
             "type": "string",
             "nullable": true
           },
@@ -11984,6 +11992,22 @@
         ],
         "type": "string"
       },
+      "ReleaseHistoryResource": {
+        "type": "object",
+        "properties": {
+          "grabbed": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "failed": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "ReleaseProfileResource": {
         "type": "object",
         "properties": {
@@ -12044,6 +12068,9 @@
           "customFormatScore": {
             "type": "integer",
             "format": "int32"
+          },
+          "history": {
+            "$ref": "#/components/schemas/ReleaseHistoryResource"
           },
           "qualityWeight": {
             "type": "integer",
@@ -12422,6 +12449,9 @@
             "type": "boolean"
           },
           "isDocker": {
+            "type": "boolean"
+          },
+          "isContainerized": {
             "type": "boolean"
           },
           "mode": {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
`src/Radarr.Api.V3/openapi.json` on develop was last updated on 2025-09-11 (24be516fd). Since then 80 backend commits have landed, so the published document is missing several fields.

The API Docs pipeline job is still running and still working: it generates the document, commits it, and force-pushes `api-docs` (most recently today, on top of the current develop tip). What it no longer does is open the pull request, so the output never reaches develop. The last `api-docs` pull request was #11236, merged 2025-09-11.

This commit is the output of `./docs.sh Windows`, byte-identical to what the pipeline pushed to `api-docs`. It adds:

- `HostConfigResource.allowedHosts`
- `HostConfigResource.trustedNetworks`
- `SystemResource.isContainerized`
- `ReleaseResource.history`
- the `ReleaseHistoryResource` schema

No source changes, so nothing else in the document moves.

#### Screenshot (if UI related)
N/A

#### Todos
- [ ] Tests - N/A, generated file only, no source change
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) - N/A, no new strings
- [ ] [Wiki Updates](https://wiki.servarr.com) - N/A

#### Issues Fixed or Closed by this PR

* Related to #11687 (why this has to be done by hand). Does not fix it - the cause is in the pipeline credentials, not the repo.
