### PR TITLE
fix: CleanTitle discrepancy

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/NormalizeTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/NormalizeTitleFixture.cs
@@ -14,6 +14,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Law_and_Order_SVU", "lawordersvu")]
         [TestCase("Slap Shot 3: The Junior League", "slapshot3juniorleague")]
         [TestCase("Slap Shot 3 The Junior League", "slapshot3juniorleague")]
+        [TestCase("Boyz n the Hood", "boyznhood")]
+        [TestCase("An A to Z of Paddington", "antozpaddington")]
         public void should_normalize_series_title(string parsedSeriesName, string seriesName)
         {
             var result = parsedSeriesName.CleanMovieTitle();

--- a/src/NzbDrone.Core.Test/ParserTests/NormalizeTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/NormalizeTitleFixture.cs
@@ -12,6 +12,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Castle (2009)", "castle2009")]
         [TestCase("Parenthood.2010", "parenthood2010")]
         [TestCase("Law_and_Order_SVU", "lawordersvu")]
+        [TestCase("Slap Shot 3: The Junior League", "slapshot3juniorleague")]
+        [TestCase("Slap Shot 3 The Junior League", "slapshot3juniorleague")]
         public void should_normalize_series_title(string parsedSeriesName, string seriesName)
         {
             var result = parsedSeriesName.CleanMovieTitle();

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -110,8 +110,8 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex NormalizeAlternativeTitleRegex = new Regex(@"[ ]+(?:A\.K\.A\.)[ ]+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex NormalizeRegex = new Regex(@"((?:\b|_)(?<!^|[^a-zA-Z0-9_']\w[^a-zA-Z0-9_'])([aà](?!$|[^a-zA-Z0-9_']\w[^a-zA-Z0-9_'])|an|the|and|or|of)(?!$)(?:\b|_))|\W|_",
-                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex NormalizeRegex = new Regex(@"((?:\b|_)(?<!^|[^a-zA-Z0-9_']\w[^a-zA-Z0-9_'])[aà](?!$|[^a-zA-Z0-9_']\w[^a-zA-Z0-9_'])(?:\b|_)|(?:\b|_)(?<!^)(?:an|the|and|or|of)(?!$)(?:\b|_))|\W|_",
+                                                            RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex ReportImdbId = new Regex(@"(?<imdbid>tt\d{7,8})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex ReportTmdbId = new Regex(@"tmdb(id)?-(?<tmdbid>\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
`NormalizeRegex` in the `CleanTitle` function does not correctly remove articles in some cases. This causes matching issues during the QueueRefresh. 

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)