### PR TITLE
Fixed: Incorrect status codes and content types in API docs

### DIFF
--- a/src/NzbDrone.Api.Test/ApplicationModels/ProducesResponseTypeConventionFixture.cs
+++ b/src/NzbDrone.Api.Test/ApplicationModels/ProducesResponseTypeConventionFixture.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using NUnit.Framework;
+using Radarr.Http;
+
+namespace NzbDrone.Api.Test.ApplicationModels
+{
+    [TestFixture]
+    public class ProducesResponseTypeConventionFixture
+    {
+        private sealed class SampleResource
+        {
+        }
+
+        private sealed class SampleController
+        {
+            [ProducesResponseType(StatusCodes.Status202Accepted)]
+            public ActionResult<SampleResource> Untyped() => null;
+
+            [ProducesResponseType(typeof(SampleResource), StatusCodes.Status202Accepted)]
+            public ActionResult<List<SampleResource>> AlreadyTyped() => null;
+
+            [ProducesResponseType(StatusCodes.Status202Accepted)]
+            public IActionResult NotAnActionResultOfT() => null;
+        }
+
+        private static ProducesResponseTypeAttribute Apply(string methodName)
+        {
+            var method = typeof(SampleController).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            var attribute = method.GetCustomAttribute<ProducesResponseTypeAttribute>();
+
+            var action = new ActionModel(method, new List<object> { attribute });
+            action.Filters.Add(attribute);
+
+            new ProducesResponseTypeConvention().Apply(action);
+
+            return attribute;
+        }
+
+        [Test]
+        public void should_fill_response_type_in_from_the_action_result_argument()
+        {
+            Apply(nameof(SampleController.Untyped)).Type.Should().Be(typeof(SampleResource));
+        }
+
+        [Test]
+        public void should_not_overwrite_an_explicitly_declared_response_type()
+        {
+            Apply(nameof(SampleController.AlreadyTyped)).Type.Should().Be(typeof(SampleResource));
+        }
+
+        [Test]
+        public void should_leave_actions_that_do_not_return_action_result_of_t_alone()
+        {
+            Apply(nameof(SampleController.NotAnActionResultOfT)).Type.Should().Be(typeof(void));
+        }
+    }
+}

--- a/src/NzbDrone.Host.Test/StringResultOutputFormatterFixture.cs
+++ b/src/NzbDrone.Host.Test/StringResultOutputFormatterFixture.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using NUnit.Framework;
+using NzbDrone.Host;
+
+namespace NzbDrone.App.Test
+{
+    [TestFixture]
+    public class StringResultOutputFormatterFixture
+    {
+        private sealed class SampleResource
+        {
+        }
+
+        private static IReadOnlyList<string> GetSupportedContentTypes<T>(IOutputFormatter formatter)
+        {
+            return ((IApiResponseTypeMetadataProvider)formatter).GetSupportedContentTypes(null, typeof(T));
+        }
+
+        [Test]
+        public void should_offer_text_plain_for_string_results()
+        {
+            GetSupportedContentTypes<string>(new StringResultOutputFormatter())
+                .Should()
+                .BeEquivalentTo("text/plain");
+        }
+
+        [Test]
+        public void should_offer_text_plain_for_actions_declared_as_object()
+        {
+            GetSupportedContentTypes<object>(new StringResultOutputFormatter())
+                .Should()
+                .BeEquivalentTo("text/plain");
+        }
+
+        [Test]
+        public void should_not_offer_text_plain_for_other_types()
+        {
+            GetSupportedContentTypes<SampleResource>(new StringResultOutputFormatter())
+                .Should()
+                .BeNullOrEmpty();
+        }
+
+        [Test]
+        public void should_differ_from_the_framework_formatter_it_replaces()
+        {
+            GetSupportedContentTypes<SampleResource>(new StringOutputFormatter())
+                .Should()
+                .BeEquivalentTo("text/plain");
+        }
+    }
+}

--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using DryIoc;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.HostFiltering;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -86,6 +88,11 @@ namespace NzbDrone.Host
             .AddControllers(options =>
             {
                 options.ReturnHttpNotAcceptable = true;
+
+                options.Conventions.Add(new ProducesResponseTypeConvention());
+
+                var stringFormatterIndex = options.OutputFormatters.ToList().FindIndex(f => f is StringOutputFormatter);
+                options.OutputFormatters[stringFormatterIndex] = new StringResultOutputFormatter();
             })
             .AddApplicationPart(typeof(SystemController).Assembly)
             .AddApplicationPart(typeof(StaticResourceController).Assembly)

