### PR TITLE
Fixed: Missing response types in API docs

### DIFF
--- a/src/NzbDrone.Api.Test/ApplicationModels/ProducesResponseTypeConventionFixture.cs
+++ b/src/NzbDrone.Api.Test/ApplicationModels/ProducesResponseTypeConventionFixture.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using NUnit.Framework;
+using Radarr.Http;
+
+namespace NzbDrone.Api.Test.ApplicationModels
+{
+    [TestFixture]
+    public class ProducesResponseTypeConventionFixture
+    {
+        private sealed class SampleResource
+        {
+        }
+
+        private sealed class SampleController
+        {
+            [ProducesResponseType(StatusCodes.Status202Accepted)]
+            public ActionResult<SampleResource> Untyped() => null;
+
+            [ProducesResponseType(typeof(SampleResource), StatusCodes.Status202Accepted)]
+            public ActionResult<List<SampleResource>> AlreadyTyped() => null;
+
+            [ProducesResponseType(StatusCodes.Status202Accepted)]
+            public IActionResult NotAnActionResultOfT() => null;
+        }
+
+        private static ProducesResponseTypeAttribute Apply(string methodName)
+        {
+            var method = typeof(SampleController).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            var attribute = method.GetCustomAttribute<ProducesResponseTypeAttribute>();
+
+            var action = new ActionModel(method, new List<object> { attribute });
+            action.Filters.Add(attribute);
+
+            new ProducesResponseTypeConvention().Apply(action);
+
+            return attribute;
+        }
+
+        [Test]
+        public void should_fill_response_type_in_from_the_action_result_argument()
+        {
+            Apply(nameof(SampleController.Untyped)).Type.Should().Be(typeof(SampleResource));
+        }
+
+        [Test]
+        public void should_not_overwrite_an_explicitly_declared_response_type()
+        {
+            Apply(nameof(SampleController.AlreadyTyped)).Type.Should().Be(typeof(SampleResource));
+        }
+
+        [Test]
+        public void should_leave_actions_that_do_not_return_action_result_of_t_alone()
+        {
+            Apply(nameof(SampleController.NotAnActionResultOfT)).Type.Should().Be(typeof(void));
+        }
+    }
+}

--- a/src/NzbDrone.Host.Test/StringResultOutputFormatterFixture.cs
+++ b/src/NzbDrone.Host.Test/StringResultOutputFormatterFixture.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using NUnit.Framework;
+using NzbDrone.Host;
+
+namespace NzbDrone.App.Test
+{
+    [TestFixture]
+    public class StringResultOutputFormatterFixture
+    {
+        private sealed class SampleResource
+        {
+        }
+
+        private static IReadOnlyList<string> GetSupportedContentTypes<T>(IOutputFormatter formatter)
+        {
+            return ((IApiResponseTypeMetadataProvider)formatter).GetSupportedContentTypes(null, typeof(T));
+        }
+
+        [Test]
+        public void should_offer_text_plain_for_string_results()
+        {
+            GetSupportedContentTypes<string>(new StringResultOutputFormatter())
+                .Should()
+                .BeEquivalentTo("text/plain");
+        }
+
+        [Test]
+        public void should_offer_text_plain_for_actions_declared_as_object()
+        {
+            GetSupportedContentTypes<object>(new StringResultOutputFormatter())
+                .Should()
+                .BeEquivalentTo("text/plain");
+        }
+
+        [Test]
+        public void should_not_offer_text_plain_for_other_types()
+        {
+            GetSupportedContentTypes<SampleResource>(new StringResultOutputFormatter())
+                .Should()
+                .BeNullOrEmpty();
+        }
+
+        [Test]
+        public void should_differ_from_the_framework_formatter_it_replaces()
+        {
+            GetSupportedContentTypes<SampleResource>(new StringOutputFormatter())
+                .Should()
+                .BeEquivalentTo("text/plain");
+        }
+    }
+}

--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using DryIoc;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.HostFiltering;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -86,6 +88,11 @@ namespace NzbDrone.Host
             .AddControllers(options =>
             {
                 options.ReturnHttpNotAcceptable = true;
+
+                options.Conventions.Add(new ProducesResponseTypeConvention());
+
+                var stringFormatterIndex = options.OutputFormatters.ToList().FindIndex(f => f is StringOutputFormatter);
+                options.OutputFormatters[stringFormatterIndex] = new StringResultOutputFormatter();
             })
             .AddApplicationPart(typeof(SystemController).Assembly)
             .AddApplicationPart(typeof(StaticResourceController).Assembly)

--- a/src/NzbDrone.Host/StringResultOutputFormatter.cs
+++ b/src/NzbDrone.Host/StringResultOutputFormatter.cs
@@ -1,0 +1,17 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Formatters;
+
+namespace NzbDrone.Host
+{
+    // StringOutputFormatter writes string results only, but inherits a CanWriteType that accepts
+    // every type, so ApiExplorer advertises text/plain for every action. Narrowing it keeps runtime
+    // behaviour identical while the generated OpenAPI document lists text/plain only where it applies.
+    public class StringResultOutputFormatter : StringOutputFormatter
+    {
+        protected override bool CanWriteType(Type type)
+        {
+            // Actions declared as object can still return a string at runtime.
+            return type == null || type == typeof(object) || typeof(string).IsAssignableFrom(type);
+        }
+    }
+}

--- a/src/NzbDrone.Integration.Test/ApiTests/FileSystemFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/FileSystemFixture.cs
@@ -120,5 +120,17 @@ namespace NzbDrone.Integration.Test.ApiTests
 
             result.First()["name"].Should().Be("somevideo.mkv");
         }
+
+        [Test]
+        public void get_all_mediafiles_for_folder_that_does_not_exist()
+        {
+            var request = FileSystem.BuildRequest("mediafiles");
+            request.Method = Method.GET;
+            request.AddQueryParameter("path", Path.Combine(_folder, "does_not_exist"));
+
+            var result = FileSystem.Execute<List<Dictionary<string, string>>>(request, HttpStatusCode.OK);
+
+            result.Should().BeEmpty();
+        }
     }
 }

--- a/src/Radarr.Api.V3/AutoTagging/AutoTaggingController.cs
+++ b/src/Radarr.Api.V3/AutoTagging/AutoTaggingController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.AutoTagging;
@@ -49,6 +50,7 @@ namespace Radarr.Api.V3.AutoTagging
             return _autoTaggingService.GetById(id).ToResource();
         }
 
