### PR TITLE
Fixed: only one edition tag preserved when multiple are present

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -105,6 +105,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("96.Hours.Movie.3.EXTENDED.2014.German.DL.1080p.BluRay.x264-ENCOUNTERS", "96 Hours Movie 3", "EXTENDED", 2014)]
         [TestCase("Movie.War.Q.EXTENDED.CUT.2013.German.DL.1080p.BluRay.x264-HQX", "Movie War Q", "EXTENDED CUT", 2013)]
         [TestCase("Sin.Movie.2005.RECUT.EXTENDED.German.DL.1080p.BluRay.x264-DETAiLS", "Sin Movie", "RECUT EXTENDED", 2005)]
+        [TestCase("Der.Herr.der.Ringe.Die.zwei.Tuerme.2002.REMASTERED.EXTENDED.German.AC3.DL.1080p.BluRay.x265-FuN", "Der Herr der Ringe Die zwei Tuerme", "REMASTERED EXTENDED", 2002, Description = "multiple non-adjacent edition tags")]
         [TestCase("2.Movie.in.L.A.1996.GERMAN.DL.720p.WEB.H264-SOV", "2 Movie in L.A.", "", 1996)]
         [TestCase("8.2019.GERMAN.720p.BluRay.x264-UNiVERSUM", "8", "", 2019)]
         [TestCase("Life.Movie.2014.German.DL.PAL.DVDR-ETM", "Life Movie", "", 2014)]

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -17,8 +17,6 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex EditionRegex = new Regex(@"\(?\b(?<edition>(((Recut.|Extended.|Ultimate.)?(Director.?s|Collector.?s|Theatrical|Ultimate|Extended|Despecialized|(Special|Rouge|Final|Assembly|Imperial|Diamond|Signature|Hunter|Rekall)(?=(.(Cut|Edition|Version)))|\d{2,3}(th)?.Anniversary)(?:.(Cut|Edition|Version))?(.(Extended|Uncensored|Remastered|Unrated|Uncut|Open.?Matte|IMAX|Fan.?Edit))?|((Uncensored|Remastered|Unrated|Uncut|Open?.Matte|IMAX|Fan.?Edit|Restored|((2|3|4)in1))))))\b\)?", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex ReportEditionRegex = new Regex(@"^.+?" + EditionRegex, RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
         private static readonly Regex HardcodedSubsRegex = new Regex(@"\b((?<hcsub>(\w+(?<!SOFT|MULTI|HORRIBLE)SUBS?))|(?<hc>(HC|SUBBED)))\b",
                                                         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
@@ -357,15 +355,13 @@ namespace NzbDrone.Core.Parser
 
         public static string ParseEdition(string languageTitle)
         {
-            var editionMatch = ReportEditionRegex.Match(languageTitle);
+            var editionMatches = EditionRegex.Matches(languageTitle);
 
-            if (editionMatch.Success && editionMatch.Groups["edition"].Value != null &&
-                editionMatch.Groups["edition"].Value.IsNotNullOrWhiteSpace())
-            {
-                return editionMatch.Groups["edition"].Value.Replace(".", " ");
-            }
+            var editions = editionMatches
+                .Select(m => m.Groups["edition"].Value)
+                .Where(e => e.IsNotNullOrWhiteSpace());
 
-            return "";
+            return string.Join(" ", editions).Replace(".", " ");
         }
 
         public static string ReplaceGermanUmlauts(string s)


### PR DESCRIPTION
## What

When a release filename contains more than one valid edition tag
(for example REMASTERED.EXTENDED), only the first tag was kept in
the parsed Edition and in the renamed filename.

## Why

ParseEdition matched the edition regex once and returned only that
single match. It now scans the whole title for every valid edition
tag and combines them, so REMASTERED.EXTENDED becomes
"Remastered Extended" instead of just "Remastered".

## Testing

Added a parser test case covering a filename with two non-adjacent
edition tags. Existing edition test cases (single tags and already
compound tags such as "Extended Cut") are unaffected.

Fixes #11533.