--- a/src/NzbDrone.Host/StringResultOutputFormatter.cs
+++ b/src/NzbDrone.Host/StringResultOutputFormatter.cs
@@ -1,0 +1,17 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Formatters;
+
+namespace NzbDrone.Host
+{
+    // StringOutputFormatter writes string results only, but inherits a CanWriteType that accepts
+    // every type, so ApiExplorer advertises text/plain for every action. Narrowing it keeps runtime
+    // behaviour identical while the generated OpenAPI document lists text/plain only where it applies.
+    public class StringResultOutputFormatter : StringOutputFormatter
+    {
+        protected override bool CanWriteType(Type type)
+        {
+            // Actions declared as object can still return a string at runtime.
+            return type == null || type == typeof(object) || typeof(string).IsAssignableFrom(type);
+        }
+    }
+}

--- a/src/Radarr.Api.V3/AutoTagging/AutoTaggingController.cs
+++ b/src/Radarr.Api.V3/AutoTagging/AutoTaggingController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.AutoTagging;
@@ -49,6 +50,7 @@ namespace Radarr.Api.V3.AutoTagging
             return _autoTaggingService.GetById(id).ToResource();
         }
 
+        [ProducesResponseType(typeof(AutoTaggingResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<AutoTaggingResource> Create([FromBody] AutoTaggingResource autoTagResource)
@@ -60,6 +62,7 @@ namespace Radarr.Api.V3.AutoTagging
             return Created(_autoTaggingService.Insert(model).Id);
         }
 
+        [ProducesResponseType(typeof(AutoTaggingResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<AutoTaggingResource> Update([FromBody] AutoTaggingResource resource)

--- a/src/Radarr.Api.V3/Collections/CollectionController.cs
+++ b/src/Radarr.Api.V3/Collections/CollectionController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
@@ -88,6 +89,7 @@ namespace Radarr.Api.V3.Collections
             return collectionResources;
         }
 
+        [ProducesResponseType(typeof(CollectionResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<CollectionResource> UpdateCollection([FromBody] CollectionResource collectionResource)
@@ -101,6 +103,7 @@ namespace Radarr.Api.V3.Collections
             return Accepted(updatedMovie.Id);
         }
 
+        [ProducesResponseType(typeof(List<CollectionResource>), StatusCodes.Status202Accepted)]
         [HttpPut]
         [Consumes("application/json")]
         public ActionResult UpdateCollections([FromBody] CollectionUpdateResource resource)

--- a/src/Radarr.Api.V3/Commands/CommandController.cs
+++ b/src/Radarr.Api.V3/Commands/CommandController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Composition;
 using NzbDrone.Common.Serializer;
@@ -48,6 +49,7 @@ namespace Radarr.Api.V3.Commands
             return _commandQueueManager.Get(id).ToResource();
         }
 
+        [ProducesResponseType(typeof(CommandResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         [Produces("application/json")]

--- a/src/Radarr.Api.V3/Config/ConfigController.cs
+++ b/src/Radarr.Api.V3/Config/ConfigController.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Reflection;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Configuration;
 using Radarr.Http.REST;
@@ -32,6 +33,7 @@ namespace Radarr.Api.V3.Config
             return resource;
         }
 
+        [ProducesResponseType(StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public virtual ActionResult<TResource> SaveConfig([FromBody] TResource resource)

--- a/src/Radarr.Api.V3/Config/HostConfigController.cs
+++ b/src/Radarr.Api.V3/Config/HostConfigController.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Network;
@@ -123,6 +124,7 @@ namespace Radarr.Api.V3.Config
             return resource;
         }
 
+        [ProducesResponseType(typeof(HostConfigResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         public ActionResult<HostConfigResource> SaveHostConfig([FromBody] HostConfigResource resource)
         {

--- a/src/Radarr.Api.V3/Config/NamingConfigController.cs
+++ b/src/Radarr.Api.V3/Config/NamingConfigController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Organizer;
@@ -44,6 +45,7 @@ namespace Radarr.Api.V3.Config
             return resource;
         }
 
+        [ProducesResponseType(typeof(NamingConfigResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         public ActionResult<NamingConfigResource> UpdateNamingConfig([FromBody] NamingConfigResource resource)
         {

--- a/src/Radarr.Api.V3/Config/UiConfigController.cs
+++ b/src/Radarr.Api.V3/Config/UiConfigController.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Reflection;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Languages;
@@ -36,6 +37,7 @@ namespace Radarr.Api.V3.Config
                 .WithMessage("Invalid UI Language ID");
         }
 
+        [ProducesResponseType(typeof(UiConfigResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         public override ActionResult<UiConfigResource> SaveConfig([FromBody] UiConfigResource resource)
         {

--- a/src/Radarr.Api.V3/CustomFilters/CustomFilterController.cs
+++ b/src/Radarr.Api.V3/CustomFilters/CustomFilterController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.CustomFilters;
 using Radarr.Http;
@@ -28,6 +29,7 @@ namespace Radarr.Api.V3.CustomFilters
             return _customFilterService.All().ToResource();
         }
 
+        [ProducesResponseType(typeof(CustomFilterResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<CustomFilterResource> AddCustomFilter([FromBody] CustomFilterResource resource)
@@ -37,6 +39,7 @@ namespace Radarr.Api.V3.CustomFilters
             return Created(customFilter.Id);
         }
 
+        [ProducesResponseType(typeof(CustomFilterResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<CustomFilterResource> UpdateCustomFilter([FromBody] CustomFilterResource resource)

--- a/src/Radarr.Api.V3/CustomFormats/CustomFormatController.cs
+++ b/src/Radarr.Api.V3/CustomFormats/CustomFormatController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.CustomFormats;
@@ -53,6 +54,7 @@ namespace Radarr.Api.V3.CustomFormats
             return _formatService.All().ToResource(true);
         }
 
+        [ProducesResponseType(typeof(CustomFormatResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<CustomFormatResource> Create([FromBody] CustomFormatResource customFormatResource)
@@ -64,6 +66,7 @@ namespace Radarr.Api.V3.CustomFormats
             return Created(_formatService.Insert(model).Id);
         }
 
+        [ProducesResponseType(typeof(CustomFormatResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<CustomFormatResource> Update([FromBody] CustomFormatResource resource)
@@ -77,6 +80,7 @@ namespace Radarr.Api.V3.CustomFormats
             return Accepted(model.Id);
         }
 
+        [ProducesResponseType(typeof(List<CustomFormatResource>), StatusCodes.Status202Accepted)]
         [HttpPut("bulk")]
         [Consumes("application/json")]
         [Produces("application/json")]

--- a/src/Radarr.Api.V3/ImportLists/ImportListExclusionController.cs
+++ b/src/Radarr.Api.V3/ImportLists/ImportListExclusionController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.ImportLists.ImportExclusions;
@@ -62,6 +63,7 @@ namespace Radarr.Api.V3.ImportLists
             return pageSpec.ApplyToPage(_importListExclusionService.Paged, ImportListExclusionResourceMapper.ToResource);
         }
 
+        [ProducesResponseType(typeof(ImportListExclusionResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<ImportListExclusionResource> AddImportListExclusion([FromBody] ImportListExclusionResource resource)
@@ -71,6 +73,7 @@ namespace Radarr.Api.V3.ImportLists
             return Created(importListExclusion.Id);
         }
 
+        [ProducesResponseType(typeof(ImportListExclusionResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<ImportListExclusionResource> UpdateImportListExclusion([FromBody] ImportListExclusionResource resource)

--- a/src/Radarr.Api.V3/Metadata/MetadataController.cs
+++ b/src/Radarr.Api.V3/Metadata/MetadataController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Extras.Metadata;
 using NzbDrone.SignalR;
@@ -18,7 +19,7 @@ namespace Radarr.Api.V3.Metadata
         }
 
         [NonAction]
-        public override ActionResult<MetadataResource> UpdateProvider([FromBody] MetadataBulkResource providerResource)
+        public override ActionResult<List<MetadataResource>> UpdateProvider([FromBody] MetadataBulkResource providerResource)
         {
             throw new NotImplementedException();
         }

--- a/src/Radarr.Api.V3/MovieFiles/MovieFileController.cs
+++ b/src/Radarr.Api.V3/MovieFiles/MovieFileController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Datastore.Events;
@@ -82,6 +83,7 @@ namespace Radarr.Api.V3.MovieFiles
                 .ToList();
         }
 
+        [ProducesResponseType(typeof(MovieFileResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<MovieFileResource> SetMovieFile([FromBody] MovieFileResource movieFileResource)
@@ -105,6 +107,7 @@ namespace Radarr.Api.V3.MovieFiles
             return Accepted(movieFile.Id);
         }
 
+        [ProducesResponseType(typeof(List<MovieFileResource>), StatusCodes.Status202Accepted)]
         [Obsolete("Use bulk endpoint instead")]
         [HttpPut("editor")]
         [Consumes("application/json")]
@@ -188,6 +191,7 @@ namespace Radarr.Api.V3.MovieFiles
             return new { };
         }
 
+        [ProducesResponseType(typeof(List<MovieFileResource>), StatusCodes.Status202Accepted)]
         [HttpPut("bulk")]
         [Consumes("application/json")]
         public object SetPropertiesBulk([FromBody] List<MovieFileResource> resources)

--- a/src/Radarr.Api.V3/Movies/MovieController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
@@ -233,6 +234,7 @@ namespace Radarr.Api.V3.Movies
             return translation;
         }
 
+        [ProducesResponseType(typeof(MovieResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         [Produces("application/json")]
@@ -243,6 +245,7 @@ namespace Radarr.Api.V3.Movies
             return Created(movie.Id);
         }
 
+        [ProducesResponseType(typeof(MovieResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         [Produces("application/json")]

--- a/src/Radarr.Api.V3/Movies/MovieEditorController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieEditorController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
@@ -43,6 +44,7 @@ namespace Radarr.Api.V3.Movies
             _upgradableSpecification = upgradableSpecification;
         }
 
+        [ProducesResponseType(typeof(List<MovieResource>), StatusCodes.Status202Accepted)]
         [HttpPut]
         public IActionResult SaveAll([FromBody] MovieEditorResource resource)
         {

--- a/src/Radarr.Api.V3/Notifications/NotificationController.cs
+++ b/src/Radarr.Api.V3/Notifications/NotificationController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Notifications;
 using NzbDrone.SignalR;
@@ -18,7 +19,7 @@ namespace Radarr.Api.V3.Notifications
         }
 
         [NonAction]
-        public override ActionResult<NotificationResource> UpdateProvider([FromBody] NotificationBulkResource providerResource)
+        public override ActionResult<List<NotificationResource>> UpdateProvider([FromBody] NotificationBulkResource providerResource)
         {
             throw new NotImplementedException();
         }

--- a/src/Radarr.Api.V3/Profiles/Delay/DelayProfileController.cs
+++ b/src/Radarr.Api.V3/Profiles/Delay/DelayProfileController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Profiles.Delay;
 using Radarr.Http;
@@ -33,6 +34,7 @@ namespace Radarr.Api.V3.Profiles.Delay
             });
         }
 
+        [ProducesResponseType(typeof(DelayProfileResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<DelayProfileResource> Create([FromBody] DelayProfileResource resource)
@@ -54,6 +56,7 @@ namespace Radarr.Api.V3.Profiles.Delay
             _delayProfileService.Delete(id);
         }
 
+        [ProducesResponseType(typeof(DelayProfileResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<DelayProfileResource> Update([FromBody] DelayProfileResource resource)

--- a/src/Radarr.Api.V3/Profiles/Quality/QualityProfileController.cs
+++ b/src/Radarr.Api.V3/Profiles/Quality/QualityProfileController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.CustomFormats;
@@ -46,6 +47,7 @@ namespace Radarr.Api.V3.Profiles.Quality
             });
         }
 
+        [ProducesResponseType(typeof(QualityProfileResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<QualityProfileResource> Create([FromBody] QualityProfileResource resource)
@@ -61,6 +63,7 @@ namespace Radarr.Api.V3.Profiles.Quality
             _qualityProfileService.Delete(id);
         }
 
+        [ProducesResponseType(typeof(QualityProfileResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<QualityProfileResource> Update([FromBody] QualityProfileResource resource)

--- a/src/Radarr.Api.V3/Profiles/Release/ReleaseProfileController.cs
+++ b/src/Radarr.Api.V3/Profiles/Release/ReleaseProfileController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Indexers;
@@ -46,6 +47,7 @@ namespace Radarr.Api.V3.Profiles.Release
             });
         }
 
+        [ProducesResponseType(typeof(ReleaseProfileResource), StatusCodes.Status201Created)]
         [RestPostById]
         public ActionResult<ReleaseProfileResource> Create([FromBody] ReleaseProfileResource resource)
         {
@@ -60,6 +62,7 @@ namespace Radarr.Api.V3.Profiles.Release
             _profileService.Delete(id);
         }
 
+        [ProducesResponseType(typeof(ReleaseProfileResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         public ActionResult<ReleaseProfileResource> Update([FromBody] ReleaseProfileResource resource)
         {

--- a/src/Radarr.Api.V3/ProviderControllerBase.cs
+++ b/src/Radarr.Api.V3/ProviderControllerBase.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Serializer;
@@ -75,6 +76,7 @@ namespace Radarr.Api.V3
             return result.OrderBy(p => p.Name).ToList();
         }
 
+        [ProducesResponseType(StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         [Produces("application/json")]
@@ -92,6 +94,7 @@ namespace Radarr.Api.V3
             return Created(providerDefinition.Id);
         }
 
+        [ProducesResponseType(StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         [Produces("application/json")]
@@ -124,10 +127,11 @@ namespace Radarr.Api.V3
             return Accepted(existingDefinition.Id);
         }
 
+        [ProducesResponseType(StatusCodes.Status202Accepted)]
         [HttpPut("bulk")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        public virtual ActionResult<TProviderResource> UpdateProvider([FromBody] TBulkProviderResource providerResource)
+        public virtual ActionResult<List<TProviderResource>> UpdateProvider([FromBody] TBulkProviderResource providerResource)
         {
             if (!providerResource.Ids.Any())
             {

--- a/src/Radarr.Api.V3/Qualities/QualityDefinitionController.cs
+++ b/src/Radarr.Api.V3/Qualities/QualityDefinitionController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.Messaging.Events;
@@ -29,6 +30,7 @@ namespace Radarr.Api.V3.Qualities
                 .SetValidator(new QualityDefinitionResourceValidator());
         }
 
+        [ProducesResponseType(typeof(QualityDefinitionResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         public ActionResult<QualityDefinitionResource> Update([FromBody] QualityDefinitionResource resource)
         {
@@ -48,6 +50,7 @@ namespace Radarr.Api.V3.Qualities
             return _qualityDefinitionService.All().ToResource();
         }
 
+        [ProducesResponseType(typeof(List<QualityDefinitionResource>), StatusCodes.Status202Accepted)]
         [HttpPut("update")]
         public object UpdateMany([FromBody] List<QualityDefinitionResource> resource)
         {

--- a/src/Radarr.Api.V3/RemotePathMappings/RemotePathMappingController.cs
+++ b/src/Radarr.Api.V3/RemotePathMappings/RemotePathMappingController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.RemotePathMappings;
@@ -51,6 +52,7 @@ namespace Radarr.Api.V3.RemotePathMappings
             return _remotePathMappingService.Get(id).ToResource();
         }
 
+        [ProducesResponseType(typeof(RemotePathMappingResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<RemotePathMappingResource> CreateMapping([FromBody] RemotePathMappingResource resource)
@@ -72,6 +74,7 @@ namespace Radarr.Api.V3.RemotePathMappings
             _remotePathMappingService.Remove(id);
         }
 
+        [ProducesResponseType(typeof(RemotePathMappingResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         public ActionResult<RemotePathMappingResource> UpdateMapping([FromBody] RemotePathMappingResource resource)
         {

--- a/src/Radarr.Api.V3/RootFolders/RootFolderController.cs
+++ b/src/Radarr.Api.V3/RootFolders/RootFolderController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.RootFolders;
 using NzbDrone.Core.Validation.Paths;
@@ -48,6 +49,7 @@ namespace Radarr.Api.V3.RootFolders
             return _rootFolderService.Get(id, timeout).ToResource();
         }
 
+        [ProducesResponseType(typeof(RootFolderResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<RootFolderResource> CreateRootFolder([FromBody] RootFolderResource rootFolderResource)

--- a/src/Radarr.Api.V3/Tags/TagController.cs
+++ b/src/Radarr.Api.V3/Tags/TagController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.AutoTagging;
 using NzbDrone.Core.Datastore.Events;
@@ -43,6 +44,7 @@ namespace Radarr.Api.V3.Tags
             return _tagService.All().ToResource();
         }
 
+        [ProducesResponseType(typeof(TagResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<TagResource> Create([FromBody] TagResource resource)
@@ -50,6 +52,7 @@ namespace Radarr.Api.V3.Tags
             return Created(_tagService.Add(resource.ToModel()).Id);
         }
 
+        [ProducesResponseType(typeof(TagResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<TagResource> Update([FromBody] TagResource resource)

--- a/src/Radarr.Api.V3/openapi.json
+++ b/src/Radarr.Api.V3/openapi.json
@@ -54,14 +54,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AlternativeTitleResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -103,11 +95,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/AlternativeTitleResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AlternativeTitleResource"
@@ -231,14 +218,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/AutoTaggingResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AutoTaggingResource"
@@ -299,14 +281,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/AutoTaggingResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AutoTaggingResource"
@@ -361,11 +338,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/AutoTaggingResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AutoTaggingResource"
@@ -402,14 +374,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/BackupResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -582,14 +546,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/BlocklistResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -824,8 +780,26 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK"
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CollectionResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CollectionResource"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -855,14 +829,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectionResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CollectionResource"
@@ -896,11 +865,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectionResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CollectionResource"
@@ -931,8 +895,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -951,14 +915,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/CommandResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -1021,11 +977,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CommandResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CommandResource"
@@ -1091,11 +1042,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreditResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CreditResource"
@@ -1120,14 +1066,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/CustomFilterResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -1162,14 +1100,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CustomFilterResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomFilterResource"
@@ -1210,14 +1143,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CustomFilterResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomFilterResource"
@@ -1272,11 +1200,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CustomFilterResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomFilterResource"
@@ -1327,14 +1250,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CustomFormatResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomFormatResource"
@@ -1375,14 +1293,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CustomFormatResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomFormatResource"
@@ -1437,11 +1350,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CustomFormatResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomFormatResource"
@@ -1472,12 +1380,15 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CustomFormatResource"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomFormatResource"
+                  }
                 }
               }
             }
@@ -1592,14 +1503,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DelayProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DelayProfileResource"
@@ -1622,14 +1528,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DelayProfileResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -1697,14 +1595,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DelayProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DelayProfileResource"
@@ -1738,11 +1631,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DelayProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DelayProfileResource"
@@ -1786,14 +1674,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DelayProfileResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -1824,14 +1704,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DiskSpaceResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -1898,8 +1770,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -1945,8 +1817,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
@@ -1997,11 +1869,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DownloadClientResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DownloadClientResource"
@@ -2032,12 +1899,15 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DownloadClientResource"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DownloadClientResource"
+                  }
                 }
               }
             }
@@ -2204,14 +2074,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DownloadClientConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DownloadClientConfigResource"
@@ -2245,11 +2110,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DownloadClientConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DownloadClientConfigResource"
@@ -2284,14 +2144,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ExtraFileResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -2401,14 +2253,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/HealthResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -2667,11 +2511,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/HostConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HostConfigResource"
@@ -2722,14 +2561,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/HostConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HostConfigResource"
@@ -2763,11 +2597,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/HostConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HostConfigResource"
@@ -2828,8 +2657,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -2875,8 +2704,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
@@ -2927,11 +2756,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListResource"
@@ -2962,12 +2786,15 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ImportListResource"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ImportListResource"
+                  }
                 }
               }
             }
@@ -3134,14 +2961,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListConfigResource"
@@ -3175,11 +2997,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListConfigResource"
@@ -3231,14 +3048,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListExclusionResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListExclusionResource"
@@ -3332,14 +3144,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListExclusionResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListExclusionResource"
@@ -3394,11 +3201,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListExclusionResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListExclusionResource"
@@ -3604,8 +3406,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -3651,8 +3453,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
@@ -3703,11 +3505,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/IndexerResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/IndexerResource"
@@ -3738,12 +3535,15 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IndexerResource"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IndexerResource"
+                  }
                 }
               }
             }
@@ -3910,14 +3710,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/IndexerConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/IndexerConfigResource"
@@ -3951,11 +3746,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/IndexerConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/IndexerConfigResource"
@@ -3980,14 +3770,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/IndexerFlagResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -4018,14 +3800,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/LanguageResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -4067,11 +3841,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/LanguageResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/LanguageResource"
@@ -4204,14 +3973,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/LogFileResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -4408,14 +4169,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MediaManagementConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MediaManagementConfigResource"
@@ -4449,11 +4205,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MediaManagementConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MediaManagementConfigResource"
@@ -4514,8 +4265,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -4561,8 +4312,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
@@ -4613,11 +4364,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetadataResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MetadataResource"
@@ -4773,14 +4519,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetadataConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MetadataConfigResource"
@@ -4814,11 +4555,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetadataConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MetadataConfigResource"
@@ -4930,14 +4666,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/MovieResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -4972,8 +4700,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -5018,8 +4746,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
@@ -5086,11 +4814,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MovieResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MovieResource"
@@ -5131,8 +4854,26 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK"
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MovieResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MovieResource"
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -5237,14 +4978,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MovieFileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MovieFileResource"
@@ -5299,11 +5035,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MovieFileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MovieFileResource"
@@ -5334,8 +5065,26 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK"
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MovieFileResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MovieFileResource"
+                  }
+                }
+              }
+            }
           }
         },
         "deprecated": true
@@ -5378,8 +5127,26 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK"
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MovieFileResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MovieFileResource"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -5538,11 +5305,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/NamingConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NamingConfigResource"
@@ -5593,14 +5355,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/NamingConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NamingConfigResource"
@@ -5634,11 +5391,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/NamingConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NamingConfigResource"
@@ -5763,8 +5515,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -5810,8 +5562,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
@@ -5862,11 +5614,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotificationResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NotificationResource"
@@ -5996,11 +5743,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ParseResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ParseResource"
@@ -6087,14 +5829,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityDefinitionResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QualityDefinitionResource"
@@ -6128,11 +5865,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityDefinitionResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QualityDefinitionResource"
@@ -6157,14 +5889,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/QualityDefinitionResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -6220,8 +5944,26 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK"
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityDefinitionResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityDefinitionResource"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -6235,11 +5977,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityDefinitionLimitsResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QualityDefinitionLimitsResource"
@@ -6270,14 +6007,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QualityProfileResource"
@@ -6300,14 +6032,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/QualityProfileResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -6375,14 +6099,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QualityProfileResource"
@@ -6416,11 +6135,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QualityProfileResource"
@@ -6445,11 +6159,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QualityProfileResource"
@@ -6775,14 +6484,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/QueueResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -6813,11 +6514,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QueueStatusResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QueueStatusResource"
@@ -6909,14 +6605,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReleaseProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ReleaseProfileResource"
@@ -6939,14 +6630,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ReleaseProfileResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7024,14 +6707,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReleaseProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ReleaseProfileResource"
@@ -7065,11 +6743,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReleaseProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ReleaseProfileResource"
@@ -7103,14 +6776,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ReleaseResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7147,14 +6812,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/RemotePathMappingResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RemotePathMappingResource"
@@ -7177,14 +6837,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/RemotePathMappingResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7262,14 +6914,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/RemotePathMappingResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RemotePathMappingResource"
@@ -7303,11 +6950,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/RemotePathMappingResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RemotePathMappingResource"
@@ -7345,14 +6987,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/RenameMovieResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7389,14 +7023,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/RootFolderResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RootFolderResource"
@@ -7419,14 +7048,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/RootFolderResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7489,11 +7110,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/RootFolderResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RootFolderResource"
@@ -7586,11 +7202,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/SystemResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SystemResource"
@@ -7663,14 +7274,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TagResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7705,14 +7308,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/TagResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TagResource"
@@ -7753,14 +7351,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/TagResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TagResource"
@@ -7815,11 +7408,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/TagResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TagResource"
@@ -7844,14 +7432,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TagDetailsResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7893,11 +7473,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/TagDetailsResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TagDetailsResource"
@@ -7922,14 +7497,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TaskResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7971,11 +7538,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/TaskResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TaskResource"
@@ -8016,14 +7578,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/UiConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UiConfigResource"
@@ -8057,11 +7614,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/UiConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UiConfigResource"
@@ -8105,14 +7657,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/UpdateResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -8143,14 +7687,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/LogFileResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",

--- a/src/Radarr.Api.V3/openapi.json
+++ b/src/Radarr.Api.V3/openapi.json
@@ -9572,6 +9572,10 @@
           "authenticationRequired": {
             "$ref": "#/components/schemas/AuthenticationRequiredType"
           },
+          "allowedHosts": {
+            "type": "string",
+            "nullable": true
+          },
           "analyticsEnabled": {
             "type": "boolean"
           },
@@ -9616,6 +9620,10 @@
             "nullable": true
           },
           "urlBase": {
+            "type": "string",
+            "nullable": true
+          },
+          "trustedNetworks": {
             "type": "string",
             "nullable": true
           },
@@ -11984,6 +11992,22 @@
         ],
         "type": "string"
       },
+      "ReleaseHistoryResource": {
+        "type": "object",
+        "properties": {
+          "grabbed": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "failed": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "ReleaseProfileResource": {
         "type": "object",
         "properties": {
@@ -12044,6 +12068,9 @@
           "customFormatScore": {
             "type": "integer",
             "format": "int32"
+          },
+          "history": {
+            "$ref": "#/components/schemas/ReleaseHistoryResource"
           },
           "qualityWeight": {
             "type": "integer",
@@ -12422,6 +12449,9 @@
             "type": "boolean"
           },
           "isDocker": {
+            "type": "boolean"
+          },
+          "isContainerized": {
             "type": "boolean"
           },
           "mode": {

--- a/src/Radarr.Http/ProducesResponseTypeConvention.cs
+++ b/src/Radarr.Http/ProducesResponseTypeConvention.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace Radarr.Http
+{
+    // ProducesResponseType can't name the resource type of a generic base controller, so those
+    // actions declare the status code alone. MVC fills the body type in from the return type for
+    // 200 and 201 but not for the 202 the REST controllers return from updates, so do it here.
+    public class ProducesResponseTypeConvention : IActionModelConvention
+    {
+        public void Apply(ActionModel action)
+        {
+            var returnType = action.ActionMethod.ReturnType;
+
+            if (!returnType.IsGenericType || returnType.GetGenericTypeDefinition() != typeof(ActionResult<>))
+            {
+                return;
+            }
+
+            var resourceType = returnType.GetGenericArguments()[0];
+
+            foreach (var attribute in action.Filters.OfType<ProducesResponseTypeAttribute>().Where(a => a.Type == typeof(void)))
+            {
+                attribute.Type = resourceType;
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
`openapi.json` describes response metadata that does not match what the API returns. Verified against a running Debug build on every point below.

**Every create and update was documented as 200.** All 237 operations declared `200` and nothing else, but `RestController.Created`/`Accepted` use `CreatedAtAction`/`AcceptedAtAction`, so creates answer 201 and updates answer 202. A generated client that checks for 200 treats every successful write as a failure.

```
POST /api/v3/tag           -> 201
PUT  /api/v3/tag/{id}      -> 202
PUT  /api/v3/config/ui/{id} -> 202
```

Annotating those actions with `ProducesResponseType` covers 52 operations. `ProducesResponseType` cannot name the resource type of a generic base controller, and MVC infers the body type from the return type for 201 but not 202, so `ProducesResponseTypeConvention` fills it in for the actions inherited from `ConfigController` and `ProviderControllerBase`.

**`text/plain` was advertised on 98 operations that reject it.** `StringOutputFormatter` writes string results only, but inherits a `CanWriteType` that accepts every type, so ApiExplorer listed `text/plain` for every action without an explicit `Produces`. `GET /api/v3/system/status` with `Accept: text/plain` returns 406, not a `SystemResource`. `StringResultOutputFormatter` narrows `CanWriteType`, which leaves runtime content negotiation unchanged and drops `text/plain` from the document everywhere except `GET /api/v3/localization`, which does serve it.

**The bulk provider update was documented as a single object.** It returns an array of resources but declared `ActionResult<TProviderResource>`.

Net effect on the document: response codes go from `{200: 237}` to `{200: 185, 201: 17, 202: 35}`, and `text/plain` from 98 operations to 1.

Runtime behaviour is deliberately unchanged. Content negotiation was re-checked after the change: `application/json` 200, `text/json` 200, `text/plain` 406, and `/api/v3/localization` still serves `text/plain` for `*/*`.

This is three corrections rather than one, but they are all response metadata on the same generated artifact and share one regeneration, so splitting them would mean three sequential PRs each regenerating `openapi.json`. Happy to split if you would rather review them separately.

Stacked on #11685 (`Update API docs`), which brings develop's `openapi.json` up to date first, so the regenerated file here shows only what these source changes cause. Please merge that one first.

#### Screenshot (if UI related)
N/A

#### Todos
- [x] Tests - `ProducesResponseTypeConventionFixture` (3) and `StringResultOutputFormatterFixture` (4)
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) - N/A, no new strings
- [ ] [Wiki Updates](https://wiki.servarr.com) - N/A

#### Issues Fixed or Closed by this PR

* None