+        [ProducesResponseType(typeof(AutoTaggingResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<AutoTaggingResource> Create([FromBody] AutoTaggingResource autoTagResource)
@@ -60,6 +62,7 @@ namespace Radarr.Api.V3.AutoTagging
             return Created(_autoTaggingService.Insert(model).Id);
         }
 
+        [ProducesResponseType(typeof(AutoTaggingResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<AutoTaggingResource> Update([FromBody] AutoTaggingResource resource)

--- a/src/Radarr.Api.V3/AutoTagging/AutoTaggingController.cs
+++ b/src/Radarr.Api.V3/AutoTagging/AutoTaggingController.cs
@@ -90,7 +90,7 @@ namespace Radarr.Api.V3.AutoTagging
         }
 
         [HttpGet("schema")]
-        public object GetTemplates()
+        public List<AutoTaggingSpecificationSchema> GetTemplates()
         {
             var schema = _specifications.OrderBy(x => x.Order).Select(x => x.ToSchema()).ToList();
 

--- a/src/Radarr.Api.V3/Collections/CollectionController.cs
+++ b/src/Radarr.Api.V3/Collections/CollectionController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
@@ -88,6 +89,7 @@ namespace Radarr.Api.V3.Collections
             return collectionResources;
         }
 
+        [ProducesResponseType(typeof(CollectionResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<CollectionResource> UpdateCollection([FromBody] CollectionResource collectionResource)
@@ -101,6 +103,7 @@ namespace Radarr.Api.V3.Collections
             return Accepted(updatedMovie.Id);
         }
 
+        [ProducesResponseType(typeof(List<CollectionResource>), StatusCodes.Status202Accepted)]
         [HttpPut]
         [Consumes("application/json")]
         public ActionResult UpdateCollections([FromBody] CollectionUpdateResource resource)

--- a/src/Radarr.Api.V3/Commands/CommandController.cs
+++ b/src/Radarr.Api.V3/Commands/CommandController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Composition;
 using NzbDrone.Common.Serializer;
@@ -48,6 +49,7 @@ namespace Radarr.Api.V3.Commands
             return _commandQueueManager.Get(id).ToResource();
         }
 
+        [ProducesResponseType(typeof(CommandResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         [Produces("application/json")]

--- a/src/Radarr.Api.V3/Config/ConfigController.cs
+++ b/src/Radarr.Api.V3/Config/ConfigController.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Reflection;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Configuration;
 using Radarr.Http.REST;
@@ -32,6 +33,7 @@ namespace Radarr.Api.V3.Config
             return resource;
         }
 
+        [ProducesResponseType(StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public virtual ActionResult<TResource> SaveConfig([FromBody] TResource resource)

--- a/src/Radarr.Api.V3/Config/HostConfigController.cs
+++ b/src/Radarr.Api.V3/Config/HostConfigController.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Network;
@@ -123,6 +124,7 @@ namespace Radarr.Api.V3.Config
             return resource;
         }
 
+        [ProducesResponseType(typeof(HostConfigResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         public ActionResult<HostConfigResource> SaveHostConfig([FromBody] HostConfigResource resource)
         {

--- a/src/Radarr.Api.V3/Config/NamingConfigController.cs
+++ b/src/Radarr.Api.V3/Config/NamingConfigController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Organizer;
@@ -44,6 +45,7 @@ namespace Radarr.Api.V3.Config
             return resource;
         }
 
+        [ProducesResponseType(typeof(NamingConfigResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         public ActionResult<NamingConfigResource> UpdateNamingConfig([FromBody] NamingConfigResource resource)
         {

--- a/src/Radarr.Api.V3/Config/NamingConfigController.cs
+++ b/src/Radarr.Api.V3/Config/NamingConfigController.cs
@@ -58,7 +58,7 @@ namespace Radarr.Api.V3.Config
         }
 
         [HttpGet("examples")]
-        public object GetExamples([FromQuery]NamingConfigResource config)
+        public NamingExampleResource GetExamples([FromQuery]NamingConfigResource config)
         {
             if (config.Id == 0)
             {

--- a/src/Radarr.Api.V3/Config/UiConfigController.cs
+++ b/src/Radarr.Api.V3/Config/UiConfigController.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Reflection;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Languages;
@@ -36,6 +37,7 @@ namespace Radarr.Api.V3.Config
                 .WithMessage("Invalid UI Language ID");
         }
 
+        [ProducesResponseType(typeof(UiConfigResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         public override ActionResult<UiConfigResource> SaveConfig([FromBody] UiConfigResource resource)
         {

--- a/src/Radarr.Api.V3/Credits/CreditController.cs
+++ b/src/Radarr.Api.V3/Credits/CreditController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.Movies;
@@ -28,21 +29,21 @@ namespace Radarr.Api.V3.Credits
         }
 
         [HttpGet]
-        public object GetCredits(int? movieId, int? movieMetadataId)
+        public List<CreditResource> GetCredits(int? movieId, int? movieMetadataId)
         {
             if (movieMetadataId.HasValue)
             {
-                return MapToResource(_creditService.GetAllCreditsForMovieMetadata(movieMetadataId.Value));
+                return MapToResource(_creditService.GetAllCreditsForMovieMetadata(movieMetadataId.Value)).ToList();
             }
 
             if (movieId.HasValue)
             {
                 var movie = _movieService.GetMovie(movieId.Value);
 
-                return MapToResource(_creditService.GetAllCreditsForMovieMetadata(movie.MovieMetadataId));
+                return MapToResource(_creditService.GetAllCreditsForMovieMetadata(movie.MovieMetadataId)).ToList();
             }
 
-            return MapToResource(_creditService.GetAllCredits());
+            return MapToResource(_creditService.GetAllCredits()).ToList();
         }
 
         private IEnumerable<CreditResource> MapToResource(IEnumerable<Credit> credits)

--- a/src/Radarr.Api.V3/CustomFilters/CustomFilterController.cs
+++ b/src/Radarr.Api.V3/CustomFilters/CustomFilterController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.CustomFilters;
 using Radarr.Http;
@@ -28,6 +29,7 @@ namespace Radarr.Api.V3.CustomFilters
             return _customFilterService.All().ToResource();
         }
 
+        [ProducesResponseType(typeof(CustomFilterResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<CustomFilterResource> AddCustomFilter([FromBody] CustomFilterResource resource)
@@ -37,6 +39,7 @@ namespace Radarr.Api.V3.CustomFilters
             return Created(customFilter.Id);
         }
 
+        [ProducesResponseType(typeof(CustomFilterResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<CustomFilterResource> UpdateCustomFilter([FromBody] CustomFilterResource resource)

--- a/src/Radarr.Api.V3/CustomFormats/CustomFormatController.cs
+++ b/src/Radarr.Api.V3/CustomFormats/CustomFormatController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.CustomFormats;
@@ -53,6 +54,7 @@ namespace Radarr.Api.V3.CustomFormats
             return _formatService.All().ToResource(true);
         }
 
+        [ProducesResponseType(typeof(CustomFormatResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<CustomFormatResource> Create([FromBody] CustomFormatResource customFormatResource)
@@ -64,6 +66,7 @@ namespace Radarr.Api.V3.CustomFormats
             return Created(_formatService.Insert(model).Id);
         }
 
+        [ProducesResponseType(typeof(CustomFormatResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<CustomFormatResource> Update([FromBody] CustomFormatResource resource)
@@ -77,6 +80,7 @@ namespace Radarr.Api.V3.CustomFormats
             return Accepted(model.Id);
         }
 
+        [ProducesResponseType(typeof(List<CustomFormatResource>), StatusCodes.Status202Accepted)]
         [HttpPut("bulk")]
         [Consumes("application/json")]
         [Produces("application/json")]

--- a/src/Radarr.Api.V3/CustomFormats/CustomFormatController.cs
+++ b/src/Radarr.Api.V3/CustomFormats/CustomFormatController.cs
@@ -119,7 +119,7 @@ namespace Radarr.Api.V3.CustomFormats
         }
 
         [HttpGet("schema")]
-        public object GetTemplates()
+        public List<CustomFormatSpecificationSchema> GetTemplates()
         {
             var schema = _specifications.OrderBy(x => x.Order).Select(x => x.ToSchema()).ToList();
 

--- a/src/Radarr.Api.V3/FileSystem/FileSystemController.cs
+++ b/src/Radarr.Api.V3/FileSystem/FileSystemController.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
@@ -26,37 +26,37 @@ namespace Radarr.Api.V3.FileSystem
         }
 
         [HttpGet]
-        public IActionResult GetContents(string path, bool includeFiles = false, bool allowFoldersWithoutTrailingSlashes = false)
+        public FileSystemResult GetContents(string path, bool includeFiles = false, bool allowFoldersWithoutTrailingSlashes = false)
         {
-            return Ok(_fileSystemLookupService.LookupContents(path, includeFiles, allowFoldersWithoutTrailingSlashes));
+            return _fileSystemLookupService.LookupContents(path, includeFiles, allowFoldersWithoutTrailingSlashes);
         }
 
         [HttpGet("type")]
-        public object GetEntityType(string path)
+        public FileSystemTypeResource GetEntityType(string path)
         {
             if (_diskProvider.FileExists(path))
             {
-                return new { type = "file" };
+                return new FileSystemTypeResource { Type = FileSystemEntityType.File };
             }
 
             // Return folder even if it doesn't exist on disk to avoid leaking anything from the UI about the underlying system
-            return new { type = "folder" };
+            return new FileSystemTypeResource { Type = FileSystemEntityType.Folder };
         }
 
         [HttpGet("mediafiles")]
-        public object GetMediaFiles(string path)
+        public List<FileSystemMediaFileResource> GetMediaFiles(string path)
         {
             if (!_diskProvider.FolderExists(path))
             {
-                return Array.Empty<string>();
+                return new List<FileSystemMediaFileResource>();
             }
 
-            return _diskScanService.GetVideoFiles(path).Select(f => new
+            return _diskScanService.GetVideoFiles(path).Select(f => new FileSystemMediaFileResource
             {
                 Path = f,
                 RelativePath = path.GetRelativePath(f),
                 Name = Path.GetFileName(f)
-            });
+            }).ToList();
         }
     }
 }

--- a/src/Radarr.Api.V3/FileSystem/FileSystemMediaFileResource.cs
+++ b/src/Radarr.Api.V3/FileSystem/FileSystemMediaFileResource.cs
@@ -1,0 +1,9 @@
+namespace Radarr.Api.V3.FileSystem
+{
+    public class FileSystemMediaFileResource
+    {
+        public string Path { get; set; }
+        public string RelativePath { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/Radarr.Api.V3/FileSystem/FileSystemTypeResource.cs
+++ b/src/Radarr.Api.V3/FileSystem/FileSystemTypeResource.cs
@@ -1,0 +1,9 @@
+using NzbDrone.Common.Disk;
+
+namespace Radarr.Api.V3.FileSystem
+{
+    public class FileSystemTypeResource
+    {
+        public FileSystemEntityType Type { get; set; }
+    }
+}

--- a/src/Radarr.Api.V3/ImportLists/ImportListExclusionController.cs
+++ b/src/Radarr.Api.V3/ImportLists/ImportListExclusionController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.ImportLists.ImportExclusions;
@@ -62,6 +63,7 @@ namespace Radarr.Api.V3.ImportLists
             return pageSpec.ApplyToPage(_importListExclusionService.Paged, ImportListExclusionResourceMapper.ToResource);
         }
 
+        [ProducesResponseType(typeof(ImportListExclusionResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<ImportListExclusionResource> AddImportListExclusion([FromBody] ImportListExclusionResource resource)
@@ -71,6 +73,7 @@ namespace Radarr.Api.V3.ImportLists
             return Created(importListExclusion.Id);
         }
 
+        [ProducesResponseType(typeof(ImportListExclusionResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<ImportListExclusionResource> UpdateImportListExclusion([FromBody] ImportListExclusionResource resource)

--- a/src/Radarr.Api.V3/ImportLists/ImportListExclusionController.cs
+++ b/src/Radarr.Api.V3/ImportLists/ImportListExclusionController.cs
@@ -83,7 +83,7 @@ namespace Radarr.Api.V3.ImportLists
         }
 
         [HttpPost("bulk")]
-        public object AddImportListExclusions([FromBody] List<ImportListExclusionResource> resources)
+        public List<ImportListExclusionResource> AddImportListExclusions([FromBody] List<ImportListExclusionResource> resources)
         {
             var importListExclusions = _importListExclusionService.Add(resources.ToModel());
 

--- a/src/Radarr.Api.V3/ImportLists/ImportListMoviesController.cs
+++ b/src/Radarr.Api.V3/ImportLists/ImportListMoviesController.cs
@@ -54,7 +54,7 @@ namespace Radarr.Api.V3.ImportLists
         }
 
         [HttpGet]
-        public object GetDiscoverMovies(bool includeRecommendations = false, bool includeTrending = false, bool includePopular = false)
+        public List<ImportListMoviesResource> GetDiscoverMovies(bool includeRecommendations = false, bool includeTrending = false, bool includePopular = false)
         {
             var movieLanguage = (Language)_configService.MovieInfoLanguage;
 
@@ -116,7 +116,7 @@ namespace Radarr.Api.V3.ImportLists
         }
 
         [HttpPost]
-        public object AddMovies([FromBody] List<MovieResource> resource)
+        public List<MovieResource> AddMovies([FromBody] List<MovieResource> resource)
         {
             var newMovies = resource.ToModel();
 

--- a/src/Radarr.Api.V3/Indexers/ReleaseController.cs
+++ b/src/Radarr.Api.V3/Indexers/ReleaseController.cs
@@ -67,7 +67,7 @@ namespace Radarr.Api.V3.Indexers
 
         [HttpPost]
         [Consumes("application/json")]
-        public async Task<object> DownloadRelease([FromBody] ReleaseResource release)
+        public async Task<ReleaseResource> DownloadRelease([FromBody] ReleaseResource release)
         {
             var remoteMovie = _remoteMovieCache.Find(GetCacheKey(release));
 

--- a/src/Radarr.Api.V3/Logs/LogFileControllerBase.cs
+++ b/src/Radarr.Api.V3/Logs/LogFileControllerBase.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NLog;
 using NzbDrone.Common.Disk;
@@ -51,6 +52,8 @@ namespace Radarr.Api.V3.Logs
         }
 
         [HttpGet(@"{filename:regex([[-.a-zA-Z0-9]]+?\.txt)}")]
+        [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK, "text/plain")]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public IActionResult GetLogFileResponse(string filename)
         {
             LogManager.Flush();

--- a/src/Radarr.Api.V3/ManualImport/ManualImportController.cs
+++ b/src/Radarr.Api.V3/ManualImport/ManualImportController.cs
@@ -36,7 +36,7 @@ namespace Radarr.Api.V3.ManualImport
 
         [HttpPost]
         [Consumes("application/json")]
-        public object ReprocessItems([FromBody] List<ManualImportReprocessResource> items)
+        public List<ManualImportReprocessResource> ReprocessItems([FromBody] List<ManualImportReprocessResource> items)
         {
             if (items is { Count: 0 })
             {

--- a/src/Radarr.Api.V3/MediaCovers/MediaCoverController.cs
+++ b/src/Radarr.Api.V3/MediaCovers/MediaCoverController.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.StaticFiles;
 using NzbDrone.Common.Disk;
@@ -26,6 +27,8 @@ namespace Radarr.Api.V3.MediaCovers
         }
 
         [HttpGet(@"{movieId:int}/{filename:regex((.+)\.(jpg|png|gif))}")]
+        [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK, "image/jpeg", "image/png", "image/gif")]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public IActionResult GetMediaCover(int movieId, string filename)
         {
             var filePath = Path.Combine(_appFolderInfo.GetAppDataPath(), "MediaCover", movieId.ToString(), filename);

--- a/src/Radarr.Api.V3/Metadata/MetadataController.cs
+++ b/src/Radarr.Api.V3/Metadata/MetadataController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Extras.Metadata;
 using NzbDrone.SignalR;
@@ -18,7 +19,7 @@ namespace Radarr.Api.V3.Metadata
         }
 
         [NonAction]
-        public override ActionResult<MetadataResource> UpdateProvider([FromBody] MetadataBulkResource providerResource)
+        public override ActionResult<List<MetadataResource>> UpdateProvider([FromBody] MetadataBulkResource providerResource)
         {
             throw new NotImplementedException();
         }

--- a/src/Radarr.Api.V3/MovieFiles/MovieFileController.cs
+++ b/src/Radarr.Api.V3/MovieFiles/MovieFileController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Datastore.Events;
@@ -82,6 +83,7 @@ namespace Radarr.Api.V3.MovieFiles
                 .ToList();
         }
 
+        [ProducesResponseType(typeof(MovieFileResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<MovieFileResource> SetMovieFile([FromBody] MovieFileResource movieFileResource)
@@ -105,6 +107,7 @@ namespace Radarr.Api.V3.MovieFiles
             return Accepted(movieFile.Id);
         }
 
+        [ProducesResponseType(typeof(List<MovieFileResource>), StatusCodes.Status202Accepted)]
         [Obsolete("Use bulk endpoint instead")]
         [HttpPut("editor")]
         [Consumes("application/json")]
@@ -188,6 +191,7 @@ namespace Radarr.Api.V3.MovieFiles
             return new { };
         }
 
+        [ProducesResponseType(typeof(List<MovieFileResource>), StatusCodes.Status202Accepted)]
         [HttpPut("bulk")]
         [Consumes("application/json")]
         public object SetPropertiesBulk([FromBody] List<MovieFileResource> resources)

--- a/src/Radarr.Api.V3/Movies/MovieController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
@@ -233,6 +234,7 @@ namespace Radarr.Api.V3.Movies
             return translation;
         }
 
+        [ProducesResponseType(typeof(MovieResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         [Produces("application/json")]
@@ -243,6 +245,7 @@ namespace Radarr.Api.V3.Movies
             return Created(movie.Id);
         }
 
+        [ProducesResponseType(typeof(MovieResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         [Produces("application/json")]

--- a/src/Radarr.Api.V3/Movies/MovieEditorController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieEditorController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
@@ -43,6 +44,7 @@ namespace Radarr.Api.V3.Movies
             _upgradableSpecification = upgradableSpecification;
         }
 
+        [ProducesResponseType(typeof(List<MovieResource>), StatusCodes.Status202Accepted)]
         [HttpPut]
         public IActionResult SaveAll([FromBody] MovieEditorResource resource)
         {

--- a/src/Radarr.Api.V3/Movies/MovieFolderController.cs
+++ b/src/Radarr.Api.V3/Movies/MovieFolderController.cs
@@ -19,14 +19,14 @@ public class MovieFolderController : Controller
 
     [HttpGet("{id}/folder")]
     [Produces("application/json")]
-    public object GetFolder([FromRoute] int id)
+    public MovieFolderResource GetFolder([FromRoute] int id)
     {
         var series = _movieService.GetMovie(id);
         var folder = _fileNameBuilder.GetMovieFolder(series);
 
-        return new
+        return new MovieFolderResource
         {
-            folder
+            Folder = folder
         };
     }
 }

--- a/src/Radarr.Api.V3/Movies/MovieFolderResource.cs
+++ b/src/Radarr.Api.V3/Movies/MovieFolderResource.cs
@@ -1,0 +1,6 @@
+namespace Radarr.Api.V3.Movies;
+
+public class MovieFolderResource
+{
+    public string Folder { get; set; }
+}

--- a/src/Radarr.Api.V3/Notifications/NotificationController.cs
+++ b/src/Radarr.Api.V3/Notifications/NotificationController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Notifications;
 using NzbDrone.SignalR;
@@ -18,7 +19,7 @@ namespace Radarr.Api.V3.Notifications
         }
 
         [NonAction]
-        public override ActionResult<NotificationResource> UpdateProvider([FromBody] NotificationBulkResource providerResource)
+        public override ActionResult<List<NotificationResource>> UpdateProvider([FromBody] NotificationBulkResource providerResource)
         {
             throw new NotImplementedException();
         }

--- a/src/Radarr.Api.V3/Profiles/Delay/DelayProfileController.cs
+++ b/src/Radarr.Api.V3/Profiles/Delay/DelayProfileController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Profiles.Delay;
 using Radarr.Http;
@@ -33,6 +34,7 @@ namespace Radarr.Api.V3.Profiles.Delay
             });
         }
 
+        [ProducesResponseType(typeof(DelayProfileResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<DelayProfileResource> Create([FromBody] DelayProfileResource resource)
@@ -54,6 +56,7 @@ namespace Radarr.Api.V3.Profiles.Delay
             _delayProfileService.Delete(id);
         }
 
+        [ProducesResponseType(typeof(DelayProfileResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<DelayProfileResource> Update([FromBody] DelayProfileResource resource)

--- a/src/Radarr.Api.V3/Profiles/Quality/QualityProfileController.cs
+++ b/src/Radarr.Api.V3/Profiles/Quality/QualityProfileController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.CustomFormats;
@@ -46,6 +47,7 @@ namespace Radarr.Api.V3.Profiles.Quality
             });
         }
 
+        [ProducesResponseType(typeof(QualityProfileResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<QualityProfileResource> Create([FromBody] QualityProfileResource resource)
@@ -61,6 +63,7 @@ namespace Radarr.Api.V3.Profiles.Quality
             _qualityProfileService.Delete(id);
         }
 
+        [ProducesResponseType(typeof(QualityProfileResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<QualityProfileResource> Update([FromBody] QualityProfileResource resource)

--- a/src/Radarr.Api.V3/Profiles/Release/ReleaseProfileController.cs
+++ b/src/Radarr.Api.V3/Profiles/Release/ReleaseProfileController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Indexers;
@@ -46,6 +47,7 @@ namespace Radarr.Api.V3.Profiles.Release
             });
         }
 
+        [ProducesResponseType(typeof(ReleaseProfileResource), StatusCodes.Status201Created)]
         [RestPostById]
         public ActionResult<ReleaseProfileResource> Create([FromBody] ReleaseProfileResource resource)
         {
@@ -60,6 +62,7 @@ namespace Radarr.Api.V3.Profiles.Release
             _profileService.Delete(id);
         }
 
+        [ProducesResponseType(typeof(ReleaseProfileResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         public ActionResult<ReleaseProfileResource> Update([FromBody] ReleaseProfileResource resource)
         {

--- a/src/Radarr.Api.V3/ProviderControllerBase.cs
+++ b/src/Radarr.Api.V3/ProviderControllerBase.cs
@@ -224,7 +224,7 @@ namespace Radarr.Api.V3
         [SkipValidation(true, false)]
         [HttpPost("test")]
         [Consumes("application/json")]
-        public object Test([FromBody] TProviderResource providerResource, [FromQuery] bool forceTest = false)
+        public string Test([FromBody] TProviderResource providerResource, [FromQuery] bool forceTest = false)
         {
             var existingDefinition = providerResource.Id > 0 ? _providerFactory.Find(providerResource.Id) : null;
             var providerDefinition = GetDefinition(providerResource, existingDefinition, true, !forceTest, true);
@@ -234,6 +234,8 @@ namespace Radarr.Api.V3
             return "{}";
         }
 
+        [ProducesResponseType(typeof(List<ProviderTestAllResult>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(List<ProviderTestAllResult>), StatusCodes.Status400BadRequest)]
         [HttpPost("testall")]
         [Produces("application/json")]
         public IActionResult TestAll()
@@ -264,6 +266,7 @@ namespace Radarr.Api.V3
         [HttpPost("action/{name}")]
         [Consumes("application/json")]
         [Produces("application/json")]
+        [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
         public IActionResult RequestAction([FromRoute] string name, [FromBody] TProviderResource providerResource)
         {
             var existingDefinition = providerResource.Id > 0 ? _providerFactory.Find(providerResource.Id) : null;

--- a/src/Radarr.Api.V3/ProviderControllerBase.cs
+++ b/src/Radarr.Api.V3/ProviderControllerBase.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Serializer;
@@ -75,6 +76,7 @@ namespace Radarr.Api.V3
             return result.OrderBy(p => p.Name).ToList();
         }
 
+        [ProducesResponseType(StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         [Produces("application/json")]
@@ -92,6 +94,7 @@ namespace Radarr.Api.V3
             return Created(providerDefinition.Id);
         }
 
+        [ProducesResponseType(StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         [Produces("application/json")]
@@ -124,10 +127,11 @@ namespace Radarr.Api.V3
             return Accepted(existingDefinition.Id);
         }
 
+        [ProducesResponseType(StatusCodes.Status202Accepted)]
         [HttpPut("bulk")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        public virtual ActionResult<TProviderResource> UpdateProvider([FromBody] TBulkProviderResource providerResource)
+        public virtual ActionResult<List<TProviderResource>> UpdateProvider([FromBody] TBulkProviderResource providerResource)
         {
             if (!providerResource.Ids.Any())
             {

--- a/src/Radarr.Api.V3/Qualities/QualityDefinitionController.cs
+++ b/src/Radarr.Api.V3/Qualities/QualityDefinitionController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.Messaging.Events;
@@ -29,6 +30,7 @@ namespace Radarr.Api.V3.Qualities
                 .SetValidator(new QualityDefinitionResourceValidator());
         }
 
+        [ProducesResponseType(typeof(QualityDefinitionResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         public ActionResult<QualityDefinitionResource> Update([FromBody] QualityDefinitionResource resource)
         {
@@ -48,6 +50,7 @@ namespace Radarr.Api.V3.Qualities
             return _qualityDefinitionService.All().ToResource();
         }
 
+        [ProducesResponseType(typeof(List<QualityDefinitionResource>), StatusCodes.Status202Accepted)]
         [HttpPut("update")]
         public object UpdateMany([FromBody] List<QualityDefinitionResource> resource)
         {

--- a/src/Radarr.Api.V3/RemotePathMappings/RemotePathMappingController.cs
+++ b/src/Radarr.Api.V3/RemotePathMappings/RemotePathMappingController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.RemotePathMappings;
@@ -51,6 +52,7 @@ namespace Radarr.Api.V3.RemotePathMappings
             return _remotePathMappingService.Get(id).ToResource();
         }
 
+        [ProducesResponseType(typeof(RemotePathMappingResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<RemotePathMappingResource> CreateMapping([FromBody] RemotePathMappingResource resource)
@@ -72,6 +74,7 @@ namespace Radarr.Api.V3.RemotePathMappings
             _remotePathMappingService.Remove(id);
         }
 
+        [ProducesResponseType(typeof(RemotePathMappingResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         public ActionResult<RemotePathMappingResource> UpdateMapping([FromBody] RemotePathMappingResource resource)
         {

--- a/src/Radarr.Api.V3/RootFolders/RootFolderController.cs
+++ b/src/Radarr.Api.V3/RootFolders/RootFolderController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.RootFolders;
 using NzbDrone.Core.Validation.Paths;
@@ -48,6 +49,7 @@ namespace Radarr.Api.V3.RootFolders
             return _rootFolderService.Get(id, timeout).ToResource();
         }
 
+        [ProducesResponseType(typeof(RootFolderResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<RootFolderResource> CreateRootFolder([FromBody] RootFolderResource rootFolderResource)

--- a/src/Radarr.Api.V3/System/Backup/BackupController.cs
+++ b/src/Radarr.Api.V3/System/Backup/BackupController.cs
@@ -72,7 +72,7 @@ namespace Radarr.Api.V3.System.Backup
         }
 
         [HttpPost("restore/{id:int}")]
-        public object Restore([FromRoute] int id)
+        public BackupRestoreResource Restore([FromRoute] int id)
         {
             var backup = GetBackup(id);
 
@@ -85,7 +85,7 @@ namespace Radarr.Api.V3.System.Backup
 
             _backupService.Restore(path);
 
-            return new
+            return new BackupRestoreResource
             {
                 RestartRequired = true
             };
@@ -93,7 +93,7 @@ namespace Radarr.Api.V3.System.Backup
 
         [HttpPost("restore/upload")]
         [RequestFormLimits(MultipartBodyLengthLimit = 5000000000)]
-        public object UploadAndRestore()
+        public BackupRestoreResource UploadAndRestore()
         {
             var files = Request.Form.Files;
 
@@ -118,7 +118,7 @@ namespace Radarr.Api.V3.System.Backup
             // Cleanup restored file
             _diskProvider.DeleteFile(path);
 
-            return new
+            return new BackupRestoreResource
             {
                 RestartRequired = true
             };

--- a/src/Radarr.Api.V3/System/Backup/BackupRestoreResource.cs
+++ b/src/Radarr.Api.V3/System/Backup/BackupRestoreResource.cs
@@ -1,0 +1,7 @@
+namespace Radarr.Api.V3.System.Backup
+{
+    public class BackupRestoreResource
+    {
+        public bool RestartRequired { get; set; }
+    }
+}

--- a/src/Radarr.Api.V3/System/SystemController.cs
+++ b/src/Radarr.Api.V3/System/SystemController.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Internal;
@@ -94,6 +96,7 @@ namespace Radarr.Api.V3.System
         }
 
         [HttpGet("routes")]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK, "text/plain")]
         public IActionResult GetRoutes()
         {
             using (var sw = new StringWriter())
@@ -105,23 +108,23 @@ namespace Radarr.Api.V3.System
         }
 
         [HttpGet("routes/duplicate")]
-        public object DuplicateRoutes()
+        public Dictionary<string, List<string>> DuplicateRoutes()
         {
             return _detector.GetDuplicateEndpoints(_endpointData);
         }
 
         [HttpPost("shutdown")]
-        public object Shutdown()
+        public SystemShutdownResource Shutdown()
         {
             Task.Factory.StartNew(() => _lifecycleService.Shutdown());
-            return new { ShuttingDown = true };
+            return new SystemShutdownResource { ShuttingDown = true };
         }
 
         [HttpPost("restart")]
-        public object Restart()
+        public SystemRestartResource Restart()
         {
             Task.Factory.StartNew(() => _lifecycleService.Restart());
-            return new { Restarting = true };
+            return new SystemRestartResource { Restarting = true };
         }
     }
 }

--- a/src/Radarr.Api.V3/System/SystemRestartResource.cs
+++ b/src/Radarr.Api.V3/System/SystemRestartResource.cs
@@ -1,0 +1,7 @@
+namespace Radarr.Api.V3.System
+{
+    public class SystemRestartResource
+    {
+        public bool Restarting { get; set; }
+    }
+}

--- a/src/Radarr.Api.V3/System/SystemShutdownResource.cs
+++ b/src/Radarr.Api.V3/System/SystemShutdownResource.cs
@@ -1,0 +1,7 @@
+namespace Radarr.Api.V3.System
+{
+    public class SystemShutdownResource
+    {
+        public bool ShuttingDown { get; set; }
+    }
+}

--- a/src/Radarr.Api.V3/Tags/TagController.cs
+++ b/src/Radarr.Api.V3/Tags/TagController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.AutoTagging;
 using NzbDrone.Core.Datastore.Events;
@@ -43,6 +44,7 @@ namespace Radarr.Api.V3.Tags
             return _tagService.All().ToResource();
         }
 
+        [ProducesResponseType(typeof(TagResource), StatusCodes.Status201Created)]
         [RestPostById]
         [Consumes("application/json")]
         public ActionResult<TagResource> Create([FromBody] TagResource resource)
@@ -50,6 +52,7 @@ namespace Radarr.Api.V3.Tags
             return Created(_tagService.Add(resource.ToModel()).Id);
         }
 
+        [ProducesResponseType(typeof(TagResource), StatusCodes.Status202Accepted)]
         [RestPutById]
         [Consumes("application/json")]
         public ActionResult<TagResource> Update([FromBody] TagResource resource)

--- a/src/Radarr.Api.V3/openapi.json
+++ b/src/Radarr.Api.V3/openapi.json
@@ -54,14 +54,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AlternativeTitleResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -103,11 +95,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/AlternativeTitleResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AlternativeTitleResource"
@@ -231,14 +218,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/AutoTaggingResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AutoTaggingResource"
@@ -299,14 +281,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/AutoTaggingResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AutoTaggingResource"
@@ -361,11 +338,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/AutoTaggingResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AutoTaggingResource"
@@ -402,14 +374,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/BackupResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -582,14 +546,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/BlocklistResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -824,8 +780,26 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK"
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CollectionResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CollectionResource"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -855,14 +829,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectionResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CollectionResource"
@@ -896,11 +865,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectionResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CollectionResource"
@@ -931,8 +895,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -951,14 +915,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/CommandResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -1021,11 +977,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CommandResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CommandResource"
@@ -1091,11 +1042,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreditResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CreditResource"
@@ -1120,14 +1066,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/CustomFilterResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -1162,14 +1100,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CustomFilterResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomFilterResource"
@@ -1210,14 +1143,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CustomFilterResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomFilterResource"
@@ -1272,11 +1200,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CustomFilterResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomFilterResource"
@@ -1327,14 +1250,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CustomFormatResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomFormatResource"
@@ -1375,14 +1293,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CustomFormatResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomFormatResource"
@@ -1437,11 +1350,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CustomFormatResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomFormatResource"
@@ -1472,12 +1380,15 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CustomFormatResource"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomFormatResource"
+                  }
                 }
               }
             }
@@ -1592,14 +1503,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DelayProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DelayProfileResource"
@@ -1622,14 +1528,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DelayProfileResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -1697,14 +1595,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DelayProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DelayProfileResource"
@@ -1738,11 +1631,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DelayProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DelayProfileResource"
@@ -1786,14 +1674,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DelayProfileResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -1824,14 +1704,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DiskSpaceResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -1898,8 +1770,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -1945,8 +1817,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
@@ -1997,11 +1869,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DownloadClientResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DownloadClientResource"
@@ -2032,12 +1899,15 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DownloadClientResource"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DownloadClientResource"
+                  }
                 }
               }
             }
@@ -2204,14 +2074,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DownloadClientConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DownloadClientConfigResource"
@@ -2245,11 +2110,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DownloadClientConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DownloadClientConfigResource"
@@ -2284,14 +2144,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ExtraFileResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -2401,14 +2253,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/HealthResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -2667,11 +2511,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/HostConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HostConfigResource"
@@ -2722,14 +2561,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/HostConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HostConfigResource"
@@ -2763,11 +2597,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/HostConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HostConfigResource"
@@ -2828,8 +2657,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -2875,8 +2704,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
@@ -2927,11 +2756,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListResource"
@@ -2962,12 +2786,15 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ImportListResource"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ImportListResource"
+                  }
                 }
               }
             }
@@ -3134,14 +2961,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListConfigResource"
@@ -3175,11 +2997,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListConfigResource"
@@ -3231,14 +3048,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListExclusionResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListExclusionResource"
@@ -3332,14 +3144,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListExclusionResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListExclusionResource"
@@ -3394,11 +3201,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListExclusionResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListExclusionResource"
@@ -3604,8 +3406,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -3651,8 +3453,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
@@ -3703,11 +3505,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/IndexerResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/IndexerResource"
@@ -3738,12 +3535,15 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IndexerResource"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IndexerResource"
+                  }
                 }
               }
             }
@@ -3910,14 +3710,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/IndexerConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/IndexerConfigResource"
@@ -3951,11 +3746,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/IndexerConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/IndexerConfigResource"
@@ -3980,14 +3770,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/IndexerFlagResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -4018,14 +3800,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/LanguageResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -4067,11 +3841,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/LanguageResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/LanguageResource"
@@ -4204,14 +3973,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/LogFileResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -4408,14 +4169,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MediaManagementConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MediaManagementConfigResource"
@@ -4449,11 +4205,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MediaManagementConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MediaManagementConfigResource"
@@ -4514,8 +4265,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -4561,8 +4312,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
@@ -4613,11 +4364,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetadataResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MetadataResource"
@@ -4773,14 +4519,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetadataConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MetadataConfigResource"
@@ -4814,11 +4555,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetadataConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MetadataConfigResource"
@@ -4930,14 +4666,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/MovieResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -4972,8 +4700,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -5018,8 +4746,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
@@ -5086,11 +4814,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MovieResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MovieResource"
@@ -5131,8 +4854,26 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK"
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MovieResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MovieResource"
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -5237,14 +4978,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MovieFileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MovieFileResource"
@@ -5299,11 +5035,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MovieFileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MovieFileResource"
@@ -5334,8 +5065,26 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK"
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MovieFileResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MovieFileResource"
+                  }
+                }
+              }
+            }
           }
         },
         "deprecated": true
@@ -5378,8 +5127,26 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK"
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MovieFileResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MovieFileResource"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -5538,11 +5305,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/NamingConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NamingConfigResource"
@@ -5593,14 +5355,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/NamingConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NamingConfigResource"
@@ -5634,11 +5391,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/NamingConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NamingConfigResource"
@@ -5763,8 +5515,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -5810,8 +5562,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
               "application/json": {
                 "schema": {
@@ -5862,11 +5614,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotificationResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NotificationResource"
@@ -5996,11 +5743,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ParseResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ParseResource"
@@ -6087,14 +5829,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityDefinitionResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QualityDefinitionResource"
@@ -6128,11 +5865,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityDefinitionResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QualityDefinitionResource"
@@ -6157,14 +5889,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/QualityDefinitionResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -6220,8 +5944,26 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK"
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityDefinitionResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityDefinitionResource"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -6235,11 +5977,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityDefinitionLimitsResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QualityDefinitionLimitsResource"
@@ -6270,14 +6007,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QualityProfileResource"
@@ -6300,14 +6032,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/QualityProfileResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -6375,14 +6099,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QualityProfileResource"
@@ -6416,11 +6135,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QualityProfileResource"
@@ -6445,11 +6159,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QualityProfileResource"
@@ -6775,14 +6484,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/QueueResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -6813,11 +6514,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/QueueStatusResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QueueStatusResource"
@@ -6909,14 +6605,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReleaseProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ReleaseProfileResource"
@@ -6939,14 +6630,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ReleaseProfileResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7024,14 +6707,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReleaseProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ReleaseProfileResource"
@@ -7065,11 +6743,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReleaseProfileResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ReleaseProfileResource"
@@ -7103,14 +6776,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ReleaseResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7147,14 +6812,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/RemotePathMappingResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RemotePathMappingResource"
@@ -7177,14 +6837,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/RemotePathMappingResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7262,14 +6914,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/RemotePathMappingResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RemotePathMappingResource"
@@ -7303,11 +6950,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/RemotePathMappingResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RemotePathMappingResource"
@@ -7345,14 +6987,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/RenameMovieResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7389,14 +7023,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/RootFolderResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RootFolderResource"
@@ -7419,14 +7048,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/RootFolderResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7489,11 +7110,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/RootFolderResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RootFolderResource"
@@ -7586,11 +7202,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/SystemResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SystemResource"
@@ -7663,14 +7274,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TagResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7705,14 +7308,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/TagResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TagResource"
@@ -7753,14 +7351,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/TagResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TagResource"
@@ -7815,11 +7408,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/TagResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TagResource"
@@ -7844,14 +7432,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TagDetailsResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7893,11 +7473,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/TagDetailsResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TagDetailsResource"
@@ -7922,14 +7497,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TaskResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -7971,11 +7538,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/TaskResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TaskResource"
@@ -8016,14 +7578,9 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/UiConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UiConfigResource"
@@ -8057,11 +7614,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/UiConfigResource"
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UiConfigResource"
@@ -8105,14 +7657,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/UpdateResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -8143,14 +7687,6 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/LogFileResource"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "type": "array",

--- a/src/Radarr.Api.V3/openapi.json
+++ b/src/Radarr.Api.V3/openapi.json
@@ -360,7 +360,25 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AutoTaggingSpecificationSchema"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AutoTaggingSpecificationSchema"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -436,7 +454,19 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRestoreResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRestoreResource"
+                }
+              }
+            }
           }
         }
       }
@@ -448,7 +478,19 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRestoreResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRestoreResource"
+                }
+              }
+            }
           }
         }
       }
@@ -1017,7 +1059,25 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CreditResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CreditResource"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -1422,7 +1482,25 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomFormatSpecificationSchema"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomFormatSpecificationSchema"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -1982,7 +2060,24 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }
@@ -1994,7 +2089,30 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProviderTestAllResult"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProviderTestAllResult"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -2025,7 +2143,12 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { }
+              }
+            }
           }
         }
       }
@@ -2197,7 +2320,19 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileSystemResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileSystemResult"
+                }
+              }
+            }
           }
         }
       }
@@ -2218,7 +2353,19 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileSystemTypeResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileSystemTypeResource"
+                }
+              }
+            }
           }
         }
       }
@@ -2239,7 +2386,25 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FileSystemMediaFileResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FileSystemMediaFileResource"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -2869,7 +3034,24 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }
@@ -2881,7 +3063,30 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProviderTestAllResult"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProviderTestAllResult"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -2912,7 +3117,12 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { }
+              }
+            }
           }
         }
       }
@@ -3251,7 +3461,25 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ImportListExclusionResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ImportListExclusionResource"
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -3318,7 +3546,25 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ImportListMoviesResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ImportListMoviesResource"
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -3356,7 +3602,25 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MovieResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MovieResource"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -3618,7 +3882,24 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }
@@ -3630,7 +3911,30 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProviderTestAllResult"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProviderTestAllResult"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -3661,7 +3965,12 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { }
+              }
+            }
           }
         }
       }
@@ -4012,7 +4321,30 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -4088,7 +4420,25 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManualImportReprocessResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManualImportReprocessResource"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -4120,7 +4470,42 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/gif": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -4427,7 +4812,24 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }
@@ -4439,7 +4841,30 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProviderTestAllResult"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProviderTestAllResult"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -4470,7 +4895,12 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { }
+              }
+            }
           }
         }
       }
@@ -5169,7 +5599,14 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MovieFolderResource"
+                }
+              }
+            }
           }
         }
       }
@@ -5465,7 +5902,19 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingExampleResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingExampleResource"
+                }
+              }
+            }
           }
         }
       }
@@ -5677,7 +6126,24 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }
@@ -5689,7 +6155,30 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProviderTestAllResult"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProviderTestAllResult"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -5720,7 +6209,12 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { }
+              }
+            }
           }
         }
       }
@@ -6545,7 +7039,19 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseResource"
+                }
+              }
+            }
           }
         }
       },
@@ -7224,7 +7730,14 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }
@@ -7236,7 +7749,31 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -7248,7 +7785,19 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemShutdownResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemShutdownResource"
+                }
+              }
+            }
           }
         }
       }
@@ -7260,7 +7809,19 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemRestartResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemRestartResource"
+                }
+              }
+            }
           }
         }
       }
@@ -7726,7 +8287,30 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -7759,6 +8343,31 @@
           },
           "addMethod": {
             "$ref": "#/components/schemas/AddMovieMethod"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AlternativeTitle": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sourceType": {
+            "$ref": "#/components/schemas/SourceType"
+          },
+          "movieMetadataId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "cleanTitle": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -7922,6 +8531,15 @@
           "time": {
             "type": "string",
             "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupRestoreResource": {
+        "type": "object",
+        "properties": {
+          "restartRequired": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -8947,6 +9565,96 @@
         ],
         "type": "string"
       },
+      "FileSystemEntityType": {
+        "enum": [
+          "parent",
+          "drive",
+          "folder",
+          "file"
+        ],
+        "type": "string"
+      },
+      "FileSystemMediaFileResource": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "relativePath": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "FileSystemModel": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/FileSystemEntityType"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "extension": {
+            "type": "string",
+            "nullable": true
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "lastModified": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "FileSystemResult": {
+        "type": "object",
+        "properties": {
+          "parent": {
+            "type": "string",
+            "nullable": true
+          },
+          "directories": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileSystemModel"
+            },
+            "nullable": true
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileSystemModel"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "FileSystemTypeResource": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/FileSystemEntityType"
+          }
+        },
+        "additionalProperties": false
+      },
       "HealthCheckResult": {
         "enum": [
           "ok",
@@ -9399,6 +10107,137 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ImportListExclusionResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportListMoviesResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "originalLanguage": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "status": {
+            "$ref": "#/components/schemas/MovieStatusType"
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "inCinemas": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "physicalRelease": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "digitalRelease": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaCover"
+            },
+            "nullable": true
+          },
+          "website": {
+            "type": "string",
+            "nullable": true
+          },
+          "remotePoster": {
+            "type": "string",
+            "nullable": true
+          },
+          "year": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "youTubeTrailerId": {
+            "type": "string",
+            "nullable": true
+          },
+          "studio": {
+            "type": "string",
+            "nullable": true
+          },
+          "runtime": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "tmdbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "folder": {
+            "type": "string",
+            "nullable": true
+          },
+          "certification": {
+            "type": "string",
+            "nullable": true
+          },
+          "popularity": {
+            "type": "number",
+            "format": "float"
+          },
+          "genres": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "ratings": {
+            "$ref": "#/components/schemas/Ratings"
+          },
+          "collection": {
+            "$ref": "#/components/schemas/MovieCollection"
+          },
+          "isExcluded": {
+            "type": "boolean"
+          },
+          "isExisting": {
+            "type": "boolean"
+          },
+          "isTrending": {
+            "type": "boolean"
+          },
+          "isPopular": {
+            "type": "boolean"
+          },
+          "isRecommendation": {
+            "type": "boolean"
+          },
+          "lists": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
             },
             "nullable": true
           }
@@ -10255,6 +11094,85 @@
         ],
         "type": "string"
       },
+      "MovieCollection": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "cleanTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "tmdbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "monitored": {
+            "type": "boolean"
+          },
+          "qualityProfileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "rootFolderPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "searchOnAdd": {
+            "type": "boolean"
+          },
+          "minimumAvailability": {
+            "$ref": "#/components/schemas/MovieStatusType"
+          },
+          "lastInfoSync": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaCover"
+            },
+            "nullable": true
+          },
+          "added": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "movies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MovieMetadata"
+            },
+            "nullable": true
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "MovieCollectionResource": {
         "type": "object",
         "properties": {
@@ -10439,6 +11357,16 @@
         },
         "additionalProperties": false
       },
+      "MovieFolderResource": {
+        "type": "object",
+        "properties": {
+          "folder": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "MovieHistoryEventType": {
         "enum": [
           "unknown",
@@ -10451,6 +11379,165 @@
           "downloadIgnored"
         ],
         "type": "string"
+      },
+      "MovieMetadata": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tmdbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaCover"
+            },
+            "nullable": true
+          },
+          "genres": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "inCinemas": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "physicalRelease": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "digitalRelease": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "certification": {
+            "type": "string",
+            "nullable": true
+          },
+          "year": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "ratings": {
+            "$ref": "#/components/schemas/Ratings"
+          },
+          "collectionTmdbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "collectionTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastInfoSync": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "runtime": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "website": {
+            "type": "string",
+            "nullable": true
+          },
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "cleanTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/MovieStatusType"
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "alternativeTitles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlternativeTitle"
+            },
+            "nullable": true
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MovieTranslation"
+            },
+            "nullable": true
+          },
+          "secondaryYear": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "youTubeTrailerId": {
+            "type": "string",
+            "nullable": true
+          },
+          "studio": {
+            "type": "string",
+            "nullable": true
+          },
+          "originalTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "cleanOriginalTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "originalLanguage": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "recommendations": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "popularity": {
+            "type": "number",
+            "format": "float"
+          },
+          "isRecentMovie": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
       },
       "MovieResource": {
         "type": "object",
@@ -10738,6 +11825,35 @@
         ],
         "type": "string"
       },
+      "MovieTranslation": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "movieMetadataId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "cleanTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          }
+        },
+        "additionalProperties": false
+      },
       "NamingConfigResource": {
         "type": "object",
         "properties": {
@@ -10759,6 +11875,20 @@
             "nullable": true
           },
           "movieFolderFormat": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "NamingExampleResource": {
+        "type": "object",
+        "properties": {
+          "movieExample": {
+            "type": "string",
+            "nullable": true
+          },
+          "movieFolderExample": {
             "type": "string",
             "nullable": true
           }
@@ -11034,6 +12164,33 @@
         ],
         "type": "string"
       },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": { }
+      },
       "ProfileFormatItemResource": {
         "type": "object",
         "properties": {
@@ -11084,6 +12241,27 @@
           "error"
         ],
         "type": "string"
+      },
+      "ProviderTestAllResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isValid": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "validationFailures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationFailure"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
       },
       "ProxyType": {
         "enum": [
@@ -11908,6 +13086,14 @@
         },
         "additionalProperties": false
       },
+      "Severity": {
+        "enum": [
+          "error",
+          "warning",
+          "info"
+        ],
+        "type": "string"
+      },
       "SortDirection": {
         "enum": [
           "default",
@@ -12041,6 +13227,24 @@
           "packageUpdateMechanismMessage": {
             "type": "string",
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SystemRestartResource": {
+        "type": "object",
+        "properties": {
+          "restarting": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SystemShutdownResource": {
+        "type": "object",
+        "properties": {
+          "shuttingDown": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -12377,6 +13581,46 @@
           },
           "hash": {
             "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ValidationFailure": {
+        "type": "object",
+        "properties": {
+          "propertyName": {
+            "type": "string",
+            "nullable": true
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          },
+          "attemptedValue": {
+            "nullable": true
+          },
+          "customState": {
+            "nullable": true
+          },
+          "severity": {
+            "$ref": "#/components/schemas/Severity"
+          },
+          "errorCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "formattedMessageArguments": {
+            "type": "array",
+            "items": { },
+            "nullable": true,
+            "deprecated": true
+          },
+          "formattedMessagePlaceholderValues": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            },
             "nullable": true
           }
         },

--- a/src/Radarr.Api.V3/openapi.json
+++ b/src/Radarr.Api.V3/openapi.json
@@ -9572,6 +9572,10 @@
           "authenticationRequired": {
             "$ref": "#/components/schemas/AuthenticationRequiredType"
           },
+          "allowedHosts": {
+            "type": "string",
+            "nullable": true
+          },
           "analyticsEnabled": {
             "type": "boolean"
           },
@@ -9616,6 +9620,10 @@
             "nullable": true
           },
           "urlBase": {
+            "type": "string",
+            "nullable": true
+          },
+          "trustedNetworks": {
             "type": "string",
             "nullable": true
           },
@@ -11984,6 +11992,22 @@
         ],
         "type": "string"
       },
+      "ReleaseHistoryResource": {
+        "type": "object",
+        "properties": {
+          "grabbed": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "failed": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "ReleaseProfileResource": {
         "type": "object",
         "properties": {
@@ -12044,6 +12068,9 @@
           "customFormatScore": {
             "type": "integer",
             "format": "int32"
+          },
+          "history": {
+            "$ref": "#/components/schemas/ReleaseHistoryResource"
           },
           "qualityWeight": {
             "type": "integer",
@@ -12422,6 +12449,9 @@
             "type": "boolean"
           },
           "isDocker": {
+            "type": "boolean"
+          },
+          "isContainerized": {
             "type": "boolean"
           },
           "mode": {

--- a/src/Radarr.Http/ProducesResponseTypeConvention.cs
+++ b/src/Radarr.Http/ProducesResponseTypeConvention.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace Radarr.Http
+{
+    // ProducesResponseType can't name the resource type of a generic base controller, so those
+    // actions declare the status code alone. MVC fills the body type in from the return type for
+    // 200 and 201 but not for the 202 the REST controllers return from updates, so do it here.
+    public class ProducesResponseTypeConvention : IActionModelConvention
+    {
+        public void Apply(ActionModel action)
+        {
+            var returnType = action.ActionMethod.ReturnType;
+
+            if (!returnType.IsGenericType || returnType.GetGenericTypeDefinition() != typeof(ActionResult<>))
+            {
+                return;
+            }
+
+            var resourceType = returnType.GetGenericArguments()[0];
+
+            foreach (var attribute in action.Filters.OfType<ProducesResponseTypeAttribute>().Where(a => a.Type == typeof(void)))
+            {
+                attribute.Type = resourceType;
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
40 non-DELETE `/api/v3` operations documented a `200` with no response body at all, because the action declares `object` or `IActionResult` and ApiExplorer cannot see through that. Four resource types the API actually returns — `NamingExampleResource`, `FileSystemResult`, `ProviderTestAllResult` and `ImportListMoviesResource` — appeared nowhere in the document, since no action declared them.

This declares the type the action already returns. Runtime behaviour is unchanged throughout; only the declared types and metadata move.

**Declared the existing return type** for `autotagging/schema`, `customformat/schema`, `config/naming/examples`, `credit`, `filesystem`, `importlist/movie` (GET and POST), `exclusions/bulk`, `manualimport` and `system/routes/duplicate`. `{provider}/testall` is annotated rather than retyped, because it genuinely answers 200 or 400 with the same body.

**Added resource types** for the endpoints returning anonymous objects: `MovieFolderResource`, `FileSystemTypeResource`, `FileSystemMediaFileResource`, `SystemShutdownResource`, `SystemRestartResource` and `BackupRestoreResource`. Property names are unchanged so the serialised output is identical. `filesystem/type` uses the existing `FileSystemEntityType` enum, which is what `FileSystemFixture` already deserialises that field as.

**Annotated the responses that are not JSON**: log files and media covers as binary with their real content types plus the 404 they can return, `system/routes` as `text/plain`, and `{provider}/action/{name}` as an unconstrained JSON body since the payload is provider-defined.

Two smaller things found along the way:

- `filesystem/mediafiles` returned `string[]` for a folder that does not exist but an array of objects otherwise — one endpoint, two shapes. Both serialise to `[]` when empty, so this is not a wire change.
- `POST /api/v3/release` returns the `ReleaseResource` it was handed while declaring `object`.

Net effect: operations documenting no response body drop from 40 to 3.

**What is deliberately left.** Three operations (`history/failed/{id}`, `queue/grab/{id}`, `queue/grab/bulk`) and the `object`-returning DELETE endpoints return a literal `{}`. Documenting that means either an empty schema, which says nothing useful, or changing them to 204, which would break clients. Both are your call rather than mine, so they are untouched. Same for `Field.value`, `ReleaseProfileResource.required`/`.ignored` and `ReleaseResource.indexerFlags`, which are `object` in C# and genuinely dynamic.

#### Verification
Checked against a running Debug build rather than by inspection:

- Every affected response validates against the schema this generates. Because Radarr's schemas carry `additionalProperties: false`, passing validation also proves no property was added or dropped — including a 60-item `credit` list and a 63,031-item `mediafiles` response.
- Responses captured before and after are byte-identical, `filesystem/type` included, so the enum change is invisible on the wire.
- `FileSystemFixture` passes 7/7, and the integration suite passes 101/113 with 12 skipped, unchanged from develop.

#### Screenshot (if UI related)
N/A

#### Todos
- [x] Tests — added `get_all_mediafiles_for_folder_that_does_not_exist`, covering the branch this changes. Note it passes on both old and new code, since both emit `[]`; the rest of this PR is type declarations covered by the existing fixtures.
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) — N/A, no new strings
- [ ] [Wiki Updates](https://wiki.servarr.com) — N/A

#### Issues Fixed or Closed by this PR

* Stacked on #11686, which should merge first. Related: #11685, #11687.
